### PR TITLE
chore: bump packages to 0.4.0-dev

### DIFF
--- a/packages/terradart_annotations/CHANGELOG.md
+++ b/packages/terradart_annotations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0-dev - 2026-05-17
+
+No user-facing API changes. Workspace consistency bump alongside `terradart_codegen` 0.4.0-dev (Plan 5.D: codegen correctness improvements).
+
 ## 0.3.0-dev - 2026-05-16
 
 No user-facing API changes. Workspace consistency bump alongside `terradart_google` 0.3.0-dev (Wave 4).

--- a/packages/terradart_annotations/pubspec.yaml
+++ b/packages/terradart_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_annotations
 description: Annotation surface consumed by terradart_codegen-generated abstract resource classes (@TerraformResource, @ForceNew, @Sensitive).
-version: 0.3.0-dev
+version: 0.4.0-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.4.0-dev - 2026-05-17
+
+Plan 5.D — codegen correctness improvements (4 PRs).
+
+### Added
+
+- **Gate 6: sealed-class `encode()` round-trip (structural)** — new universal QA gate (joining the existing 5 from Plan 5.A) that, for every shipped sealed-class member, constructs a synthetic instance, calls `encode()` (or `toArgMap()` fallback), and asserts the result is a non-empty `Map<String, Object?>` (or single-element `List<Map<...>>` for `nesting_mode: list, max_items: 1`), every required ctor param's snake_case schema key is present (recursively — discriminator-block wire formats nest required keys inside), no raw `TfArg<T>` values leak, and no `UnimplementedError` is thrown. Currently covers 34 sealed-class members across 11 sealed classes.
+- `SealedClassExtractor` + `SyntheticInstanceBuilder` modules under `lib/src/codegen/universal_invariants/` — building blocks for Gate 6 (regex-based prelude parsing).
+- `MinItemsAssertEmitter` — wrap-promote now emits curator-facing commented `assert(list.length >= N)` hint snippets for top-level list-shape nested blocks with `min_items >= 1 && max_items != 1`. Curator copies the snippet into their helper-class constructor on next regen. Scalar attribute constraints (`min_length` / `max_length` / `min` / `max` / `regex`) stay at the schemantic layer.
+- `tool/measure_param_order.dart` — standalone measurement script that quantifies how well a candidate paramOrder heuristic predicts the curator-curated orders across the 49-yaml corpus. Output (gitignored, regenerable) drives a Wave 5-close decision matrix on whether to ship the heuristic.
+
+### Fixed
+
+- `MmYamlParser` now reads `deprecation_message:` from MM YAML field overrides into `Constraints.deprecationMessage`. `IrMerger._mergeAttr` propagates the field with the MM-wins precedence used for `regex` / `minLength` / etc. Closes a Plan 4.2-era dead-code path in `wrap_init_generator._buildDeprecatedParamsAxis` that read a perpetually-null field. Skeleton emission of `deprecatedParams:` (the now-populated downstream consumer) stays deferred to Plan 5.E (Renovate-driven schema-bump automation).
+- `exactly_one_of_emitter.dart` skeleton: replaced misleading `String encode()` signature with `Map<String, Object?> encode()`. The previous shape mismatched all 12 production sealed-class instances and pointed curators at the wrong wire format.
+
 ## 0.3.0-dev - 2026-05-16
 
 No user-facing CLI changes. WrapperOverride YAML registry expands from 30 to **49 resources** (Wave 4 additions: see `terradart_google` 0.3.0-dev for the resource list). Plan 5.A's 5 universal QA gates continue to hold over the expanded registry. Workspace consistency bump alongside `terradart_google` 0.3.0-dev.

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart Stage 1 codegen — parses Terraform provider schema JSON and Magic Modules YAML and emits annotated abstract Dart classes. Ships the terradart CLI.
-version: 0.3.0-dev
+version: 0.4.0-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -28,7 +28,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.3.0-dev
+  terradart_core: ^0.4.0-dev
 
 dev_dependencies:
   test: ^1.25.6

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0-dev - 2026-05-17
+
+No user-facing API changes. Workspace consistency bump alongside `terradart_codegen` 0.4.0-dev (Plan 5.D: codegen correctness improvements — MM YAML deprecation parsing fix, encode skeleton fix + Gate 6, paramOrder measurement tool, min_items assert hints).
+
 ## 0.3.0-dev - 2026-05-16
 
 No user-facing API changes. Workspace consistency bump alongside `terradart_google` 0.3.0-dev (Wave 4: 21 new GA resources across 6 Firebase / Cloud Functions / Firestore services).

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.3.0-dev
+version: 0.4.0-dev
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.0-dev - 2026-05-17
+
+### Added
+
+- `BucketObjectContent` sealed class (in `storage/google_storage_bucket_object.dart`) now exposes an `encode()` method for parity with other sealed-class encoders. No production behavior change — the parent factory still wires `blockKey + value` directly into the argMap.
+- Gate 6 (`test/synth/encode_round_trip_test.dart`) — 34 sealed-class members across 11 sealed classes now exercise encode round-trip structural assertions (see `terradart_codegen` 0.4.0-dev for the gate's contract).
+
 ## 0.3.0-dev - 2026-05-16
 
 Wave 4: adds 21 new GA resources across 6 Firebase / Cloud Functions / Firestore services. terradart_google now 49 resources, 22 per-service barrels.

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: terradart curated GCP factory wrappers — 28 google_* resources + 1 data source (compute, BigQuery, KMS, Cloud Storage, DNS, Cloud Run v2, Logging, Monitoring, Pub/Sub, Cloud Tasks, Secret Manager, Cloud Scheduler, IAM) for Dart-first Terraform stacks.
-version: 0.3.0-dev
+version: 0.4.0-dev
 publish_to: none  # Removed by tool/prepare_publish.sh before dart pub publish.
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart


### PR DESCRIPTION
## Summary

Plan 5.D (codegen correctness improvements) release. Bumps all 4 packages 0.3.0-dev -> 0.4.0-dev, and `terradart_codegen`'s `terradart_core` caret constraint `^0.3.0-dev` -> `^0.4.0-dev` in lockstep (per the standing inter-package caret rule that workspace `pub get` hides but per-package CI `pub get` surfaces).

### User-facing additions

- **terradart_codegen 0.4.0-dev**: Gate 6 (sealed-class encode round-trip structural), MinItemsAssertEmitter wrap-promote hints, MmYamlParser deprecation_message parsing fix, exactly_one_of_emitter skeleton signature fix, and the `tool/measure_param_order.dart` measurement script.
- **terradart_google 0.4.0-dev**: BucketObjectContent.encode() (parity, no behavior change), Gate 6 test coverage across 34 sealed-class members.
- **terradart_core 0.4.0-dev** / **terradart_annotations 0.4.0-dev**: no API change; workspace consistency bump.

### Plan 5.D PRs in this release

| PR | Title |
|---|---|
| #36 | fix(codegen): populate deprecation_message in MM YAML parser |
| #37 | feat(codegen): fix encode() skeleton + add Gate 6 encode round-trip |
| #38 | tool: add paramOrder heuristic measurement script |
| #39 | feat(codegen): emit assert hints for min_items>=1 list slots |

## Test plan

- [x] terradart_codegen full suite: 289 PASS + 5 skip
- [x] terradart_google full suite: 148 PASS + 2 skip (Gates 1-6 all green)
- [x] terradart wrap --check: all 98 files match (no shipped Dart drift)
- [x] dart format --set-exit-if-changed .: 0 changed (405 files)
- [x] dart analyze packages/ --fatal-infos --fatal-warnings: No issues found

## Post-merge

User manually tags `v0.4.0-dev` via GitHub Releases UI -> publish workflow (3-phase serial pipeline per PR #30: no-deps matrix -> 180s -> codegen -> 180s -> google) runs end-to-end. After publish, Wave 5 (IAM completion + Cloud SQL) can begin.