### PR TITLE
feat: Phase 4.1 Wave 3b — L4 e2e gates (baseline diff, tf-out snapshot, determinism)

### DIFF
--- a/examples/cloud_scheduler_quickstart/pubspec.lock
+++ b/examples/cloud_scheduler_quickstart/pubspec.lock
@@ -319,21 +319,21 @@ packages:
       path: "../../packages/terradart_annotations"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   terradart_core:
     dependency: "direct main"
     description:
       path: "../../packages/terradart_core"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   terradart_google:
     dependency: "direct main"
     description:
       path: "../../packages/terradart_google"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   test_api:
     dependency: transitive
     description:

--- a/examples/cloud_tasks_quickstart/pubspec.lock
+++ b/examples/cloud_tasks_quickstart/pubspec.lock
@@ -319,21 +319,21 @@ packages:
       path: "../../packages/terradart_annotations"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   terradart_core:
     dependency: "direct main"
     description:
       path: "../../packages/terradart_core"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   terradart_google:
     dependency: "direct main"
     description:
       path: "../../packages/terradart_google"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   test_api:
     dependency: transitive
     description:

--- a/examples/iam_quickstart/pubspec.lock
+++ b/examples/iam_quickstart/pubspec.lock
@@ -319,21 +319,21 @@ packages:
       path: "../../packages/terradart_annotations"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   terradart_core:
     dependency: "direct main"
     description:
       path: "../../packages/terradart_core"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   terradart_google:
     dependency: "direct main"
     description:
       path: "../../packages/terradart_google"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   test_api:
     dependency: transitive
     description:

--- a/examples/pubsub_quickstart/pubspec.lock
+++ b/examples/pubsub_quickstart/pubspec.lock
@@ -319,21 +319,21 @@ packages:
       path: "../../packages/terradart_annotations"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   terradart_core:
     dependency: "direct main"
     description:
       path: "../../packages/terradart_core"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   terradart_google:
     dependency: "direct main"
     description:
       path: "../../packages/terradart_google"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   test_api:
     dependency: transitive
     description:

--- a/examples/secret_manager_quickstart/pubspec.lock
+++ b/examples/secret_manager_quickstart/pubspec.lock
@@ -319,21 +319,21 @@ packages:
       path: "../../packages/terradart_annotations"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   terradart_core:
     dependency: "direct main"
     description:
       path: "../../packages/terradart_core"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   terradart_google:
     dependency: "direct main"
     description:
       path: "../../packages/terradart_google"
       relative: true
     source: path
-    version: "0.0.2-dev"
+    version: "0.0.4-dev"
   test_api:
     dependency: transitive
     description:

--- a/packages/terradart_codegen/dart_test.yaml
+++ b/packages/terradart_codegen/dart_test.yaml
@@ -1,0 +1,25 @@
+# Tag configuration for `dart test`.
+#
+# `e2e` tests exercise the full `terradart wrap` pipeline end-to-end
+# (multiple `buildCliRunner().run(...)` invocations against the fixture
+# schema, then byte-level tree comparison across tmp dirs). They are
+# SKIPPED by default so the fast unit + integration loop stays small and
+# the CI matrix `test` job (which invokes plain `dart test --reporter=github`)
+# doesn't pull in subprocess-heavy work.
+#
+# To run the e2e tests explicitly:
+#
+#   dart test -t e2e --run-skipped
+#
+# (Both flags are needed: `--run-skipped` overrides the `skip: true`
+# below, and `-t e2e` narrows the run to just the tagged tests.)
+#
+# The Wave 5 `wrap_check` CI job will opt in via this same flag pair.
+tags:
+  # `integration` is the pre-existing tag used by `test/cli/integration_test.dart`
+  # (subprocess invocations of the `terradart` CLI binary). It runs in the
+  # default loop -- declared here only to silence the
+  # "tag wasn't specified" warning.
+  integration:
+  e2e:
+    skip: "e2e tests are opt-in; run with `dart test -t e2e --run-skipped`"

