### PR TITLE
test: ship 5 universal QA gates (Plan 5.A)

### DIFF
--- a/packages/terradart_codegen/lib/src/codegen/universal_invariants/enum_extractor.dart
+++ b/packages/terradart_codegen/lib/src/codegen/universal_invariants/enum_extractor.dart
@@ -22,9 +22,11 @@ class EnumExtractor {
     dotAll: true,
   );
 
-  /// Within the body, matches each `member('STRING_VALUE')`.
+  /// Within the body, matches each `member('STRING_VALUE')`. The optional
+  /// trailing comma + whitespace before `)` handles Dart format's multi-line
+  /// member style: `name(\n    'LONG_VALUE',\n  )`.
   static final RegExp _memberEntry = RegExp(
-    r"([a-z][a-zA-Z0-9_]*)\s*\(\s*'([^']*)'\s*\)",
+    r"([a-z][a-zA-Z0-9_]*)\s*\(\s*'([^']*)'\s*,?\s*\)",
   );
 
   List<EmittedEnum> extract(String dartSource) {

--- a/packages/terradart_codegen/lib/src/codegen/universal_invariants/enum_extractor.dart
+++ b/packages/terradart_codegen/lib/src/codegen/universal_invariants/enum_extractor.dart
@@ -1,0 +1,47 @@
+/// One emitted Dart enum: name + member-to-terraformValue map.
+class EmittedEnum {
+  const EmittedEnum({required this.name, required this.members});
+  final String name;
+  final Map<String, String> members;
+}
+
+/// Parses Dart source for `enum Foo { a('A'), b('B'); const Foo(this.terraformValue);
+/// final String terraformValue; }` blocks via regex. Returns one [EmittedEnum]
+/// per `enum` keyword found whose body matches the convention.
+///
+/// Conservative: an enum without the `String terraformValue` getter is
+/// skipped (it isn't using the project's convention, so Gate 3 / Gate 5
+/// don't apply to it).
+class EnumExtractor {
+  const EnumExtractor();
+
+  /// Matches: `enum <Name> { ... }` followed by the const constructor +
+  /// terraformValue field. Captures (name, body).
+  static final RegExp _enumBlock = RegExp(
+    r'enum\s+([A-Z][A-Za-z0-9_]*)\s*\{([^}]*?)const\s+\1\s*\(this\.terraformValue\)\s*;\s*final\s+String\s+terraformValue\s*;',
+    dotAll: true,
+  );
+
+  /// Within the body, matches each `member('STRING_VALUE')`.
+  static final RegExp _memberEntry = RegExp(
+    r"([a-z][a-zA-Z0-9_]*)\s*\(\s*'([^']*)'\s*\)",
+  );
+
+  List<EmittedEnum> extract(String dartSource) {
+    final result = <EmittedEnum>[];
+    for (final match in _enumBlock.allMatches(dartSource)) {
+      final name = match.group(1)!;
+      final body = match.group(2)!;
+      final members = <String, String>{};
+      for (final entry in _memberEntry.allMatches(body)) {
+        final memberName = entry.group(1)!;
+        final terraformValue = entry.group(2)!;
+        members[memberName] = terraformValue;
+      }
+      if (members.isNotEmpty) {
+        result.add(EmittedEnum(name: name, members: members));
+      }
+    }
+    return result;
+  }
+}

--- a/packages/terradart_codegen/lib/src/codegen/universal_invariants/path_walker.dart
+++ b/packages/terradart_codegen/lib/src/codegen/universal_invariants/path_walker.dart
@@ -1,0 +1,25 @@
+import '../../ir/attribute.dart';
+import '../../ir/nested_block.dart';
+
+/// Resolves a dotted path against an IR `BlockDef`. Used by Gates 1 and 3
+/// to bridge yaml override entries to IR slots.
+class PathWalker {
+  const PathWalker();
+
+  /// Returns the [Attribute] at [pathSegments], walking through nested
+  /// blocks segment-by-segment until the last segment, which must be a
+  /// leaf attribute. Returns `null` if any segment cannot be resolved.
+  Attribute? resolveAttribute(BlockDef root, List<String> pathSegments) {
+    if (pathSegments.isEmpty) return null;
+    BlockDef current = root;
+    for (var i = 0; i < pathSegments.length - 1; i++) {
+      final segment = pathSegments[i];
+      final next =
+          current.nestedBlocks.where((n) => n.name == segment).firstOrNull;
+      if (next == null) return null;
+      current = next.block;
+    }
+    final leafName = pathSegments.last;
+    return current.attributes.where((a) => a.name == leafName).firstOrNull;
+  }
+}

--- a/packages/terradart_codegen/lib/src/codegen/universal_invariants/synthetic_argmap_builder.dart
+++ b/packages/terradart_codegen/lib/src/codegen/universal_invariants/synthetic_argmap_builder.dart
@@ -1,0 +1,50 @@
+import 'package:terradart_core/terradart_core.dart';
+
+/// Builds a synthetic `argMap` that mirrors how a real wrapper encodes
+/// the given dotted sensitive path. Used by Gate 2 to drive
+/// `JsonEncoder.encodeArgMapWithSensitive` without instantiating an
+/// actual Resource (each resource has different required fields, which
+/// would make the per-resource test boilerplate explode at 120 resources).
+///
+/// Convention mirrors wrap pipeline emission:
+/// - Top-level scalar path → `'name': TfArg.literal(value)`.
+/// - Depth ≥ 2 path → `'block': TfArg.literal([{nested: ...}])`, with
+///   `[{...}]` wrapping at every block segment (matches the
+///   `max_items=1` nested-block convention).
+class SyntheticArgMapBuilder {
+  const SyntheticArgMapBuilder();
+
+  Map<String, TfArg<dynamic>?> buildForPath(
+    String dottedPath,
+    String leafValue,
+  ) {
+    final segments = dottedPath.split('.');
+    if (segments.length == 1) {
+      return <String, TfArg<dynamic>?>{
+        segments.first: TfArg.literal<String>(leafValue),
+      };
+    }
+    final topKey = segments.first;
+    final encoded = _buildNested(segments.sublist(1), leafValue);
+    return <String, TfArg<dynamic>?>{
+      topKey: TfArg.literal<List<dynamic>>([encoded]),
+    };
+  }
+
+  /// Builds the encoded structure starting from a sub-block, mirroring
+  /// the `[{...}]` list-wrap that wrap pipeline emits for every nested
+  /// block.
+  Map<String, dynamic> _buildNested(
+    List<String> remainingSegments,
+    String leafValue,
+  ) {
+    if (remainingSegments.length == 1) {
+      return <String, dynamic>{remainingSegments.first: leafValue};
+    }
+    final head = remainingSegments.first;
+    final rest = _buildNested(remainingSegments.sublist(1), leafValue);
+    return <String, dynamic>{
+      head: <dynamic>[rest],
+    };
+  }
+}

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
+  terradart_core: ^0.1.0-dev
 
 dev_dependencies:
   test: ^1.25.6

--- a/packages/terradart_codegen/test/codegen/universal_invariants/enum_extractor_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants/enum_extractor_test.dart
@@ -34,6 +34,30 @@ enum BucketStorageClass {
       expect(const EnumExtractor().extract(src), isEmpty);
     });
 
