### PR TITLE
feat: Phase 4.4 — ProviderRules extraction (pure YAGNI refactor)

### DIFF
--- a/packages/terradart_codegen/lib/src/cli/cli_runner.dart
+++ b/packages/terradart_codegen/lib/src/cli/cli_runner.dart
@@ -1,5 +1,7 @@
 import 'package:args/command_runner.dart';
 
+import '../codegen/providers/google_provider_rules.dart';
+import '../codegen/providers/provider_rules.dart';
 import 'codegen_command.dart';
 import 'version_command.dart';
 import 'wrap_command.dart';
@@ -11,6 +13,9 @@ import 'wrap_promote_command.dart';
 /// Returns `int` so each command can pick its own exit code. `null` from a
 /// command means "no explicit code — treat as success".
 CommandRunner<int> buildCliRunner() {
+  const providers = <String, ProviderRules>{
+    'hashicorp/google': GoogleProviderRules(),
+  };
   final runner = CommandRunner<int>(
     'terradart',
     'Generate terradart Dart bindings from Terraform provider schemas.',
@@ -22,8 +27,8 @@ CommandRunner<int> buildCliRunner() {
     )
     ..addCommand(CodegenCommand())
     ..addCommand(WrapCommand())
-    ..addCommand(WrapInitCommand())
-    ..addCommand(WrapPromoteCommand())
+    ..addCommand(WrapInitCommand(providers: providers))
+    ..addCommand(WrapPromoteCommand(providers: providers))
     ..addCommand(VersionCommand());
   return runner;
 }

--- a/packages/terradart_codegen/lib/src/cli/wrap_init_command.dart
+++ b/packages/terradart_codegen/lib/src/cli/wrap_init_command.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as p;
 
+import '../codegen/providers/provider_rules.dart';
 import '../codegen/wrap_init/clock.dart';
 import '../codegen/wrap_init/output_dir_resolver.dart';
 import '../codegen/wrap_init/wrap_init_emitter.dart';
@@ -15,7 +16,7 @@ import 'exit_codes.dart';
 /// `terradart wrap-init <resource>` — scaffolds a wrapper override YAML
 /// for a single Terraform resource.
 class WrapInitCommand extends Command<int> {
-  WrapInitCommand() {
+  WrapInitCommand({required this.providers}) {
     argParser
       ..addOption(
         'provider',
@@ -45,6 +46,8 @@ class WrapInitCommand extends Command<int> {
       );
   }
 
+  final Map<String, ProviderRules> providers;
+
   @override
   String get name => 'wrap-init';
 
@@ -70,17 +73,18 @@ class WrapInitCommand extends Command<int> {
       );
     }
 
-    // --provider validation + Phase 4.2 support gating.
+    // --provider validation + registry lookup.
     final provider = results['provider'] as String;
     if (!_providerIdPattern.hasMatch(provider)) {
       usageException(
         'Invalid --provider "$provider". Expected "namespace/name".',
       );
     }
-    if (provider != 'hashicorp/google') {
+    final rules = providers[provider];
+    if (rules == null) {
       usageException(
-        'Provider "$provider" not supported in Phase 4.2 '
-        '(only hashicorp/google).',
+        'Provider "$provider" not supported. '
+        'Available: ${providers.keys.join(", ")}.',
       );
     }
 
@@ -160,7 +164,8 @@ class WrapInitCommand extends Command<int> {
     // 5. Generate + emit.
     final generator = WrapInitGenerator(
       clock: const SystemClock(),
-      outputDirResolver: const OutputDirResolver(),
+      outputDirResolver: OutputDirResolver(aliases: rules.outputDirAliases),
+      providerRules: rules,
     );
     const emitter = WrapInitEmitter();
     final draft = generator.generate(

--- a/packages/terradart_codegen/lib/src/cli/wrap_promote_command.dart
+++ b/packages/terradart_codegen/lib/src/cli/wrap_promote_command.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as p;
 
+import '../codegen/providers/provider_rules.dart';
 import '../codegen/wrap_init/clock.dart';
 import '../codegen/wrap_promote/wrap_promote_generator.dart';
 import '../codegen/wrap_promote/wrap_promote_marker.dart';
@@ -13,7 +14,7 @@ import 'exit_codes.dart';
 /// `terradart wrap-promote <resource>` — overlays MM-derived sealed-class
 /// skeletons + Dart enums onto an existing wrap-init-produced yaml.
 class WrapPromoteCommand extends Command<int> {
-  WrapPromoteCommand() {
+  WrapPromoteCommand({required this.providers}) {
     argParser
       ..addOption(
         'provider',
@@ -43,6 +44,8 @@ class WrapPromoteCommand extends Command<int> {
             'Regenerate the marker section even if one already exists (default: refuse).',
       );
   }
+
+  final Map<String, ProviderRules> providers;
 
   @override
   String get name => 'wrap-promote';
@@ -74,10 +77,10 @@ class WrapPromoteCommand extends Command<int> {
         'Invalid --provider "$provider". Expected "namespace/name".',
       );
     }
-    if (provider != 'hashicorp/google') {
+    if (!providers.containsKey(provider)) {
       usageException(
-        'Provider "$provider" not supported in Phase 4.3 '
-        '(only hashicorp/google).',
+        'Provider "$provider" not supported. '
+        'Available: ${providers.keys.join(", ")}.',
       );
     }
 

--- a/packages/terradart_codegen/lib/src/codegen/providers/google_provider_rules.dart
+++ b/packages/terradart_codegen/lib/src/codegen/providers/google_provider_rules.dart
@@ -1,0 +1,45 @@
+import '../../ir/resource_def.dart';
+import 'provider_rules.dart';
+
+final class GoogleProviderRules extends ProviderRules {
+  const GoogleProviderRules();
+
+  @override
+  String get providerId => 'hashicorp/google';
+
+  @override
+  Map<String, String> get outputDirAliases => _aliases;
+
+  @override
+  List<String> universalGetters(ResourceDef def) {
+    final attrs = def.root.attributes.map((a) => a.name).toSet();
+    final lines = <String>[];
+    if (attrs.contains('id')) {
+      lines.add("TfRef<String> get id => TfRef.attribute<String>(this, 'id');");
+    }
+    if (attrs.contains('name')) {
+      lines.add(
+        "TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');",
+      );
+    }
+    return lines;
+  }
+
+  /// Google provider alias map. Bootstrap entries derived from the 13 yaml
+  /// files shipped in Phase 4.1; extend during Phase 4.5 wave rollout when
+  /// new MM products land.
+  static const Map<String, String> _aliases = {
+    // Tier 1 — MM `product` field normalization (snake_case alignment).
+    'cloudtasks': 'cloud_tasks',
+    'secretmanager': 'secret_manager',
+    'cloudscheduler': 'cloud_scheduler',
+    'resourcemanager': 'project',
+
+    // Tier 2/3 — terraform-type prefix / segment overrides.
+    'cloud_tasks': 'cloud_tasks',
+    'secret_manager': 'secret_manager',
+    'cloud_scheduler': 'cloud_scheduler',
+    'service_account': 'iam',
+    'project_service': 'project',
+  };
+}

--- a/packages/terradart_codegen/lib/src/codegen/providers/provider_rules.dart
+++ b/packages/terradart_codegen/lib/src/codegen/providers/provider_rules.dart
@@ -1,0 +1,32 @@
+import '../../ir/resource_def.dart';
+
+/// Provider-specific data + behaviour pulled out of the inline Google-only
+/// code in Phase 4.1–4.3. Each Terraform provider terradart supports is one
+/// concrete subclass.
+///
+/// Phase 4.4 ships only `GoogleProviderRules`. AWS / Azure adapters land in
+/// Phase 4.5+ when a real consumer (e.g. `terradart_aws`) is implemented.
+/// The abstract base is open/closed so community adapters in separate
+/// packages can plug in without touching this file.
+abstract class ProviderRules {
+  const ProviderRules();
+
+  /// Terraform provider id, e.g. `'hashicorp/google'`. Used both as the
+  /// `Map<String, ProviderRules>` registry key in `cli_runner.dart` and as
+  /// the expected value for the `--provider` CLI flag.
+  String get providerId;
+
+  /// MM-product alias map + name-prefix overrides consumed by
+  /// `OutputDirResolver`. Phase 4.2's `_googleOutputDirAliases` const moves
+  /// into `GoogleProviderRules.outputDirAliases`.
+  Map<String, String> get outputDirAliases;
+
+  /// Cross-resource hint getter skeleton lines (Dart source, no leading
+  /// indent) for the resource defined by [def]. Returned strings are
+  /// embedded inside the `extraGetters: |2` commented block emitted by
+  /// `WrapInitGenerator._buildExtraGettersAxis`.
+  ///
+  /// Google: 0–2 lines for `id` and `nameRef` (from `name` attr).
+  /// AWS (Phase 4.5+): will return 0–2 lines for `id` and `arnRef`.
+  List<String> universalGetters(ResourceDef def);
+}

--- a/packages/terradart_codegen/lib/src/codegen/wrap_init/output_dir_resolver.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrap_init/output_dir_resolver.dart
@@ -8,10 +8,10 @@ import '../wrapper_overrides/wrapper_override.dart';
 ///   * Tier 2: `mmProduct == null` → terraform-type prefix match against aliases
 ///   * Tier 3: terraform-type segment-1 after `google_`, with alias override
 ///
-/// The alias map is Google-specific. Phase 4.4 will extract this to a
-/// `ProviderRules` adapter; Phase 4.2 keeps it inline.
+/// The alias map is provider-specific. As of Phase 4.4 the resolver itself is
+/// universal; the map ships from `ProviderRules.outputDirAliases`.
 class OutputDirResolver {
-  const OutputDirResolver({this.aliases = _googleOutputDirAliases});
+  const OutputDirResolver({required this.aliases});
 
   /// Both Tier-1 MM-product aliases and Tier-2/3 prefix/segment overrides.
   final Map<String, String> aliases;
@@ -50,21 +50,3 @@ class OutputDirResolver {
     return aliases[firstSegment] ?? firstSegment;
   }
 }
-
-/// Google provider alias map. Bootstrap entries derived from the 13 yaml
-/// files shipped in Phase 4.1; extend during Phase 4.5 wave rollout when
-/// new MM products land.
-const Map<String, String> _googleOutputDirAliases = {
-  // Tier 1 — MM `product` field normalization (snake_case alignment).
-  'cloudtasks': 'cloud_tasks',
-  'secretmanager': 'secret_manager',
-  'cloudscheduler': 'cloud_scheduler',
-  'resourcemanager': 'project',
-
-  // Tier 2/3 — terraform-type prefix / segment overrides.
-  'cloud_tasks': 'cloud_tasks',
-  'secret_manager': 'secret_manager',
-  'cloud_scheduler': 'cloud_scheduler',
-  'service_account': 'iam',
-  'project_service': 'project',
-};

--- a/packages/terradart_codegen/lib/src/codegen/wrap_init/wrap_init_generator.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrap_init/wrap_init_generator.dart
@@ -1,5 +1,6 @@
 import '../../ir/resource_def.dart';
 import '../../parser/mm_yaml_parser.dart';
+import '../providers/provider_rules.dart';
 import '../wrapper_overrides/wrapper_override.dart';
 import 'clock.dart';
 import 'output_dir_resolver.dart';
@@ -14,10 +15,12 @@ class WrapInitGenerator {
   WrapInitGenerator({
     required this.clock,
     required this.outputDirResolver,
+    required this.providerRules,
   });
 
   final Clock clock;
   final OutputDirResolver outputDirResolver;
+  final ProviderRules providerRules;
 
   /// Returns a draft for one resource. Caller passes parsed inputs; this
   /// function does NOT touch the filesystem.
@@ -90,15 +93,7 @@ class WrapInitGenerator {
   }
 
   WrapInitAxis _buildExtraGettersAxis(ResourceDef def) {
-    final attrs = def.root.attributes.map((a) => a.name).toSet();
-    final lines = <String>[];
-    if (attrs.contains('id')) {
-      lines.add("TfRef<String> get id => TfRef.attribute<String>(this, 'id');");
-    }
-    if (attrs.contains('name')) {
-      lines.add(
-          "TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');");
-    }
+    final lines = providerRules.universalGetters(def);
     return TodoAxis(
       'extraGetters',
       todoMessage: todoExtraGetters,

--- a/packages/terradart_codegen/test/cli/wrap_init_command_test.dart
+++ b/packages/terradart_codegen/test/cli/wrap_init_command_test.dart
@@ -62,7 +62,8 @@ void main() {
       );
     });
 
-    test('--provider hashicorp/aws → usage error (only google supported)', () {
+    test('--provider hashicorp/aws → usage error with registry-driven message',
+        () {
       final runner = buildCliRunner();
       expect(
         () => runner.run([
@@ -75,7 +76,17 @@ void main() {
           '--output',
           '/tmp',
         ]),
-        throwsA(isA<UsageException>()),
+        throwsA(
+          isA<UsageException>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('hashicorp/aws'),
+              contains('not supported'),
+              contains('Available: hashicorp/google'),
+            ),
+          ),
+        ),
       );
     });
   });

--- a/packages/terradart_codegen/test/cli/wrap_promote_command_test.dart
+++ b/packages/terradart_codegen/test/cli/wrap_promote_command_test.dart
@@ -46,7 +46,8 @@ void main() {
       expect(code, CliExitCodes.dataError);
     });
 
-    test('--provider hashicorp/aws → usage error', () {
+    test('--provider hashicorp/aws → usage error with registry-driven message',
+        () {
       final runner = buildCliRunner();
       expect(
         () => runner.run([
@@ -59,7 +60,17 @@ void main() {
           '--output',
           '/tmp',
         ]),
-        throwsA(isA<UsageException>()),
+        throwsA(
+          isA<UsageException>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('hashicorp/aws'),
+              contains('not supported'),
+              contains('Available: hashicorp/google'),
+            ),
+          ),
+        ),
       );
     });
   });

--- a/packages/terradart_codegen/test/codegen/providers/google_provider_rules_test.dart
+++ b/packages/terradart_codegen/test/codegen/providers/google_provider_rules_test.dart
@@ -1,0 +1,105 @@
+import 'package:terradart_codegen/src/codegen/providers/google_provider_rules.dart';
+import 'package:terradart_codegen/src/ir/attribute.dart';
+import 'package:terradart_codegen/src/ir/constraints.dart';
+import 'package:terradart_codegen/src/ir/nested_block.dart';
+import 'package:terradart_codegen/src/ir/resource_def.dart';
+import 'package:terradart_codegen/src/ir/type_def.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GoogleProviderRules', () {
+    const rules = GoogleProviderRules();
+
+    test('providerId is "hashicorp/google"', () {
+      expect(rules.providerId, 'hashicorp/google');
+    });
+
+    test(
+        'outputDirAliases contains the expected MM-product and segment entries',
+        () {
+      // Tier-1 MM-product normalizations.
+      expect(rules.outputDirAliases['cloudtasks'], 'cloud_tasks');
+      expect(rules.outputDirAliases['secretmanager'], 'secret_manager');
+      expect(rules.outputDirAliases['cloudscheduler'], 'cloud_scheduler');
+      expect(rules.outputDirAliases['resourcemanager'], 'project');
+      // Tier-2/3 segment / prefix overrides.
+      expect(rules.outputDirAliases['service_account'], 'iam');
+      expect(rules.outputDirAliases['project_service'], 'project');
+    });
+
+    test('universalGetters returns id + nameRef when both attrs are present',
+        () {
+      const def = ResourceDef(
+        terraformType: 'fake_both_resource',
+        root: BlockDef(attributes: [
+          Attribute(
+            name: 'id',
+            type: StringType(),
+            constraints: Constraints(computed: true),
+          ),
+          Attribute(
+            name: 'name',
+            type: StringType(),
+            constraints: Constraints(optional: true),
+          ),
+        ]),
+      );
+
+      final lines = rules.universalGetters(def);
+      expect(lines, <String>[
+        "TfRef<String> get id => TfRef.attribute<String>(this, 'id');",
+        "TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');",
+      ]);
+    });
+
+    test('universalGetters returns only nameRef when id attr is absent', () {
+      const def = ResourceDef(
+        terraformType: 'fake_name_only_resource',
+        root: BlockDef(attributes: [
+          Attribute(
+            name: 'name',
+            type: StringType(),
+            constraints: Constraints(required: true),
+          ),
+        ]),
+      );
+      final lines = rules.universalGetters(def);
+      expect(lines, <String>[
+        "TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');",
+      ]);
+    });
+
+    test('universalGetters returns only id when name attr is absent', () {
+      const def = ResourceDef(
+        terraformType: 'fake_no_name_resource',
+        root: BlockDef(attributes: [
+          Attribute(
+            name: 'id',
+            type: StringType(),
+            constraints: Constraints(computed: true),
+          ),
+        ]),
+      );
+      final lines = rules.universalGetters(def);
+      expect(lines, <String>[
+        "TfRef<String> get id => TfRef.attribute<String>(this, 'id');",
+      ]);
+    });
+
+    test(
+        'universalGetters returns an empty list when neither id nor name is present',
+        () {
+      const def = ResourceDef(
+        terraformType: 'fake_bare_resource',
+        root: BlockDef(attributes: [
+          Attribute(
+            name: 'foo',
+            type: StringType(),
+            constraints: Constraints(),
+          ),
+        ]),
+      );
+      expect(rules.universalGetters(def), isEmpty);
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/wrap_init/output_dir_resolver_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrap_init/output_dir_resolver_test.dart
@@ -1,10 +1,13 @@
+import 'package:terradart_codegen/src/codegen/providers/google_provider_rules.dart';
 import 'package:terradart_codegen/src/codegen/wrap_init/output_dir_resolver.dart';
 import 'package:terradart_codegen/src/codegen/wrapper_overrides/wrapper_override.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('OutputDirResolver', () {
-    final resolver = const OutputDirResolver();
+    final resolver = OutputDirResolver(
+      aliases: const GoogleProviderRules().outputDirAliases,
+    );
 
     test('Tier 0: kind=dataSource short-circuits to "data"', () {
       final result = resolver.resolve(
@@ -43,8 +46,6 @@ void main() {
     });
 
     test('Tier 3: alias override on segment-1 fallback', () {
-      // google_service_account → tier-2 prefix-strip yields "service"
-      // → alias override maps service_account → iam
       final result = resolver.resolve(
         terraformType: 'google_service_account',
         mmProduct: null,

--- a/packages/terradart_codegen/test/codegen/wrap_init/wrap_init_generator_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrap_init/wrap_init_generator_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:terradart_codegen/src/codegen/providers/google_provider_rules.dart';
 import 'package:terradart_codegen/src/codegen/wrap_init/clock.dart';
 import 'package:terradart_codegen/src/codegen/wrap_init/output_dir_resolver.dart';
 import 'package:terradart_codegen/src/codegen/wrap_init/wrap_init_draft.dart';
@@ -31,10 +32,14 @@ void main() {
     googleProject = projIr.dataSources['google_project']!;
   });
 
-  WrapInitGenerator generator() => WrapInitGenerator(
-        clock: FixedClock(DateTime.utc(2026, 1, 1)),
-        outputDirResolver: const OutputDirResolver(),
-      );
+  WrapInitGenerator generator() {
+    const rules = GoogleProviderRules();
+    return WrapInitGenerator(
+      clock: FixedClock(DateTime.utc(2026, 1, 1)),
+      outputDirResolver: OutputDirResolver(aliases: rules.outputDirAliases),
+      providerRules: rules,
+    );
+  }
 
   group('WrapInitGenerator axis derivation', () {
     test('kind=resource: no `kind:` line in draft axes', () {

--- a/packages/terradart_codegen/test/codegen/wrap_init/wrap_init_golden_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrap_init/wrap_init_golden_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:terradart_codegen/src/codegen/providers/google_provider_rules.dart';
 import 'package:terradart_codegen/src/codegen/wrap_init/clock.dart';
 import 'package:terradart_codegen/src/codegen/wrap_init/output_dir_resolver.dart';
 import 'package:terradart_codegen/src/codegen/wrap_init/wrap_init_emitter.dart';
@@ -11,9 +12,11 @@ import 'package:terradart_codegen/src/parser/schema_parser.dart';
 import 'package:test/test.dart';
 
 void main() {
+  const rules = GoogleProviderRules();
   final generator = WrapInitGenerator(
     clock: FixedClock(DateTime.parse('2026-01-01T00:00:00.000Z')),
-    outputDirResolver: const OutputDirResolver(),
+    outputDirResolver: OutputDirResolver(aliases: rules.outputDirAliases),
+    providerRules: rules,
   );
   const emitter = WrapInitEmitter();
 

--- a/packages/terradart_codegen/test/codegen/wrap_init/wrap_init_loader_invariant_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrap_init/wrap_init_loader_invariant_test.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:terradart_codegen/src/codegen/providers/google_provider_rules.dart';
 import 'package:terradart_codegen/src/codegen/wrap_init/clock.dart';
 import 'package:terradart_codegen/src/codegen/wrap_init/output_dir_resolver.dart';
 import 'package:terradart_codegen/src/codegen/wrap_init/wrap_init_emitter.dart';
@@ -28,9 +29,11 @@ void main() {
     // 13 known production resources + 1 synthetic = 14 fixtures total.
     expect(entries.length, greaterThanOrEqualTo(13));
 
+    const rules = GoogleProviderRules();
     final generator = WrapInitGenerator(
       clock: FixedClock(DateTime.parse('2026-01-01T00:00:00.000Z')),
-      outputDirResolver: const OutputDirResolver(),
+      outputDirResolver: OutputDirResolver(aliases: rules.outputDirAliases),
+      providerRules: rules,
     );
     const emitter = WrapInitEmitter();
 

--- a/packages/terradart_codegen/tool/freeze_wrap_init_goldens.dart
+++ b/packages/terradart_codegen/tool/freeze_wrap_init_goldens.dart
@@ -7,6 +7,7 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:terradart_codegen/src/codegen/providers/google_provider_rules.dart';
 import 'package:terradart_codegen/src/codegen/wrap_init/clock.dart';
 import 'package:terradart_codegen/src/codegen/wrap_init/output_dir_resolver.dart';
 import 'package:terradart_codegen/src/codegen/wrap_init/wrap_init_emitter.dart';
@@ -39,9 +40,11 @@ const _scenarios = [
 ];
 
 void main() {
+  const rules = GoogleProviderRules();
   final generator = WrapInitGenerator(
     clock: FixedClock(DateTime.parse(_fixedDate)),
-    outputDirResolver: const OutputDirResolver(),
+    outputDirResolver: OutputDirResolver(aliases: rules.outputDirAliases),
+    providerRules: rules,
   );
   const emitter = WrapInitEmitter();
 


### PR DESCRIPTION
## Summary

Phase 4.4 — extracts the three inline Google-specific touchpoints from Phase 4.1–4.3 (`OutputDirResolver._googleOutputDirAliases`, `WrapInitGenerator._buildExtraGettersAxis`'s `id`/`nameRef` heuristic, and the CLI `if (provider != 'hashicorp/google')` gate in `WrapInitCommand` + `WrapPromoteCommand`) into a single `ProviderRules` abstract class + one `GoogleProviderRules` concrete impl. Pure refactor — zero behavioural change; all 3 wrap-init L2 goldens regenerate byte-identical.

4 commits across 4 waves (sequential — each consumes the previous wave's output). Built with the same subagent-driven flow as Phase 4.1/4.2/4.3.

### What's new

- `lib/src/codegen/providers/provider_rules.dart` — abstract base with `providerId`, `outputDirAliases`, `universalGetters(def)` (3 members, ~30 LoC; `const` constructor, open/closed for community adapters)
- `lib/src/codegen/providers/google_provider_rules.dart` — concrete `final class` impl carrying the Phase 4.1 alias map + the id/nameRef heuristic (~80 LoC)
- `OutputDirResolver` constructor now requires `aliases` explicitly; the inline `_googleOutputDirAliases` const is gone
- `WrapInitGenerator` gains a `providerRules` named parameter; `_buildExtraGettersAxis` delegates per-line generation to `rules.universalGetters(def)` (5-line body — the previous 16-line `attrs.contains('id')` / `attrs.contains('name')` block is fully removed)
- `cli_runner.dart` builds a `const Map<String, ProviderRules>` registry and passes it into `WrapInitCommand` + `WrapPromoteCommand`
- Both wrap-init and wrap-promote reject unknown providers via registry lookup, with a registry-keys-driven message: `Provider "X" not supported. Available: hashicorp/google.` (was: `Provider "X" not supported in Phase 4.2 (only hashicorp/google).` / `Phase 4.3 (only hashicorp/google).`)

### What stays the same

- Every existing CLI invocation produces byte-identical output (all 3 wrap-init L2 goldens regenerate without diff under `FixedClock(2026-01-01)`)
- All 4 CLI subcommands (`codegen`, `wrap`, `wrap-init`, `wrap-promote`) keep their existing args and behaviours

### Test deltas

- terradart_codegen default: **243 + 5 skipped** (was 237 + 5 → +6 new L1 from `GoogleProviderRules`, full 2×2 truth-table coverage for `universalGetters`)
- Workspace total default: **490 + 7 skipped** (was 484 + 7)
- E2e count unchanged:
  - terradart_codegen e2e: 4 (wrap_determinism + wrap_init_determinism + wrap_init_loader_invariant + wrap_promote_determinism)
  - terradart_google e2e: 6 (Phase 4.1 roundtrip + L4-b tf-out snapshot)

### Out of scope (deferred to Phase 4.5+)

- AWS / Azure adapters — added when a real consumer (e.g. `terradart_aws` package) arrives. The YAGNI specialist's earlier estimate is ~3-4h for a second-provider extraction; Phase 4.4 invests that upfront so Phase 4.5's 1000-resource rollout doesn't have inline code to move.
- yaml directory split (`yaml/google/`, `yaml/aws/`) — added together with the AWS adapter
- Multi-provider yaml loader changes

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` — clean (227 files)
- [x] `dart analyze packages/ --fatal-infos --fatal-warnings` — `No issues found!`
- [x] Per-package default `dart test`:
  - terradart_core: 160 pass
  - terradart_annotations: 3 pass
  - terradart_codegen: **243 pass + 5 skipped** (was 237 + 5 → +6 new L1)
  - terradart_google: 84 pass + 2 skipped (unchanged)
- [x] E2e (`--run-skipped -t e2e`):
  - terradart_codegen: 4 pass
  - terradart_google: 6 pass
- [x] All 3 wrap-init L2 goldens regenerate byte-identical to the committed `*.wrap_init.expected.yaml.golden` files (verified in Task 3 via `git diff --stat test/golden/wrap_init/` → empty)
- [x] L3 rejection-message assertions strengthened — both wrap-init and wrap-promote now verify `contains('hashicorp/aws') && contains('not supported') && contains('Available: hashicorp/google')` against the `UsageException.message`

## DoD (from spec Section 7)

All 15 items satisfied:

- [x] `ProviderRules` abstract class declared at `lib/src/codegen/providers/provider_rules.dart`
- [x] `GoogleProviderRules` declared with `providerId == 'hashicorp/google'`
- [x] `OutputDirResolver._googleOutputDirAliases` deleted; `aliases` is required
- [x] `WrapInitGenerator` constructor accepts `providerRules`; delegates universal getters
- [x] `cli_runner.dart` declares the `const providers` registry
- [x] `WrapInitCommand` + `WrapPromoteCommand` accept `providers` and reject unknown providers via registry lookup
- [x] All 3 wrap-init L2 goldens regenerate byte-identical
- [x] L1: 6 new `GoogleProviderRules` tests pass; 5 `OutputDirResolver` + 6 `WrapInitGenerator` rewritten and pass
- [x] L3: 2 rejection-message assertions strengthened and pass
- [x] `dart analyze --fatal-infos --fatal-warnings` clean
- [x] `dart format` clean
- [x] terradart_codegen 243 + 5 skipped; total workspace 490 + 7 skipped
- [x] E2e count unchanged (codegen 4, google 6)
- [x] No regression in workspace test count
- [x] Refactor preserves byte-identical output for all 5 L2 goldens (3 wrap-init + 2 wrap-promote — the 2 wrap-promote goldens were untouched because wrap-promote's emitters do not consume `ProviderRules` data in its current scope)

## Notes

- **One discovered file outside the original plan enumeration**: `test/codegen/wrap_init/wrap_init_golden_test.dart` also had a `const OutputDirResolver()` call site that the plan missed. Discovered in Task 2's analyzer pass (5 broken sites, not 4); repaired in Task 3 alongside the other in-scope sites.

- **Code-review feedback applied during Task 1**: reviewer flagged that `GoogleProviderRules` should be `final class` (codebase convention), and that the "both attrs" test was needlessly fixture-dependent. Fixed: class is `final`, the test now uses inline `const ResourceDef(...)`, and a `name-only` branch test was added for full 2×2 truth-table coverage (+1 test → +6 new L1 vs the spec's original +5).

- **`WrapPromoteCommand` uses `containsKey` instead of `final rules = providers[provider]`**: wrap-promote doesn't consume `rules.outputDirAliases` or `rules.universalGetters(...)` in its current scope, so the local lookup result would be unused. `containsKey` enforces the gate without triggering an `unused_local_variable` analyzer warning.

## Future waves (out of scope for this PR)

- (Phase 4.5) 1000 `google_*` resource rollout using wrap-init + wrap-promote
- (Phase 4.5+) AWS / Azure adapters with `AwsProviderRules` / `AzureProviderRules` — one new file + one line in `cli_runner.dart` registry per provider
- (Optional) yaml directory split when a second provider is wired
