### PR TITLE
refactor: redesign pub.dev publish flow for reliability

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,19 +6,23 @@ on:
       - 'v*.*.*-dev'
       - 'v*.*.*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v0.0.4-dev). Required for workflow_dispatch.'
+        required: true
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  publish:
+  publish-leaves:
+    name: publish ${{ matrix.package }}
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        package: [terradart_annotations, terradart_core, terradart_codegen, terradart_google]
-      max-parallel: 1
+        package: [terradart_annotations, terradart_core, terradart_codegen]
     steps:
       - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1
@@ -26,16 +30,30 @@ jobs:
           sdk: stable
       - run: dart pub get
 
-      - name: Pre-publish path-deps swap
-        run: tool/prepare_publish.sh ${{ github.ref_name }} ${{ matrix.package }}
+      - name: Pre-publish pubspec mutations
+        run: tool/prepare_publish.sh ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }} ${{ matrix.package }}
 
-      - name: pana check
+      - name: Publish to pub.dev
+        run: dart pub publish --force
+        working-directory: packages/${{ matrix.package }}
+
+  publish-google:
+    name: publish terradart_google
+    needs: publish-leaves
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for pub.dev index propagation
         run: |
-          dart pub global activate pana
-          (cd packages/${{ matrix.package }} && dart pub global run pana --no-warning --exit-code-threshold 100)
+          echo "Waiting 3 minutes for pub.dev index to update before publishing terradart_google..."
+          sleep 180
 
-      - name: Verify generated schema files (terradart_google only)
-        if: matrix.package == 'terradart_google'
+      - uses: actions/checkout@v6
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - run: dart pub get
+
+      - name: Verify generated schema files
         run: |
           EXPECTED=12
           ACTUAL=$(find packages/terradart_google/lib/src/generated -name "*.schema.g.dart" | wc -l)
@@ -44,6 +62,9 @@ jobs:
             exit 1
           fi
 
+      - name: Pre-publish pubspec mutations
+        run: tool/prepare_publish.sh ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }} terradart_google
+
       - name: Publish to pub.dev
         run: dart pub publish --force
-        working-directory: packages/${{ matrix.package }}
+        working-directory: packages/terradart_google

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,15 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
       - run: dart pub get
 
       - name: Pre-publish pubspec mutations
-        run: tool/prepare_publish.sh ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }} ${{ matrix.package }}
+        run: tool/prepare_publish.sh "${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}" ${{ matrix.package }}
 
       - name: Publish to pub.dev
         run: dart pub publish --force
@@ -51,6 +56,11 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
       - run: dart pub get
 
       - name: Verify generated schema files
@@ -63,7 +73,7 @@ jobs:
           fi
 
       - name: Pre-publish pubspec mutations
-        run: tool/prepare_publish.sh ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }} terradart_google
+        run: tool/prepare_publish.sh "${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}" terradart_google
 
       - name: Publish to pub.dev
         run: dart pub publish --force

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -85,10 +85,10 @@ Subsequent releases use the tag-driven flow above.
 If `publish-leaves` succeeds for some packages but fails for others, or if `publish-google` fails:
 
 1. Fix the underlying issue (CHANGELOG, version, lib naming, etc.) and commit.
-2. Bump to the next version (pub.dev rejects re-publishing the same version).
+2. Bump all 4 packages to the next version (pub.dev rejects re-publishing an existing version).
 3. Tag the new version and push.
 
-   Packages that already published successfully will be skipped automatically once the new tag is pushed (the next version's publish will only affect packages that weren't yet on pub.dev at this version).
+   All 4 packages will publish at the next version — successful packages from the previous attempt will simply receive a new minor bump (lockstep is preserved). There is no selective skip mechanism.
 
 ## Post-flight
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,49 +1,97 @@
 # Release Checklist
 
-## Pre-flight
+terradart releases 4 packages in lockstep: `terradart_annotations`, `terradart_core`, `terradart_codegen`, `terradart_google`. All 4 share the same version (e.g. `0.0.4-dev`).
+
+## Pre-flight (local)
 
 - [ ] CI green on main