+    test('extracts a multi-line member (Dart format trailing-comma style)', () {
+      const src = '''
+enum SubnetworkResolveSubnetMask {
+  arpAllRanges('ARP_ALL_RANGES'),
+  arpBroadcastPrimaryRangeWithLearning(
+    'ARP_BROADCAST_PRIMARY_RANGE_WITH_LEARNING',
+  );
+
+  const SubnetworkResolveSubnetMask(this.terraformValue);
+  final String terraformValue;
+}
+''';
+      final enums = const EnumExtractor().extract(src);
+      expect(enums, hasLength(1));
+      expect(
+        enums.single.members,
+        equals({
+          'arpAllRanges': 'ARP_ALL_RANGES',
+          'arpBroadcastPrimaryRangeWithLearning':
+              'ARP_BROADCAST_PRIMARY_RANGE_WITH_LEARNING',
+        }),
+      );
+    });
+
     test('extracts multiple enum declarations in one file', () {
       const src = '''
 enum A {

--- a/packages/terradart_codegen/test/codegen/universal_invariants/enum_extractor_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants/enum_extractor_test.dart
@@ -1,0 +1,56 @@
+import 'package:terradart_codegen/src/codegen/universal_invariants/enum_extractor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EnumExtractor', () {
+    test('extracts (member, terraformValue) pairs from a canonical enum block',
+        () {
+      const src = '''
+enum BucketStorageClass {
+  standard('STANDARD'),
+  nearline('NEARLINE'),
+  archive('ARCHIVE');
+
+  const BucketStorageClass(this.terraformValue);
+  final String terraformValue;
+}
+''';
+      final enums = const EnumExtractor().extract(src);
+      expect(enums, hasLength(1));
+      final ev = enums.single;
+      expect(ev.name, equals('BucketStorageClass'));
+      expect(
+        ev.members,
+        equals({
+          'standard': 'STANDARD',
+          'nearline': 'NEARLINE',
+          'archive': 'ARCHIVE',
+        }),
+      );
+    });
+
+    test('returns empty list for source with no enum declarations', () {
+      const src = 'class Foo {}\nvoid bar() {}';
+      expect(const EnumExtractor().extract(src), isEmpty);
+    });
+
+    test('extracts multiple enum declarations in one file', () {
+      const src = '''
+enum A {
+  x('X');
+  const A(this.terraformValue);
+  final String terraformValue;
+}
+
+enum B {
+  y('Y'),
+  z('Z');
+  const B(this.terraformValue);
+  final String terraformValue;
+}
+''';
+      final enums = const EnumExtractor().extract(src);
+      expect(enums.map((e) => e.name).toSet(), equals({'A', 'B'}));
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/universal_invariants/path_walker_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants/path_walker_test.dart
@@ -1,0 +1,63 @@
+import 'package:terradart_codegen/src/codegen/universal_invariants/path_walker.dart';
+import 'package:terradart_codegen/src/ir/attribute.dart';
+import 'package:terradart_codegen/src/ir/constraints.dart';
+import 'package:terradart_codegen/src/ir/nested_block.dart';
+import 'package:terradart_codegen/src/ir/type_def.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PathWalker', () {
+    const walker = PathWalker();
+
+    test('resolves a top-level attribute', () {
+      const block = BlockDef(
+        attributes: [
+          Attribute(
+            name: 'name',
+            type: StringType(),
+            constraints: Constraints(required: true),
+          ),
+        ],
+        nestedBlocks: [],
+      );
+      final attr = walker.resolveAttribute(block, ['name']);
+      expect(attr, isNotNull);
+      expect(attr!.name, equals('name'));
+      expect(attr.constraints.required, isTrue);
+    });
+
+    test('resolves a depth-2 attribute through a nested block', () {
+      const block = BlockDef(
+        attributes: [],
+        nestedBlocks: [
+          NestedBlockDef(
+            name: 'customer_encryption',
+            nesting: NestingMode.single,
+            constraints: Constraints(optional: true),
+            block: BlockDef(
+              attributes: [
+                Attribute(
+                  name: 'encryption_key',
+                  type: StringType(),
+                  constraints: Constraints(required: true, sensitive: true),
+                ),
+              ],
+              nestedBlocks: [],
+            ),
+          ),
+        ],
+      );
+      final attr = walker.resolveAttribute(
+        block,
+        ['customer_encryption', 'encryption_key'],
+      );
+      expect(attr, isNotNull);
+      expect(attr!.constraints.sensitive, isTrue);
+    });
+
+    test('returns null for an unknown path', () {
+      const block = BlockDef(attributes: [], nestedBlocks: []);
+      expect(walker.resolveAttribute(block, ['missing']), isNull);
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/universal_invariants/synthetic_argmap_builder_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants/synthetic_argmap_builder_test.dart
@@ -1,0 +1,55 @@
+import 'package:terradart_codegen/src/codegen/universal_invariants/synthetic_argmap_builder.dart';
+import 'package:terradart_core/terradart_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SyntheticArgMapBuilder', () {
+    const builder = SyntheticArgMapBuilder();
+
+    test('depth-1 path produces a flat TfArg<String> entry', () {
+      final argMap = builder.buildForPath('secret_data', 'plaintext-value');
+      expect(argMap, hasLength(1));
+      expect(argMap['secret_data'], isA<TfArg<String>>());
+      expect((argMap['secret_data']! as TfArgLiteral<String>).value,
+          equals('plaintext-value'));
+    });
+
+    test('depth-2 path wraps the leaf in `TfArg.literal([{leaf: value}])`', () {
+      final argMap = builder.buildForPath(
+        'customer_encryption.encryption_key',
+        'plaintext-value',
+      );
+      expect(argMap, hasLength(1));
+      final outer = argMap['customer_encryption'];
+      expect(outer, isA<TfArgLiteral<List<dynamic>>>());
+      final encoded = (outer! as TfArgLiteral<List<dynamic>>).value;
+      expect(
+          encoded,
+          equals([
+            {'encryption_key': 'plaintext-value'},
+          ]));
+    });
+
+    test('depth-4 path produces nested [{...}] structure', () {
+      final argMap = builder.buildForPath(
+        'boot_disk.initialize_params.source_image_encryption_key.raw_key',
+        'plaintext',
+      );
+      final outer = argMap['boot_disk'];
+      expect(outer, isA<TfArgLiteral<List<dynamic>>>());
+      expect(
+          (outer! as TfArgLiteral<List<dynamic>>).value,
+          equals([
+            {
+              'initialize_params': [
+                {
+                  'source_image_encryption_key': [
+                    {'raw_key': 'plaintext'},
+                  ],
+                },
+              ],
+            },
+          ]));
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/universal_invariants_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants_test.dart
@@ -3,12 +3,43 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:terradart_codegen/src/codegen/universal_invariants/enum_extractor.dart';
+import 'package:terradart_codegen/src/codegen/universal_invariants/path_walker.dart';
 import 'package:terradart_codegen/src/codegen/wrapper_overrides/_registry.dart';
+import 'package:terradart_codegen/src/codegen/wrapper_overrides/yaml_loader.dart';
+import 'package:terradart_codegen/src/ir/provider_schema_ir.dart';
+import 'package:terradart_codegen/src/parser/ir_merger.dart';
+import 'package:terradart_codegen/src/parser/mm_yaml_parser.dart';
 import 'package:terradart_codegen/src/parser/schema_parser.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('Universal invariants', () {
+    late LoadedOverrides loaded;
+    late ProviderSchemaIR ir;
+
+    setUpAll(() {
+      loaded = loadWrapperOverrides(
+        rootDir: 'lib/src/codegen/wrapper_overrides/yaml',
+      );
+      final rawIr = const SchemaJsonParser().parseString(
+        File('test/fixtures/wrap/source/schema.json').readAsStringSync(),
+        providerVersion: '7.31.0',
+      );
+      // SchemaJsonParser does not populate enum_values (Terraform schema JSON
+      // has no such field). enum_values come from the Magic Modules YAML
+      // mirror. Merge them in so Gate 3's schema-side enum check is non-vacuous.
+      final mmDir = Directory('test/fixtures/wrap/source/mm');
+      final mmOverrides = <String, MmResourceOverrides>{};
+      for (final ent in mmDir.listSync()) {
+        if (ent is! File) continue;
+        if (!ent.path.endsWith('.yaml')) continue;
+        final terraformType = p.basenameWithoutExtension(ent.path);
+        mmOverrides[terraformType] =
+            const MmYamlParser().parseString(ent.readAsStringSync());
+      }
+      ir = const IrMerger().merge(base: rawIr, overrides: mmOverrides);
+    });
+
     group('Gate 4: UnimplementedError(TODO(wrap-promote)) ban', () {
       test('zero occurrences in shipped terradart_google source', () {
         // Only terradart_google ships wrap-promote sealed classes; terradart_codegen
@@ -93,15 +124,6 @@ void main() {
 
     group('Gate 1: paramOrder covers every required schema attribute', () {
       test('every required attr is in paramOrder or customSlots', () {
-        final loaded = loadWrapperOverrides(
-          rootDir: 'lib/src/codegen/wrapper_overrides/yaml',
-        );
-        final schemaSrc = File(
-          'test/fixtures/wrap/source/schema.json',
-        ).readAsStringSync();
-        final ir = const SchemaJsonParser()
-            .parseString(schemaSrc, providerVersion: '7.31.0');
-
         final offenders = <String>[];
 
         // Resources side.
@@ -163,6 +185,97 @@ void main() {
               'A required attr absent from both is silently dropped from '
               'the factory constructor.\n'
               'Offenders: ${offenders.join("\n  ")}',
+        );
+      });
+    });
+
+    group('Gate 3: enum terraformValue matches schema enum_values exactly', () {
+      test('every dartTypeOverrides enum round-trips through the schema', () {
+        const walker = PathWalker();
+        const extractor = EnumExtractor();
+
+        // Pre-extract every emitted enum across all wrapper + schema files,
+        // keyed by Dart enum name.
+        final emittedEnums = <String, EmittedEnum>{};
+        final root = Directory(
+          p.join('..', 'terradart_google', 'lib', 'src'),
+        );
+        expect(
+          root.existsSync(),
+          isTrue,
+          reason: 'terradart_google/lib/src not found from '
+              'terradart_codegen working dir',
+        );
+        // Scan scope is intentionally terradart_google/lib/src so that wrapper
+        // types like TfArg (defined in terradart_core) cannot collide with
+        // emittedEnums when the dartTypeName regex extracts capital-prefixed
+        // identifiers like `TfArg<EnumName>?`.
+        for (final ent in root.listSync(recursive: true)) {
+          if (ent is! File) continue;
+          if (!ent.path.endsWith('.dart')) continue;
+          for (final e in extractor.extract(ent.readAsStringSync())) {
+            emittedEnums[e.name] = e;
+          }
+        }
+
+        final offenders = <String>[];
+
+        for (final entry in loaded.resources.entries) {
+          final terraformType = entry.key;
+          final override = entry.value;
+          final dartTypeOverrides = override.dartTypeOverrides ?? {};
+          final def = ir.resources[terraformType];
+          if (def == null) continue;
+
+          dartTypeOverrides.forEach((fieldPath, dartTypeName) {
+            // dartTypeName may be `EnumName` or `TfArg<EnumName>?`.
+            // Strip the wrapper so the lookup matches a bare enum name.
+            final bareEnumName = RegExp(r'[A-Z][A-Za-z0-9]*')
+                .allMatches(dartTypeName)
+                .map((m) => m.group(0)!)
+                .where((n) => emittedEnums.containsKey(n))
+                .firstOrNull;
+            if (bareEnumName == null) return; // dartTypeOverrides entry
+            //                                   doesn't reference an enum
+
+            final emitted = emittedEnums[bareEnumName]!;
+            final attr =
+                walker.resolveAttribute(def.root, fieldPath.split('.'));
+            if (attr == null) {
+              offenders.add(
+                '$terraformType: dartTypeOverrides field "$fieldPath" '
+                'has no matching IR attribute',
+              );
+              return;
+            }
+            final schemaEnumValues = attr.constraints.enumValues?.toSet();
+            if (schemaEnumValues == null) return;
+            // ^ schema has no enum_values for this field; the enum was
+            // hand-authored (e.g. KmsKeyPurpose). Gate 3 only enforces
+            // round-trip when the schema has the source of truth.
+
+            final emittedTerraformValues = emitted.members.values.toSet();
+            // Dart's default Set uses reference equality; compare structurally.
+            final equal =
+                emittedTerraformValues.containsAll(schemaEnumValues) &&
+                    schemaEnumValues.containsAll(emittedTerraformValues);
+            if (!equal) {
+              offenders.add(
+                '$terraformType.$fieldPath ($bareEnumName): '
+                'emitted=$emittedTerraformValues schema=$schemaEnumValues',
+              );
+            }
+          });
+        }
+
+        expect(
+          offenders,
+          isEmpty,
+          reason: 'Enum terraformValue strings drifted from the schema '
+              'enum_values. This is the TG-2 bug class extended — even '
+              'with correct Dart identifiers, the wire-value set may '
+              'have grown or shrunk vs. the schema.\n'
+              'Offenders:\n  ${offenders.join("\n  ")}',
         );
       });
     });

--- a/packages/terradart_codegen/test/codegen/universal_invariants_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants_test.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:terradart_codegen/src/codegen/universal_invariants/enum_extractor.dart';
+import 'package:terradart_codegen/src/codegen/wrapper_overrides/_registry.dart';
+import 'package:terradart_codegen/src/parser/schema_parser.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -85,6 +87,82 @@ void main() {
               'bug class — wrap-promote ValidValuesEmitter producing '
               'garbage Dart identifiers like `addCOSTTOMED` or `3DES`.\n'
               'Offenders: ${offenders.join(", ")}',
+        );
+      });
+    });
+
+    group('Gate 1: paramOrder covers every required schema attribute', () {
+      test('every required attr is in paramOrder or customSlots', () {
+        final loaded = loadWrapperOverrides(
+          rootDir: 'lib/src/codegen/wrapper_overrides/yaml',
+        );
+        final schemaSrc = File(
+          'test/fixtures/wrap/source/schema.json',
+        ).readAsStringSync();
+        final ir = const SchemaJsonParser()
+            .parseString(schemaSrc, providerVersion: '7.31.0');
+
+        final offenders = <String>[];
+
+        // Resources side.
+        for (final entry in loaded.resources.entries) {
+          final terraformType = entry.key;
+          final override = entry.value;
+          final def = ir.resources[terraformType];
+          // TODO(gate1-unmatched): a yaml override naming a resource absent
+          // from the fixture schema (typo, or fixture stale) is silently
+          // skipped here. Add a complementary assertion that every override
+          // key resolves to an IR def.
+          if (def == null) continue;
+
+          // NOTE: only root-level attributes are checked. Required nested
+          // blocks (min_items > 0) are excluded by scope — track in a future
+          // gate if regressions emerge.
+          final requiredAttrs = def.root.attributes
+              .where((a) => a.constraints.required)
+              .map((a) => a.name)
+              .toSet();
+
+          final fromParamOrder = override.paramOrder?.toSet() ?? <String>{};
+          final fromCustomSlots =
+              override.customSlots?.keys.toSet() ?? <String>{};
+          final covered = fromParamOrder.union(fromCustomSlots);
+
+          final missing = requiredAttrs.difference(covered);
+          if (missing.isNotEmpty) {
+            offenders.add('$terraformType: missing required attrs $missing');
+          }
+        }
+
+        // Data sources side (same logic against `ir.dataSources`).
+        for (final entry in loaded.dataSources.entries) {
+          final terraformType = entry.key;
+          final override = entry.value;
+          final def = ir.dataSources[terraformType];
+          if (def == null) continue;
+
+          final requiredAttrs = def.root.attributes
+              .where((a) => a.constraints.required)
+              .map((a) => a.name)
+              .toSet();
+          final fromParamOrder = override.paramOrder?.toSet() ?? <String>{};
+          final fromCustomSlots =
+              override.customSlots?.keys.toSet() ?? <String>{};
+          final covered = fromParamOrder.union(fromCustomSlots);
+          final missing = requiredAttrs.difference(covered);
+          if (missing.isNotEmpty) {
+            offenders.add('$terraformType: missing required attrs $missing');
+          }
+        }
+
+        expect(
+          offenders,
+          isEmpty,
+          reason: 'paramOrder must list every required schema attribute '
+              '(or the attribute must be covered via customSlots). '
+              'A required attr absent from both is silently dropped from '
+              'the factory constructor.\n'
+              'Offenders: ${offenders.join("\n  ")}',
         );
       });
     });

--- a/packages/terradart_codegen/test/codegen/universal_invariants_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants_test.dart
@@ -2,6 +2,7 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:terradart_codegen/src/codegen/universal_invariants/enum_extractor.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -36,6 +37,53 @@ void main() {
           reason: 'wrap-promote sealed-class scaffold left a TODO in '
               'shipped Dart. Replace UnimplementedError(...) bodies '
               'with actual encode() implementations.\n'
+              'Offenders: ${offenders.join(", ")}',
+        );
+      });
+    });
+
+    group('Gate 5: identifier sanity (lowerCamelCase enum members)', () {
+      test('every emitted enum member is lowerCamelCase', () {
+        final root = Directory(
+          p.join('..', 'terradart_google', 'lib', 'src'),
+        );
+        expect(
+          root.existsSync(),
+          isTrue,
+          reason: 'terradart_google/lib/src not found from '
+              'terradart_codegen working dir',
+        );
+        // ^[a-z]: must start with lowercase letter.
+        // ([a-z0-9]|[A-Z][a-z0-9]+)*: each capital must be followed by at
+        // least one lowercase letter or digit (no consecutive capitals).
+        // Forbids: ALL_CAPS, leading-digit, snake_case, hyphenated, and
+        // embedded-CAPS runs like addCOSTTOMED.
+        final lowerCamelCase = RegExp(r'^[a-z]([a-z0-9]|[A-Z][a-z0-9]+)*$');
+
+        final offenders = <String>[];
+        for (final ent in root.listSync(recursive: true)) {
+          if (ent is! File) continue;
+          if (!ent.path.endsWith('.dart')) continue;
+          final src = ent.readAsStringSync();
+          final emittedEnums = const EnumExtractor().extract(src);
+          for (final enumDecl in emittedEnums) {
+            for (final memberName in enumDecl.members.keys) {
+              if (!lowerCamelCase.hasMatch(memberName)) {
+                offenders.add(
+                  '${p.relative(ent.path, from: root.path)}: '
+                  '${enumDecl.name}.$memberName',
+                );
+              }
+            }
+          }
+        }
+        expect(
+          offenders,
+          isEmpty,
+          reason: 'Emitted enum member identifier violates lowerCamelCase '
+              '(^[a-z]([a-z0-9]|[A-Z][a-z0-9]+)*\$). This is the TG-2 '
+              'bug class — wrap-promote ValidValuesEmitter producing '
+              'garbage Dart identifiers like `addCOSTTOMED` or `3DES`.\n'
               'Offenders: ${offenders.join(", ")}',
         );
       });

--- a/packages/terradart_codegen/test/codegen/universal_invariants_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants_test.dart
@@ -1,0 +1,44 @@
+// packages/terradart_codegen/test/codegen/universal_invariants_test.dart
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  group('Universal invariants', () {
+    group('Gate 4: UnimplementedError(TODO(wrap-promote)) ban', () {
+      test('zero occurrences in shipped terradart_google source', () {
+        // Only terradart_google ships wrap-promote sealed classes; terradart_codegen
+        // contains the emitter (legitimately includes the placeholder string) and
+        // golden fixtures (.golden, not .dart), both correctly outside this root.
+        final root = Directory(
+          p.join('..', 'terradart_google', 'lib', 'src'),
+        );
+        expect(
+          root.existsSync(),
+          isTrue,
+          reason: 'terradart_google/lib/src not found from '
+              'terradart_codegen working dir',
+        );
+
+        final offenders = <String>[];
+        for (final ent in root.listSync(recursive: true)) {
+          if (ent is! File) continue;
+          if (!ent.path.endsWith('.dart')) continue;
+          final content = ent.readAsStringSync();
+          if (content.contains("UnimplementedError('TODO(wrap-promote)")) {
+            offenders.add(p.relative(ent.path, from: root.path));
+          }
+        }
+        expect(
+          offenders,
+          isEmpty,
+          reason: 'wrap-promote sealed-class scaffold left a TODO in '
+              'shipped Dart. Replace UnimplementedError(...) bodies '
+              'with actual encode() implementations.\n'
+              'Offenders: ${offenders.join(", ")}',
+        );
+      });
+    });
+  });
+}

--- a/packages/terradart_google/test/synth/sensitive_round_trip_test.dart
+++ b/packages/terradart_google/test/synth/sensitive_round_trip_test.dart
@@ -1,0 +1,100 @@
+// packages/terradart_google/test/synth/sensitive_round_trip_test.dart
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:terradart_codegen/src/codegen/universal_invariants/synthetic_argmap_builder.dart';
+import 'package:terradart_core/terradart_core.dart';
+import 'package:test/test.dart';
+
+/// Parses `const Set<String> <Name>Sensitive = <String>{ 'a', 'b.c' };` from
+/// a generated `.schema.dart` file. Returns the parsed paths (or empty
+/// set if the const is `<String>{}` / not present).
+Set<String> _parseSensitiveSet(String dartSource) {
+  // Capture: between `<String>{` and the closing `};`. Tolerates
+  // multi-line + arbitrary whitespace.
+  final block = RegExp(
+    r'const\s+Set<String>\s+\w+Sensitive\s*=\s*<String>\{([^}]*)\};',
+    dotAll: true,
+  );
+  final match = block.firstMatch(dartSource);
+  if (match == null) return <String>{};
+  final body = match.group(1)!;
+  return RegExp(r"'([^']+)'").allMatches(body).map((m) => m.group(1)!).toSet();
+}
+
+void main() {
+  group('Gate 2: sensitive mask round-trip per resource', () {
+    final generatedDir = Directory(p.join('lib', 'src', 'generated'));
+    final schemaFiles = generatedDir
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.schema.dart'))
+        .toList();
+
+    test(
+      'generated dir contains at least 28 schema files (curated corpus)',
+      () {
+        expect(
+          schemaFiles,
+          hasLength(greaterThanOrEqualTo(28)),
+          reason:
+              'terradart_google/lib/src/generated/ should hold at least 28 '
+              '<resource>.schema.dart files (curated corpus floor). Partial '
+              'regen or stale checkout suspected if fewer.',
+        );
+      },
+    );
+
+    for (final schemaFile in schemaFiles) {
+      final fileName = p.basenameWithoutExtension(schemaFile.path);
+      // fileName looks like `google_compute_instance.schema` — strip `.schema`.
+      final resourceName = fileName.endsWith('.schema')
+          ? fileName.substring(0, fileName.length - '.schema'.length)
+          : fileName;
+      final src = schemaFile.readAsStringSync();
+      final paths = _parseSensitiveSet(src);
+      if (paths.isEmpty) continue;
+
+      test('$resourceName: every sensitive path masks to "" at synth time', () {
+        const builder = SyntheticArgMapBuilder();
+        for (final path in paths) {
+          final argMap = builder.buildForPath(path, 'plaintext-secret');
+          final encoded = JsonEncoder.encodeArgMapWithSensitive(
+            argMap: argMap,
+            sensitiveFields: {path},
+          );
+          // Walk the encoded structure following the path to retrieve the leaf.
+          final leaf = _walkEncodedPath(encoded, path.split('.'));
+          expect(
+            leaf,
+            equals(''),
+            reason:
+                '$resourceName: path "$path" not masked '
+                '(encoded leaf is $leaf, expected "")',
+          );
+        }
+      });
+    }
+  });
+}
+
+Object? _walkEncodedPath(Map<String, dynamic> root, List<String> segments) {
+  Object? current = root;
+  for (var i = 0; i < segments.length; i++) {
+    final segment = segments[i];
+    if (current is Map) {
+      current = current[segment];
+    } else if (current is List && current.isNotEmpty) {
+      // Single-element nested-block wrap: re-enter the map inside.
+      final first = current.first;
+      if (first is Map) {
+        current = first[segment];
+      } else {
+        return null;
+      }
+    } else {
+      return null;
+    }
+  }
+  return current;
+}


### PR DESCRIPTION
## Summary

Adds 5 repo-wide invariant gates that run on every PR via the existing `test (<package>)` CI matrix. Each gate targets a bug class that the current format / analyze / test pipeline does not catch.

## The 5 gates

| Gate | Lives in | Bug class caught |
|---|---|---|
| **Gate 1** — `paramOrder` coverage | `terradart_codegen` | A required schema attribute absent from `paramOrder ∪ customSlots.keys` is silently dropped from the factory constructor. |
| **Gate 2** — sensitive mask round-trip | `terradart_google` | A sensitive path that `JsonEncoder._maskNestedPaths` cannot walk through leaks plaintext into `tf-out/main.tf.json`. |
| **Gate 3** — enum `terraformValue` round-trip | `terradart_codegen` | The schema's `enum_values` set drifts from the emitted Dart enum's `terraformValue` set (TG-2 extended). |
| **Gate 4** — `UnimplementedError` ban | `terradart_codegen` | A `throw UnimplementedError('TODO(wrap-promote): ...')` scaffold body ships unfilled (compiles + analyses fine, crashes at runtime). |
| **Gate 5** — identifier sanity | `terradart_codegen` | An emitted enum identifier violates lowerCamelCase (e.g. `addCOSTTOMED` from a broken `_screamingToCamel`). Regex `^[a-z]([a-z0-9]|[A-Z][a-z0-9]+)*$` requires every capital to be followed by lowercase/digit. |

All 5 pass on the current 28 curated resources. Wave 4+ curation must keep them green.

## Implementation cost

- **6 new files in `terradart_codegen`**: 3 helpers (`EnumExtractor`, `PathWalker`, `SyntheticArgMapBuilder`) + 3 unit-test files for them + 1 main gate test file holding Gates 1, 3, 4, 5.
- **1 new file in `terradart_google`**: parametric Gate 2 test that auto-scales over every resource with a non-empty `<Resource>Sensitive` const.
- **1 line in `terradart_codegen/pubspec.yaml`**: adds `terradart_core: ^0.1.0-dev` dependency so `SyntheticArgMapBuilder`'s `TfArg` import satisfies `depend_on_referenced_packages`.

No `.github/workflows/ci.yml` edit needed — the existing `test (<package>)` matrix runs `dart test --reporter=github` per-package and walks `test/` recursively, so the new files are picked up automatically.

## Behavioural impact

Zero runtime behaviour change. Pure observability + invariant enforcement at PR time.

## Notable design choices

- **Shared `setUpAll` at the outer `Universal invariants` group scope** so Gates 1 and 3 share a single 7.5 MB schema parse instead of duplicating per-gate.
- **`IrMerger` applied in `setUpAll`** so `Constraints.enumValues` is populated. `SchemaJsonParser` alone never sets that field — values come from the Magic Modules YAML mirror.
- **Structural set equality via two-way `containsAll`** in Gate 3 — Dart's default `Set<String>` `==` is reference equality, so `{a, b} == {a, b}` is `false` for distinct instances.
- **EnumExtractor regex accepts trailing comma + whitespace** before the closing paren of a member literal, so Dart format's multi-line member style (e.g. `arpBroadcastPrimaryRangeWithLearning(\n    'ARP_BROADCAST_PRIMARY_RANGE_WITH_LEARNING',\n  )`) is parsed correctly.
- **Discovery guard floor** in Gate 2: `hasLength(greaterThanOrEqualTo(28))` catches partial regen / stale checkout while keeping the corpus floor explicit.

## Follow-ups (not blockers)

- Gate 1 currently only checks root-level required attributes (NOTE comment in-source). A future gate could extend to required nested blocks.
- Gate 1's `if (def == null) continue;` silently skips yaml overrides naming a resource absent from the fixture schema (TODO comment in-source). A complementary assertion would tighten this.
- Gate 3 iterates `loaded.resources` only — data sources have no `dartTypeOverrides` today.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` — 298 files, 0 changed
- [x] `dart analyze packages/ --fatal-infos --fatal-warnings` — clean
- [x] `dart test` per-package: terradart_codegen +273 ~5, terradart_google +88 ~2 — all green
- [x] Gate-specific runs: universal_invariants_test.dart +4, sensitive_round_trip_test.dart +4
- [x] CI confirms the same on the PR run.

## Related

Phase 5 design spec section 4 (Universal QA gates). Independent of Wave 4 (Firebase / Functions) and per-service barrels (Plan 5.B).