--- a/packages/terradart_codegen/test/cli/wrap_determinism_test.dart
+++ b/packages/terradart_codegen/test/cli/wrap_determinism_test.dart
@@ -1,0 +1,73 @@
+@Tags(['e2e'])
+library;
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:terradart_codegen/src/cli/cli_runner.dart';
+import 'package:test/test.dart';
+
+/// L4-d invariant: `terradart wrap` is deterministic. Running the command
+/// twice against the same source schema must produce byte-identical output
+/// trees (same set of files, same relative paths, same byte content).
+///
+/// Determinism matters because Wave 3a's `--check` mode and Wave 4's CI
+/// gate both depend on a stable canonical output -- any per-run drift
+/// (timestamps, iteration order over hash maps, etc.) would make those
+/// gates flaky.
+void main() {
+  test(
+    'L4-d: terradart wrap is deterministic (2 consecutive runs byte-identical)',
+    () async {
+      final tmpA = await Directory.systemTemp.createTemp('phase4_det_a_');
+      final tmpB = await Directory.systemTemp.createTemp('phase4_det_b_');
+      try {
+        List<String> args(String out) => [
+              'wrap',
+              '--provider',
+              'hashicorp/google',
+              '--source',
+              p.join('test', 'fixtures', 'wrap', 'source'),
+              '--output',
+              out,
+            ];
+
+        final codeA = await buildCliRunner().run(args(tmpA.path));
+        expect(codeA, 0, reason: 'first wrap run failed (exit $codeA)');
+        final codeB = await buildCliRunner().run(args(tmpB.path));
+        expect(codeB, 0, reason: 'second wrap run failed (exit $codeB)');
+
+        final filesA = Directory(tmpA.path)
+            .listSync(recursive: true)
+            .whereType<File>()
+            .toList()
+          ..sort((a, b) => a.path.compareTo(b.path));
+        final filesB = Directory(tmpB.path)
+            .listSync(recursive: true)
+            .whereType<File>()
+            .toList()
+          ..sort((a, b) => a.path.compareTo(b.path));
+
+        expect(
+          filesB.length,
+          filesA.length,
+          reason: 'file count diverged: A=${filesA.length} B=${filesB.length}',
+        );
+
+        for (var i = 0; i < filesA.length; i++) {
+          final relA = p.relative(filesA[i].path, from: tmpA.path);
+          final relB = p.relative(filesB[i].path, from: tmpB.path);
+          expect(relB, relA, reason: 'file path order diverged at index $i');
+          expect(
+            filesB[i].readAsStringSync(),
+            filesA[i].readAsStringSync(),
+            reason: 'non-deterministic content in $relA',
+          );
+        }
+      } finally {
+        await tmpA.delete(recursive: true);
+        await tmpB.delete(recursive: true);
+      }
+    },
+  );
+}

--- a/packages/terradart_google/dart_test.yaml
+++ b/packages/terradart_google/dart_test.yaml
@@ -1,0 +1,19 @@
+# Tag configuration for `dart test`.
+#
+# `e2e` tests perform real `dart run` subprocess invocations and file I/O
+# outside the package (e.g. driving every `examples/<service>_quickstart`
+# synth). They are SKIPPED by default so the fast unit + integration loop
+# stays small and the CI matrix `test` job (which invokes plain
+# `dart test --reporter=github`) doesn't pull in subprocess-heavy work.
+#
+# To run the e2e tests explicitly:
+#
+#   dart test -t e2e --run-skipped
+#
+# (Both flags are needed: `--run-skipped` overrides the `skip: true`
+# below, and `-t e2e` narrows the run to just the tagged tests.)
+#
+# The Wave 5 `wrap_check` CI job will opt in via this same flag pair.
+tags:
+  e2e:
+    skip: "e2e tests are opt-in; run with `dart test -t e2e --run-skipped`"

