### PR TITLE
chore: gate publish jobs on pub-dev GitHub Actions environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,7 @@ jobs:
     name: publish ${{ matrix.package }}
     needs: resolve-tag
     runs-on: ubuntu-latest
+    environment: pub-dev
     strategy:
       fail-fast: false
       matrix:
@@ -86,6 +87,7 @@ jobs:
     name: publish terradart_google
     needs: [resolve-tag, publish-leaves]
     runs-on: ubuntu-latest
+    environment: pub-dev
     steps:
       - name: Wait for pub.dev index propagation
         run: |
@@ -136,6 +138,7 @@ jobs:
     name: publish ${{ inputs.package }} (single-package recovery)
     needs: resolve-tag
     runs-on: ubuntu-latest
+    environment: pub-dev
     steps:
       - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
## Summary

Adds `environment: pub-dev` to all 3 publish jobs (`publish-leaves`, `publish-google`, `publish-single`) so workflow_dispatch from the default branch can authenticate against pub.dev. Required follow-up to PR #26, which added single-package recovery mode but discovered the recovery path is blocked by pub.dev's tag-ref-only OIDC validation.

## Why

PR #26's first real exercise (workflow_dispatch with `package = terradart_google` from `main`) failed at the publish step with:

```
publishing is only allowed from 'tag' refType, this token has 'branch' refType
```

pub.dev's "Enable publishing from workflow_dispatch events" allows the trigger but, unless "Require GitHub Actions environment" is also enabled, restricts the OIDC claim to `refType=tag`. workflow_dispatch from a branch (the recovery use case) is rejected.

The fix is the environment-claim path: pub.dev requires + validates a specific GitHub Actions environment name, which authorises branch-ref publishes within the trust boundary of "anyone who can run workflow_dispatch on this repo".

## Required manual setup (before merging)

1. **On each of the 4 pub.dev packages** (`terradart_annotations`, `terradart_core`, `terradart_codegen`, `terradart_google`):
   - Enable `Require GitHub Actions environment`
   - Set environment name to `pub-dev`
2. **In GitHub repo Settings > Environments**:
   - Create the `pub-dev` environment
   - Leave `Required reviewers` empty (validates the claim only; no manual approval gate)

The IDE diagnostic on this PR ("Value 'pub-dev' is not valid") will resolve once step 2 lands — VS Code's Actions extension validates environment names against the live repo config.

## What changes

3 single-line additions to `.github/workflows/publish.yml`:

```diff
   publish-leaves:
+    environment: pub-dev

   publish-google:
+    environment: pub-dev

   publish-single:
+    environment: pub-dev
```

No other behavioural change.

## Side effect on the normal release flow

Tag-push publishes (the primary release flow) now also route through the `pub-dev` environment. With no required reviewers, this is an auth-claim-only check — the existing tag-push automation continues to work non-interactively.

## Related

- PR #26 (single-package recovery mode that this unblocks)
- pub.dev docs: <https://dart.dev/go/publishing-from-github>