### PR TITLE
chore: bump packages to 0.0.3-dev

### DIFF
--- a/packages/terradart_annotations/pubspec.yaml
+++ b/packages/terradart_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_annotations
 description: Annotation surface consumed by terradart_codegen-generated abstract resource classes (@TerraformResource, @ForceNew, @Sensitive).
-version: 0.0.2-dev
+version: 0.0.3-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart Stage 1 codegen — parses Terraform provider schema JSON and Magic Modules YAML and emits annotated abstract Dart classes. Ships the terradart CLI.
-version: 0.0.2-dev
+version: 0.0.3-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.0.2-dev
+version: 0.0.3-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: terradart hand-written, blessed Tier 1 GCP factories (Pub/Sub, Cloud Tasks, Secret Manager, Cloud Scheduler, IAM, service accounts) for Dart-first Terraform stacks.
-version: 0.0.2-dev
+version: 0.0.3-dev
 publish_to: none  # Removed by tool/prepare_publish.sh before dart pub publish.
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart


### PR DESCRIPTION
Lockstep version bump for v0.0.3-dev release. CHANGELOG entries already exist.