### PR TITLE
feat(codegen): emit assert hints for min_items>=1 list slots (Plan 5.D PR 4)

### DIFF
--- a/packages/terradart_codegen/lib/src/codegen/wrap_promote/min_items_assert_emitter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrap_promote/min_items_assert_emitter.dart
@@ -1,0 +1,62 @@
+import '../../ir/nested_block.dart';
+import '../../ir/resource_def.dart';
+import '../naming.dart';
+
+/// Emits curator-facing comment hints suggesting `assert(<slot>.length >= N)`
+/// for every list-shaped nested block with `min_items >= 1 && max_items != 1`.
+///
+/// Output is comment-only — the curator must copy the suggested assert into
+/// the helper class they author in their yaml's `prelude:` block. The emitter
+/// cannot name the helper class itself because that's a curator-authored
+/// abstraction (e.g. `AppHostingTrafficTarget` vs. `TrafficSplitBundle` are
+/// both legitimate names for the same schema slot).
+///
+/// Scope per Plan 5.D-codegen PR 4:
+/// - `nested_block.nesting in {list, set}`
+/// - `nested_block.minItems != null && nested_block.minItems >= 1`
+/// - `nested_block.maxItems != 1` (max_items==1 is already encoded as a
+///   non-nullable `required SingleObj` parameter — an assert there is noise)
+///
+/// Scalar attribute constraints (`min_length`, `max_length`, `min`, `max`,
+/// `regex`) are NOT covered here — they are handled at the schemantic layer
+/// via `@StringField` and similar annotations.
+class MinItemsAssertEmitter {
+  const MinItemsAssertEmitter();
+
+  /// Returns a multi-line comment block of assert hints, or empty string when
+  /// the resource has no qualifying nested blocks. The result is intended to
+  /// be appended verbatim inside the wrap-promote marker section.
+  String emit(ResourceDef def) {
+    final hints = <String>[];
+    for (final nb in def.root.nestedBlocks) {
+      if (nb.nesting != NestingMode.list && nb.nesting != NestingMode.set) {
+        continue;
+      }
+      if (nb.minItems == null || nb.minItems! < 1) continue;
+      if (nb.maxItems == 1) continue;
+      hints.add(_hintFor(nb));
+    }
+    if (hints.isEmpty) return '';
+    final buf = StringBuffer()
+      ..writeln('# Assert hints (curator: integrate into helper class '
+          'constructors):')
+      ..writeln('# ');
+    for (final hint in hints) {
+      buf.write(hint);
+    }
+    return buf.toString();
+  }
+
+  String _hintFor(NestedBlockDef nb) {
+    final camel = snakeToCamel(nb.name);
+    final min = nb.minItems!;
+    final entries = min == 1 ? 'entry' : 'entries';
+    return '# class <HelperClassName> {\n'
+        '#   const <HelperClassName>({required this.$camel})\n'
+        '#     : assert($camel.length >= $min,\n'
+        "#             '<HelperClassName>.$camel must have at least $min $entries '\n"
+        "#             '(schema enforces min_items=$min)');\n"
+        '# }\n'
+        '# \n';
+  }
+}

--- a/packages/terradart_codegen/lib/src/codegen/wrap_promote/min_items_assert_emitter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrap_promote/min_items_assert_emitter.dart
@@ -16,6 +16,10 @@ import '../naming.dart';
 /// - `nested_block.minItems != null && nested_block.minItems >= 1`
 /// - `nested_block.maxItems != 1` (max_items==1 is already encoded as a
 ///   non-nullable `required SingleObj` parameter — an assert there is noise)
+/// - **Top-level `def.root.nestedBlocks` only — recursion is deliberately
+///   omitted.** Wave 4 helpers `AppHostingTrafficTarget.splits` (depth 1)
+///   and `IndexFieldTextSpec.indexSpecs` (depth 3) are NOT covered by this
+///   emitter; deeper walking is future scope. See PR 4 body for rationale.
 ///
 /// Scalar attribute constraints (`min_length`, `max_length`, `min`, `max`,
 /// `regex`) are NOT covered here — they are handled at the schemantic layer

--- a/packages/terradart_codegen/lib/src/codegen/wrap_promote/wrap_promote_generator.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrap_promote/wrap_promote_generator.dart
@@ -2,6 +2,7 @@ import '../../ir/resource_def.dart';
 import '../../parser/mm_yaml_parser.dart';
 import '../wrap_init/clock.dart';
 import 'exactly_one_of_emitter.dart';
+import 'min_items_assert_emitter.dart';
 import 'prose_enum_extractor.dart';
 import 'valid_values_emitter.dart';
 import 'wrap_promote_marker.dart';
@@ -88,6 +89,16 @@ class WrapPromoteGenerator {
       for (final entry in dartTypeOverrideEntries) {
         body.writeln(entry);
       }
+      body.writeln();
+    }
+
+    // 3. min_items >= 1 list-shape nested blocks → assert hints.
+    //    Curator-facing scaffold only — copies into hand-authored helper
+    //    class. See `min_items_assert_emitter.dart` for scope rules.
+    const minItemsEmitter = MinItemsAssertEmitter();
+    final assertHints = minItemsEmitter.emit(def);
+    if (assertHints.isNotEmpty) {
+      body.write(assertHints);
       body.writeln();
     }
 

