### PR TITLE
feat(codegen): fix encode() skeleton + add Gate 6 encode round-trip (Plan 5.D PR 2)

### DIFF
--- a/packages/terradart_codegen/lib/src/codegen/universal_invariants/sealed_class_extractor.dart
+++ b/packages/terradart_codegen/lib/src/codegen/universal_invariants/sealed_class_extractor.dart
@@ -90,19 +90,19 @@ class SealedClassExtractor {
   }
 }
 
-class SealedClass {
+final class SealedClass {
   const SealedClass({required this.name, required this.members});
   final String name;
   final List<SealedClassMember> members;
 }
 
-class SealedClassMember {
+final class SealedClassMember {
   const SealedClassMember({required this.name, required this.params});
   final String name;
   final List<SealedClassParam> params;
 }
 
-class SealedClassParam {
+final class SealedClassParam {
   const SealedClassParam({required this.name, required this.required});
   final String name;
   final bool required;

--- a/packages/terradart_codegen/lib/src/codegen/universal_invariants/sealed_class_extractor.dart
+++ b/packages/terradart_codegen/lib/src/codegen/universal_invariants/sealed_class_extractor.dart
@@ -1,0 +1,109 @@
+// Pure-function extractor that finds sealed-class declarations and their
+// `final class` members inside a yaml override's `prelude:` Dart-source text.
+//
+// Implementation note: this uses focused regex rather than `package:analyzer`.
+// Trade-off documented in Plan 5.D PR 2: production yaml preludes follow
+// curator-disciplined patterns (the 12 shipped sealed-class members all share
+// constructor / field declaration shapes), and regex avoids widening the
+// codegen dep graph. If Wave 5+ patterns break the regex, migrate to analyzer
+// as a follow-up — see docs/superpowers/specs/2026-05-16-plan5d-codegen-correctness-design.md
+// section "Open decisions deferred to plan".
+
+class SealedClassExtractor {
+  const SealedClassExtractor();
+
+  /// Returns one [SealedClass] entry per `sealed class ... { ... }` block
+  /// discovered in [preludeText], with members populated from the surrounding
+  /// `final class <Name> extends <Sealed> { ... }` declarations.
+  List<SealedClass> extract(String preludeText) {
+    final sealedDecls = _sealedDeclPattern.allMatches(preludeText).toList();
+    if (sealedDecls.isEmpty) return const [];
+    return sealedDecls.map((sealedMatch) {
+      final sealedName = sealedMatch.group(1)!;
+      final members = <SealedClassMember>[];
+      for (final memberMatch
+          in _memberDeclPatternFor(sealedName).allMatches(preludeText)) {
+        final memberName = memberMatch.group(1)!;
+        final bodyStart = memberMatch.end;
+        final body = _extractClassBody(preludeText, bodyStart);
+        members.add(SealedClassMember(
+          name: memberName,
+          params: _extractParams(body),
+        ));
+      }
+      return SealedClass(name: sealedName, members: members);
+    }).toList(growable: false);
+  }
+
+  static final _sealedDeclPattern =
+      RegExp(r'sealed\s+class\s+(\w+)\s*\{', multiLine: true);
+
+  static RegExp _memberDeclPatternFor(String sealedName) => RegExp(
+        r'final\s+class\s+(\w+)\s+extends\s+' +
+            RegExp.escape(sealedName) +
+            r'\s*\{',
+        multiLine: true,
+      );
+
+  static final _ctorParamPattern = RegExp(
+    r'const\s+\w+\s*\(\s*\{([^}]*)\}\s*\)\s*[;:]',
+    multiLine: true,
+    dotAll: true,
+  );
+
+  /// Walks [source] starting at [start] balancing `{` and `}` and returns the
+  /// substring containing the class body (between the opening and matching
+  /// closing braces — minus the braces themselves).
+  String _extractClassBody(String source, int start) {
+    var depth = 1;
+    var i = start;
+    while (i < source.length && depth > 0) {
+      final ch = source[i];
+      if (ch == '{') depth++;
+      if (ch == '}') depth--;
+      i++;
+    }
+    // i now sits one past the matching '}'. Return body without braces.
+    return source.substring(start, i - 1);
+  }
+
+  List<SealedClassParam> _extractParams(String classBody) {
+    final ctorMatch = _ctorParamPattern.firstMatch(classBody);
+    if (ctorMatch == null) return const [];
+    final paramsBlock = ctorMatch.group(1)!;
+    final params = <SealedClassParam>[];
+    for (final raw in paramsBlock.split(',')) {
+      final trimmed = raw.trim();
+      if (trimmed.isEmpty) continue;
+      // Forms expected:
+      //   required this.splits
+      //   this.codebaseBranch
+      final required = trimmed.startsWith('required ');
+      final afterRequired =
+          required ? trimmed.substring('required '.length) : trimmed;
+      if (!afterRequired.startsWith('this.')) continue;
+      final name = afterRequired.substring('this.'.length).trim();
+      if (name.isEmpty) continue;
+      params.add(SealedClassParam(name: name, required: required));
+    }
+    return params;
+  }
+}
+
+class SealedClass {
+  const SealedClass({required this.name, required this.members});
+  final String name;
+  final List<SealedClassMember> members;
+}
+
+class SealedClassMember {
+  const SealedClassMember({required this.name, required this.params});
+  final String name;
+  final List<SealedClassParam> params;
+}
+
+class SealedClassParam {
+  const SealedClassParam({required this.name, required this.required});
+  final String name;
+  final bool required;
+}

--- a/packages/terradart_codegen/lib/src/codegen/universal_invariants/synthetic_instance_builder.dart
+++ b/packages/terradart_codegen/lib/src/codegen/universal_invariants/synthetic_instance_builder.dart
@@ -1,0 +1,29 @@
+import 'sealed_class_extractor.dart';
+
+/// Builds Dart-source-text expressions that construct a synthetic instance of
+/// a sealed-class [SealedClassMember]. Required params get a `<TODO>` placeholder
+/// that the consumer (Gate 6 test generator) replaces with a type-aware
+/// synthetic value (e.g. `TfArg.literal('mock-value')` for `TfArg<String>`).
+/// Optional params are omitted from the expression (the synthetic instance
+/// tests the all-optionals-null path).
+///
+/// The two-stage construction (this builder produces the skeleton, Gate 6
+/// emission fills in synthetic values per type) keeps this class
+/// type-system-agnostic. Adding type awareness here would require parsing the
+/// field declarations as well — currently the extractor only captures param
+/// names and required flags.
+final class SyntheticInstanceBuilder {
+  const SyntheticInstanceBuilder();
+
+  /// Returns a constructor-call expression like `TargetSplit(splits: <TODO>)`
+  /// for [member]. Optional params are omitted.
+  ///
+  /// Callers expected to substring-replace `<TODO>` with a synthetic value
+  /// expression appropriate for the param's Dart type.
+  String buildExpression(SealedClassMember member) {
+    final required = member.params.where((p) => p.required).toList();
+    if (required.isEmpty) return '${member.name}()';
+    final args = required.map((p) => '${p.name}: <TODO>').join(', ');
+    return '${member.name}($args)';
+  }
+}

--- a/packages/terradart_codegen/lib/src/codegen/wrap_promote/exactly_one_of_emitter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrap_promote/exactly_one_of_emitter.dart
@@ -44,7 +44,7 @@ class ExactlyOneOfEmitter {
     buf.writeln('  sealed class $sealedName {');
     buf.writeln('    const $sealedName();');
     buf.writeln('    String get blockKey;');
-    buf.writeln('    String encode();');
+    buf.writeln('    Map<String, Object?> encode();');
     buf.writeln('  }');
 
     for (final member in groupMembers) {
@@ -68,11 +68,11 @@ class ExactlyOneOfEmitter {
       buf.writeln("    String get blockKey => '$member';");
       buf.writeln();
       buf.writeln('    @override');
-      buf.writeln('    String encode() {');
+      buf.writeln('    Map<String, Object?> encode() {');
       buf.writeln(
           '      // TODO(wrap-promote): implement encode for $memberPascal.');
       buf.writeln(
-          "      // Pattern: '{key = \${field.encode()}, ...}' with `if (optional != null)` guards.");
+          "      // Pattern: { if (optional != null) 'optional_key': optional!.toTfJson(), 'required_key': required.toTfJson(), ... }");
       buf.writeln(
           "      throw UnimplementedError('TODO(wrap-promote): implement encode for $memberPascal');");
       buf.writeln('    }');

--- a/packages/terradart_codegen/lib/src/codegen/wrap_promote/exactly_one_of_emitter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrap_promote/exactly_one_of_emitter.dart
@@ -12,7 +12,7 @@ import '../naming.dart';
 /// Phase 4.3: skeleton level. Class names, constructor parameter lists, and
 /// `blockKey` getters are fully generated from the IR. The `encode()` body
 /// is left as `UnimplementedError` for the human reviewer to fill in (the
-/// TfArg encoding pattern varies per resource and is too risky to auto-fill).
+/// argMap encoding pattern varies per resource and is too risky to auto-fill).
 class ExactlyOneOfEmitter {
   const ExactlyOneOfEmitter();
 

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_storage_bucket_object.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_storage_bucket_object.yaml
@@ -169,6 +169,14 @@ prelude: |
     /// [blockKey]. Always a `TfArg<String>` (source is a file path,
     /// content is the inline string).
     TfArg<String> get value;
+
+    /// Wire-format encoding (`{blockKey: value.toTfJson()}`). The parent
+    /// factory uses the `blockKey` + `value` pair directly in its argMap
+    /// (relying on the synth layer to unwrap the [TfArg]); this method
+    /// exists for parity with other sealed-class encoders (e.g.
+    /// [BucketObjectRetention.toArgMap], `AppHostingBuildSource.encode`)
+    /// and is exercised by the Gate 6 encode round-trip test.
+    Map<String, Object?> encode() => {blockKey: value.toTfJson()};
   }
 
   /// Upload from a local filesystem path. Terraform reads the file at

--- a/packages/terradart_codegen/test/codegen/universal_invariants/sealed_class_extractor_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants/sealed_class_extractor_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:terradart_codegen/src/codegen/universal_invariants/sealed_class_extractor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SealedClassExtractor', () {
+    test('parses a single sealed class with two members from prelude text', () {
+      const prelude = '''
+sealed class TrafficChoice {
+  const TrafficChoice();
+  String get blockKey;
+  Map<String, Object?> encode();
+}
+
+final class TargetSplit extends TrafficChoice {
+  const TargetSplit({required this.splits});
+
+  final List<AppHostingTrafficSplit> splits;
+
+  @override
+  String get blockKey => 'target';
+
+  @override
+  Map<String, Object?> encode() => {'splits': splits.map((s) => s.toArgMap()).toList()};
+}
+
+final class RolloutPolicy extends TrafficChoice {
+  const RolloutPolicy({this.codebaseBranch, this.disabled});
+
+  final TfArg<String>? codebaseBranch;
+  final TfArg<bool>? disabled;
+
+  @override
+  String get blockKey => 'rollout_policy';
+
+  @override
+  Map<String, Object?> encode() => {
+        if (codebaseBranch != null) 'codebase_branch': codebaseBranch!.toTfJson(),
+        if (disabled != null) 'disabled': disabled!.toTfJson(),
+      };
+}
+''';
+
+      final extracted = const SealedClassExtractor().extract(prelude);
+
+      expect(extracted, hasLength(1),
+          reason: 'one sealed class expected in this prelude fragment');
+      final sealed = extracted.single;
+      expect(sealed.name, 'TrafficChoice');
+      expect(sealed.members, hasLength(2));
+
+      final byName = {for (final m in sealed.members) m.name: m};
+      expect(byName.keys, containsAll(['TargetSplit', 'RolloutPolicy']));
+
+      final targetSplit = byName['TargetSplit']!;
+      expect(targetSplit.params, hasLength(1));
+      expect(targetSplit.params.single.name, 'splits');
+      expect(targetSplit.params.single.required, isTrue);
+
+      final rollout = byName['RolloutPolicy']!;
+      expect(rollout.params, hasLength(2));
+      final pByName = {for (final p in rollout.params) p.name: p};
+      expect(pByName['codebaseBranch']!.required, isFalse);
+      expect(pByName['disabled']!.required, isFalse);
+    });
+
+    test('parses google_cloud_scheduler_job.yaml prelude end-to-end', () {
+      final yaml = File(
+        'lib/src/codegen/wrapper_overrides/yaml/google_cloud_scheduler_job.yaml',
+      ).readAsStringSync();
+      // Crude prelude slice: from the `prelude:` key to the end of the yaml.
+      // Component B-3 (Gate 6) parses yaml properly via the yaml package; this
+      // test is a smoke check that the regex robustly handles a real production
+      // prelude.
+      final preludeStart = yaml.indexOf('prelude:');
+      expect(preludeStart, greaterThan(0));
+      final preludeText = yaml.substring(preludeStart);
+
+      final extracted = const SealedClassExtractor().extract(preludeText);
+      expect(extracted.map((s) => s.name), contains('SchedulerTarget'));
+      final scheduler =
+          extracted.singleWhere((s) => s.name == 'SchedulerTarget');
+      // SchedulerTarget has 3 known members per the Wave 4 yaml.
+      expect(scheduler.members.map((m) => m.name),
+          containsAll(['PubsubTarget', 'HttpTarget', 'AppEngineHttpTarget']));
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/universal_invariants/synthetic_instance_builder_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants/synthetic_instance_builder_test.dart
@@ -1,0 +1,42 @@
+import 'package:terradart_codegen/src/codegen/universal_invariants/sealed_class_extractor.dart';
+import 'package:terradart_codegen/src/codegen/universal_invariants/synthetic_instance_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SyntheticInstanceBuilder', () {
+    test('builds a constructor expression for a member with one required param',
+        () {
+      const member = SealedClassMember(
+        name: 'TargetSplit',
+        params: [SealedClassParam(name: 'splits', required: true)],
+      );
+
+      final expr = const SyntheticInstanceBuilder().buildExpression(member);
+
+      // The synth value for a required param is left as `<TODO>` for the
+      // emitted test to fill in via Component B-3's type-aware logic. The
+      // expression shape must include the constructor call with all required
+      // params present.
+      expect(expr, contains('TargetSplit('));
+      expect(expr, contains('splits:'));
+      expect(expr, endsWith(')'));
+    });
+
+    test('omits optional params from the constructor expression', () {
+      const member = SealedClassMember(
+        name: 'RolloutPolicy',
+        params: [
+          SealedClassParam(name: 'codebaseBranch', required: false),
+          SealedClassParam(name: 'disabled', required: false),
+        ],
+      );
+
+      final expr = const SyntheticInstanceBuilder().buildExpression(member);
+
+      // Both params are optional; the synthetic expression invokes the
+      // constructor with no args (testing the "all optional null" path of
+      // encode round-trip).
+      expect(expr, 'RolloutPolicy()');
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/universal_invariants/synthetic_instance_builder_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants/synthetic_instance_builder_test.dart
@@ -38,5 +38,25 @@ void main() {
       // encode round-trip).
       expect(expr, 'RolloutPolicy()');
     });
+
+    test(
+        'preserves required params in input order and skips optionals when '
+        'they are interleaved', () {
+      const member = SealedClassMember(
+        name: 'BigqueryAccess',
+        params: [
+          SealedClassParam(name: 'userByEmail', required: true),
+          SealedClassParam(name: 'domain', required: false),
+          SealedClassParam(name: 'role', required: true),
+        ],
+      );
+
+      final expr = const SyntheticInstanceBuilder().buildExpression(member);
+
+      // Required `userByEmail` and `role` must appear in input order; the
+      // interleaved optional `domain` must NOT appear. Guards against a
+      // future regression that reorders or drops required params.
+      expect(expr, 'BigqueryAccess(userByEmail: <TODO>, role: <TODO>)');
+    });
   });
 }

--- a/packages/terradart_codegen/test/golden/wrap_promote/google_synthetic_choice.wrap_promote.expected.yaml.golden
+++ b/packages/terradart_codegen/test/golden/wrap_promote/google_synthetic_choice.wrap_promote.expected.yaml.golden
@@ -8,7 +8,7 @@ prelude: |
   sealed class GoogleSyntheticChoiceChoice {
     const GoogleSyntheticChoiceChoice();
     String get blockKey;
-    String encode();
+    Map<String, Object?> encode();
   }
 
   final class OptionA extends GoogleSyntheticChoiceChoice {
@@ -21,9 +21,9 @@ prelude: |
     String get blockKey => 'option_a';
 
     @override
-    String encode() {
+    Map<String, Object?> encode() {
       // TODO(wrap-promote): implement encode for OptionA.
-      // Pattern: '{key = ${field.encode()}, ...}' with `if (optional != null)` guards.
+      // Pattern: { if (optional != null) 'optional_key': optional!.toTfJson(), 'required_key': required.toTfJson(), ... }
       throw UnimplementedError('TODO(wrap-promote): implement encode for OptionA');
     }
   }
@@ -40,9 +40,9 @@ prelude: |
     String get blockKey => 'option_b';
 
     @override
-    String encode() {
+    Map<String, Object?> encode() {
       // TODO(wrap-promote): implement encode for OptionB.
-      // Pattern: '{key = ${field.encode()}, ...}' with `if (optional != null)` guards.
+      // Pattern: { if (optional != null) 'optional_key': optional!.toTfJson(), 'required_key': required.toTfJson(), ... }
       throw UnimplementedError('TODO(wrap-promote): implement encode for OptionB');
     }
   }

--- a/packages/terradart_google/lib/src/storage/google_storage_bucket_object.dart
+++ b/packages/terradart_google/lib/src/storage/google_storage_bucket_object.dart
@@ -45,6 +45,14 @@ sealed class BucketObjectContent {
   /// [blockKey]. Always a `TfArg<String>` (source is a file path,
   /// content is the inline string).
   TfArg<String> get value;
+
+  /// Wire-format encoding (`{blockKey: value.toTfJson()}`). The parent
+  /// factory uses the `blockKey` + `value` pair directly in its argMap
+  /// (relying on the synth layer to unwrap the [TfArg]); this method
+  /// exists for parity with other sealed-class encoders (e.g.
+  /// [BucketObjectRetention.toArgMap], `AppHostingBuildSource.encode`)
+  /// and is exercised by the Gate 6 encode round-trip test.
+  Map<String, Object?> encode() => {blockKey: value.toTfJson()};
 }
 
 /// Upload from a local filesystem path. Terraform reads the file at

--- a/packages/terradart_google/test/synth/encode_round_trip_test.dart
+++ b/packages/terradart_google/test/synth/encode_round_trip_test.dart
@@ -6,130 +6,292 @@
 // Discovers every sealed-class member declared in production yaml overrides
 // via [SealedClassExtractor], constructs a synthetic instance via the
 // hand-curated [_syntheticInstances] lookup table, invokes encode() (with
-// toArgMap() fallback), and asserts the encoded Map shape:
+// toArgMap() fallback), and asserts the encoded shape:
 //
-//   * the result is a non-empty Map<String, Object?>;
-//   * every required attr's snake_case schema key is present in the keys;
-//   * no raw TfArg<T> values leak into the encoded payload
-//     (.toTfJson() should have unwrapped them at serialization time).
+//   * the encoded value is non-empty (Map or single-element List<Map>);
+//   * every required attr's snake_case schema key appears as a key SOMEWHERE
+//     in the encoded payload (top-level or nested under a discriminator
+//     block — the production wire format mostly puts ctor params inside a
+//     `{<discriminator>: [<innerMap>]}` block per the schema's `nesting_mode`
+//     conventions, so a recursive key walk is necessary);
+//   * no raw TfArg<T> values leak ANYWHERE in the encoded payload
+//     (every encoder should have unwrapped via `.toTfJson()` at
+//     serialization time — walked recursively).
 //
-// Component B-3-a (this commit) ships the FRAMEWORK only — the lookup table
-// is intentionally empty and the whole group is marked `skip:` so CI stays
-// green between B-3-a and B-3-b. Component B-3-b removes the skip and
-// fills the table in lockstep with the discovered members.
+// Component B-3-a shipped the FRAMEWORK only — the lookup table was empty
+// and the whole group was marked `skip:`. Component B-3-b (this commit)
+// fills the table for all 34 sealed-class members and removes the skip.
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:terradart_codegen/src/codegen/universal_invariants/sealed_class_extractor.dart';
 import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/bigquery.dart';
+import 'package:terradart_google/cloud_functions.dart';
+import 'package:terradart_google/cloud_run.dart';
+import 'package:terradart_google/cloud_scheduler.dart';
+import 'package:terradart_google/firebase_app_hosting.dart';
+import 'package:terradart_google/firestore.dart';
+import 'package:terradart_google/secret_manager.dart';
+import 'package:terradart_google/storage.dart';
 import 'package:test/test.dart';
 
 /// Hand-curated lookup: sealed-class-member-name -> a thunk that returns a
 /// constructed instance. Each thunk supplies synthetic `TfArg<T>` values for
-/// required params and omits all optional params.
+/// required params and omits all optional params (the framework tests the
+/// all-optionals-null encode path).
 ///
 /// Add an entry per new sealed-class member shipped in future waves. Gate 6
 /// fails loudly when a sealed-class is extracted from yaml but no entry
 /// exists here — keeping the table in lockstep with yaml is a curator
 /// responsibility.
 ///
-/// Component B-3-a (this commit) ships the framework with an empty table —
-/// the per-test "Gate 6 lookup table missing entry" failures are expected
-/// and intentional. Component B-3-b fills the table in lockstep.
+/// Replication members are private (`_AutoReplication` / `_UserManagedReplication`);
+/// the lookup key uses the literal private-class name produced by the
+/// extractor, but thunk bodies construct via the public `Replication.auto()` /
+/// `Replication.userManaged(...)` factories.
 final Map<String, Object Function()> _syntheticInstances = {
-  // Filled in by Component B-3-b — see plan 5.D PR 2 Task 10.
+  // --- Access (8) — bigquery_dataset ---------------------------------------
+  'AccessUserByEmail': () =>
+      AccessUserByEmail(userByEmail: TfArg.literal('user@example.com')),
+  'AccessGroupByEmail': () =>
+      AccessGroupByEmail(groupByEmail: TfArg.literal('group@example.com')),
+  'AccessSpecialGroup': () =>
+      AccessSpecialGroup(specialGroup: TfArg.literal('projectReaders')),
+  'AccessDomain': () => AccessDomain(domain: TfArg.literal('example.com')),
+  'AccessIamMember': () =>
+      AccessIamMember(iamMember: TfArg.literal('allUsers')),
+  'AccessView': () => AccessView(
+    view: DatasetView(
+      projectId: TfArg.literal('p'),
+      datasetId: TfArg.literal('d'),
+      tableId: TfArg.literal('t'),
+    ),
+  ),
+  'AccessDataset': () => AccessDataset(
+    dataset: DatasetAccessChild(
+      dataset: DatasetReference(
+        projectId: TfArg.literal('p'),
+        datasetId: TfArg.literal('d'),
+      ),
+      targetTypes: [TfArg.literal('VIEWS')],
+    ),
+  ),
+  'AccessRoutine': () => AccessRoutine(
+    routine: DatasetRoutineRef(
+      projectId: TfArg.literal('p'),
+      datasetId: TfArg.literal('d'),
+      routineId: TfArg.literal('r'),
+    ),
+  ),
+
+  // --- EnvVarSource (2) — cloud_run_v2_service -----------------------------
+  'EnvVarFromLiteral': () => EnvVarFromLiteral(TfArg.literal('mock-value')),
+  'EnvVarFromSecret': () =>
+      EnvVarFromSecret(secret: TfArg.literal('mock-secret')),
+
+  // --- VolumeSource (5) — cloud_run_v2_service -----------------------------
+  'VolumeSecret': () => VolumeSecret(secret: TfArg.literal('mock-secret')),
+  'CloudSqlVolume': () => const CloudSqlVolume(),
+  'EmptyDirVolume': () => const EmptyDirVolume(),
+  'GcsVolume': () => GcsVolume(bucket: TfArg.literal('mock-bucket')),
+  'NfsVolume': () => NfsVolume(
+    server: TfArg.literal('nfs.example.com'),
+    path: TfArg.literal('/exports/data'),
+  ),
+
+  // --- SchedulerTarget (3) — cloud_scheduler_job ---------------------------
+  'PubsubTarget': () =>
+      PubsubTarget(topicName: TfArg.literal('projects/p/topics/t')),
+  'HttpTarget': () =>
+      HttpTarget(uri: TfArg.literal('https://example.com/webhook')),
+  'AppEngineHttpTarget': () =>
+      AppEngineHttpTarget(relativeUri: TfArg.literal('/handler')),
+
+  // --- SourceConfig (2) — cloudfunctions2_function -------------------------
+  'StorageSource': () => StorageSource(
+    bucket: TfArg.literal('mock-bucket'),
+    object: TfArg.literal('mock-object.zip'),
+  ),
+  'RepoSource': () => RepoSource(repoName: TfArg.literal('mock-repo')),
+
+  // --- UpdatePolicy (2) — cloudfunctions2_function -------------------------
+  'AutomaticUpdatePolicy': () => const AutomaticUpdatePolicy(),
+  'OnDeployUpdatePolicy': () => const OnDeployUpdatePolicy(),
+
+  // --- AppHostingBuildSource (2) — firebase_app_hosting_build --------------
+  'AppHostingBuildSourceCodebase': () => const AppHostingBuildSourceCodebase(),
+  'AppHostingBuildSourceContainer': () => AppHostingBuildSourceContainer(
+    image: TfArg.literal('us-central1-docker.pkg.dev/p/r/web:1.0.0'),
+  ),
+
+  // --- BackupRecurrence (2) — firestore_backup_schedule --------------------
+  // These return List<Map<String, Object?>> (single-element, per the
+  // nesting_mode: list, max_items: 1 schema convention). The dispatch logic
+  // unwraps to the single inner map for the structural assertions.
+  'DailyRecurrence': () => const DailyRecurrence(),
+  'WeeklyRecurrence': () => const WeeklyRecurrence(),
+
+  // --- IndexFieldSpec (4) — firestore_index --------------------------------
+  'IndexFieldOrder': () => const IndexFieldOrder(FirestoreIndexOrder.ascending),
+  'IndexFieldArrayConfig': () => const IndexFieldArrayConfig(),
+  'IndexFieldSearchConfig': () => const IndexFieldSearchConfig(),
+  'IndexFieldVectorConfig': () => const IndexFieldVectorConfig(dimension: 768),
+
+  // --- Replication (2, private members) — secret_manager_secret ------------
+  // Extractor produces the literal `_AutoReplication` / `_UserManagedReplication`
+  // names; the thunks must construct via the public `Replication.auto()` /
+  // `Replication.userManaged(...)` factories.
+  '_AutoReplication': () => Replication.auto(),
+  '_UserManagedReplication': () =>
+      Replication.userManaged([Replica(location: TfArg.literal('us-east1'))]),
+
+  // --- BucketObjectContent (2) — storage_bucket_object ---------------------
+  'BucketObjectFromSource': () =>
+      BucketObjectFromSource(source: TfArg.literal('./mock/path.bin')),
+  'BucketObjectFromContent': () =>
+      BucketObjectFromContent(content: TfArg.literal('mock-inline-payload')),
 };
 
 void main() {
-  group(
-    'Gate 6: encode round-trip structural',
-    () {
-      final yamlDir = Directory(
-        p.join(
-          '..',
-          'terradart_codegen',
-          'lib',
-          'src',
-          'codegen',
-          'wrapper_overrides',
-          'yaml',
-        ),
-      );
-      final yamlFiles =
-          yamlDir
-              .listSync()
-              .whereType<File>()
-              .where((f) => f.path.endsWith('.yaml'))
-              .toList()
-            ..sort((a, b) => a.path.compareTo(b.path));
+  group('Gate 6: encode round-trip structural', () {
+    final yamlDir = Directory(
+      p.join(
+        '..',
+        'terradart_codegen',
+        'lib',
+        'src',
+        'codegen',
+        'wrapper_overrides',
+        'yaml',
+      ),
+    );
+    final yamlFiles =
+        yamlDir
+            .listSync()
+            .whereType<File>()
+            .where((f) => f.path.endsWith('.yaml'))
+            .toList()
+          ..sort((a, b) => a.path.compareTo(b.path));
 
-      for (final yamlFile in yamlFiles) {
-        final yamlSource = yamlFile.readAsStringSync();
-        if (!yamlSource.contains('sealed class')) continue;
+    for (final yamlFile in yamlFiles) {
+      final yamlSource = yamlFile.readAsStringSync();
+      if (!yamlSource.contains('sealed class')) continue;
 
-        final preludeStart = yamlSource.indexOf('prelude:');
-        if (preludeStart < 0) continue;
-        final preludeText = yamlSource.substring(preludeStart);
-        final sealedClasses = const SealedClassExtractor().extract(preludeText);
+      final preludeStart = yamlSource.indexOf('prelude:');
+      if (preludeStart < 0) continue;
+      final preludeText = yamlSource.substring(preludeStart);
+      final sealedClasses = const SealedClassExtractor().extract(preludeText);
 
-        for (final sealed in sealedClasses) {
-          for (final member in sealed.members) {
-            test('${sealed.name}.${member.name}: encode() round-trips '
-                'with required keys present', () {
-              final thunk = _syntheticInstances[member.name];
+      for (final sealed in sealedClasses) {
+        for (final member in sealed.members) {
+          test('${sealed.name}.${member.name}: encode() round-trips '
+              'with required keys present', () {
+            final thunk = _syntheticInstances[member.name];
+            expect(
+              thunk,
+              isNotNull,
+              reason:
+                  'Gate 6 lookup table missing entry for ${member.name}. '
+                  'Add a constructor thunk to _syntheticInstances in '
+                  'encode_round_trip_test.dart. See Plan 5.D PR 2 Task 10.',
+            );
+
+            final instance = thunk!();
+
+            // Production wrappers expose either `encode()` (most common) or
+            // `toArgMap()` (e.g. cloud_run_v2_service helpers). Try
+            // `encode()` first via dynamic dispatch; fall back to
+            // `toArgMap()`. Both can return either `Map<String, Object?>`
+            // OR a single-element `List<Map<String, Object?>>` (the latter
+            // used by `BackupRecurrence.{DailyRecurrence,WeeklyRecurrence}`
+            // because their underlying blocks are
+            // `nesting_mode: list, max_items: 1`).
+            final dyn = instance as dynamic;
+            Object? raw;
+            try {
+              raw = dyn.encode();
+            } on NoSuchMethodError {
+              raw = dyn.toArgMap();
+            }
+
+            // The encoded payload must be non-empty (as a wire-shape — for
+            // the Map case, at least one key; for the List<Map> case, at
+            // least one element).
+            if (raw is Map) {
+              expect(raw, isNotEmpty, reason: 'encoded Map must not be empty');
+            } else if (raw is List) {
               expect(
-                thunk,
-                isNotNull,
-                reason:
-                    'Gate 6 lookup table missing entry for ${member.name}. '
-                    'Add a constructor thunk to _syntheticInstances in '
-                    'encode_round_trip_test.dart. See Plan 5.D PR 2 Task 10.',
-              );
-
-              final instance = thunk!();
-
-              // The wrapper may expose `encode()` (return Map) OR
-              // `toArgMap()` (return Map). Try encode() first via dynamic
-              // dispatch; fall back to toArgMap().
-              final dyn = instance as dynamic;
-              late Map<String, Object?> result;
-              try {
-                result = dyn.encode() as Map<String, Object?>;
-              } on NoSuchMethodError {
-                result = dyn.toArgMap() as Map<String, Object?>;
-              }
-
-              expect(result, isA<Map<String, Object?>>());
-              expect(
-                result,
+                raw,
                 isNotEmpty,
-                reason: 'encoded Map must not be empty',
+                reason: 'encoded List<Map> must not be empty',
               );
-              for (final param in member.params.where((p) => p.required)) {
-                // Convert camelCase param name -> snake_case schema key.
-                final schemaKey = _camelToSnake(param.name);
-                expect(
-                  result.keys,
-                  contains(schemaKey),
-                  reason:
-                      'required attr "$schemaKey" '
-                      '(camel: ${param.name}) must be a key in encoded Map',
-                );
-              }
+            }
+
+            // Unwrap to a Map for the required-key + TfArg-leak walks.
+            late Map<String, Object?> result;
+            if (raw is Map<String, Object?>) {
+              result = raw;
+            } else if (raw is List &&
+                raw.length == 1 &&
+                raw.first is Map<String, Object?>) {
+              result = raw.first as Map<String, Object?>;
+            } else {
+              fail(
+                'encode()/toArgMap() must return Map<String, Object?> '
+                'or single-element List<Map<String, Object?>>. '
+                'Got: ${raw.runtimeType}',
+              );
+            }
+
+            // Collect every key encountered anywhere in the encoded
+            // payload, descending through nested Maps and List<Map>
+            // values. Production sealed-class members mostly follow the
+            // discriminator-block pattern (`{<discriminator>: [<innerMap>]}`)
+            // where the constructor's required params live INSIDE the
+            // inner map rather than at the top level — a recursive walk
+            // is the only way the required-key invariant can pass for
+            // both that pattern and the flat-merge pattern uniformly.
+            // The invariant Gate 6 enforces is "the wrapper's encode()
+            // mentions every required ctor param somewhere in its output";
+            // a recursive search still catches the bug of an encoder
+            // accidentally dropping a required attr (the key would be
+            // absent at every depth).
+            final allKeys = _collectAllKeys(result);
+            for (final param in member.params.where((p) => p.required)) {
+              // Convert camelCase param name -> snake_case schema key.
+              final schemaKey = _camelToSnake(param.name);
               expect(
-                result.values,
-                everyElement(isNot(isA<TfArg<dynamic>>())),
+                allKeys,
+                contains(schemaKey),
                 reason:
-                    'encoded values must be TfArg-unwrapped '
-                    '(.toTfJson() should have been called)',
+                    'required attr "$schemaKey" '
+                    '(camel: ${param.name}) must appear as a key somewhere '
+                    'in the encoded payload (top-level or nested under a '
+                    'discriminator block). Top-level keys observed: '
+                    '${result.keys.toList()}; all keys recursively: '
+                    '${allKeys.toList()}.',
               );
-            });
-          }
+            }
+            // No raw TfArg<T> may leak anywhere in the encoded payload —
+            // every TfArg must have been unwrapped via `.toTfJson()` at
+            // serialization time. Walk all values recursively, not just
+            // the top-level map's values: nested helper-class encoders
+            // could forget the unwrap deep in the tree.
+            final tfArgLeaks = _findTfArgLeaks(result);
+            expect(
+              tfArgLeaks,
+              isEmpty,
+              reason:
+                  'encoded values must be TfArg-unwrapped '
+                  '(.toTfJson() should have been called). Found raw '
+                  'TfArg instances at: $tfArgLeaks',
+            );
+          });
         }
       }
-    },
-    skip: 'Gate 6 lookup table not yet filled — see Plan 5.D PR 2 B-3-b',
-  );
+    }
+  });
 }
 
 String _camelToSnake(String camel) {
@@ -144,4 +306,54 @@ String _camelToSnake(String camel) {
     }
   }
   return buf.toString();
+}
+
+/// Returns every key encountered anywhere in [root], descending through
+/// nested Map and List values. Used by the required-attr assertion so a
+/// ctor param nested under a discriminator block (e.g.
+/// `{'gcs': [{'bucket': ...}]}`) is found at any depth.
+Set<String> _collectAllKeys(Object? root) {
+  final keys = <String>{};
+  void walk(Object? node) {
+    if (node is Map) {
+      for (final entry in node.entries) {
+        if (entry.key is String) keys.add(entry.key as String);
+        walk(entry.value);
+      }
+    } else if (node is List) {
+      for (final item in node) {
+        walk(item);
+      }
+    }
+  }
+
+  walk(root);
+  return keys;
+}
+
+/// Walks [root] recursively and returns a list of human-readable paths
+/// where a raw [TfArg] instance was found. The encoded payload must
+/// never contain a raw TfArg — every encoder should have unwrapped via
+/// `.toTfJson()` before returning. An empty result means the wrapper is
+/// clean.
+List<String> _findTfArgLeaks(Object? root) {
+  final leaks = <String>[];
+  void walk(Object? node, String path) {
+    if (node is TfArg) {
+      leaks.add('$path (runtimeType=${node.runtimeType})');
+      return;
+    }
+    if (node is Map) {
+      for (final entry in node.entries) {
+        walk(entry.value, '$path.${entry.key}');
+      }
+    } else if (node is List) {
+      for (var i = 0; i < node.length; i++) {
+        walk(node[i], '$path[$i]');
+      }
+    }
+  }
+
+  walk(root, r'$');
+  return leaks;
 }

--- a/packages/terradart_google/test/synth/encode_round_trip_test.dart
+++ b/packages/terradart_google/test/synth/encode_round_trip_test.dart
@@ -1,0 +1,147 @@
+// packages/terradart_google/test/synth/encode_round_trip_test.dart
+//
+// Gate 6: encode round-trip structural test (PR 2 of Plan 5.D codegen
+// correctness work — see docs/superpowers/plans/2026-05-16-plan5d-2-encode-gate6-plan.md).
+//
+// Discovers every sealed-class member declared in production yaml overrides
+// via [SealedClassExtractor], constructs a synthetic instance via the
+// hand-curated [_syntheticInstances] lookup table, invokes encode() (with
+// toArgMap() fallback), and asserts the encoded Map shape:
+//
+//   * the result is a non-empty Map<String, Object?>;
+//   * every required attr's snake_case schema key is present in the keys;
+//   * no raw TfArg<T> values leak into the encoded payload
+//     (.toTfJson() should have unwrapped them at serialization time).
+//
+// Component B-3-a (this commit) ships the FRAMEWORK only — the lookup table
+// is intentionally empty and the whole group is marked `skip:` so CI stays
+// green between B-3-a and B-3-b. Component B-3-b removes the skip and
+// fills the table in lockstep with the discovered members.
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:terradart_codegen/src/codegen/universal_invariants/sealed_class_extractor.dart';
+import 'package:terradart_core/terradart_core.dart';
+import 'package:test/test.dart';
+
+/// Hand-curated lookup: sealed-class-member-name -> a thunk that returns a
+/// constructed instance. Each thunk supplies synthetic `TfArg<T>` values for
+/// required params and omits all optional params.
+///
+/// Add an entry per new sealed-class member shipped in future waves. Gate 6
+/// fails loudly when a sealed-class is extracted from yaml but no entry
+/// exists here — keeping the table in lockstep with yaml is a curator
+/// responsibility.
+///
+/// Component B-3-a (this commit) ships the framework with an empty table —
+/// the per-test "Gate 6 lookup table missing entry" failures are expected
+/// and intentional. Component B-3-b fills the table in lockstep.
+final Map<String, Object Function()> _syntheticInstances = {
+  // Filled in by Component B-3-b — see plan 5.D PR 2 Task 10.
+};
+
+void main() {
+  group(
+    'Gate 6: encode round-trip structural',
+    () {
+      final yamlDir = Directory(
+        p.join(
+          '..',
+          'terradart_codegen',
+          'lib',
+          'src',
+          'codegen',
+          'wrapper_overrides',
+          'yaml',
+        ),
+      );
+      final yamlFiles =
+          yamlDir
+              .listSync()
+              .whereType<File>()
+              .where((f) => f.path.endsWith('.yaml'))
+              .toList()
+            ..sort((a, b) => a.path.compareTo(b.path));
+
+      for (final yamlFile in yamlFiles) {
+        final yamlSource = yamlFile.readAsStringSync();
+        if (!yamlSource.contains('sealed class')) continue;
+
+        final preludeStart = yamlSource.indexOf('prelude:');
+        if (preludeStart < 0) continue;
+        final preludeText = yamlSource.substring(preludeStart);
+        final sealedClasses = const SealedClassExtractor().extract(preludeText);
+
+        for (final sealed in sealedClasses) {
+          for (final member in sealed.members) {
+            test('${sealed.name}.${member.name}: encode() round-trips '
+                'with required keys present', () {
+              final thunk = _syntheticInstances[member.name];
+              expect(
+                thunk,
+                isNotNull,
+                reason:
+                    'Gate 6 lookup table missing entry for ${member.name}. '
+                    'Add a constructor thunk to _syntheticInstances in '
+                    'encode_round_trip_test.dart. See Plan 5.D PR 2 Task 10.',
+              );
+
+              final instance = thunk!();
+
+              // The wrapper may expose `encode()` (return Map) OR
+              // `toArgMap()` (return Map). Try encode() first via dynamic
+              // dispatch; fall back to toArgMap().
+              final dyn = instance as dynamic;
+              late Map<String, Object?> result;
+              try {
+                result = dyn.encode() as Map<String, Object?>;
+              } on NoSuchMethodError {
+                result = dyn.toArgMap() as Map<String, Object?>;
+              }
+
+              expect(result, isA<Map<String, Object?>>());
+              expect(
+                result,
+                isNotEmpty,
+                reason: 'encoded Map must not be empty',
+              );
+              for (final param in member.params.where((p) => p.required)) {
+                // Convert camelCase param name -> snake_case schema key.
+                final schemaKey = _camelToSnake(param.name);
+                expect(
+                  result.keys,
+                  contains(schemaKey),
+                  reason:
+                      'required attr "$schemaKey" '
+                      '(camel: ${param.name}) must be a key in encoded Map',
+                );
+              }
+              expect(
+                result.values,
+                everyElement(isNot(isA<TfArg<dynamic>>())),
+                reason:
+                    'encoded values must be TfArg-unwrapped '
+                    '(.toTfJson() should have been called)',
+              );
+            });
+          }
+        }
+      }
+    },
+    skip: 'Gate 6 lookup table not yet filled — see Plan 5.D PR 2 B-3-b',
+  );
+}
+
+String _camelToSnake(String camel) {
+  final buf = StringBuffer();
+  for (var i = 0; i < camel.length; i++) {
+    final ch = camel[i];
+    if (i > 0 && ch == ch.toUpperCase() && ch != ch.toLowerCase()) {
+      buf.write('_');
+      buf.write(ch.toLowerCase());
+    } else {
+      buf.write(ch);
+    }
+  }
+  return buf.toString();
+}


### PR DESCRIPTION
## Summary

Plan 5.D PR 2 of 4 — fixes a misleading skeleton in `exactly_one_of_emitter.dart` and adds Gate 6 (encode round-trip structural) as the missing safety net for sealed-class `encode()` bodies.

### Part A: encode signature fix

The skeleton previously emitted `String encode()` which mismatched **all 12 production sealed-class instances** (every shipped wrapper returns `Map<String, Object?>`). The new skeleton aligns with reality and stops misleading curators. Pattern hint also rewritten to show the actual Map-builder convention rather than the misleading HCL-string pattern.

### Part B: Gate 6 (encode round-trip structural)

New CI gate that, for every shipped sealed-class member, constructs a synthetic instance, calls `encode()` (or `toArgMap()` fallback), and asserts:
- Result is non-empty `Map<String, Object?>` (or single-element `List<Map<...>>` for `nesting_mode: list, max_items: 1`)
- Every required ctor param's snake_case schema key is present (recursively — discriminator-block wire formats nest required keys inside)
- No raw `TfArg<T>` values leak (`.toTfJson()` must have been called)
- No `UnimplementedError` thrown

Catches: forgotten attrs in encode bodies, type mismatches, raw `TfArg<T>` leaks, and any lingering `UnimplementedError` that Gate 4 misses because it lives in `prelude:` rather than shipped Dart.

**Implementation**: regex-based `SealedClassExtractor` walks every yaml override's `prelude:` to discover sealed classes and their members; hand-curated `_syntheticInstances` lookup table provides constructor thunks; recursive `_collectAllKeys` / `_findTfArgLeaks` walkers handle nested wire formats. 34 sealed-class members across 11 sealed classes from 9 yaml files all covered.

**Decision (locked at spec time)**: regex (not `package:analyzer`) — production preludes follow curator-disciplined patterns, and avoids widening the codegen dep graph. Migration to analyzer is a follow-up if Wave 5+ patterns break the regex.

### Wrapper gap fix

`BucketObjectContent` (in `google_storage_bucket_object.yaml`) was the only sealed class without an `encode()` method — the parent factory uses `blockKey + value` directly into argMap. Added `encode()` for Gate 6 dispatch parity; production behavior unchanged.

Plan: docs/superpowers/plans/2026-05-16-plan5d-2-encode-gate6-plan.md
Spec: docs/superpowers/specs/2026-05-16-plan5d-codegen-correctness-design.md

## Test plan

- [x] terradart_codegen: 282 tests pass + 5 skipped (was 277 on main; +5 from SealedClassExtractor + SyntheticInstanceBuilder)
- [x] terradart_google: 148 tests pass + 2 skipped (was 114 on main; +34 from new Gate 6)
- [x] Gate 6 covers all 34 sealed-class members across 11 sealed classes (Access x8, EnvVarSource x2, VolumeSource x5, SchedulerTarget x3, SourceConfig x2, UpdatePolicy x2, AppHostingBuildSource x2, BackupRecurrence x2, IndexFieldSpec x4, Replication x2, BucketObjectContent x2)
- [x] terradart wrap --check: all 98 files match
- [x] dart format --set-exit-if-changed .: 0 changed
- [x] dart analyze packages/ --fatal-infos --fatal-warnings: No issues found