### PR TITLE
ci(publish): bump pub.dev propagation wait from 3min to 5min

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,8 +67,8 @@ jobs:
     steps:
       - name: Wait for pub.dev index propagation
         run: |
-          echo "Waiting 3 minutes for pub.dev to index terradart_core before publishing terradart_codegen..."
-          sleep 180
+          echo "Waiting 5 minutes for pub.dev to index terradart_core before publishing terradart_codegen..."
+          sleep 300
 
       - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1
@@ -95,8 +95,8 @@ jobs:
     steps:
       - name: Wait for pub.dev index propagation
         run: |
-          echo "Waiting 3 minutes for pub.dev to index terradart_codegen + terradart_core before publishing terradart_google..."
-          sleep 180
+          echo "Waiting 5 minutes for pub.dev to index terradart_codegen + terradart_core before publishing terradart_google..."
+          sleep 300
 
       - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
## Why

The Wave 5 publish (`v0.6.0-dev`) failed at the `publish terradart_codegen` job with:

```
Because terradart_codegen depends on terradart_core ^0.6.0-dev
which doesn't match any versions, version solving failed.

You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on terradart_core: dart pub add terradart_core:^0.5.0-dev
```

`terradart_core@0.6.0-dev` had been published seconds earlier, but pub.dev's index hadn't propagated by the time the 3-minute wait elapsed. `terradart_google` was then skipped because of the upstream failure, leaving v0.6.0-dev only partially published (core only).

The failed jobs were rerun manually, but the underlying timing fragility remains.

## Change

Both inter-package waits (`core → codegen` and `codegen → google`) bumped from `sleep 180` → `sleep 300`. Pipeline time increases by ~4 min total.

## Context on prior attempts

- `52ff67b` tried 10 min, `b0bdcb3` reverted it (presumably because +14 min of pipeline time was judged too long for the typical case).
- **5 min is the middle ground**: covers the vast majority of pub.dev propagation cases while keeping the pipeline reasonable.

## If 5 min still proves insufficient

Replace the simple sleep with a polling loop that queries pub.dev's API for the just-published version's availability and proceeds as soon as it resolves:
- Typical resolution: tens of seconds
- Worst observed (this incident): a few minutes (exact figure unknown — anywhere between 3 min and the rerun retry was successful)

Polling would make pipeline time bounded by actual propagation, not a worst-case constant.

## Test plan

- [x] sed-only change to `.github/workflows/publish.yml` (4 lines), no logic / no Dart code touched
- [x] Local verification: `grep -nE "sleep|Waiting" .github/workflows/publish.yml` shows both waits now `sleep 300` with "Waiting 5 minutes" labels
- [x] CI confirms no syntax regression on the PR run (lints workflow yaml)
- [x] Real-world validation: applies on the next release tag (the current Wave 5 v0.6.0-dev publish is being recovered via manual `gh run rerun`)