### PR TITLE
feat: Phase 4.1 Wave 5 — CI integration for terradart wrap (wrap_check, publish gate, regenerate workflow)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,25 @@ jobs:
       - run: dart test --reporter=github
         working-directory: packages/${{ matrix.package }}
 
+  wrap_check:
+    name: terradart wrap --check
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - run: dart pub get
+      - name: Verify generated wrappers are up to date
+        working-directory: packages/terradart_codegen
+        run: |
+          dart run bin/terradart.dart wrap \
+            --provider hashicorp/google \
+            --source test/fixtures/wrap/source \
+            --output ../terradart_google/lib/src \
+            --check
+
   terraform_validate:
     name: terraform validate (${{ matrix.example }})
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,12 +63,13 @@ jobs:
           yq --version
       - run: dart pub get
 
-      - name: Verify generated schema files
+      - name: Verify generated schema and wrapper files
+        working-directory: packages/terradart_google
         run: |
-          EXPECTED=12
-          ACTUAL=$(find packages/terradart_google/lib/src/generated -name "*.schema.g.dart" | wc -l)
-          if [ "$ACTUAL" -ne "$EXPECTED" ]; then
-            echo "::error::Expected $EXPECTED generated .g.dart files, got $ACTUAL"
+          schema_g_count=$(find lib/src/generated -name "*.schema.g.dart" | wc -l)
+          wrapper_count=$(find lib/src -mindepth 2 -name 'google_*.dart' -not -path 'lib/src/generated/*' | wc -l)
+          if [ "$schema_g_count" -ne 12 ] || [ "$wrapper_count" -ne 13 ]; then
+            echo "::error::Expected 12 schema.g.dart + 13 wrapper, got $schema_g_count + $wrapper_count"
             exit 1
           fi
 

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -1,0 +1,51 @@
+name: Regenerate wrapper files
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to regenerate against
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ inputs.pr }}
+    steps:
+      - name: Validate PR input
+        run: |
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid PR number: '$PR_NUMBER' (must be digits only)"
+            exit 1
+          fi
+      - uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ inputs.pr }}/head
+          fetch-depth: 0
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - run: dart pub get
+      - name: Run terradart wrap
+        working-directory: packages/terradart_codegen
+        run: |
+          dart run bin/terradart.dart wrap \
+            --provider hashicorp/google \
+            --source test/fixtures/wrap/source \
+            --output ../terradart_google/lib/src \
+            --force
+      - name: Commit and push if changed
+        run: |
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add packages/terradart_google/lib/src
+            git commit -m "regen: terradart wrap (PR #${PR_NUMBER})"
+            git push origin "HEAD:refs/pull/${PR_NUMBER}/head"
+          fi


### PR DESCRIPTION
## Summary

Phase 4.1 Wave 5 (final wave) — wires `terradart wrap` into CI as a merge gate, extends `publish.yml`'s file-count gate to cover the new generated wrappers, and adds a maintainer-triggered `regenerate.yml` workflow for one-click regeneration of a PR's wrap output.

Worked the four tasks in reverse order per request (30 → 29 → 28 → 27). ADR-0014 is drafted in `docs/decisions/0014-phase4.1-emitter-rollout-physical-replace.md` but **not part of this commit** — `docs/` is gitignored (existing ADRs 0001–0012 follow the same local-only convention).

- **Task 27 — `wrap_check` CI job** (`.github/workflows/ci.yml`): adds a `wrap_check` job that `needs: test`. Runs `terradart wrap --provider hashicorp/google --source test/fixtures/wrap/source --output ../terradart_google/lib/src --check` from `packages/terradart_codegen/`. Exits 65 (E301) if any of the 14 emitted files drifts from `lib/src/`. Becomes the merge gate that catches "edited override yaml but forgot to re-run wrap".
- **Task 28 — `publish.yml` file-count gate** (`.github/workflows/publish.yml`): replaces the existing `Verify generated schema files` step with a two-axis check. `schema_g_count = 12` (Schemantic-generated, unchanged) AND `wrapper_count = 13` (`google_*.dart` excluding the `generated/` subdir) — both must match before `terradart_google` ships to pub.dev.
- **Task 29 — `regenerate.yml` workflow** (`.github/workflows/regenerate.yml`, new): `workflow_dispatch` with a `pr` input. Checks out the PR head, runs `terradart wrap --force`, and (if anything changed) commits + pushes a `regen: terradart wrap (PR #N)` commit back to the PR branch as `github-actions[bot]`. Maintainer-only opt-in.
- **Task 30 — ADR-0014** (local-only, 123 lines, Status: Accepted): captures the rationale and consequences of physically replacing the 13 hand-written Tier 1 wrappers with `terradart wrap` output. Partially supersedes ADR-0008's "Tier 1 hand-written quality tier" concept.

## Test plan

- [x] `python3 -c "import yaml, sys; yaml.safe_load(sys.stdin)" < .github/workflows/ci.yml` — exit 0
- [x] `python3 -c "import yaml, sys; yaml.safe_load(sys.stdin)" < .github/workflows/publish.yml` — exit 0
- [x] `python3 -c "import yaml, sys; yaml.safe_load(sys.stdin)" < .github/workflows/regenerate.yml` — exit 0
- [x] Local `find lib/src \( -path 'lib/src/generated' -prune \) -o -name 'google_*.dart' -print | wc -l` from `packages/terradart_google/` returns **13** (matches the new publish gate)
- [x] Local `find lib/src/generated -name '*.schema.g.dart' | wc -l` returns **12** (unchanged from existing gate)
- [x] Local `dart run bin/terradart.dart wrap --provider hashicorp/google --source test/fixtures/wrap/source --output ../terradart_google/lib/src --check` from `packages/terradart_codegen/` exits **0** (`all 14 files match`)
- [x] This PR's CI run will be the first to exercise the new `wrap_check` job — the gate itself is the test
- [x] `regenerate.yml` cannot be exercised in this PR (it's `workflow_dispatch`-only). Smoke verification will happen the first time a maintainer triggers it against a real PR with override-yaml drift

## DoD-13 / DoD-14 (from the Phase 4.1 plan)

- DoD-13: `wrap_check` job in CI ✓
- DoD-14: `publish.yml` file-count gate extended ✓ + `regenerate.yml` workflow ✓

Phase 4.1 plan's Definition of Done is now 14/14 with this PR merged.

## Notes

- The optional "e2e gates" step in `wrap_check` (running `dart test --run-skipped -t e2e`) was intentionally skipped. `--check` already covers L4-a baseline byte-identity. L4-b (`tf-out` snapshot) duplicates the existing `terraform_validate` matrix. Leaving as a possible Wave 6 follow-up if a dedicated e2e merge gate is wanted.
- ADR-0014 lives at `docs/decisions/0014-phase4.1-emitter-rollout-physical-replace.md` on the local checkout for context. If the project policy on `docs/` ever flips to tracking ADRs, the file is ready to be `git add -f`'d.