-- [ ] CHANGELOG.md updated (root + 4 per-package)
-- [ ] Version bumped lockstep in all 4 pubspec.yaml
-- [ ] Local pana ≥ 100 for all 4 packages
-- [ ] `dart pub publish --dry-run` passes for all 4 packages (after path-deps swap)
+- [ ] Bump version in all 4 `packages/*/pubspec.yaml` to the target version (e.g. `0.0.4-dev`)
+- [ ] Add `## <version> - YYYY-MM-DD` entry to all 4 `packages/*/CHANGELOG.md`
+- [ ] Run pana score check on each package:
 
-## Publish (preferred: tag-driven via publish.yml OIDC)
+  ```bash
+  dart pub global activate pana
+  for pkg in terradart_annotations terradart_core terradart_codegen terradart_google; do
+    (cd "packages/$pkg" && dart pub global run pana --no-warning --exit-code-threshold 100)
+  done
+  ```
+
+- [ ] Run dry-run after path-deps swap (in a throwaway clone or after `git stash`):
+
+  ```bash
+  for pkg in terradart_annotations terradart_core terradart_codegen terradart_google; do
+    tool/prepare_publish.sh v0.0.X-dev "$pkg"
+    (cd "packages/$pkg" && dart pub publish --dry-run)
+  done
+  git checkout packages/*/pubspec.yaml  # restore
+  ```
+
+- [ ] Commit pubspec + CHANGELOG bumps to main
+
+## Publish (preferred: tag-driven via `publish.yml`)
 
 ```bash
 git tag v0.0.X-dev
 git push origin v0.0.X-dev
-# Watch publish.yml on GitHub Actions; OIDC trusted publisher does the publish.
 ```
 
-## Manual recovery (if publish.yml fails or first-time publish)
+Watch `publish.yml` on GitHub Actions:
 
-Order matters: leaves first, then dependents, with index propagation wait.
+1. **`publish-leaves`** job: 3 leaves (`terradart_annotations`, `terradart_core`, `terradart_codegen`) publish in parallel via OIDC trusted publisher.
+2. **`publish-google`** job: waits 3 minutes for pub.dev index propagation, then publishes `terradart_google` (which depends on the 3 leaves).
+
+`prepare_publish.sh` runs in CI and:
+
+- Verifies `pubspec.yaml` version matches the tag (fails fast if not bumped).
+- Verifies `CHANGELOG.md` has an entry for the version.
+- Strips `publish_to: none` from `terradart_google`.
+- Swaps `path:` deps in `terradart_google` to hosted `^VERSION` constraints.
+
+## Initial publish (OIDC not yet available)
+
+pub.dev's OIDC trusted publisher only works for **previously published** packages. The first publish of a new package must be done manually with `dart pub publish` (interactive auth via `dart pub token add`).
+
+Order: 3 leaves first, wait 3 minutes for index propagation, then `terradart_google`.
 
 ```bash
-tool/prepare_publish.sh v0.0.X-dev terradart_annotations
-(cd packages/terradart_annotations && dart pub publish)
+# 1. Bump pubspec + CHANGELOG locally first (per pre-flight above), commit, then run:
 
-tool/prepare_publish.sh v0.0.X-dev terradart
-(cd packages/terradart && dart pub publish)
+for pkg in terradart_annotations terradart_core terradart_codegen; do
+  tool/prepare_publish.sh v0.0.X-dev "$pkg"
+  (cd "packages/$pkg" && dart pub publish)
+done
 
-tool/prepare_publish.sh v0.0.X-dev terradart_codegen
-(cd packages/terradart_codegen && dart pub publish)
-
-# Wait 3 minutes for pub.dev index propagation.
+# 2. Wait for pub.dev to index the leaves.
 sleep 180
 
+# 3. Publish terradart_google (depends on the leaves).
 tool/prepare_publish.sh v0.0.X-dev terradart_google
 (cd packages/terradart_google && dart pub publish)
 
-# Restore path: deps after publish.
+# 4. Restore the path: deps in working tree (CI will redo this on next tag).
 git checkout packages/*/pubspec.yaml
-rm -f packages/*/pubspec.yaml.bak
 ```
