### PR TITLE
chore: bump packages to 0.2.1-dev + serialize publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,14 +15,32 @@ permissions:
   id-token: write
   contents: read
 
+# Publish ordering rationale.
+#
+# terradart_codegen's published pubspec declares `terradart_core: ^X.Y.Z-dev`,
+# and terradart_google's published pubspec is rewritten by
+# tool/prepare_publish.sh to declare hosted ^X.Y.Z-dev constraints for
+# terradart_core, terradart_annotations, and terradart_codegen. pub.dev
+# validates these constraints against its index at upload time, so a
+# dependent package can't ship until its dependencies' versions are visible
+# on pub.dev.
+#
+# Phase 1 publishes the two no-deps packages in parallel.
+# Phase 2 waits for pub.dev's index to catch up, then publishes terradart_codegen.
+# Phase 3 waits again, then publishes terradart_google.
+#
+# Previous shape (matrix of all 3 leaves in parallel) raced terradart_codegen
+# against terradart_core's index propagation and intermittently failed
+# version-solving at the codegen upload step.
+
 jobs:
-  publish-leaves:
+  publish-no-deps:
     name: publish ${{ matrix.package }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        package: [terradart_annotations, terradart_core, terradart_codegen]
+        package: [terradart_annotations, terradart_core]
     steps:
       - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1
@@ -42,14 +60,42 @@ jobs:
         run: dart pub publish --force
         working-directory: packages/${{ matrix.package }}
 
-  publish-google:
-    name: publish terradart_google
-    needs: publish-leaves
+  publish-codegen:
+    name: publish terradart_codegen
+    needs: publish-no-deps
     runs-on: ubuntu-latest
     steps:
       - name: Wait for pub.dev index propagation
         run: |
-          echo "Waiting 3 minutes for pub.dev index to update before publishing terradart_google..."
+          echo "Waiting 3 minutes for pub.dev to index terradart_core before publishing terradart_codegen..."
+          sleep 180
+
+      - uses: actions/checkout@v6
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+      - run: dart pub get
+
+      - name: Pre-publish pubspec mutations
+        run: tool/prepare_publish.sh "${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}" terradart_codegen
+
+      - name: Publish to pub.dev
+        run: dart pub publish --force
+        working-directory: packages/terradart_codegen
+
+  publish-google:
+    name: publish terradart_google
+    needs: publish-codegen
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for pub.dev index propagation
+        run: |
+          echo "Waiting 3 minutes for pub.dev to index terradart_codegen + terradart_core + terradart_annotations before publishing terradart_google..."
           sleep 180
 
       - uses: actions/checkout@v6

--- a/packages/terradart_annotations/CHANGELOG.md
+++ b/packages/terradart_annotations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1-dev - 2026-05-16
+
+No user-facing API changes. Workspace consistency bump after the 0.2.0-dev publish run partially failed (`terradart_codegen` and `terradart_google` did not reach pub.dev). 0.2.1-dev republishes the workspace through a re-ordered publish pipeline.
+
 ## 0.2.0-dev - 2026-05-16
 
 No user-facing API changes. Version bumped for workspace consistency with `terradart_core` 0.2.0-dev (TfArg.duration + nested-path sensitive masking fix) and `terradart_codegen` 0.2.0-dev (curator workflow improvements).

--- a/packages/terradart_annotations/pubspec.yaml
+++ b/packages/terradart_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_annotations
 description: Annotation surface consumed by terradart_codegen-generated abstract resource classes (@TerraformResource, @ForceNew, @Sensitive).
-version: 0.2.0-dev
+version: 0.2.1-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1-dev - 2026-05-16
+
+No API change since 0.2.0-dev. Re-published after the 0.2.0-dev tag's publish run failed at the parallel matrix validation step — `terradart_codegen` was uploaded before pub.dev's index had `terradart_core` 0.2.0-dev, causing the `^0.2.0-dev` constraint to fail version solving. 0.2.1-dev ships through a re-ordered publish pipeline (`publish-codegen` now waits for `publish-no-deps` to complete + pub.dev index propagation before uploading).
+
 ## 0.2.0-dev - 2026-05-16
 
 ### Added

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart Stage 1 codegen — parses Terraform provider schema JSON and Magic Modules YAML and emits annotated abstract Dart classes. Ships the terradart CLI.
-version: 0.2.0-dev
+version: 0.2.1-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -28,7 +28,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.2.0-dev
+  terradart_core: ^0.2.1-dev
 
 dev_dependencies:
   test: ^1.25.6

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1-dev - 2026-05-16
+
+No API change since 0.2.0-dev. Workspace consistency bump after the 0.2.0-dev publish run partially failed; 0.2.1-dev republishes through a re-ordered publish pipeline.
+
 ## 0.2.0-dev - 2026-05-16
 
 ### Added

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.2.0-dev
+version: 0.2.1-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1-dev - 2026-05-16
+
+No API change since the 0.2.0-dev attempt. Neither 0.1.0-dev nor 0.2.0-dev reached pub.dev for this package — 0.1.0-dev was blocked by an unrelated `terradart_google` job failure, and 0.2.0-dev was blocked by the upstream `terradart_codegen` failure in the parallel matrix. 0.2.1-dev ships through a re-ordered publish pipeline (`publish-google` now waits for `publish-codegen` instead of the parallel `publish-leaves` matrix) and is the first version of this package to land on pub.dev.
+
 ## 0.2.0-dev - 2026-05-16
 
 No API change since the 0.1.0-dev attempt. The 0.1.0-dev publish run did not reach pub.dev for this package (the leaf packages succeeded but `terradart_google` did not); 0.2.0-dev is the first version to ship the full surface documented below.

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: terradart curated GCP factory wrappers — 28 google_* resources + 1 data source (compute, BigQuery, KMS, Cloud Storage, DNS, Cloud Run v2, Logging, Monitoring, Pub/Sub, Cloud Tasks, Secret Manager, Cloud Scheduler, IAM) for Dart-first Terraform stacks.
-version: 0.2.0-dev
+version: 0.2.1-dev
 publish_to: none  # Removed by tool/prepare_publish.sh before dart pub publish.
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart


### PR DESCRIPTION
## Summary

Bumps the 4 packages from `0.2.0-dev` to `0.2.1-dev` and re-orders the publish workflow so dependent packages don't race their dependencies' pub.dev index propagation. Recovers from the 0.2.0-dev publish where `terradart_codegen` and `terradart_google` did not reach pub.dev.

## Why 0.2.0-dev failed

`publish-leaves` ran the 3 leaf packages as a parallel matrix:

```yaml
matrix:
  package: [terradart_annotations, terradart_core, terradart_codegen]
```

`terradart_codegen`'s published pubspec declares `terradart_core: ^0.2.0-dev` (added by Plan 5.A Task 1 to satisfy the analyzer's `depend_on_referenced_packages` strict-info). At upload time pub.dev validates that constraint against its index — and the index didn't have `terradart_core 0.2.0-dev` yet, because core's parallel sibling publish was still propagating. Codegen's upload failed version-solving.