--- a/packages/terradart_google/test/e2e/tfout_snapshot_test.dart
+++ b/packages/terradart_google/test/e2e/tfout_snapshot_test.dart
@@ -1,0 +1,82 @@
+@Tags(['e2e'])
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// L4-b invariant: every quickstart in `examples/<service>_quickstart` must
+/// synth to a `tf-out/main.tf.json` that matches its checked-in baseline at
+/// `test/golden/tfout_snapshot_<service>.json`.
+///
+/// Baselines are regenerated via `tool/freeze_tfout_snapshots.dart`. The
+/// env vars below mirror the CI `terraform_validate` matrix so the
+/// snapshot stays in sync with what CI actually validates.
+void main() {
+  const services = <String>[
+    'pubsub',
+    'cloud_tasks',
+    'secret_manager',
+    'cloud_scheduler',
+    'iam',
+  ];
+
+  // Mirrors CI `terraform_validate` env. We deliberately ADD to (not
+  // replace) the parent environment because `dart` itself needs PATH /
+  // PUB_CACHE / etc -- the synth output is env-driven only through these
+  // two keys, so any extra vars are inert.
+  const env = <String, String>{
+    'GCP_PROJECT_ID': 'ci-test-project-id',
+    'DB_PASSWORD': 'ci-test-secret',
+  };
+
+  // Resolve the examples dir from the package root (test cwd is
+  // `packages/terradart_google/`). Repo layout: `<repo>/packages/...` and
+  // `<repo>/examples/...`.
+  final examplesRoot = p.normalize(p.join('..', '..', 'examples'));
+
+  for (final svc in services) {
+    test('L4-b: $svc tf-out unchanged', () async {
+      final exDir = p.join(examplesRoot, '${svc}_quickstart');
+      final synth = await Process.run(
+        'dart',
+        ['run', 'bin/infra.dart'],
+        workingDirectory: exDir,
+        environment: env,
+      );
+      expect(
+        synth.exitCode,
+        0,
+        reason: 'dart run failed for $svc:\n${synth.stderr}\n${synth.stdout}',
+      );
+
+      final actualFile = File(p.join(exDir, 'tf-out', 'main.tf.json'));
+      expect(
+        actualFile.existsSync(),
+        isTrue,
+        reason: 'tf-out/main.tf.json not produced for $svc',
+      );
+      final actual = jsonDecode(actualFile.readAsStringSync());
+
+      final expectedFile = File(
+        p.join('test', 'golden', 'tfout_snapshot_$svc.json'),
+      );
+      expect(
+        expectedFile.existsSync(),
+        isTrue,
+        reason: 'missing snapshot baseline: ${expectedFile.path}',
+      );
+      final expected = jsonDecode(expectedFile.readAsStringSync());
+
+      expect(
+        actual,
+        equals(expected),
+        reason:
+            '$svc tf-out drifted. Re-run '
+            '`dart run tool/freeze_tfout_snapshots.dart` if intentional.',
+      );
+    });
+  }
+}

--- a/packages/terradart_google/test/e2e/wrap_baseline_test.dart
+++ b/packages/terradart_google/test/e2e/wrap_baseline_test.dart
@@ -1,0 +1,72 @@
+@Tags(['e2e'])
+library;
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// L4-a invariant: every file in `test/golden/handwritten_baseline/` must
+/// be byte-identical with its live counterpart in
+/// `lib/src/<service>/<basename>.dart`.
+///
+/// The baseline is the Wave 0 freeze of the 13 hand-written wrappers
+/// (12 Tier 1 resources + 1 data source). Any drift between the live files
+/// and the baseline indicates someone edited production code without
+/// re-freezing the baseline -- the wrap codegen pipeline (Wave 3a) must
+/// remain a 1:1 replacement, so the baseline acts as the contract.
+void main() {
+  test(
+    'L4-a: handwritten_baseline <-> lib/src/<service>/google_*.dart byte-identical',
+    () {
+      final baselineDir = Directory(
+        p.join('test', 'golden', 'handwritten_baseline'),
+      );
+      expect(
+        baselineDir.existsSync(),
+        isTrue,
+        reason: 'baseline dir missing: ${baselineDir.path}',
+      );
+
+      // Search across every subdir of `lib/src/` that ships a hand-written
+      // wrapper. Order is irrelevant -- baseline filenames are unique.
+      const candidates = <String>[
+        'lib/src/pubsub',
+        'lib/src/cloud_tasks',
+        'lib/src/secret_manager',
+        'lib/src/cloud_scheduler',
+        'lib/src/iam',
+        'lib/src/project',
+        'lib/src/data',
+      ];
+
+      final missing = <String>[];
+      final differing = <String>[];
+
+      final baselineFiles = baselineDir.listSync().whereType<File>().toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+      for (final f in baselineFiles) {
+        final base = p.basename(f.path);
+        String? actualPath;
+        for (final candidate in candidates) {
+          final c = File(p.join(candidate, base));
+          if (c.existsSync()) {
+            actualPath = c.path;
+            break;
+          }
+        }
+        if (actualPath == null) {
+          missing.add(base);
+          continue;
+        }
+        if (f.readAsStringSync() != File(actualPath).readAsStringSync()) {
+          differing.add(base);
+        }
+      }
+
+      expect(missing, isEmpty, reason: 'missing in lib/src/: $missing');
+      expect(differing, isEmpty, reason: 'differing files: $differing');
+    },
+  );
+}