+
+After all 4 packages exist on pub.dev, set up trusted publisher for each:
+
+1. Visit `https://pub.dev/packages/<pkg>/admin` for each package.
+2. **Automated publishing → GitHub Actions → Add**.
+3. Repository: `nozomi-koborinai/terradart`, tag pattern: `v*-dev` (and/or `v*.*.*`).
+
+Subsequent releases use the tag-driven flow above.
+
+## Manual recovery (`publish.yml` partially failed)
+
+If `publish-leaves` succeeds for some packages but fails for others, or if `publish-google` fails:
+
+1. Fix the underlying issue (CHANGELOG, version, lib naming, etc.) and commit.
+2. Bump to the next version (pub.dev rejects re-publishing the same version).
+3. Tag the new version and push.
+
+   Packages that already published successfully will be skipped automatically once the new tag is pushed (the next version's publish will only affect packages that weren't yet on pub.dev at this version).
 
 ## Post-flight
 
 - [ ] All 4 listings on pub.dev show the correct version
-- [ ] GitHub Release created with CHANGELOG excerpt
-- [ ] Verified publisher badge appears
-- [ ] (next-release setup) pub.dev → each package admin → "Automated publishing" → enable GitHub Actions trust
+- [ ] GitHub Release created (`gh release create v0.0.X-dev --notes ...`)
+- [ ] Verified publisher badge appears on all 4 pub.dev pages

--- a/tool/prepare_publish.sh
+++ b/tool/prepare_publish.sh
@@ -1,31 +1,36 @@
 #!/usr/bin/env bash
-# Pre-publish path-deps swap for terradart_google.
+# Pre-publish pubspec mutations for pub.dev.
 # Usage: tool/prepare_publish.sh <tag> <package_dir>
-#   e.g. tool/prepare_publish.sh v0.0.1-dev terradart_google
+#   e.g. tool/prepare_publish.sh v0.0.4-dev terradart_google
 
 set -euo pipefail
-TAG="${1:?tag required, e.g. v0.0.1-dev}"
+TAG="${1:?tag required, e.g. v0.0.4-dev}"
 PKG="${2:?package dir, e.g. terradart_google}"
-VERSION="${TAG#v}"   # v0.0.1-dev -> 0.0.1-dev
+VERSION="${TAG#v}"
 
 cd "packages/$PKG"
-# Strip publish_to line (including optional inline comment).
-sed -i.bak '/^publish_to:/d' pubspec.yaml
-rm -f pubspec.yaml.bak
-# Sync version field to the tag version.
-perl -pi -e "s/^version: .*/version: $VERSION/" pubspec.yaml
 
-if [[ "$PKG" == "terradart_google" ]]; then
-  python3 - "$VERSION" <<'EOF'
-import re, pathlib, sys
-version = sys.argv[1]
-p = pathlib.Path("pubspec.yaml")
-s = p.read_text()
-for dep in ("terradart_core", "terradart_annotations", "terradart_codegen"):
-    s = re.sub(rf"  {dep}:\n    path: \.\./{dep}", f"  {dep}: ^{version}", s)
-p.write_text(s)
-EOF
+# 1. Verify pubspec version matches the tag. Caller must bump pubspec + CHANGELOG before tagging.
+PUBSPEC_VERSION=$(yq e '.version' pubspec.yaml)
+if [[ "$PUBSPEC_VERSION" != "$VERSION" ]]; then
+  echo "::error::pubspec version ($PUBSPEC_VERSION) != tag version ($VERSION). Bump packages/$PKG/pubspec.yaml + CHANGELOG before tagging."
+  exit 1
 fi
 
