### PR TITLE
chore: bump packages to 0.2.0-dev

### DIFF
--- a/packages/terradart_annotations/CHANGELOG.md
+++ b/packages/terradart_annotations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0-dev - 2026-05-16
+
+No user-facing API changes. Version bumped for workspace consistency with `terradart_core` 0.2.0-dev (TfArg.duration + nested-path sensitive masking fix) and `terradart_codegen` 0.2.0-dev (curator workflow improvements).
+
 ## 0.1.0-dev - 2026-05-14
 
 No user-facing API changes. Version bumped for workspace consistency with `terradart_core` 0.1.0-dev (typed enum serialization) and `terradart_google` 0.1.0-dev (+15 resources).

--- a/packages/terradart_annotations/pubspec.yaml
+++ b/packages/terradart_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_annotations
 description: Annotation surface consumed by terradart_codegen-generated abstract resource classes (@TerraformResource, @ForceNew, @Sensitive).
-version: 0.1.0-dev
+version: 0.2.0-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.2.0-dev - 2026-05-16
+
+### Added
+
+- `extraSensitiveFields:` yaml override axis — curators can declare per-resource sensitive paths beyond what the Terraform schema flags. Each entry is a dotted path (e.g. `metadata_startup_script`); the resulting `<Resource>Sensitive` const ships the union of schema-declared and curator-declared paths.
+- `terradart wrap --only=<resource>` — regenerates a single wrapper file even when sibling yaml overrides have validation errors. Designed for the case where unrelated breakage in another resource blocks the whole-package `wrap` cycle.
+- `wrap-promote` now extracts enum candidates from prose descriptions matching `Possible values: A, B, C` in addition to schema `enum_values` blocks. Falls back to the prose set when the schema declares no enum, with MM yaml taking priority when both are present.
+- 5 universal QA gates (CI-only invariants over `terradart_google/lib/src/**`): `paramOrder` covers every required schema attribute, emitted enum `terraformValue` matches schema `enum_values`, no `UnimplementedError('TODO(wrap-promote)')` ships in the curated source, every emitted enum member is lowerCamelCase, and sensitive path masking round-trips to `""`.
+
 ## 0.1.0-dev - 2026-05-14
 
 ### Added

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.1.0-dev
+  terradart_core: ^0.2.0-dev
 
 dev_dependencies:
   test: ^1.25.6

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart Stage 1 codegen — parses Terraform provider schema JSON and Magic Modules YAML and emits annotated abstract Dart classes. Ships the terradart CLI.
-version: 0.1.0-dev
+version: 0.2.0-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.0-dev - 2026-05-16
+
+### Added
+
+- `TfArg.duration(Duration)` factory — converts a Dart `Duration` to the `"{seconds}s"` form Terraform expects for duration-string fields (`rotation_period`, `message_retention_duration`, the `'s'`-suffixed forms of `ack_deadline_seconds`, etc.). Sub-second precision and negative durations are rejected with `ArgumentError`.
+
+### Fixed
+
+- `JsonEncoder.encodeArgMapWithSensitive` now masks sensitive paths through nested-block (`List<Map>`) structures. Previously, paths like `customer_encryption.encryption_key` were left as plaintext in `tf-out/main.tf.json` because the masker only walked top-level keys. Ref interpolations (`${...}`) continue to pass through unchanged so Terraform wiring is preserved.
+
 ## 0.1.0-dev - 2026-05-14
 
 ### Added

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.1.0-dev
+version: 0.2.0-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0-dev - 2026-05-16
+
+No API change since the 0.1.0-dev attempt. The 0.1.0-dev publish run did not reach pub.dev for this package (the leaf packages succeeded but `terradart_google` did not); 0.2.0-dev is the first version to ship the full surface documented below.
+
 ## 0.1.0-dev - 2026-05-14
 
 Adds 15 new GCP resource factories. Total surface: **28 resources + 1 data source**.

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: terradart curated GCP factory wrappers — 28 google_* resources + 1 data source (compute, BigQuery, KMS, Cloud Storage, DNS, Cloud Run v2, Logging, Monitoring, Pub/Sub, Cloud Tasks, Secret Manager, Cloud Scheduler, IAM) for Dart-first Terraform stacks.
-version: 0.1.0-dev
+version: 0.2.0-dev
 publish_to: none  # Removed by tool/prepare_publish.sh before dart pub publish.
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart


### PR DESCRIPTION
## Summary

Bumps all 4 packages from `0.1.0-dev` to `0.2.0-dev` and adds CHANGELOG entries for each. Recovers from the `0.1.0-dev` publish run where the 3 leaf packages reached pub.dev but `terradart_google` did not — bump + re-tag is the dart.dev-documented recovery path.

## What's in 0.2.0-dev

| Package | What's new |
|---|---|
| `terradart_core` | `TfArg.duration(Duration)` factory; nested-block sensitive masking fix in `JsonEncoder.encodeArgMapWithSensitive` |
| `terradart_codegen` | `extraSensitiveFields:` yaml axis; `terradart wrap --only=<resource>`; prose-derived enum extraction in `wrap-promote`; 5 CI invariant gates over `terradart_google/lib/src/**` |
| `terradart_google` | No API change since 0.1.0-dev attempt — 0.2.0-dev is the first version that will land on pub.dev for this package |
| `terradart_annotations` | No user-facing API change; workspace consistency bump |

## Why 0.2.0-dev (not 0.1.1-dev)

`terradart_google` 0.1.0-dev's CHANGELOG documents the per-service barrels (16 new public-API barrel files added in PR #25). Per semver-style intent for `-dev` releases, the new public-API surface is a minor bump, not a patch. Adopting the same minor bump across all 4 packages keeps the workspace versions aligned.

## Release process

After merge:

1. From GitHub Releases UI: Draft a new release → tag `v0.2.0-dev` → publish release.
2. The tag push triggers `.github/workflows/publish.yml`, which publishes all 4 packages to pub.dev in the standard order: `publish-leaves` matrix (annotations / core / codegen in parallel) → `publish-google` (after 3-min pub.dev index propagation wait).
3. Verify the 4 packages at <https://pub.dev/packages/terradart_core>, etc.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed packages/` — 288 files, 0 changed
- [x] `dart analyze packages/ --fatal-infos --fatal-warnings` — clean
- [x] Manual: 4 pubspec.yaml files show `version: 0.2.0-dev`
- [x] Manual: 4 CHANGELOG.md files have a new `## 0.2.0-dev - 2026-05-16` section