Concretely, the v0.2.0-dev tag-push outcome:
- ✓ `terradart_annotations 0.2.0-dev` published
- ✓ `terradart_core 0.2.0-dev` published
- ✗ `terradart_codegen` failed (`terradart_core ^0.2.0-dev which doesn't match any versions`)
- ⏭ `terradart_google` skipped (blocked by `needs: publish-leaves`)

This race existed since Plan 5.A Task 1 added the codegen → core caret constraint, but the v0.1.0-dev publish predated that constraint and dodged it.

## What changes

### Publish workflow

`.github/workflows/publish.yml` restructured into 3 serial phases:

| Phase | Jobs | Why serial |
|---|---|---|
| 1 | `publish-no-deps` matrix `[terradart_annotations, terradart_core]` parallel | No inter-deps; safe to race |
| 2 | `publish-codegen` (single job, `needs: publish-no-deps`) | Waits 180s for pub.dev to index `terradart_core` |
| 3 | `publish-google` (`needs: publish-codegen`) | Waits 180s again; preserves the existing schema invariant check |

Adds ~3 minutes to total publish runtime (one new wait between phase 1 and 2). The shape mirrors what `publish-google` already does after `publish-leaves`.

### Versions

| Package | 0.2.0-dev → 0.2.1-dev |
|---|---|
| `terradart_annotations` | Workspace consistency bump |
| `terradart_core` | Workspace consistency bump |
| `terradart_codegen` | Re-publish (failed at 0.2.0-dev); caret on `terradart_core` also bumped from `^0.2.0-dev` to `^0.2.1-dev` |
| `terradart_google` | First version to land on pub.dev (0.1.0-dev and 0.2.0-dev both failed mid-flow) |

No API change in any package.

## Release process

After merge:

1. From GitHub Releases UI: Draft a new release → tag `v0.2.1-dev` → publish.
2. Tag push triggers the re-ordered pipeline: phase 1 publishes annotations + core in ~30s → 3-min wait → phase 2 publishes codegen → 3-min wait → phase 3 publishes google. Total runtime ~8 minutes.
3. annotations and core re-publish at 0.2.1-dev (content unchanged from 0.2.0-dev). codegen and google publish for the first time at this minor.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed packages/` — 288 files, 0 changed
- [x] `dart analyze packages/ --fatal-infos --fatal-warnings` — clean
- [x] `yq . .github/workflows/publish.yml` — valid YAML
- [x] 4 pubspec.yaml at `0.2.1-dev`; codegen's `terradart_core` caret at `^0.2.1-dev`
- [x] 4 CHANGELOG.md have `## 0.2.1-dev - 2026-05-16` sections noting the re-publish
- [x] Tag push verifies the new pipeline end-to-end on pub.dev.