### PR TITLE
feat: wrap --only flag + prose-enum extraction in wrap-promote

### DIFF
--- a/packages/terradart_codegen/lib/src/cli/wrap_command.dart
+++ b/packages/terradart_codegen/lib/src/cli/wrap_command.dart
@@ -11,6 +11,7 @@ import '../codegen/file_emitter.dart';
 import '../codegen/generated_file_header.dart';
 import '../codegen/wrapper_emitter.dart';
 import '../codegen/wrapper_overrides/_registry.dart';
+import '../codegen/wrapper_overrides/yaml_loader.dart';
 import '../parser/schema_parser.dart';
 import 'exit_codes.dart';
 
@@ -53,6 +54,14 @@ class WrapCommand extends Command<int> {
         negatable: false,
         help: 'Overwrite files that are missing or have a non-TerraDart '
             'generated-file header (E401 is suppressed).',
+      )
+      ..addOption(
+        'only',
+        help: 'Regenerate only this Terraform type. Skips every other yaml '
+            'override under the registry — useful when a sibling yaml has '
+            'unstripped `wrap-promote` markers that would otherwise break '
+            'the full-registry load.',
+        valueHelp: 'TERRAFORM_TYPE',
       );
   }
 
@@ -94,6 +103,7 @@ class WrapCommand extends Command<int> {
 
     final check = results['check'] as bool;
     final force = results['force'] as bool;
+    final only = results['only'] as String?;
 
     // 1. Load schema.json from <source>/schema.json. The parser is tolerant
     //    of missing data_source_schemas / resource_schemas keys (returns an
@@ -126,7 +136,16 @@ class WrapCommand extends Command<int> {
       );
       return CliExitCodes.software;
     }
-    final loaded = loadWrapperOverrides(rootDir: yamlRootUri.toFilePath());
+    final LoadedOverrides loaded;
+    try {
+      loaded = loadWrapperOverrides(
+        rootDir: yamlRootUri.toFilePath(),
+        only: only,
+      );
+    } on StateError catch (e) {
+      stderr.writeln('terradart wrap: $e');
+      return CliExitCodes.dataError;
+    }
 
     // 3. Emit every override into an in-memory map keyed by repo-relative
     //    output path. Doing this before any filesystem mutation lets the

--- a/packages/terradart_codegen/lib/src/codegen/wrap_promote/prose_enum_extractor.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrap_promote/prose_enum_extractor.dart
@@ -1,0 +1,79 @@
+import '../../ir/attribute.dart';
+import '../../ir/nested_block.dart';
+import '../../ir/resource_def.dart';
+
+/// Scans the IR's attribute descriptions for the prose-form "Possible
+/// values: A, B, C" pattern that MM authors sometimes use in lieu of a
+/// structured `enum_values:` block.
+///
+/// Used by `wrap-promote` as a fallback enum-source when the MM yaml does
+/// not declare `enum_values:` for a field but the description happens to
+/// list the values out loud. The extractor is conservative on purpose —
+/// matches require ≥2 comma-separated tokens that look enum-like (alpha
+/// + underscore + digit, length ≤ 40 chars each) — so prose lists of
+/// arbitrary string examples (URL templates, region names with commas,
+/// etc.) do not get mistaken for enums.
+///
+/// Output paths are dotted (e.g. `'private_visibility_config.networks.network_url'`)
+/// so they line up with `mm.fieldOverrides` keys.
+class ProseEnumExtractor {
+  const ProseEnumExtractor();
+
+  /// Match `Possible values:` (case-sensitive, MM convention) followed by
+  /// the comma-separated list segment, terminated by the first `.`,
+  /// newline, or end-of-string. Capture group 1 is the raw value list.
+  static final RegExp _possibleValuesPattern = RegExp(
+    r'Possible values:\s*([^.\n]+?)(?:\.|\n|$)',
+  );
+
+  /// Each extracted token must look enum-like: alpha + digits + underscore
+  /// only, 1-40 chars. Rejects URL fragments, dotted addresses, anything
+  /// containing whitespace.
+  static final RegExp _enumTokenPattern =
+      RegExp(r'^[A-Za-z][A-Za-z0-9_]{0,39}$');
+
+  /// Returns a map from dotted field path to the extracted enum value
+  /// list, for every attribute whose description matches the prose
+  /// pattern and yields ≥2 enum-like tokens. Fields that do not match
+  /// are omitted (the map will not contain `null` lists).
+  Map<String, List<String>> extract(ResourceDef def) {
+    final result = <String, List<String>>{};
+    _walk(def.root.attributes, def.root.nestedBlocks, '', result);
+    return result;
+  }
+
+  void _walk(
+    List<Attribute> attrs,
+    List<NestedBlockDef> nested,
+    String prefix,
+    Map<String, List<String>> sink,
+  ) {
+    for (final a in attrs) {
+      final desc = a.description;
+      if (desc == null) continue;
+      final values = _extractValues(desc);
+      if (values == null) continue;
+      final key = prefix.isEmpty ? a.name : '$prefix.${a.name}';
+      sink[key] = values;
+    }
+    for (final n in nested) {
+      final nextPrefix = prefix.isEmpty ? n.name : '$prefix.${n.name}';
+      _walk(n.block.attributes, n.block.nestedBlocks, nextPrefix, sink);
+    }
+  }
+
+  /// Returns the enum-token list from [desc], or `null` if no usable
+  /// match was found.
+  List<String>? _extractValues(String desc) {
+    final match = _possibleValuesPattern.firstMatch(desc);
+    if (match == null) return null;
+    final raw = match.group(1) ?? '';
+    final tokens =
+        raw.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
+    if (tokens.length < 2) return null;
+    for (final t in tokens) {
+      if (!_enumTokenPattern.hasMatch(t)) return null;
+    }
+    return tokens;
+  }
+}

