### PR TITLE
chore: instrument terraform_validate matrix with per-step timing for Phase 5.0 baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,10 @@ jobs:
       matrix:
         example: [pubsub, cloud_tasks, secret_manager, cloud_scheduler, iam, compute, kms, storage, bigquery, dns, ops, cloud_run, monitoring]
     steps:
+      - name: Job start
+        id: job_start
+        run: echo "started_ns=$(date +%s%N)" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1
         with:
@@ -97,16 +101,61 @@ jobs:
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.15.2"
-      - run: dart pub get
-      - run: dart pub get
+
+      - name: Setup checkpoint
+        id: after_setup
+        run: echo "ts_ns=$(date +%s%N)" >> "$GITHUB_OUTPUT"
+
+      - name: Workspace pub get
+        id: pub_get_workspace
+        run: |
+          start=$(date +%s%N)
+          dart pub get
+          echo "duration_ms=$(( ($(date +%s%N) - start) / 1000000 ))" >> "$GITHUB_OUTPUT"
+
+      - name: Example pub get
+        id: pub_get_example
         working-directory: examples/${{ matrix.example }}_quickstart
-      - run: dart run bin/infra.dart
+        run: |
+          start=$(date +%s%N)
+          dart pub get
+          echo "duration_ms=$(( ($(date +%s%N) - start) / 1000000 ))" >> "$GITHUB_OUTPUT"
+
+      - name: Synth
+        id: synth
         working-directory: examples/${{ matrix.example }}_quickstart
         env:
           GCP_PROJECT_ID: ci-test-project-id
           DB_PASSWORD: ci-test-secret
-      - run: |
+        run: |
+          start=$(date +%s%N)
+          dart run bin/infra.dart
+          echo "duration_ms=$(( ($(date +%s%N) - start) / 1000000 ))" >> "$GITHUB_OUTPUT"
+
+      - name: Terraform validate
+        id: tf_validate
+        working-directory: examples/${{ matrix.example }}_quickstart/tf-out
+        run: |
+          start=$(date +%s%N)
           terraform fmt -check
           terraform init -backend=false
           terraform validate
-        working-directory: examples/${{ matrix.example }}_quickstart/tf-out
+          echo "duration_ms=$(( ($(date +%s%N) - start) / 1000000 ))" >> "$GITHUB_OUTPUT"
+
+      - name: Phase 5.0 timing summary
+        if: always()
+        run: |
+          job_start_ns="${{ steps.job_start.outputs.started_ns }}"
+          after_setup_ns="${{ steps.after_setup.outputs.ts_ns }}"
+          setup_ms=$(( (after_setup_ns - job_start_ns) / 1000000 ))
+          {
+            echo "### ${{ matrix.example }}_quickstart timing"
+            echo ""
+            echo "| Step | Duration (ms) |"
+            echo "|---|---|"
+            echo "| Setup (checkout + Dart + Terraform install) | $setup_ms |"
+            echo "| Workspace \`pub get\` | ${{ steps.pub_get_workspace.outputs.duration_ms }} |"
+            echo "| Example \`pub get\` | ${{ steps.pub_get_example.outputs.duration_ms }} |"
+            echo "| Synth (\`dart run bin/infra.dart\`) | ${{ steps.synth.outputs.duration_ms }} |"
+            echo "| \`terraform fmt + init + validate\` | ${{ steps.tf_validate.outputs.duration_ms }} |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds per-step timing instrumentation to the `terraform_validate` matrix so Phase 5.0 design has concrete data on where the 13-entry matrix's runner-minutes are spent. Pure observability overlay — no behavioural change to the CI gate.

## What's measured per matrix entry

For each of the 13 example × `terraform_validate` jobs on every PR:

| Step | Why it matters at scale |
|---|---|
| **Setup** (checkout + Dart + Terraform install) | Fixed cost paid by every matrix entry. Determines whether a "batch onto a single runner" mitigation pays back. |
| **Workspace `dart pub get`** | Resolves the monorepo. Caching candidate. |
| **Example `dart pub get`** | Resolves the example's path-deps. Caching candidate. |
| **Synth (`dart run bin/infra.dart`)** | Actual user-facing work. The signal we want to keep gating on. |
| **`terraform fmt + init + validate`** | The validation gate. The Phase 5 question is whether this is worth its setup cost at 1000 resources. |

Each step writes `duration_ms` to its own `$GITHUB_OUTPUT`; a final `Phase 5.0 timing summary` step aggregates them into a markdown table written to `$GITHUB_STEP_SUMMARY` (visible on the Actions run page).

13 entries × 5 timing columns = **65 data points per PR**. Aggregating across 5-10 PRs gives a baseline distribution that informs:

- Whether setup overhead dominates work-time (→ batched-single-runner mitigation pays back).
- Whether `terraform validate` itself or `pub get` dominates (→ pub-cache or run-step matters more).
- The variance across services (→ matrix vs. variant-driven gate design).

## Why now (Phase 5.0 baseline)

Phase 5 bottleneck analysis flagged the `terraform_validate` matrix as the highest-risk CI cost at 1,000 resources (linear scaling would exhaust GitHub Actions free tier in days). Before redesigning the gate — per-variant matrix? batched single-runner loop? selective-by-diff? — we need to know where the time actually goes in the current 13-entry shape. **Setup overhead vs. work-time ratio is the first decision input.**

## Coverage

- Every matrix entry on every PR captures all 5 step durations.
- Aggregated table renders on the Actions run page; CI artifact ingest can pull from there if we want longer-term storage.
- No new dependencies, no new third-party actions — pure `date +%s%N` arithmetic.

## Note on Setup measurement

GHA does not expose individual action-installation duration as a step output. The `Setup checkpoint` step captures a wall-clock delta from `job_start` through `checkout + setup-dart + setup-terraform`, which lumps:

- Runner boot time (~5-15s typical)
- Action archive download
- Tool extraction + PATH wiring

This is the right granularity for the Phase 5 decision (is this fixed cost amortizable across multiple validates on one runner?).

## Test plan

- [x] Workflow YAML parses (verified locally by `actionlint`-style mental review; CI run will be the actual verification).
- [x] No change to any existing step's command, working directory, or env vars — pure instrumentation overlay.
- [ ] On merge, the first PR's Actions run will show the summary table per matrix entry.

## Related

Phase 5.0 instrumentation week, day 1 — static baselines already taken (tarball trajectory, sensitive path depth, surface area). This PR adds the live-CI measurement that needs PRs flowing to accumulate data.
