### PR TITLE
fix(codegen): populate deprecation_message in MM YAML parser + IrMerger (Plan 5.D PR 1)

### DIFF
--- a/packages/terradart_codegen/lib/src/parser/ir_merger.dart
+++ b/packages/terradart_codegen/lib/src/parser/ir_merger.dart
@@ -10,7 +10,8 @@ import 'mm_yaml_parser.dart';
 /// Resolution rules (see plan §15 for the spec):
 /// - schema-json owns the shape and the required/optional/computed/
 ///   sensitive/writeOnly/deprecated booleans.
-/// - MM YAML contributes forceNew, regex, minLength, maxLength, enumValues.
+/// - MM YAML contributes forceNew, regex, minLength, maxLength, enumValues,
+///   deprecationMessage.
 /// - On conflict for the MM-owned bits, MM wins.
 /// - Fields in MM YAML but not in schema-json are silently dropped.
 /// - Description: schema-json wins; MM is fallback.
@@ -77,6 +78,8 @@ class IrMerger {
         minLength: ovr.minLength ?? a.constraints.minLength,
         maxLength: ovr.maxLength ?? a.constraints.maxLength,
         enumValues: ovr.enumValues ?? a.constraints.enumValues,
+        deprecationMessage:
+            ovr.deprecationMessage ?? a.constraints.deprecationMessage,
       ),
     );
   }

--- a/packages/terradart_codegen/lib/src/parser/mm_yaml_parser.dart
+++ b/packages/terradart_codegen/lib/src/parser/mm_yaml_parser.dart
@@ -8,6 +8,7 @@ import '../ir/constraints.dart';
 /// - `forceNew` (from `immutable: true`)
 /// - `regex`, `minLength`, `maxLength` (from `validation`)
 /// - `enumValues` (from `enum_values`)
+/// - `deprecationMessage` (from `deprecation_message`)
 class MmResourceOverrides {
   /// Top-level YAML `description`, if any.
   final String? description;
@@ -82,6 +83,7 @@ class MmYamlParser {
       minLength: (prop['validation'] as YamlMap?)?['min_length'] as int?,
       maxLength: (prop['validation'] as YamlMap?)?['max_length'] as int?,
       enumValues: _enumValues(prop),
+      deprecationMessage: prop['deprecation_message'] as String?,
     );
     if (_isMeaningful(c)) {
       sink[fullKey] = c;
@@ -119,7 +121,8 @@ class MmYamlParser {
       c.regex != null ||
       c.minLength != null ||
       c.maxLength != null ||
-      c.enumValues != null;
+      c.enumValues != null ||
+      c.deprecationMessage != null;
 
   /// MM YAML uses lowerCamelCase for the `name` field, but the canonical
   /// Terraform JSON name comes from `api_name`. When `api_name` is absent

--- a/packages/terradart_codegen/test/parser/mm_yaml_deprecation_test.dart
+++ b/packages/terradart_codegen/test/parser/mm_yaml_deprecation_test.dart
@@ -96,5 +96,52 @@ properties:
       expect(attr.constraints.deprecationMessage, 'Use the new API.',
           reason: 'MM-only deprecation must survive when schema has none');
     });
+
+    test('MM YAML deprecation overrides schema-json Deprecated. placeholder',
+        () {
+      const base = ProviderSchemaIR(
+        providerName: 'test',
+        providerSource: 'test/test',
+        providerVersion: '0.0.1',
+        resources: {
+          'test_resource': ResourceDef(
+            terraformType: 'test_resource',
+            root: BlockDef(
+              attributes: [
+                Attribute(
+                  name: 'foo',
+                  type: StringType(),
+                  constraints: Constraints(
+                    deprecationMessage: 'Deprecated.',
+                  ),
+                ),
+              ],
+            ),
+          ),
+        },
+        dataSources: {},
+      );
+      final overrides = <String, MmResourceOverrides>{
+        'test_resource': const MmResourceOverrides(
+          fieldOverrides: {
+            'foo': Constraints(
+              deprecationMessage:
+                  'BigQuery deprecated this in favour of foo.bar.',
+            ),
+          },
+        ),
+      };
+
+      final merged = const IrMerger().merge(base: base, overrides: overrides);
+
+      final attr = merged.resources['test_resource']!.root.attributes
+          .singleWhere((a) => a.name == 'foo');
+      expect(
+        attr.constraints.deprecationMessage,
+        'BigQuery deprecated this in favour of foo.bar.',
+        reason:
+            'MM YAML deprecation message must override schema-json placeholder',
+      );
+    });
   });
 }

--- a/packages/terradart_codegen/test/parser/mm_yaml_deprecation_test.dart
+++ b/packages/terradart_codegen/test/parser/mm_yaml_deprecation_test.dart
@@ -1,0 +1,26 @@
+import 'package:terradart_codegen/src/parser/mm_yaml_parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MmYamlParser populates Constraints.deprecationMessage', () {
+    test('reads top-level field `deprecation_message:` into Constraints', () {
+      const yaml = '''
+name: GoogleSampleResource
+properties:
+  - name: 'sampleField'
+    type: String
+    deprecation_message: "Use new_field instead."
+''';
+      final result = const MmYamlParser().parseString(yaml);
+      final field = result.fieldOverrides['sample_field'];
+      expect(field, isNotNull,
+          reason: 'parser should expose the field override entry');
+      expect(
+        field!.deprecationMessage,
+        'Use new_field instead.',
+        reason: 'MM YAML deprecation_message should populate '
+            'Constraints.deprecationMessage',
+      );
+    });
+  });
+}