--- a/packages/terradart_codegen/test/codegen/wrap_promote/min_items_assert_emitter_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrap_promote/min_items_assert_emitter_test.dart
@@ -1,0 +1,132 @@
+import 'package:terradart_codegen/src/codegen/wrap_promote/min_items_assert_emitter.dart';
+import 'package:terradart_codegen/src/ir/constraints.dart';
+import 'package:terradart_codegen/src/ir/nested_block.dart';
+import 'package:terradart_codegen/src/ir/resource_def.dart';
+import 'package:test/test.dart';
+
+ResourceDef _resourceWith(List<NestedBlockDef> nested) => ResourceDef(
+      terraformType: 'google_synthetic',
+      description: null,
+      deprecationMessage: null,
+      root: BlockDef(
+        attributes: const [],
+        nestedBlocks: nested,
+        description: null,
+      ),
+    );
+
+NestedBlockDef _nb({
+  required String name,
+  required NestingMode nesting,
+  int? minItems,
+  int? maxItems,
+}) =>
+    NestedBlockDef(
+      name: name,
+      nesting: nesting,
+      minItems: minItems,
+      maxItems: maxItems,
+      block: const BlockDef(),
+      constraints: const Constraints(),
+    );
+
+void main() {
+  group('MinItemsAssertEmitter', () {
+    test(
+        'emits an assert hint for list nested block with min_items >= 1 '
+        'and max_items != 1', () {
+      final def = _resourceWith([
+        _nb(
+          name: 'splits',
+          nesting: NestingMode.list,
+          minItems: 1,
+          maxItems: null,
+        ),
+      ]);
+
+      final output = const MinItemsAssertEmitter().emit(def);
+
+      expect(output, contains('Assert hints'));
+      expect(output, contains('splits.length >= 1'));
+      expect(output, contains('min_items=1'));
+      expect(output, startsWith('# '),
+          reason: 'output is a curator-facing comment block');
+    });
+
+    test('emits nothing when nested block is single-shaped (max_items == 1)',
+        () {
+      final def = _resourceWith([
+        _nb(
+          name: 'target',
+          nesting: NestingMode.list,
+          minItems: 1,
+          maxItems: 1,
+        ),
+      ]);
+
+      final output = const MinItemsAssertEmitter().emit(def);
+
+      expect(output, isEmpty);
+    });
+
+    test('emits nothing when nested block lacks min_items', () {
+      final def = _resourceWith([
+        _nb(
+          name: 'conditions',
+          nesting: NestingMode.list,
+          minItems: null,
+          maxItems: null,
+        ),
+      ]);
+
+      final output = const MinItemsAssertEmitter().emit(def);
+
+      expect(output, isEmpty);
+    });
+
+    test('emits nothing when nesting is single (not list/set)', () {
+      final def = _resourceWith([
+        _nb(
+          name: 'config',
+          nesting: NestingMode.single,
+          minItems: 1,
+          maxItems: 1,
+        ),
+      ]);
+
+      final output = const MinItemsAssertEmitter().emit(def);
+
+      expect(output, isEmpty);
+    });
+
+    test('emits a hint per qualifying list nested block in a single resource',
+        () {
+      final def = _resourceWith([
+        _nb(
+          name: 'splits',
+          nesting: NestingMode.list,
+          minItems: 1,
+        ),
+        _nb(
+          name: 'target_name_servers',
+          nesting: NestingMode.set,
+          minItems: 1,
+        ),
+        _nb(
+          name: 'config',
+          nesting: NestingMode.single,
+          minItems: 1,
+          maxItems: 1,
+        ),
+      ]);
+
+      final output = const MinItemsAssertEmitter().emit(def);
+
+      expect(output, contains('splits.length >= 1'));
+      expect(output, contains('targetNameServers.length >= 1'),
+          reason: 'snake_case is converted to camelCase for Dart identifier');
+      expect(output, isNot(contains('config.length')),
+          reason: 'single-shaped nested block must be excluded');
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/wrap_promote/wrap_promote_generator_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrap_promote/wrap_promote_generator_test.dart
@@ -3,6 +3,9 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:terradart_codegen/src/codegen/wrap_init/clock.dart';
 import 'package:terradart_codegen/src/codegen/wrap_promote/wrap_promote_generator.dart';
+import 'package:terradart_codegen/src/ir/constraints.dart';
+import 'package:terradart_codegen/src/ir/nested_block.dart';
+import 'package:terradart_codegen/src/ir/resource_def.dart';
 import 'package:terradart_codegen/src/parser/mm_yaml_parser.dart';
 import 'package:terradart_codegen/src/parser/schema_parser.dart';
 import 'package:test/test.dart';
@@ -68,6 +71,84 @@ void main() {
         'google_pubsub_subscription.wrap_promote.expected.yaml.golden',
       )).readAsStringSync();
       expect(yaml, equals(golden));
+    });
+  });
+
+  group('WrapPromoteGenerator min_items assert hints (Plan 5.D PR 4)', () {
+    test(
+        'includes assert hints in marker block when qualifying nested '
+        'block is present', () {
+      // Synthetic ResourceDef with one list-shaped nested block that
+      // qualifies (min_items=1, no max_items).
+      const def = ResourceDef(
+        terraformType: 'google_synthetic',
+        description: null,
+        deprecationMessage: null,
+        root: BlockDef(
+          attributes: [],
+          nestedBlocks: [
+            NestedBlockDef(
+              name: 'splits',
+              nesting: NestingMode.list,
+              minItems: 1,
+              block: BlockDef(),
+              constraints: Constraints(),
+            ),
+          ],
+          description: null,
+        ),
+      );
+      final mm = const MmYamlParser().parseString('description: synthetic\n');
+      final generator = WrapPromoteGenerator(
+        clock: FixedClock(DateTime.parse('2026-05-17T00:00:00.000Z')),
+      );
+
+      final output = generator.generate(
+        terraformType: 'google_synthetic',
+        def: def,
+        mm: mm,
+      );
+
+      expect(output, contains('# === wrap-promote additions'));
+      expect(output, contains('# Assert hints'));
+      expect(output, contains('splits.length >= 1'));
+      expect(output, contains('# === end wrap-promote additions ==='));
+    });
+
+    test('emits empty string when no qualifying nested block exists', () {
+      // single-shaped nested block (max_items==1) does NOT qualify.
+      const def = ResourceDef(
+        terraformType: 'google_synthetic',
+        description: null,
+        deprecationMessage: null,
+        root: BlockDef(
+          attributes: [],
+          nestedBlocks: [
+            NestedBlockDef(
+              name: 'config',
+              nesting: NestingMode.single,
+              minItems: 1,
+              maxItems: 1,
+              block: BlockDef(),
+              constraints: Constraints(),
+            ),
+          ],
+          description: null,
+        ),
+      );
+      final mm = const MmYamlParser().parseString('description: synthetic\n');
+      final generator = WrapPromoteGenerator(
+        clock: FixedClock(DateTime.parse('2026-05-17T00:00:00.000Z')),
+      );
+
+      final output = generator.generate(
+        terraformType: 'google_synthetic',
+        def: def,
+        mm: mm,
+      );
+
+      // No qualifying nested block + no exactly_one_of + no enums ⇒ empty.
+      expect(output, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary

Plan 5.D PR 4 of 4 (final) — adds a `MinItemsAssertEmitter` that emits curator-facing `assert(<slot>.length >= N)` hints into the wrap-promote marker block for list-shape nested blocks with `min_items >= 1 && max_items != 1`. Curator copies the snippet into their hand-authored helper class on next regen.

### Scope (top-level only — deliberate)

The emitter walks `def.root.nestedBlocks` only; recursion is intentionally omitted. The two Wave 4 curator-hand-written asserts referenced in the original plan (`AppHostingTrafficTarget.splits` at depth 1, `IndexFieldTextSpec.indexSpecs` at depth 3) are NOT covered by this emitter. Deeper walking is future scope (Plan 5.X candidate); see the in-code docstring for rationale. The emitter does fire on top-level qualifying nested blocks (e.g. `firestore_index.fields.length >= 1`).

### Filters

- `nested_block.nesting in {list, set}`
- `nested_block.minItems != null && minItems >= 1`
- `nested_block.maxItems != 1` (max_items==1 already encoded as `required SingleObj`)
- Scalar attribute constraints (`min_length` / `max_length` / `min` / `max` / `regex`) are NOT covered — they belong at the schemantic layer via `@StringField` annotations.

### Output (curator-facing comment in the marker block)

```
# Assert hints (curator: integrate into helper class constructors):
# 
# class <HelperClassName> {
#   const <HelperClassName>({required this.splits})
#     : assert(splits.length >= 1,
#             '<HelperClassName>.splits must have at least 1 entry '
#             '(schema enforces min_items=1)');
# }
```

Curator replaces `<HelperClassName>` with the actual helper-class name they author in `prelude:`.

### No retroactive edits

Existing 49 yaml overrides are NOT modified. The marker block is curator-pull (regenerated on demand), not codegen-push.

Plan: docs/superpowers/plans/2026-05-16-plan5d-4-assert-hints-plan.md
Spec: docs/superpowers/specs/2026-05-16-plan5d-codegen-correctness-design.md (PR 4 details)

## Test plan

- [x] 5 unit tests (qualifying / max_items=1 excluded / no-min_items excluded / single nesting excluded / mixed multiple)
- [x] 2 generator-integration tests (marker block contains assert hint section; non-qualifying produces empty)
- [x] All wrap-promote tests: 34/34 PASS (existing goldens unchanged — fixtures have no qualifying nested blocks)
- [x] Full terradart_codegen suite: 289 PASS + 5 skip
- [x] Full terradart_google suite: 148 PASS + 2 skip (Gate 6 stays green)
- [x] terradart wrap --check: all 98 files match (no shipped Dart drift)
- [x] dart format --set-exit-if-changed .: 0 changed (405 files)
- [x] dart analyze packages/ --fatal-infos --fatal-warnings: No issues found