### PR TITLE
chore: single-package recovery mode for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,16 +8,55 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to publish (e.g. v0.0.4-dev). Required for workflow_dispatch.'
-        required: true
+        description: 'Tag to publish (e.g. v0.1.0-dev). Leave empty to use the latest tag matching v*.*.*.'
+        required: false
+        default: ''
+      package:
+        description: 'Publish only this package (single-package recovery mode). Leave empty to publish all 4.'
+        required: false
+        type: choice
+        default: ''
+        options:
+          - ''
+          - terradart_annotations
+          - terradart_core
+          - terradart_codegen
+          - terradart_google
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
+  resolve-tag:
+    name: resolve publish tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            tag="${{ github.ref_name }}"
+          elif [ -n "${{ inputs.tag }}" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag=$(git describe --tags --abbrev=0 --match='v*.*.*' 2>/dev/null || true)
+          fi
+          if [ -z "$tag" ]; then
+            echo "::error::Could not resolve tag (no push ref, no inputs.tag, no matching tag found in repo)."
+            exit 1
+          fi
+          echo "Resolved tag: $tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
   publish-leaves:
+    if: github.event_name == 'push' || inputs.package == ''
     name: publish ${{ matrix.package }}
+    needs: resolve-tag
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -36,15 +75,16 @@ jobs:
       - run: dart pub get
 
       - name: Pre-publish pubspec mutations
-        run: tool/prepare_publish.sh "${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}" ${{ matrix.package }}
+        run: tool/prepare_publish.sh "${{ needs.resolve-tag.outputs.tag }}" ${{ matrix.package }}
 
       - name: Publish to pub.dev
         run: dart pub publish --force
         working-directory: packages/${{ matrix.package }}
 
   publish-google:
+    if: github.event_name == 'push' || inputs.package == ''
     name: publish terradart_google
-    needs: publish-leaves
+    needs: [resolve-tag, publish-leaves]
     runs-on: ubuntu-latest
     steps:
       - name: Wait for pub.dev index propagation
@@ -85,8 +125,47 @@ jobs:
           [ "$schema_g_count" -eq "$resource_count" ] || { echo "::error::schema.g.dart count ($schema_g_count) != resource yaml count ($resource_count)"; exit 1; }
 
       - name: Pre-publish pubspec mutations
-        run: tool/prepare_publish.sh "${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}" terradart_google
+        run: tool/prepare_publish.sh "${{ needs.resolve-tag.outputs.tag }}" terradart_google
 
       - name: Publish to pub.dev
         run: dart pub publish --force
         working-directory: packages/terradart_google
+
+  publish-single:
+    if: github.event_name == 'workflow_dispatch' && inputs.package != ''
+    name: publish ${{ inputs.package }} (single-package recovery)
+    needs: resolve-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+      - run: dart pub get
+
+      - name: Verify generated schema and wrapper files
+        if: inputs.package == 'terradart_google'
+        run: |
+          # Source of truth: per-resource yaml overrides under terradart_codegen.
+          yaml_count=$(find packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml -name '*.yaml' | wc -l | tr -d ' ')
+          data_source_count=$(grep -l '^kind: data_source$' packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/*.yaml | wc -l | tr -d ' ')
+          resource_count=$((yaml_count - data_source_count))
+          schema_dart_count=$(find packages/terradart_google/lib/src -name '*.schema.dart' | wc -l | tr -d ' ')
+          wrapper_count=$(find packages/terradart_google/lib/src -mindepth 2 -name 'google_*.dart' -not -path '*/generated/*' | wc -l | tr -d ' ')
+          schema_g_count=$(find packages/terradart_google/lib/src/generated -name '*.schema.g.dart' | wc -l | tr -d ' ')
+          echo "yaml=$yaml_count (resources=$resource_count, data_sources=$data_source_count) schema.dart=$schema_dart_count wrapper=$wrapper_count schema.g.dart=$schema_g_count"
+          [ "$yaml_count" -eq "$schema_dart_count" ] || { echo "::error::schema.dart count ($schema_dart_count) != yaml count ($yaml_count)"; exit 1; }
+          [ "$yaml_count" -eq "$wrapper_count" ] || { echo "::error::wrapper count ($wrapper_count) != yaml count ($yaml_count)"; exit 1; }
+          [ "$schema_g_count" -eq "$resource_count" ] || { echo "::error::schema.g.dart count ($schema_g_count) != resource yaml count ($resource_count)"; exit 1; }
+
+      - name: Pre-publish pubspec mutations
+        run: tool/prepare_publish.sh "${{ needs.resolve-tag.outputs.tag }}" ${{ inputs.package }}
+
+      - name: Publish to pub.dev
+        run: dart pub publish --force
+        working-directory: packages/${{ inputs.package }}


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` mode that publishes only one of the 4 packages, for use when a tag-driven publish partially fails. Existing tag-push behavior is unchanged.

## Why

The tag-push trigger runs all 4 packages in parallel via the matrix. If one fails (e.g. transient pub.dev 500, network flap, schema invariant regression caught mid-flight) and the other 3 succeed, today's recovery path is:

1. Bump every package to a fresh version
2. Re-tag
3. Re-run — re-publishing the 3 already-published packages at the new version even though their content didn't change

That works but wastes a version slot and dirties the version history with empty bumps. After this PR, the maintainer can just `Run workflow` from the Actions UI, pick the failed package, and re-publish at the same tag.

## What changes

| Layer | Change |
|---|---|
| `workflow_dispatch.inputs.tag` | now **optional**; empty resolves to the latest `v*.*.*` tag in the repo |
| `workflow_dispatch.inputs.package` | **new** choice input (`''` / `terradart_annotations` / `terradart_core` / `terradart_codegen` / `terradart_google`); empty = publish all 4 |
| `resolve-tag` job | **new** — emits the resolved tag for downstream jobs (push → `github.ref_name`; dispatch w/ input → that input; dispatch empty → `git describe --tags --abbrev=0 --match='v*.*.*'`) |
| `publish-leaves`, `publish-google` | gated on `github.event_name == 'push' \|\| inputs.package == ''`; still run for full publishes |
| `publish-single` | **new** — gated on `workflow_dispatch && inputs.package != ''`; runs the same prepare + publish steps for one package; runs the `terradart_google` schema invariant only when that package is selected |

## Behavior matrix

| Trigger | tag | package | What runs |
|---|---|---|---|
| `push v0.1.0-dev` | (from ref) | n/a | resolve-tag → publish-leaves (3 in parallel) → publish-google (after 3-min wait) |
| `workflow_dispatch`, all defaults | latest tag | `''` | same as push |
| `workflow_dispatch tag=v0.1.0-dev package=terradart_codegen` | `v0.1.0-dev` | `terradart_codegen` | resolve-tag → publish-single |
| `workflow_dispatch package=terradart_google` | latest tag | `terradart_google` | resolve-tag → publish-single (with schema invariant check) |

## Caveats

- Checkout in `workflow_dispatch` mode is the default branch HEAD (existing behavior). The single-package publish uses *current main's content* with pubspecs rewritten to the resolved tag's version. If the maintainer needs to replay an *older* commit's content, they need a separate plan (checkout-by-ref) — not addressed here.
- The publish step's `dart pub publish --force` happily re-uploads identical bits if the version is unchanged, but pub.dev rejects re-publishing an already-published version. So `publish-single` cannot recover from "version X already exists on pub.dev for this package" — the maintainer would need to bump.

## Verification

The workflow itself can't be exercised without a real publish event (any trigger publishes — there is no dry-run mode). The structural change (YAML parse, job graph, conditionals) is reviewable from the diff. Real validation will come from the next publish event:

1. Merge this PR.
2. From the Actions UI, run `Publish to pub.dev` with `package = terradart_google` (other inputs empty). The resolved tag becomes the latest `v*.*.*` in the repo.
3. If it succeeds → the single-package path works and `terradart_google@v0.1.0-dev` lands on pub.dev.
4. If it errors → fix in a follow-up branch.