--- a/packages/terradart_google/test/golden/tfout_snapshot_cloud_scheduler.json
+++ b/packages/terradart_google/test/golden/tfout_snapshot_cloud_scheduler.json
@@ -1,0 +1,46 @@
+{
+  "terraform": {
+    "required_version": ">= 1.11.0",
+    "required_providers": {
+      "google": {
+        "source": "hashicorp/google",
+        "version": "~> 7.0"
+      }
+    }
+  },
+  "provider": {
+    "google": {
+      "project": "ci-test-project-id",
+      "region": "us-central1"
+    }
+  },
+  "resource": {
+    "google_pubsub_topic": {
+      "nightly_cleanup": {
+        "name": "nightly-cleanup"
+      }
+    },
+    "google_cloud_scheduler_job": {
+      "nightly_job": {
+        "name": "nightly-cleanup-job",
+        "region": "us-central1",
+        "schedule": "0 3 * * *",
+        "time_zone": "Asia/Tokyo",
+        "retry_config": {
+          "retry_count": 3,
+          "min_backoff_duration": "5s",
+          "max_backoff_duration": "60s"
+        },
+        "pubsub_target": {
+          "topic_name": "${google_pubsub_topic.nightly_cleanup.id}",
+          "data": "Y2xlYW51cA=="
+        }
+      }
+    }
+  },
+  "output": {
+    "NIGHTLY_TOPIC_ID": {
+      "value": "${google_pubsub_topic.nightly_cleanup.id}"
+    }
+  }
+}

--- a/packages/terradart_google/test/golden/tfout_snapshot_cloud_tasks.json
+++ b/packages/terradart_google/test/golden/tfout_snapshot_cloud_tasks.json
@@ -1,0 +1,51 @@
+{
+  "terraform": {
+    "required_version": ">= 1.11.0",
+    "required_providers": {
+      "google": {
+        "source": "hashicorp/google",
+        "version": "~> 7.0"
+      }
+    }
+  },
+  "provider": {
+    "google": {
+      "project": "YOUR-PROJECT-ID",
+      "region": "us-central1"
+    }
+  },
+  "resource": {
+    "google_cloud_tasks_queue": {
+      "email_jobs": {
+        "name": "email-jobs",
+        "location": "us-central1",
+        "rate_limits": {
+          "max_concurrent_dispatches": 10,
+          "max_dispatches_per_second": 5
+        },
+        "retry_config": {
+          "max_attempts": 5,
+          "min_backoff": "5s",
+          "max_backoff": "300s",
+          "max_doublings": 3
+        }
+      }
+    },
+    "google_cloud_tasks_queue_iam_member": {
+      "email_jobs_enqueuer": {
+        "name": "${google_cloud_tasks_queue.email_jobs.name}",
+        "location": "${google_cloud_tasks_queue.email_jobs.location}",
+        "role": "roles/cloudtasks.enqueuer",
+        "member": "serviceAccount:enqueuer@YOUR-PROJECT-ID.iam.gserviceaccount.com"
+      }
+    }
+  },
+  "output": {
+    "EMAIL_QUEUE_NAME": {
+      "value": "${google_cloud_tasks_queue.email_jobs.name}"
+    },
+    "EMAIL_QUEUE_LOCATION": {
+      "value": "${google_cloud_tasks_queue.email_jobs.location}"
+    }
+  }
+}