--- a/packages/terradart_codegen/test/parser/mm_yaml_deprecation_test.dart
+++ b/packages/terradart_codegen/test/parser/mm_yaml_deprecation_test.dart
@@ -22,5 +22,29 @@ properties:
             'Constraints.deprecationMessage',
       );
     });
+
+    test(
+        'property with no meaningful constraints is excluded from '
+        'fieldOverrides (regression guard for _isMeaningful)', () {
+      // A property with only `name` + `type` — no immutable, no validation, no
+      // enum_values, no deprecation_message. _isMeaningful must return false,
+      // so the property must NOT appear in fieldOverrides.
+      const yaml = '''
+name: GoogleSampleResource
+properties:
+  - name: 'plainField'
+    type: String
+''';
+      final result = const MmYamlParser().parseString(yaml);
+
+      expect(
+        result.fieldOverrides,
+        isNot(contains('plain_field')),
+        reason:
+            'A property with no meaningful constraints must be excluded from '
+            'fieldOverrides. If this fires, _isMeaningful is over-eager and '
+            'will pollute downstream IR merging with no-op entries.',
+      );
+    });
   });
 }

--- a/packages/terradart_codegen/test/parser/mm_yaml_deprecation_test.dart
+++ b/packages/terradart_codegen/test/parser/mm_yaml_deprecation_test.dart
@@ -1,3 +1,10 @@
+import 'package:terradart_codegen/src/ir/attribute.dart';
+import 'package:terradart_codegen/src/ir/constraints.dart';
+import 'package:terradart_codegen/src/ir/nested_block.dart';
+import 'package:terradart_codegen/src/ir/provider_schema_ir.dart';
+import 'package:terradart_codegen/src/ir/resource_def.dart';
+import 'package:terradart_codegen/src/ir/type_def.dart';
+import 'package:terradart_codegen/src/parser/ir_merger.dart';
 import 'package:terradart_codegen/src/parser/mm_yaml_parser.dart';
 import 'package:test/test.dart';
 
@@ -45,6 +52,49 @@ properties:
             'fieldOverrides. If this fires, _isMeaningful is over-eager and '
             'will pollute downstream IR merging with no-op entries.',
       );
+    });
+  });
+
+  group('IrMerger merges Constraints.deprecationMessage', () {
+    test('preserves MM-only deprecation when schema is silent', () {
+      const base = ProviderSchemaIR(
+        providerName: 'test',
+        providerSource: 'test/test',
+        providerVersion: '0.0.1',
+        resources: {
+          'test_resource': ResourceDef(
+            terraformType: 'test_resource',
+            root: BlockDef(
+              attributes: [
+                Attribute(
+                  name: 'foo',
+                  type: StringType(),
+                  constraints: Constraints(required: true),
+                ),
+              ],
+            ),
+          ),
+        },
+        dataSources: {},
+      );
+      final overrides = <String, MmResourceOverrides>{
+        'test_resource': const MmResourceOverrides(
+          fieldOverrides: {
+            'foo': Constraints(
+              deprecationMessage: 'Use the new API.',
+            ),
+          },
+        ),
+      };
+
+      final merged = const IrMerger().merge(base: base, overrides: overrides);
+
+      final attr = merged.resources['test_resource']!.root.attributes
+          .singleWhere((a) => a.name == 'foo');
+      expect(attr.constraints.required, isTrue,
+          reason: 'schema-side required flag must survive');
+      expect(attr.constraints.deprecationMessage, 'Use the new API.',
+          reason: 'MM-only deprecation must survive when schema has none');
     });
   });
 }


### PR DESCRIPTION
## Summary

Plan 5.D PR 1 of 4 — fixes a Plan 4.2-era dead-code bug where MM YAML's `deprecation_message:` field is silently dropped by `MmYamlParser._walkProperty`, leaving `wrap_init_generator._buildDeprecatedParamsAxis` reading a perpetually-null `Constraints.deprecationMessage`.

- `MmYamlParser._walkProperty` now reads `deprecation_message:` into `Constraints.deprecationMessage`
- `MmYamlParser._isMeaningful` now considers `deprecationMessage` so a field with only that constraint is kept in `fieldOverrides`
- `IrMerger._mergeAttr` now propagates `deprecationMessage` via the existing `MM ?? schema` precedence (consistent with `regex`, `minLength`, etc.)
- 3 new parser/merger tests: positive (deprecation reaches IR), regression guard (absent key excluded from `fieldOverrides`), and precedence (MM overrides schema placeholder)

Pure data-pipeline fix — no shipped Dart drift (\`wrap --check\`: all 98 files match). Skeleton emission for \`deprecatedParams:\` is explicitly deferred to Plan 5.E (Renovate-driven schema-bump automation, Issue #35).

Plan: docs/superpowers/plans/2026-05-16-plan5d-1-bug-fix-plan.md
Spec: docs/superpowers/specs/2026-05-16-plan5d-codegen-correctness-design.md

## Test plan

- [x] terradart_codegen: 277 tests pass, including 26 parser tests (was 23 on main; +3 deprecation tests)
- [x] terradart_google: 114 tests pass, including Gate 2 sensitive round-trip
- [x] terradart wrap --check: all 98 files match (no shipped Dart drift)
- [x] dart format --set-exit-if-changed: 0 changed (397 files)
- [x] dart analyze packages/ --fatal-infos --fatal-warnings: No issues found