### PR TITLE
chore: bump packages to 0.0.4-dev

### DIFF
--- a/packages/terradart_annotations/CHANGELOG.md
+++ b/packages/terradart_annotations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.4-dev - 2026-05-11
+
+- No user-facing API changes. Version bumped for workspace consistency with Phase 4.1 (`terradart wrap` subcommand + DataSource emitters + 13 `terradart_google` wrappers migrated to generator output).
+
 ## 0.0.3-dev - 2026-05-09
 
 - Fix: rename terradart_core main library file to match package name.

--- a/packages/terradart_annotations/pubspec.yaml
+++ b/packages/terradart_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_annotations
 description: Annotation surface consumed by terradart_codegen-generated abstract resource classes (@TerraformResource, @ForceNew, @Sensitive).
-version: 0.0.3-dev
+version: 0.0.4-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.0.4-dev - 2026-05-11
+
+- feat: new `terradart wrap` subcommand regenerates Tier 1 wrapper files from the package's production YAML overrides. Flags: `--provider`, `--source`, `--output`, `--check` (CI-gate mode, exit 65 on divergence), `--force` (overwrite non-generated files).
+- feat: `DataSourceWrapperEmitter` produces data source Layer 2 factories (`final class X extends Data<$X>`). `DataSourceClassEmitter` produces Layer 1 schema carriers (`data_<resource>.schema.dart`).
+- feat: WrapperOverride YAML schema extended from 11 to 15 axes (`kind`, `outputDir`, `schemaStubBodyMode`, `fileLeadingComment`); kind dispatches resource vs data source overrides.
+- feat: `LoaderErrorReport` aggregates YAML override validation failures into a single report with stable error codes (E101 `unknownKind`, E102 `outputDirRequired`, E103 `outputDirInvalid`, E104 `outputDirMismatchForDataSource`, E201 `axisNotAllowedForDataSource`, E301 `checkMismatch`, E401 `refuseOverwriteNonGenerated`).
+- feat: `generatedFileHeader` constant prepended to all wrap-emitted files (3 lines: GENERATED FILE marker + regen hint + `ignore_for_file: prefer_relative_imports`).
+- chore: production YAML registry covers 12 resources + 1 data source (google_project).
+
 ## 0.0.3-dev - 2026-05-09
 
 - Fix: rename terradart_core main library file to match package name.

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart Stage 1 codegen — parses Terraform provider schema JSON and Magic Modules YAML and emits annotated abstract Dart classes. Ships the terradart CLI.
-version: 0.0.3-dev
+version: 0.0.4-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.4-dev - 2026-05-11
+
+- No user-facing API changes. Version bumped for workspace consistency with Phase 4.1 (`terradart wrap` subcommand + DataSource emitters + 13 `terradart_google` wrappers migrated to generator output).
+
 ## 0.0.3-dev - 2026-05-09
 
 - Fix: rename terradart_core main library file to match package name.

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.0.3-dev
+version: 0.0.4-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.4-dev - 2026-05-11
+
+- chore: the 13 wrapper files under `lib/src/{pubsub,cloud_tasks,secret_manager,cloud_scheduler,iam,project,data}/` are now produced by `terradart wrap` (run from `packages/terradart_codegen/`). Output is byte-identical with the Wave 0 handwritten_baseline goldens; no behavioural changes for consumers.
+- feat: new Layer 1 schema carrier at `lib/src/generated/data_google_project.schema.dart` (reserved for future ResourceRef placeholder migration; not yet imported by Layer 2).
+
 ## 0.0.3-dev - 2026-05-09
 
 - Fix: rename terradart_core main library file to match package name.

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: terradart hand-written, blessed Tier 1 GCP factories (Pub/Sub, Cloud Tasks, Secret Manager, Cloud Scheduler, IAM, service accounts) for Dart-first Terraform stacks.
-version: 0.0.3-dev
+version: 0.0.4-dev
 publish_to: none  # Removed by tool/prepare_publish.sh before dart pub publish.
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart


### PR DESCRIPTION
## Summary

Bump all 4 packages from `0.0.3-dev` to `0.0.4-dev` and append Phase 4.1 release notes to each `CHANGELOG.md`. Required before pushing the `v0.0.4-dev` tag, since `tool/prepare_publish.sh` checks that `pubspec.yaml` version matches the tag and that `CHANGELOG.md` carries a matching `## VERSION` entry.

- `terradart_codegen` — substantive Phase 4.1 changelog: new `terradart wrap` subcommand, `DataSourceWrapperEmitter` + `DataSourceClassEmitter`, YAML schema 11 → 15 axes, `LoaderErrorReport` with E101-E401 codes, 3-line `generatedFileHeader`
- `terradart_google` — 13 wrapper files now produced by `terradart wrap` (byte-identical with handwritten_baseline; no behavioural change for consumers); new Layer 1 schema carrier `generated/data_google_project.schema.dart`
- `terradart_core` / `terradart_annotations` — no user-facing API changes; workspace consistency bump only

After this PR merges, the `v0.0.4-dev` tag is pushed against the resulting main commit and `publish.yml` triggers the pub.dev release for the three leaf packages plus `terradart_google` (with prepare_publish.sh swapping path: deps to hosted `^0.0.4-dev` constraints during the publish step).

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` — clean
- [x] `dart analyze packages/ --fatal-infos --fatal-warnings` — clean
- [x] All 4 `packages/*/pubspec.yaml` carry `version: 0.0.4-dev`
- [x] All 4 `packages/*/CHANGELOG.md` carry `## 0.0.4-dev - 2026-05-11`
- [x] `tool/prepare_publish.sh v0.0.4-dev <pkg>` will pass the version + changelog guard for every package (verified manually by reading the script's two assertions)

## Post-merge

- Tag `v0.0.4-dev` on the merge commit
- Push tag → `publish.yml` workflow publishes to pub.dev