--- a/packages/terradart_google/test/golden/tfout_snapshot_iam.json
+++ b/packages/terradart_google/test/golden/tfout_snapshot_iam.json
@@ -1,0 +1,93 @@
+{
+  "terraform": {
+    "required_version": ">= 1.11.0",
+    "required_providers": {
+      "google": {
+        "source": "hashicorp/google",
+        "version": "~> 7.0"
+      }
+    }
+  },
+  "provider": {
+    "google": {
+      "project": "ci-test-project-id",
+      "region": "us-central1"
+    }
+  },
+  "resource": {
+    "google_service_account": {
+      "demo": {
+        "account_id": "demo-sa",
+        "display_name": "IAM quickstart demo SA"
+      }
+    },
+    "google_pubsub_topic": {
+      "demo": {
+        "name": "demo-topic"
+      }
+    },
+    "google_pubsub_subscription": {
+      "demo_sub": {
+        "name": "demo-sub",
+        "topic": "${google_pubsub_topic.demo.id}"
+      }
+    },
+    "google_cloud_tasks_queue": {
+      "demo_queue": {
+        "name": "demo-queue",
+        "location": "us-central1"
+      }
+    },
+    "google_secret_manager_secret": {
+      "demo_secret": {
+        "secret_id": "demo-secret",
+        "replication": {
+          "auto": {}
+        }
+      }
+    },
+    "google_pubsub_topic_iam_member": {
+      "topic_publisher": {
+        "topic": "${google_pubsub_topic.demo.name}",
+        "role": "roles/pubsub.publisher",
+        "member": "${google_service_account.demo.member}"
+      }
+    },
+    "google_pubsub_subscription_iam_member": {
+      "sub_subscriber": {
+        "subscription": "${google_pubsub_subscription.demo_sub.name}",
+        "role": "roles/pubsub.subscriber",
+        "member": "${google_service_account.demo.member}"
+      }
+    },
+    "google_cloud_tasks_queue_iam_member": {
+      "queue_enqueuer": {
+        "name": "${google_cloud_tasks_queue.demo_queue.name}",
+        "location": "${google_cloud_tasks_queue.demo_queue.location}",
+        "role": "roles/cloudtasks.enqueuer",
+        "member": "${google_service_account.demo.member}"
+      }
+    },
+    "google_secret_manager_secret_iam_member": {
+      "secret_accessor": {
+        "secret_id": "${google_secret_manager_secret.demo_secret.secret_id}",
+        "role": "roles/secretmanager.secretAccessor",
+        "member": "${google_service_account.demo.member}"
+      }
+    }
+  },
+  "output": {
+    "TOPIC_ID": {
+      "value": "${google_pubsub_topic.demo.id}"
+    },
+    "SUBSCRIPTION_ID": {
+      "value": "${google_pubsub_subscription.demo_sub.id}"
+    },
+    "QUEUE_ID": {
+      "value": "${google_cloud_tasks_queue.demo_queue.id}"
+    },
+    "SECRET_ID": {
+      "value": "${google_secret_manager_secret.demo_secret.id}"
+    }
+  }
+}

--- a/packages/terradart_google/test/golden/tfout_snapshot_pubsub.json
+++ b/packages/terradart_google/test/golden/tfout_snapshot_pubsub.json
@@ -1,0 +1,40 @@
+{
+  "terraform": {
+    "required_version": ">= 1.11.0",
+    "required_providers": {
+      "google": {
+        "source": "hashicorp/google",
+        "version": "~> 7.0"
+      }
+    }
+  },
+  "provider": {
+    "google": {
+      "project": "ci-test-project-id",
+      "region": "us-central1"
+    }
+  },
+  "resource": {
+    "google_pubsub_topic": {
+      "orders": {
+        "name": "orders-prod",
+        "message_retention_duration": "604800s"
+      }
+    },
+    "google_pubsub_subscription": {
+      "orders_push": {
+        "name": "orders-push",
+        "topic": "${google_pubsub_topic.orders.id}",
+        "push_config": {
+          "push_endpoint": "https://app.example.com/push"
+        },
+        "ack_deadline_seconds": 60
+      }
+    }
+  },
+  "output": {
+    "ORDERS_TOPIC_ID": {
+      "value": "${google_pubsub_topic.orders.id}"
+    }
+  }
+}