--- a/packages/terradart_codegen/lib/src/codegen/wrap_promote/wrap_promote_generator.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrap_promote/wrap_promote_generator.dart
@@ -2,6 +2,7 @@ import '../../ir/resource_def.dart';
 import '../../parser/mm_yaml_parser.dart';
 import '../wrap_init/clock.dart';
 import 'exactly_one_of_emitter.dart';
+import 'prose_enum_extractor.dart';
 import 'valid_values_emitter.dart';
 import 'wrap_promote_marker.dart';
 
@@ -41,15 +42,28 @@ class WrapPromoteGenerator {
       body.writeln();
     }
 
-    // 2. validValues (enum_values) per field → single prelude block
-    //    containing all enums, followed by a commented dartTypeOverrides
-    //    snippet. Phase 4.5.1 aggregates here (was per-enum prelude in
-    //    Phase 4.3, which produced YAML duplicate-key violations).
+    // 2. validValues per field → single prelude block containing all
+    //    enums, followed by a commented dartTypeOverrides snippet.
+    //    Phase 4.5.1 aggregates here (was per-enum prelude in Phase 4.3,
+    //    which produced YAML duplicate-key violations).
+    //
+    //    Two enum sources, merged with MM yaml winning on conflict:
+    //    - MM yaml's structured `enum_values:` blocks (`mm.fieldOverrides`).
+    //    - The IR descriptions' "Possible values: A, B, C" prose
+    //      (Phase 4.5.2 fallback). Conservative — see
+    //      `prose_enum_extractor.dart`.
+    const proseExtractor = ProseEnumExtractor();
+    final proseEnums = proseExtractor.extract(def);
+    final allEnums = <String, List<String>>{
+      ...proseEnums,
+      for (final e in mm.fieldOverrides.entries)
+        if (e.value.enumValues != null && e.value.enumValues!.length >= 2)
+          e.key: e.value.enumValues!,
+    };
+
     final enumBodies = <String>[];
     final dartTypeOverrideEntries = <String>[];
