### PR TITLE
feat: TfArg.duration(Duration) factory for Terraform duration-string fields

### DIFF
--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_kms_crypto_key.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_kms_crypto_key.yaml
@@ -23,8 +23,9 @@ classDocComment: |-
   ///   name: TfArg.literal('payments'),
   ///   keyRing: TfArg.ref(ring.id),
   ///   purpose: TfArg.literal(KmsKeyPurpose.encryptDecrypt),
-  ///   // Terraform duration string (seconds + 's'). Must be > 86400s (1 day).
-  ///   rotationPeriod: TfArg.literal('7776000s'), // 90 days
+  ///   // Must be > 86400s (1 day). `TfArg.duration` converts the
+  ///   // Duration into the `"{seconds}s"` form Terraform expects.
+  ///   rotationPeriod: TfArg.duration(const Duration(days: 90)),
   ///   versionTemplate: const VersionTemplate(
   ///     algorithm: 'GOOGLE_SYMMETRIC_ENCRYPTION',
   ///     protectionLevel: KmsProtectionLevel.software,

--- a/packages/terradart_core/lib/src/tf_arg.dart
+++ b/packages/terradart_core/lib/src/tf_arg.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import 'duration_helper.dart';
 import 'tf_ref.dart';
 
 /// A Terraform argument: either a Dart-side literal or a Terraform-side
@@ -21,6 +22,22 @@ sealed class TfArg<T> {
 
   /// Convenience: `TfArg.ref(topic.nameRef)`.
   static TfArg<T> ref<T>(TfRef<T> ref) => TfArgRef<T>(ref);
+
+  /// Convenience for Terraform duration-string fields
+  /// (`rotation_period`, `message_retention_duration`, `ack_deadline_seconds`
+  /// when expressed in string-seconds form, etc.).
+  ///
+  /// ```dart
+  /// rotationPeriod: TfArg.duration(const Duration(days: 90)),
+  /// // emits "rotation_period": "7776000s"
+  /// ```
+  ///
+  /// Equivalent to `TfArg.literal(duration.toTfDurationString())` — the
+  /// returned [TfArg] is a `TfArgLiteral<String>` whose payload is the
+  /// `"${inSeconds}s"` representation produced by [TerraformDurationExt].
+  /// Throws [ArgumentError] for negative or sub-second durations.
+  static TfArg<String> duration(Duration duration) =>
+      TfArgLiteral<String>(duration.toTfDurationString());
 
   /// Value to pass to schemantic concrete constructor.
   ///

--- a/packages/terradart_core/test/tf_arg_test.dart
+++ b/packages/terradart_core/test/tf_arg_test.dart
@@ -84,6 +84,35 @@ void main() {
       expect(TfArg.literal(true).toTfJson(), true);
     });
   });
+
+  group('TfArg.duration', () {
+    test('encodes a whole-second Duration as "{seconds}s"', () {
+      final arg = TfArg.duration(const Duration(days: 90));
+      expect(arg, isA<TfArgLiteral<String>>());
+      expect(arg.toTfJson(), equals('7776000s'));
+    });
+
+    test('zero duration encodes as "0s"', () {
+      expect(
+        TfArg.duration(Duration.zero).toTfJson(),
+        equals('0s'),
+      );
+    });
+
+    test('rejects sub-second durations with ArgumentError', () {
+      expect(
+        () => TfArg.duration(const Duration(milliseconds: 1500)),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects negative durations with ArgumentError', () {
+      expect(
+        () => TfArg.duration(const Duration(seconds: -1)),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
 }
 
 /// Sample enum with the convention (`terraformValue` String getter).

--- a/packages/terradart_google/lib/src/kms/google_kms_crypto_key.dart
+++ b/packages/terradart_google/lib/src/kms/google_kms_crypto_key.dart
@@ -86,8 +86,9 @@ class VersionTemplate {
 ///   name: TfArg.literal('payments'),
 ///   keyRing: TfArg.ref(ring.id),
 ///   purpose: TfArg.literal(KmsKeyPurpose.encryptDecrypt),
-///   // Terraform duration string (seconds + 's'). Must be > 86400s (1 day).
-///   rotationPeriod: TfArg.literal('7776000s'), // 90 days
+///   // Must be > 86400s (1 day). `TfArg.duration` converts the
+///   // Duration into the `"{seconds}s"` form Terraform expects.
+///   rotationPeriod: TfArg.duration(const Duration(days: 90)),
 ///   versionTemplate: const VersionTemplate(
 ///     algorithm: 'GOOGLE_SYMMETRIC_ENCRYPTION',
 ///     protectionLevel: KmsProtectionLevel.software,


### PR DESCRIPTION
## Summary

Adds `TfArg.duration(Duration)`, a convenience factory that converts a Dart `Duration` into the `"{seconds}s"` form Terraform expects for duration-string fields (`rotation_period`, `message_retention_duration`, the `'s'`-suffixed forms of `ack_deadline_seconds`, etc.).

### Before

```dart
rotationPeriod: TfArg.literal('7776000s'), // 90 days
messageRetentionDuration: TfArg.literal('604800s'), // 7 days
```

### After

```dart
rotationPeriod: TfArg.duration(const Duration(days: 90)),
messageRetentionDuration: TfArg.duration(const Duration(days: 7)),
```

## Implementation

`TfArg.duration(Duration d)` is a static method on the sealed `TfArg` class. Returns a `TfArgLiteral<String>` whose payload is the `"${inSeconds}s"` form produced by the existing `TerraformDurationExt.toTfDurationString()` extension.

- Type contract preserved — every factory wrapper field that accepts `TfArg<String>?` for a duration value continues to compile.
- Emitted Terraform JSON is byte-identical to the explicit `TfArg.literal('Ns')` form.
- Sub-second precision and negative durations are rejected with `ArgumentError`, delegated to the existing extension's checks (no new validation logic added).

## Tests

Four new cases under `TfArg.duration`:

- Whole-second Duration → `"{seconds}s"` (90-day → `"7776000s"`).
- `Duration.zero` → `"0s"`.
- Sub-second Duration → `ArgumentError`.
- Negative Duration → `ArgumentError`.

## Doc update

`google_kms_crypto_key.yaml` classDocComment now shows the `TfArg.duration` form in its end-to-end example. Wrap output regenerated (1 byte-diff in the emitted Dart doc comment; no semantic change).

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` — 290 files, 0 changed.
- [x] `dart analyze packages/ --fatal-infos --fatal-warnings` — clean.
- [x] `terradart wrap --check` — all 56 files byte-identical (after the kms_crypto_key.yaml doc-comment update).
- [x] Per-package tests: core 172 (+4 for `TfArg.duration`) / annotations 3 / codegen 252 + 5 skipped / google 84 + 2 skipped.

## Related

Phase 4.5.2 PR 3 of 3 — closes the cleanup batch. PR-A (sensitive group) and PR-B (codegen DX) already merged.