--- a/packages/terradart_google/test/golden/tfout_snapshot_secret_manager.json
+++ b/packages/terradart_google/test/golden/tfout_snapshot_secret_manager.json
@@ -1,0 +1,49 @@
+{
+  "terraform": {
+    "required_version": ">= 1.11.0",
+    "required_providers": {
+      "google": {
+        "source": "hashicorp/google",
+        "version": "~> 7.0"
+      }
+    }
+  },
+  "provider": {
+    "google": {
+      "project": "ci-test-project-id",
+      "region": "us-central1"
+    }
+  },
+  "resource": {
+    "google_secret_manager_secret": {
+      "db_password": {
+        "secret_id": "db-password",
+        "replication": {
+          "auto": {}
+        },
+        "labels": {
+          "managed-by": "terradart"
+        }
+      }
+    },
+    "google_secret_manager_secret_version": {
+      "db_password_v1": {
+        "secret": "${google_secret_manager_secret.db_password.id}",
+        "secret_data_wo": "ci-test-secret",
+        "secret_data_wo_version": 1
+      }
+    },
+    "google_secret_manager_secret_iam_member": {
+      "db_password_accessor": {
+        "secret_id": "${google_secret_manager_secret.db_password.secret_id}",
+        "role": "roles/secretmanager.secretAccessor",
+        "member": "serviceAccount:app@ci-test-project-id.iam.gserviceaccount.com"
+      }
+    }
+  },
+  "output": {
+    "DB_PASSWORD_SECRET_ID": {
+      "value": "${google_secret_manager_secret.db_password.id}"
+    }
+  }
+}

--- a/packages/terradart_google/tool/freeze_tfout_snapshots.dart
+++ b/packages/terradart_google/tool/freeze_tfout_snapshots.dart
@@ -1,0 +1,77 @@
+// Regenerates the 5 quickstart tf-out snapshots under
+// `test/golden/tfout_snapshot_<service>.json`. Mirrors the CI
+// `terraform_validate` matrix env (`GCP_PROJECT_ID=ci-test-project-id`,
+// `DB_PASSWORD=ci-test-secret`) so the snapshots match what the
+// `tfout_snapshot_test.dart` e2e test produces on every run.
+//
+// Idempotent: re-running with no source changes overwrites the snapshots
+// with byte-identical content.
+//
+// Usage (from packages/terradart_google):
+//   dart run tool/freeze_tfout_snapshots.dart
+// Or from the repo root:
+//   dart run packages/terradart_google/tool/freeze_tfout_snapshots.dart
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+// Resolve paths from the script location rather than cwd so the script
+// works regardless of where it's invoked from.
+final _scriptDir = p.dirname(Platform.script.toFilePath());
+final _packageDir = p.normalize(p.join(_scriptDir, '..'));
+final _repoRoot = p.normalize(p.join(_packageDir, '..', '..'));
+
+const _services = <String>[
+  'pubsub',
+  'cloud_tasks',
+  'secret_manager',
+  'cloud_scheduler',
+  'iam',
+];
+
+const _env = <String, String>{
+  'GCP_PROJECT_ID': 'ci-test-project-id',
+  'DB_PASSWORD': 'ci-test-secret',
+};
+
+Future<void> main() async {
+  for (final svc in _services) {
+    final exDir = p.join(_repoRoot, 'examples', '${svc}_quickstart');
+
+    // 1. dart pub get (in case .dart_tool is stale or missing).
+    final pubGet = await Process.run('dart', [
+      'pub',
+      'get',
+    ], workingDirectory: exDir);
+    if (pubGet.exitCode != 0) {
+      stderr.writeln('pub get failed for $svc:\n${pubGet.stderr}');
+      exit(1);
+    }
+
+    // 2. dart run bin/infra.dart with CI env vars.
+    final synth = await Process.run(
+      'dart',
+      ['run', 'bin/infra.dart'],
+      workingDirectory: exDir,
+      environment: _env,
+    );
+    if (synth.exitCode != 0) {
+      stderr.writeln('synth failed for $svc:\n${synth.stderr}');
+      exit(1);
+    }
+
+    // 3. Copy tf-out/main.tf.json -> test/golden/tfout_snapshot_<svc>.json.
+    final src = File(p.join(exDir, 'tf-out', 'main.tf.json'));
+    if (!src.existsSync()) {
+      stderr.writeln('no tf-out/main.tf.json produced for $svc');
+      exit(1);
+    }
+    final dst = File(
+      p.join(_packageDir, 'test', 'golden', 'tfout_snapshot_$svc.json'),
+    );
+    dst.parent.createSync(recursive: true);
+    // Preserve the synth output verbatim. `synth.dart` already pretty-prints
+    // with 2-space indentation, so a raw copy keeps diffs reviewable.
+    dst.writeAsStringSync(src.readAsStringSync());
+    stdout.writeln('frozen: ${dst.path}');
+  }
+}