-    mm.fieldOverrides.forEach((field, constraints) {
-      final ev = constraints.enumValues;
-      if (ev == null || ev.length < 2) return;
+    allEnums.forEach((field, ev) {
       enumBodies.add(validEmitter.emit(
         fieldName: field,
         enumValues: ev,

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/_registry.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/_registry.dart
@@ -12,6 +12,15 @@ import 'yaml_loader.dart';
 /// The split lets callers wire each emitter to its own half:
 /// `WrapperEmitter(overrides: loaded.resources)` and (Phase 4.1)
 /// `DataSourceWrapperEmitter(overrides: loaded.dataSources)`.
-LoadedOverrides loadWrapperOverrides({required String rootDir}) {
-  return YamlOverrideLoader(rootDir: rootDir).load();
+///
+/// [only], when non-null, restricts the load to a single
+/// `<terraformType>.yaml` file under [rootDir]. Sibling yamls are not even
+/// opened — useful when one of them carries an unstripped wrap-promote
+/// marker block that would otherwise abort the full-registry load with a
+/// `Duplicate mapping key` parse error.
+LoadedOverrides loadWrapperOverrides({
+  required String rootDir,
+  String? only,
+}) {
+  return YamlOverrideLoader(rootDir: rootDir).load(only: only);
 }

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml_loader.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml_loader.dart
@@ -104,19 +104,36 @@ class YamlOverrideLoader {
   /// [FormatException] eagerly for backwards compatibility with Phase 2.x
   /// callers; those failures short-circuit before the [LoaderErrorReport]
   /// is assembled.
-  LoadedOverrides load() {
+  ///
+  /// [only], when non-null, restricts the scan to the single
+  /// `<only>.yaml` file under [rootDir]. Sibling yamls are not even
+  /// opened, so an unstripped `wrap-promote` marker block in a peer file
+  /// no longer aborts the load. Throws [StateError] if no matching file
+  /// exists.
+  LoadedOverrides load({String? only}) {
     final dir = Directory(rootDir);
     if (!dir.existsSync()) {
       throw StateError(
         'YamlOverrideLoader: rootDir does not exist: $rootDir',
       );
     }
-    final yamlFiles = dir
-        .listSync()
-        .whereType<File>()
-        .where((f) => f.path.endsWith('.yaml'))
-        .toList()
-      ..sort((a, b) => a.path.compareTo(b.path));
+    final List<File> yamlFiles;
+    if (only != null) {
+      final target = File(p.join(rootDir, '$only.yaml'));
+      if (!target.existsSync()) {
+        throw StateError(
+          'YamlOverrideLoader: --only target not found: ${target.path}',
+        );
+      }
+      yamlFiles = [target];
+    } else {
+      yamlFiles = dir
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.yaml'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+    }
 
     final errors = <LoaderError>[];
     final all = <String, WrapperOverride>{};

--- a/packages/terradart_codegen/test/cli/wrap_command_test.dart
+++ b/packages/terradart_codegen/test/cli/wrap_command_test.dart
@@ -271,6 +271,62 @@ void main() {
     });
   });
 
+  group('WrapCommand --only', () {
+    test('emits exactly 2 files (Layer 1 + Layer 2) for one resource',
+        () async {
+      final tmpOut = await Directory.systemTemp.createTemp('phase4_only_');
+      try {
+        final code = await buildCliRunner().run([
+          'wrap',
+          '--provider',
+          'hashicorp/google',
+          '--source',
+          p.join('test', 'fixtures', 'wrap', 'source'),
+          '--output',
+          tmpOut.path,
+          '--only',
+          'google_pubsub_topic',
+        ]);
+        expect(code, 0);
+
+        final files = <String>[];
+        for (final ent in Directory(tmpOut.path).listSync(recursive: true)) {
+          if (ent is File && ent.path.endsWith('.dart')) {
+            files.add(p.relative(ent.path, from: tmpOut.path));
+          }
+        }
+        expect(files, hasLength(2));
+        expect(files, contains(p.join('pubsub', 'google_pubsub_topic.dart')));
+        expect(
+          files,
+          contains(p.join('generated', 'google_pubsub_topic.schema.dart')),
+        );
+      } finally {
+        await tmpOut.delete(recursive: true);
+      }
+    });
+
+    test('unknown --only target exits with dataError', () async {
+      final tmpOut = await Directory.systemTemp.createTemp('phase4_only_');
+      try {
+        final code = await buildCliRunner().run([
+          'wrap',
+          '--provider',
+          'hashicorp/google',
+          '--source',
+          p.join('test', 'fixtures', 'wrap', 'source'),
+          '--output',
+          tmpOut.path,
+          '--only',
+          'google_no_such_resource',
+        ]);
+        expect(code, CliExitCodes.dataError);
+      } finally {
+        await tmpOut.delete(recursive: true);
+      }
+    });
+  });
+
   group('WrapCommand fixture-driven', () {
     // Fixture files are stored with a `.dart.golden` suffix (matching the
     // project-wide golden naming convention under `test/golden/`) so they

--- a/packages/terradart_codegen/test/codegen/wrap_promote/prose_enum_extractor_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrap_promote/prose_enum_extractor_test.dart
@@ -1,0 +1,132 @@
+import 'package:terradart_codegen/src/codegen/wrap_promote/prose_enum_extractor.dart';
+import 'package:terradart_codegen/src/ir/attribute.dart';
+import 'package:terradart_codegen/src/ir/constraints.dart';
+import 'package:terradart_codegen/src/ir/nested_block.dart';
+import 'package:terradart_codegen/src/ir/resource_def.dart';
+import 'package:terradart_codegen/src/ir/type_def.dart';
+import 'package:test/test.dart';
+
+ResourceDef _resourceWithAttribute({
+  required String name,
+  String? description,
+}) {
+  return ResourceDef(
+    terraformType: 'fake',
+    root: BlockDef(
+      attributes: [
+        Attribute(
+          name: name,
+          type: const StringType(),
+          constraints: const Constraints(optional: true),
+          description: description,
+        ),
+      ],
+      nestedBlocks: const [],
+    ),
+  );
+}
+
+void main() {
+  group('ProseEnumExtractor', () {
+    const extractor = ProseEnumExtractor();
+
+    test('matches canonical MM-style "Possible values: A, B, C." pattern', () {
+      final def = _resourceWithAttribute(
+        name: 'purpose',
+        description:
+            'Choose a purpose. Possible values: PRIVATE, REGIONAL, GLOBAL.',
+      );
+      expect(
+        extractor.extract(def),
+        equals({
+          'purpose': ['PRIVATE', 'REGIONAL', 'GLOBAL'],
+        }),
+      );
+    });
+
+    test('matches lowercase token lists', () {
+      final def = _resourceWithAttribute(
+        name: 'tier',
+        description: 'Performance tier. Possible values: standard, premium.',
+      );
+      expect(
+        extractor.extract(def),
+        equals({
+          'tier': ['standard', 'premium'],
+        }),
+      );
+    });
+
+    test('terminates extraction at the first period or newline', () {
+      final def = _resourceWithAttribute(
+        name: 'state',
+        description:
+            'The current state. Possible values: ON, OFF, TRANSFER. Unrelated trailing sentence.',
+      );
+      expect(
+        extractor.extract(def)['state'],
+        equals(['ON', 'OFF', 'TRANSFER']),
+      );
+    });
+
+    test('skips fields with a single value (not enum-like)', () {
+      final def = _resourceWithAttribute(
+        name: 'kind',
+        description: 'Resource kind. Possible values: STANDARD.',
+      );
+      expect(extractor.extract(def), isEmpty);
+    });
+
+    test('skips fields whose extracted tokens contain whitespace or dots', () {
+      // URL / path-style enums get rejected by the conservative token rule.
+      final def = _resourceWithAttribute(
+        name: 'url',
+        description:
+            'Possible values: https://a.example.com, https://b.example.com',
+      );
+      expect(extractor.extract(def), isEmpty);
+    });
+
+    test('skips when the marker "Possible values:" is absent', () {
+      final def = _resourceWithAttribute(
+        name: 'foo',
+        description: 'Some unrelated description without the marker phrase.',
+      );
+      expect(extractor.extract(def), isEmpty);
+    });
+
+    test('walks nested blocks and emits dotted paths', () {
+      const def = ResourceDef(
+        terraformType: 'fake',
+        root: BlockDef(
+          attributes: [],
+          nestedBlocks: [
+            NestedBlockDef(
+              name: 'dnssec_config',
+              nesting: NestingMode.single,
+              constraints: Constraints(optional: true),
+              block: BlockDef(
+                attributes: [
+                  Attribute(
+                    name: 'state',
+                    type: StringType(),
+                    constraints: Constraints(optional: true),
+                    description:
+                        'DNSSEC state. Possible values: off, on, transfer.',
+                  ),
+                ],
+                nestedBlocks: [],
+              ),
+            ),
+          ],
+        ),
+      );
+      expect(
+        const ProseEnumExtractor().extract(def),
+        equals({
+          'dnssec_config.state': ['off', 'on', 'transfer'],
+        }),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Two codegen-DX improvements that close out Wave 2/3 curation friction observations:

1. **`terradart wrap --only=<terraform_type>`** — regenerate a single resource without scanning sibling yamls. Bypasses the `Duplicate mapping key` failure mode when a peer file has an unstripped `wrap-promote` marker section.
2. **Prose-enum extraction in `wrap-promote`** — proposes enum prelude blocks for fields whose MM yaml lacks a structured `enum_values:` block but whose description contains the canonical `Possible values: A, B, C.` prose.

## `wrap --only=<terraform_type>`

### Why

`terradart wrap` loads every yaml file under the override registry root in a single pass. During concurrent multi-resource curation, an unstripped `wrap-promote` marker section in any peer yaml aborts the whole batch with a `Duplicate mapping key` parse error. Observed multiple times across Wave 2 and Wave 3 — the documented workaround was to move sibling yamls to `/tmp/` and restore them after.

### What

```bash
terradart wrap \
  --provider hashicorp/google \
  --source test/fixtures/wrap/source \
  --output ../terradart_google/lib/src \
  --only google_pubsub_topic \
  --force
```

Emits exactly 2 files (Layer 1 + Layer 2) for the named resource. Sibling yamls are not opened — a broken marker in `google_compute_firewall.yaml` no longer prevents regenerating `google_pubsub_topic`.

### Plumbing

`WrapCommand` reads `results['only']` → `loadWrapperOverrides(rootDir, only)` → `YamlOverrideLoader.load(only)` filters the file list before parsing. Errors surface as `CliExitCodes.dataError` (65) when the target yaml is missing.

### Tests

- `--only google_pubsub_topic` emits exactly 2 files at expected paths.
- Unknown target (`--only google_no_such_resource`) exits with `dataError`.

## Prose-enum extraction in `wrap-promote`

### Why

MM authors sometimes describe an enum field in prose instead of a structured `enum_values:` block:

```yaml
# MM yaml field description
description: |
  Possible values: PRIVATE, REGIONAL_MANAGED_PROXY, GLOBAL_MANAGED_PROXY,
  PRIVATE_SERVICE_CONNECT, PEER_MIGRATION, PRIVATE_NAT.
```

`wrap-promote` previously ignored these and curators had to hand-author the enum prelude from MM API reference docs. Observed on Wave 0 KMS `purpose` / `protection_level` and on Wave 3 compute_instance NIC / scheduling enums.

### What

New `ProseEnumExtractor` walks the IR's attribute descriptions (including nested blocks) and matches:

```regex
Possible values:\s*([^.\n]+?)(?:\.|\n|$)
```

Conservative token validation rejects false positives:

- Each token must match `^[A-Za-z][A-Za-z0-9_]{0,39}$` — alpha + digits + underscore, length 2-40 chars.
- ≥2 tokens required.
- URL / dotted-path / region-name / multi-word values are rejected (no whitespace, no dots, no slashes).

`WrapPromoteGenerator` merges prose-derived enums with the MM-yaml-declared `enum_values:` set; MM yaml wins on key conflicts so existing structured-source pipelines are unaffected. The merged map drives the same prelude + `dartTypeOverrides` snippet emission downstream — marker block shape unchanged.

### Tests

7 cases covering:

- Canonical MM-style ALL_CAPS list.
- lowercase token list.
- Mid-sentence termination at the first period.
- Single-value rejection (≥2 required).
- URL / dotted-path rejection.
- Missing marker phrase → empty result.
- Nested-block recursion with dotted output paths.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` — 290 files, 0 changed.
- [x] `dart analyze packages/ --fatal-infos --fatal-warnings` — clean.
- [x] `terradart wrap --check` — all 56 files byte-identical (the merged enum source is a no-op on the existing 28 yamls because every curated field already has a structured `enum_values:` block or a hand-author override).
- [x] terradart_codegen tests: 252 + 5 skipped (was 250 + 5 — +2 for `--only`, +7 for prose extractor).
- [x] Smoke: `wrap --only google_pubsub_topic` emits 2 files; `--only google_no_such_resource` exits 65.

## Related

Phase 4.5.2 PR 2 of 3 (PR-A: sensitive group, this PR-B: codegen DX, PR-C: `Duration` helper still ahead).