-dart pub publish --dry-run
+# 2. Verify CHANGELOG has an entry for this version (dart pub publish enforces this).
+if ! grep -qE "^## ${VERSION}( |$)" CHANGELOG.md; then
+  echo "::error::CHANGELOG.md is missing an entry for version $VERSION. Add '## $VERSION' before tagging."
+  exit 1
+fi
+
+# 3. Strip publish_to: line (only terradart_google has it; safe no-op for others).
+yq e 'del(.publish_to)' -i pubspec.yaml
+
+# 4. Swap path: deps for terradart_google to hosted ^VERSION constraints.
+if [[ "$PKG" == "terradart_google" ]]; then
+  yq e ".dependencies.terradart_core = \"^${VERSION}\"" -i pubspec.yaml
+  yq e ".dependencies.terradart_annotations = \"^${VERSION}\"" -i pubspec.yaml
+  yq e ".dev_dependencies.terradart_codegen = \"^${VERSION}\"" -i pubspec.yaml
+fi
+
 echo "::notice::Pre-publish swap complete for $PKG ($VERSION)"

--- a/tool/prepare_publish.sh
+++ b/tool/prepare_publish.sh
@@ -23,8 +23,8 @@ if ! grep -qE "^## ${VERSION}( |$)" CHANGELOG.md; then
   exit 1
 fi
 
-# 3. Strip publish_to: line (only terradart_google has it; safe no-op for others).
-yq e 'del(.publish_to)' -i pubspec.yaml
+# 3. Strip workspace-only fields (publish_to, resolution) — present in source pubspec but invalid on pub.dev.
+yq e 'del(.publish_to) | del(.resolution)' -i pubspec.yaml
 
 # 4. Swap path: deps for terradart_google to hosted ^VERSION constraints.
 if [[ "$PKG" == "terradart_google" ]]; then

--- a/tool/run_tests.sh
+++ b/tool/run_tests.sh
@@ -27,7 +27,8 @@ echo ">> dart analyze"
 dart analyze --fatal-infos --fatal-warnings
 
 PACKAGES=(
-  "packages/terradart"
+  "packages/terradart_annotations"
+  "packages/terradart_core"
   "packages/terradart_codegen"
   "packages/terradart_google"
 )


### PR DESCRIPTION
## Summary

Redesigns the pub.dev publish flow to fix recurring failures and brittleness identified by the agent team review.

### Root causes addressed

- `prepare_publish.sh` ran `dart pub publish --dry-run` after modifying `pubspec.yaml`, which always exited 65 because of dirty git state. **Removed.**
- Python regex in `prepare_publish.sh` was multiline-fragile. **Replaced with `yq`.**
- `pubspec.yaml` retained `resolution: workspace` when uploaded to pub.dev. **Now stripped.**
- No CHANGELOG/version sync verification, leading to silent publish failures. **Added explicit verify step.**
- No `pub.dev` index propagation wait between leaves and `terradart_google`. **Split into two jobs with `sleep 180`.**
- pana check ran after path swap, causing dependency resolution to fail when hosted versions did not yet exist. **Removed from CI; documented in `RELEASE.md` pre-flight checklist.**
- Stale references to the old `packages/terradart` path in `RELEASE.md` and `tool/run_tests.sh`. **Updated.**

### Process

The redesign was driven by three subagents:

1. **Explorer** enumerated all current and potential failure modes
2. **Architect** designed the new flow with explicit trade-offs
3. **Reviewer** found and verified two critical issues (yq install, `resolution: workspace`) plus shell quoting and recovery wording

### New publish flow

- User bumps `pubspec.yaml` + `CHANGELOG.md` for all 4 packages, commits, then tags.
- CI verifies pubspec version matches the tag and CHANGELOG has an entry; fails fast if not.
- `publish-leaves` job publishes 3 leaves in parallel via OIDC.
- `publish-google` job waits 3 minutes for index propagation, then publishes `terradart_google`.
- `workflow_dispatch` accepts a `tag` input for manual recovery.