### PR DESCRIPTION
## Summary

Phase 4.1 Wave 3b — adds the L4 verification layer for `terradart wrap`. The four invariants established in Waves 0–3a are now mechanically enforced by `@Tags(['e2e'])` tests. Default `dart test` skips them; `dart test --run-skipped -t e2e` opts in. Wave 5 will wire these into a dedicated `wrap_check` CI job.

- **Task 20 — L4-a baseline diff** (`terradart_google/test/e2e/wrap_baseline_test.dart`): walks every file under `test/golden/handwritten_baseline/` and asserts byte-identical with the matching `lib/src/<service>/<basename>.dart` across 7 candidate subdirs. 1 test.
- **Task 21 — L4-b tf-out snapshot** (`terradart_google/test/e2e/tfout_snapshot_test.dart` + 5 JSON baselines): runs each of the 5 quickstart `bin/infra.dart` entrypoints (with `GCP_PROJECT_ID` + `DB_PASSWORD` env vars matching the CI `terraform_validate` matrix) and jsonDecode-compares the synth output against `test/golden/tfout_snapshot_<service>.json`. 5 tests. `tool/freeze_tfout_snapshots.dart` regenerates the snapshots when the synth shape intentionally changes.
- **Task 22 — L4-c analyze gate**: no code change. `dart analyze packages/ --fatal-infos --fatal-warnings` is already enforced from CI's `test (terradart_core)` matrix step (covers `terradart_google` transitively because it scans `packages/`).
- **Task 23 — L4-d determinism** (`terradart_codegen/test/cli/wrap_determinism_test.dart`): runs `terradart wrap` twice into separate tmp dirs and asserts byte-identical output across all 14 emitted files. 1 test.

**E2e opt-in mechanism**: `dart_test.yaml` in both packages declares `tags.e2e.skip` so the default loop excludes the e2e tests. The opt-in command is `dart test --run-skipped -t e2e` — the `--run-skipped` is needed because `skip:` is the symmetric way to express "off by default but runnable". `exclude_tags: e2e` would have made the future Wave 5 CI opt-in awkward, so `skip:` was preferred. The pre-existing `integration` tag is also declared (no behaviour change) to silence an unused-tag warning.

**Examples lockfile refresh**: 5 quickstart `pubspec.lock` files were regenerated by the freeze tool's `dart pub get` pass and now record the freshly-released `0.0.4-dev` versions of the workspace packages (previously pinned to `0.0.2-dev`). Bundled with this commit since the lock drift was unavoidable post-tag.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` — clean
- [x] `dart analyze packages/ --fatal-infos --fatal-warnings` — clean
- [x] Default `dart test` per package (no e2e tag):
  - terradart_core: 160 pass
  - terradart_annotations: 3 pass
  - terradart_codegen: 173 pass + 2 skipped (1 pre-existing AOT + 1 new determinism e2e)
  - terradart_google: 84 pass + 2 skipped (2 new e2e tests)
- [x] `dart test --run-skipped -t e2e` per package:
  - terradart_codegen: 1 pass (L4-d determinism)
  - terradart_google: 6 pass (1 L4-a baseline + 5 L4-b tf-out snapshots)
- [x] `tool/freeze_tfout_snapshots.dart` regenerates all 5 snapshots without drift (sanity-checked once before commit)
- [x] All 5 quickstart `pubspec.lock` files reflect the just-released `0.0.4-dev` versions

## Future waves (out of scope for this PR)

- (Wave 4) examples + workspace + analyze/format polish (Tasks 24–26)
- (Wave 5) `wrap_check` CI merge gate (Task 27) — wires `dart test --run-skipped -t e2e` into CI; `publish.yml` generated-file-count gate `12 → 25` (Task 28); `regenerate.yml` manual workflow (Task 29); ADR-0014 (Task 30)
