### PR TITLE
Plan 5.G — Wave 6 Batch 0: seed mm_yaml_sources for LB stack

### DIFF
--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_autoscaler.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_autoscaler.yaml
@@ -1,0 +1,435 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'Autoscaler'
+api_variant_patterns:
+  - 'projects/{project}/zones/{zone}/autoscalers/{autoscaler}'
+kind: 'compute#autoscaler'
+description: |
+  Represents an Autoscaler resource.
+
+  Autoscalers allow you to automatically scale virtual machine instances in
+  managed instance groups according to an autoscaling policy that you
+  define.
+references:
+  guides:
+    'Autoscaling Groups of Instances': 'https://cloud.google.com/compute/docs/autoscaler/'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/autoscalers'
+docs:
+base_url: 'projects/{{project}}/zones/{{zone}}/autoscalers'
+has_self_link: true
+update_url: 'projects/{{project}}/zones/{{zone}}/autoscalers?autoscaler={{name}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+custom_code:
+sweeper:
+  url_substitutions:
+    - zone: "us-central1-a"
+    - zone: "us-central1-f"
+examples:
+  - name: 'autoscaler_single_instance'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      autoscaler_name: 'my-autoscaler'
+      instance_template_name: 'my-instance-template'
+      target_pool_name: 'my-target-pool'
+      igm_name: 'my-igm'
+        # Add test_vars_overrides and oics_vars_overrides to fix the failing test,
+        # which is caused by upgradting terraform-plugin-sdk to 2.24.0.
+      provider_name: 'google-beta'
+      provider_alias: ''
+    test_vars_overrides:
+      'provider_name': '"google-beta.us-central1"'
+      'provider_alias': '"alias  = \"us-central1\""'
+    oics_vars_overrides:
+      'provider_name': 'google-beta'
+      'provider_alias': ''
+  - name: 'autoscaler_basic'
+    primary_resource_id: 'foobar'
+    vars:
+      autoscaler_name: 'my-autoscaler'
+      instance_template_name: 'my-instance-template'
+      target_pool_name: 'my-target-pool'
+      igm_name: 'my-igm'
+parameters:
+  - name: 'zone'
+    type: ResourceRef
+    description: |
+      URL of the zone where the instance group resides.
+    required: false
+    immutable: true
+    ignore_read: true
+    default_from_api: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Zone'
+    imports: 'name'
+properties:
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. The name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    required: true
+    immutable: true
+    validation:
+      function: 'verify.ValidateGCEName'
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource.
+  - name: 'autoscalingPolicy'
+    type: NestedObject
+    description: |
+      The configuration parameters for the autoscaling algorithm. You can
+      define one or more of the policies for an autoscaler: cpuUtilization,
+      customMetricUtilizations, and loadBalancingUtilization.
+
+      If none of these are specified, the default will be to autoscale based
+      on cpuUtilization to 0.6 or 60%.
+    required: true
+    properties:
+      - name: 'minReplicas'
+        type: Integer
+        description: |
+          The minimum number of replicas that the autoscaler can scale down
+          to. This cannot be less than 0. If not provided, autoscaler will
+          choose a default value depending on maximum number of instances
+          allowed.
+        api_name: minNumReplicas
+        required: true
+        send_empty_value: true
+      - name: 'maxReplicas'
+        type: Integer
+        description: |
+          The maximum number of instances that the autoscaler can scale up
+          to. This is required when creating or updating an autoscaler. The
+          maximum number of replicas should not be lower than minimal number
+          of replicas.
+        api_name: maxNumReplicas
+        required: true
+        send_empty_value: true
+      - name: 'cooldownPeriod'
+        type: Integer
+        description: |
+          The number of seconds that the autoscaler should wait before it
+          starts collecting information from a new instance. This prevents
+          the autoscaler from collecting information when the instance is
+          initializing, during which the collected usage would not be
+          reliable. The default time autoscaler waits is 60 seconds.
+
+          Virtual machine initialization times might vary because of
+          numerous factors. We recommend that you test how long an
+          instance may take to initialize. To do this, create an instance
+          and time the startup process.
+        api_name: coolDownPeriodSec
+        default_value: 60
+      - name: 'stabilizationPeriod'
+        type: Integer
+        description: |
+          The number of seconds that the autoscaler waits for load stabilization
+          before making scale-in decisions.
+
+          This might appear as a delay in scaling in but it is an important mechanism
+          for your application to not have fluctuating size due to short term load
+          fluctuations.
+        api_name: stabilizationPeriodSec
+      - name: 'mode'
+        type: String
+        description: |
+          Defines operating mode for this policy.
+        default_value: "ON"
+      - name: 'scaleDownControl'
+        type: NestedObject
+        description: |
+          Defines scale down controls to reduce the risk of response latency
+          and outages due to abrupt scale-in events
+        min_version: 'beta'
+        required: false
+        default_from_api: true
+        properties:
+          - name: 'maxScaledDownReplicas'
+            type: NestedObject
+            at_least_one_of:
+              - 'autoscaling_policy.0.scale_down_control.0.max_scaled_down_replicas'
+              - 'autoscaling_policy.0.scale_down_control.0.time_window_sec'
+            properties:
+              - name: 'fixed'
+                type: Integer
+                description: |
+                  Specifies a fixed number of VM instances. This must be a positive
+                  integer.
+                at_least_one_of:
+                  - 'autoscaling_policy.0.scale_down_control.0.max_scaled_down_replicas.0.fixed'
+                  - 'autoscaling_policy.0.scale_down_control.0.max_scaled_down_replicas.0.percent'
+              - name: 'percent'
+                type: Integer
+                description: |
+                  Specifies a percentage of instances between 0 to 100%, inclusive.
+                  For example, specify 80 for 80%.
+                at_least_one_of:
+                  - 'autoscaling_policy.0.scale_down_control.0.max_scaled_down_replicas.0.fixed'
+                  - 'autoscaling_policy.0.scale_down_control.0.max_scaled_down_replicas.0.percent'
+          - name: 'timeWindowSec'
+            type: Integer
+            description: |
+              How long back autoscaling should look when computing recommendations
+              to include directives regarding slower scale down, as described above.
+            at_least_one_of:
+              - 'autoscaling_policy.0.scale_down_control.0.max_scaled_down_replicas'
+              - 'autoscaling_policy.0.scale_down_control.0.time_window_sec'
+      - name: 'scaleInControl'
+        type: NestedObject
+        description: |
+          Defines scale in controls to reduce the risk of response latency
+          and outages due to abrupt scale-in events
+        properties:
+          - name: 'maxScaledInReplicas'
+            type: NestedObject
+            at_least_one_of:
+              - 'autoscaling_policy.0.scale_in_control.0.max_scaled_in_replicas'
+              - 'autoscaling_policy.0.scale_in_control.0.time_window_sec'
+            properties:
+              - name: 'fixed'
+                type: Integer
+                description: |
+                  Specifies a fixed number of VM instances. This must be a positive
+                  integer.
+                at_least_one_of:
+                  - 'autoscaling_policy.0.scale_in_control.0.max_scaled_in_replicas.0.fixed'
+                  - 'autoscaling_policy.0.scale_in_control.0.max_scaled_in_replicas.0.percent'
+              - name: 'percent'
+                type: Integer
+                description: |
+                  Specifies a percentage of instances between 0 to 100%, inclusive.
+                  For example, specify 80 for 80%.
+                at_least_one_of:
+                  - 'autoscaling_policy.0.scale_in_control.0.max_scaled_in_replicas.0.fixed'
+                  - 'autoscaling_policy.0.scale_in_control.0.max_scaled_in_replicas.0.percent'
+          - name: 'timeWindowSec'
+            type: Integer
+            description: |
+              How long back autoscaling should look when computing recommendations
+              to include directives regarding slower scale down, as described above.
+            at_least_one_of:
+              - 'autoscaling_policy.0.scale_in_control.0.max_scaled_in_replicas'
+              - 'autoscaling_policy.0.scale_in_control.0.time_window_sec'
+      - name: 'cpuUtilization'
+        type: NestedObject
+        description: |
+          Defines the CPU utilization policy that allows the autoscaler to
+          scale based on the average CPU utilization of a managed instance
+          group.
+        default_from_api: true
+        properties:
+          - name: 'target'
+            type: Double
+            description: |
+              The target CPU utilization that the autoscaler should maintain.
+              Must be a float value in the range (0, 1]. If not specified, the
+              default is 0.6.
+
+              If the CPU level is below the target utilization, the autoscaler
+              scales down the number of instances until it reaches the minimum
+              number of instances you specified or until the average CPU of
+              your instances reaches the target utilization.
+
+              If the average CPU is above the target utilization, the autoscaler
+              scales up until it reaches the maximum number of instances you
+              specified or until the average utilization reaches the target
+              utilization.
+            api_name: utilizationTarget
+            required: true
+          - name: 'predictiveMethod'
+            type: String
+            description: |
+              Indicates whether predictive autoscaling based on CPU metric is enabled. Valid values are:
+
+              - NONE (default). No predictive method is used. The autoscaler scales the group to meet current demand based on real-time metrics.
+
+              - OPTIMIZE_AVAILABILITY. Predictive autoscaling improves availability by monitoring daily and weekly load patterns and scaling out ahead of anticipated demand.
+            custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.tmpl'
+            default_value: "NONE"
+      - name: 'metric'
+        type: Array
+        description: |
+          Configuration parameters of autoscaling based on a custom metric.
+        api_name: customMetricUtilizations
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'name'
+              type: String
+              description: |
+                The identifier (type) of the Stackdriver Monitoring metric.
+                The metric cannot have negative values.
+
+                The metric must have a value type of INT64 or DOUBLE.
+              api_name: metric
+              required: true
+            - name: 'singleInstanceAssignment'
+              type: Double
+              description: |
+                If scaling is based on a per-group metric value that represents the
+                total amount of work to be done or resource usage, set this value to
+                an amount assigned for a single instance of the scaled group.
+                The autoscaler will keep the number of instances proportional to the
+                value of this metric, the metric itself should not change value due
+                to group resizing.
+
+                For example, a good metric to use with the target is
+                `pubsub.googleapis.com/subscription/num_undelivered_messages`
+                or a custom metric exporting the total number of requests coming to
+                your instances.
+
+                A bad example would be a metric exporting an average or median
+                latency, since this value can't include a chunk assignable to a
+                single instance, it could be better used with utilization_target
+                instead.
+            - name: 'target'
+              type: Double
+              description: |
+                The target value of the metric that autoscaler should
+                maintain. This must be a positive value. A utilization
+                metric scales number of virtual machines handling requests
+                to increase or decrease proportionally to the metric.
+
+                For example, a good metric to use as a utilizationTarget is
+                www.googleapis.com/compute/instance/network/received_bytes_count.
+                The autoscaler will work to keep this value constant for each
+                of the instances.
+              api_name: utilizationTarget
+            - name: 'type'
+              type: Enum
+              description: |
+                Defines how target utilization value is expressed for a
+                Stackdriver Monitoring metric.
+              api_name: utilizationTargetType
+              enum_values:
+                - 'GAUGE'
+                - 'DELTA_PER_SECOND'
+                - 'DELTA_PER_MINUTE'
+            - name: 'filter'
+              type: String
+              description: |
+                A filter string to be used as the filter string for
+                a Stackdriver Monitoring TimeSeries.list API call.
+                This filter is used to select a specific TimeSeries for
+                the purpose of autoscaling and to determine whether the metric
+                is exporting per-instance or per-group data.
+
+                You can only use the AND operator for joining selectors.
+                You can only use direct equality comparison operator (=) without
+                any functions for each selector.
+                You can specify the metric in both the filter string and in the
+                metric field. However, if specified in both places, the metric must
+                be identical.
+
+                The monitored resource type determines what kind of values are
+                expected for the metric. If it is a gce_instance, the autoscaler
+                expects the metric to include a separate TimeSeries for each
+                instance in a group. In such a case, you cannot filter on resource
+                labels.
+
+                If the resource type is any other value, the autoscaler expects
+                this metric to contain values that apply to the entire autoscaled
+                instance group and resource label filtering can be performed to
+                point autoscaler at the correct TimeSeries to scale upon.
+                This is called a per-group metric for the purpose of autoscaling.
+
+                If not specified, the type defaults to gce_instance.
+
+                You should provide a filter that is selective enough to pick just
+                one TimeSeries for the autoscaled group or for each of the instances
+                (if you are using gce_instance resource type). If multiple
+                TimeSeries are returned upon the query execution, the autoscaler
+                will sum their respective values to obtain its scaling value.
+              default_value: "resource.type = gce_instance"
+      - name: 'loadBalancingUtilization'
+        type: NestedObject
+        description: |
+          Configuration parameters of autoscaling based on a load balancer.
+        properties:
+          - name: 'target'
+            type: Double
+            description: |
+              Fraction of backend capacity utilization (set in HTTP(s) load
+              balancing configuration) that autoscaler should maintain. Must
+              be a positive float value. If not defined, the default is 0.8.
+            api_name: utilizationTarget
+            required: true
+      - name: 'scalingSchedules'
+        type: Map
+        description: |
+          Scaling schedules defined for an autoscaler. Multiple schedules can be set on an autoscaler and they can overlap.
+        key_name: 'name'
+        value_type:
+          type: NestedObject
+          properties:
+            - name: 'minRequiredReplicas'
+              type: Integer
+              description: |
+                Minimum number of VM instances that autoscaler will recommend in time intervals starting according to schedule.
+              required: true
+              send_empty_value: true
+            - name: 'schedule'
+              type: String
+              description: |
+                The start timestamps of time intervals when this scaling schedule should provide a scaling signal. This field uses the extended cron format (with an optional year field).
+              required: true
+            - name: 'timeZone'
+              type: String
+              description: |
+                The time zone to be used when interpreting the schedule. The value of this field must be a time zone name from the tz database: http://en.wikipedia.org/wiki/Tz_database.
+              default_value: "UTC"
+            - name: 'durationSec'
+              type: Integer
+              description: |
+                The duration of time intervals (in seconds) for which this scaling schedule will be running. The minimum allowed value is 300.
+              required: true
+            - name: 'disabled'
+              type: Boolean
+              description: |
+                A boolean value that specifies if a scaling schedule can influence autoscaler recommendations. If set to true, then a scaling schedule has no effect.
+              default_value: false
+            - name: 'description'
+              type: String
+              description: |
+                A description of a scaling schedule.
+  - name: 'target'
+    type: ResourceRef
+    description: |
+      URL of the managed instance group that this autoscaler will scale.
+    required: true
+    custom_expand: 'templates/terraform/custom_expand/compute_full_url.tmpl'
+    resource: 'InstanceGroupManager'
+    imports: 'selfLink'

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_backend_bucket.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_backend_bucket.yaml
@@ -1,0 +1,318 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'BackendBucket'
+kind: 'compute#backendBucket'
+description: |
+  Backend buckets allow you to use Google Cloud Storage buckets with HTTP(S)
+  load balancing.
+
+  An HTTP(S) load balancer can direct traffic to specified URLs to a
+  backend bucket rather than a backend service. It can send requests for
+  static content to a Cloud Storage bucket and requests for dynamic content
+  to a virtual machine instance.
+references:
+  guides:
+    'Using a Cloud Storage bucket as a load balancer backend': 'https://cloud.google.com/compute/docs/load-balancing/http/backend-bucket'
+  api: 'https://cloud.google.com/compute/docs/reference/v1/backendBuckets'
+docs:
+base_url: 'projects/{{project}}/global/backendBuckets'
+has_self_link: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+iam_policy:
+  parent_resource_attribute: 'name'
+  import_format:
+    - 'projects/{{project}}/global/backendBuckets/{{name}}'
+    - '{{name}}'
+  min_version: 'beta'
+include_in_tgc_next: true
+custom_code:
+  encoder: 'templates/terraform/encoders/compute_backend_bucket.go.tmpl'
+  post_create: 'templates/terraform/post_create/compute_backend_bucket_security_policy.go.tmpl'
+  post_update: 'templates/terraform/post_create/compute_backend_bucket_security_policy.go.tmpl'
+examples:
+  - name: 'backend_bucket_basic'
+    primary_resource_id: 'image_backend'
+    vars:
+      backend_bucket_name: 'image-backend-bucket'
+      bucket_name: 'image-store-bucket'
+  - name: 'backend_bucket_full'
+    primary_resource_id: 'image_backend_full'
+    vars:
+      backend_bucket_name: 'image-backend-bucket-full'
+      bucket_name: 'image-store-bucket-full'
+    exclude_docs: true
+  - name: 'backend_bucket_security_policy'
+    primary_resource_id: 'image_backend'
+    vars:
+      backend_bucket_name: 'image-backend-bucket'
+      bucket_name: 'image-store-bucket'
+  - name: 'backend_bucket_query_string_whitelist'
+    primary_resource_id: 'image_backend'
+    vars:
+      backend_bucket_name: 'image-backend-bucket'
+  - name: 'backend_bucket_include_http_headers'
+    primary_resource_id: 'image_backend'
+    vars:
+      backend_bucket_name: 'image-backend-bucket'
+  - name: 'external_cdn_lb_with_backend_bucket'
+    primary_resource_id: 'default'
+    vars:
+      my_bucket: 'my-bucket'
+      index_page: 'index-page'
+      404_page: '404-page'
+      test_object: 'test-object'
+      example_ip: 'example-ip'
+      http_lb_forwarding_rule: 'http-lb-forwarding-rule'
+      http_lb_proxy: 'http-lb-proxy'
+      http_lb: 'http-lb'
+      cat_backend_bucket: 'cat-backend-bucket'
+    exclude_docs: true
+  - name: 'backend_bucket_bypass_cache'
+    primary_resource_id: 'image_backend'
+    vars:
+      backend_bucket_name: 'image-backend-bucket'
+      bucket_name: 'image-store-bucket'
+    exclude_docs: true
+  - name: 'backend_bucket_coalescing'
+    primary_resource_id: 'image_backend'
+    vars:
+      backend_bucket_name: 'image-backend-bucket'
+      bucket_name: 'image-store-bucket'
+    exclude_docs: true
+  - name: 'backend_bucket_global_ilb'
+    primary_resource_id: 'global-ilb-backend'
+    test_env_vars:
+      org_id: 'ORG_ID'
+      billing_account: 'BILLING_ACCT'
+    vars:
+      backend_bucket_name: 'global-ilb-backend-bucket'
+      bucket_name: 'global-ilb-bucket'
+    exclude_docs: true
+    skip_vcr: true
+    external_providers: ["time"]
+parameters:
+properties:
+  - name: 'bucketName'
+    type: String
+    description: 'Cloud Storage bucket name.'
+    required: true
+  - name: 'cdnPolicy'
+    type: NestedObject
+    description: 'Cloud CDN configuration for this Backend Bucket.'
+    default_from_api: true
+    properties:
+      - name: 'cacheKeyPolicy'
+        type: NestedObject
+        description: 'The CacheKeyPolicy for this CdnPolicy.'
+        properties:
+          - name: 'queryStringWhitelist'
+            type: Array
+            description: |
+              Names of query string parameters to include in cache keys.
+              Default parameters are always included. '&' and '=' will
+              be percent encoded and not treated as delimiters.
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_http_headers'
+            item_type:
+              type: String
+          - name: 'includeHttpHeaders'
+            type: Array
+            description: |
+              Allows HTTP request headers (by name) to be used in the
+              cache key.
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_http_headers'
+            item_type:
+              type: String
+      - name: 'signedUrlCacheMaxAgeSec'
+        type: Integer
+        description: |
+          Maximum number of seconds the response to a signed URL request will
+          be considered fresh. After this time period,
+          the response will be revalidated before being served.
+          When serving responses to signed URL requests,
+          Cloud CDN will internally behave as though
+          all responses from this backend had a "Cache-Control: public,
+          max-age=[TTL]" header, regardless of any existing Cache-Control
+          header. The actual headers served in responses will not be altered.
+        send_empty_value: true
+      - name: 'defaultTtl'
+        type: Integer
+        description: |
+          Specifies the default TTL for cached content served by this origin for responses
+          that do not have an existing valid TTL (max-age or s-max-age). When the `cache_mode`
+          is set to "USE_ORIGIN_HEADERS", you must omit this field.
+        default_from_api: true
+        send_empty_value: true
+      - name: 'maxTtl'
+        type: Integer
+        description: |
+          Specifies the maximum allowed TTL for cached content served by this origin. When the
+          `cache_mode` is set to "USE_ORIGIN_HEADERS", you must omit this field.
+        default_from_api: true
+      - name: 'clientTtl'
+        type: Integer
+        description: |
+          Specifies the maximum allowed TTL for cached content served by this origin. When the
+          `cache_mode` is set to "USE_ORIGIN_HEADERS", you must omit this field.
+        default_from_api: true
+        send_empty_value: true
+      - name: 'negativeCaching'
+        type: Boolean
+        description: |
+          Negative caching allows per-status code TTLs to be set, in order to apply fine-grained caching for common errors or redirects.
+        default_from_api: true
+        send_empty_value: true
+      - name: 'negativeCachingPolicy'
+        type: Array
+        description: |
+          Sets a cache TTL for the specified HTTP status code. negativeCaching must be enabled to configure negativeCachingPolicy.
+          Omitting the policy and leaving negativeCaching enabled will use Cloud CDN's default cache TTLs.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'code'
+              type: Integer
+              description: |
+                The HTTP status code to define a TTL against. Only HTTP status codes 300, 301, 308, 404, 405, 410, 421, 451 and 501
+                can be specified as values, and you cannot specify a status code more than once.
+            - name: 'ttl'
+              type: Integer
+              description: |
+                The TTL (in seconds) for which to cache responses with the corresponding status code. The maximum allowed value is 1800s
+                (30 minutes), noting that infrequently accessed objects may be evicted from the cache before the defined TTL.
+              send_empty_value: true
+      - name: 'cacheMode'
+        type: Enum
+        description: |
+          Specifies the cache setting for all responses from this backend.
+          The possible values are: USE_ORIGIN_HEADERS, FORCE_CACHE_ALL and CACHE_ALL_STATIC
+        default_from_api: true
+        enum_values:
+          - 'USE_ORIGIN_HEADERS'
+          - 'FORCE_CACHE_ALL'
+          - 'CACHE_ALL_STATIC'
+      - name: 'serveWhileStale'
+        type: Integer
+        description: |
+          Serve existing content from the cache (if available) when revalidating content with the origin, or when an error is encountered when refreshing the cache.
+        default_from_api: true
+        send_empty_value: true
+      - name: 'requestCoalescing'
+        type: Boolean
+        description: |
+          If true then Cloud CDN will combine multiple concurrent cache fill requests into a small number of requests to the origin.
+        send_empty_value: true
+      - name: 'bypassCacheOnRequestHeaders'
+        type: Array
+        description: |
+          Bypass the cache when the specified request headers are matched - e.g. Pragma or Authorization headers. Up to 5 headers can be specified. The cache is bypassed for all cdnPolicy.cacheMode settings.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'headerName'
+              type: String
+              description: |
+                The header field name to match on when bypassing cache. Values are case-insensitive.
+        max_size: 5
+  - name: 'compressionMode'
+    type: Enum
+    description: |
+      Compress text responses using Brotli or gzip compression, based on the client's Accept-Encoding header.
+    enum_values:
+      - 'AUTOMATIC'
+      - 'DISABLED'
+  - name: 'edgeSecurityPolicy'
+    type: String
+    description: |
+      The security policy associated with this backend bucket.
+    diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+    is_missing_in_cai: true
+  - name: 'customResponseHeaders'
+    type: Array
+    description: |
+      Headers that the HTTP/S load balancer should add to proxied responses.
+    item_type:
+      type: String
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'description'
+    type: String
+    description: |
+      An optional textual description of the resource; provided by the
+      client when the resource is created.
+  - name: 'enableCdn'
+    type: Boolean
+    description: |
+      If true, enable Cloud CDN for this BackendBucket.
+      Note: This cannot be set to true when loadBalancingScheme is set to INTERNAL_MANAGED.
+    include_empty_value_in_cai: true
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035.  Specifically, the name must be 1-63 characters long and
+      match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means
+      the first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the
+      last character, which cannot be a dash.
+    required: true
+    immutable: true
+    validation:
+      regex: '^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$'
+  - name: 'loadBalancingScheme'
+    is_missing_in_cai: true
+    type: Enum
+    description: |
+      The value can only be INTERNAL_MANAGED for cross-region internal layer 7 load balancer.
+      If loadBalancingScheme is not specified, the backend bucket can be used by classic global external load balancers, or global application external load balancers, or both.
+      Important: CDN cannot be enabled (enableCdn cannot be set to true) when loadBalancingScheme is set to INTERNAL_MANAGED.
+    enum_values:
+      - 'INTERNAL_MANAGED'
+    send_empty_value: true
+  - name: 'params'
+    type: NestedObject
+    ignore_read: true
+    immutable: true
+    description: |
+     Additional params passed with the request, but not persisted as part of resource payload
+    properties:
+      - name: 'resourceManagerTags'
+        type: KeyValuePairs
+        description: |
+          Resource manager tags to be bound to the backend bucket. Tag keys and values have the
+          same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id},
+          and values are in the format tagValues/456.
+        api_name: resourceManagerTags
+        ignore_read: true
+        immutable: true

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_backend_service.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_backend_service.yaml
@@ -1,0 +1,1747 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'BackendService'
+kind: 'compute#backendService'
+description: |
+  A Backend Service defines a group of virtual machines that will serve
+  traffic for load balancing. This resource is a global backend service,
+  appropriate for external load balancing or self-managed internal load balancing.
+  For managed internal load balancing, use a regional backend service instead.
+
+  Currently self-managed internal load balancing is only available in beta.
+
+  ~> **Note:** Recreating a `google_compute_backend_service` that references other dependent resources like `google_compute_url_map` will give a `resourceInUseByAnotherResource` error, when modifying the number of other dependent resources.
+  Use `lifecycle.create_before_destroy` on the dependent resources to avoid this type of error as shown in the Dynamic Backends example.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/compute/docs/load-balancing/http/backend-service'
+  api: 'https://cloud.google.com/compute/docs/reference/v1/backendServices'
+docs:
+base_url: 'projects/{{project}}/global/backendServices'
+has_self_link: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+iam_policy:
+  allowed_iam_role: 'roles/compute.admin'
+  parent_resource_attribute: 'name'
+  iam_conditions_request_type: 'QUERY_PARAM'
+  min_version: 'beta'
+include_in_tgc_next: true
+tgc_tests:
+  - name: 'TestAccComputeBackendService_backendServiceCustomMetrics_update'
+    skip: 'Test framework problem with single vs multiple block parsing of custom_metrics'
+custom_code:
+  constants: 'templates/terraform/constants/backend_service.go.tmpl'
+  encoder: 'templates/terraform/encoders/backend_service.go.tmpl'
+  decoder: 'templates/terraform/decoders/backend_service.go.tmpl'
+  post_create: 'templates/terraform/post_create/compute_backend_service_security_policy.go.tmpl'
+  post_update: 'templates/terraform/post_create/compute_backend_service_security_policy.go.tmpl'
+  tgc_decoder: 'templates/tgc_next/decoders/compute_backend_service.go.tmpl'
+schema_version: 1
+examples:
+  - name: 'backend_service_basic'
+    primary_resource_id: 'default'
+    vars:
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'health-check'
+  - name: 'backend_service_external_iap'
+    primary_resource_id: 'default'
+    vars:
+      backend_service_name: 'tf-test-backend-service-external'
+  - name: 'backend_service_cache_simple'
+    primary_resource_id: 'default'
+    vars:
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'health-check'
+  - name: 'backend_service_cache_include_http_headers'
+    primary_resource_id: 'default'
+    vars:
+      backend_service_name: 'backend-service'
+  - name: 'backend_service_cache_include_named_cookies'
+    primary_resource_id: 'default'
+    vars:
+      backend_service_name: 'backend-service'
+  - name: 'backend_service_cache'
+    primary_resource_id: 'default'
+    vars:
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'health-check'
+  - name: 'backend_service_cache_bypass_cache_on_request_headers'
+    primary_resource_id: 'default'
+    vars:
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'health-check'
+  - name: 'backend_service_traffic_director_round_robin'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      backend_service_name: 'backend-service'
+      health_check_name: 'health-check'
+  - name: 'backend_service_traffic_director_ring_hash'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      backend_service_name: 'backend-service'
+      health_check_name: 'health-check'
+  - name: 'backend_service_stateful_session_affinity'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      backend_service_name: 'backend-service'
+      health_check_name: 'health-check'
+  - name: 'backend_service_network_endpoint'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      backend_service_name: 'backend-service'
+      neg_name: 'network-endpoint'
+  - name: 'backend_service_in_flight'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      backend_service_name: 'backend-service'
+      health_check_name: 'health-check'
+  - name: 'backend_service_external_managed'
+    primary_resource_id: 'default'
+    vars:
+      backend_service_name: 'backend-service'
+      health_check_name: 'health-check'
+  - name: 'backend_service_ip_address_selection_policy'
+    primary_resource_id: 'default'
+    vars:
+      backend_service_name: 'backend-service'
+  - name: 'backend_service_custom_metrics'
+    primary_resource_id: 'default'
+    vars:
+      backend_service_name: 'backend-service'
+      default_neg_name: 'network-endpoint'
+      health_check_name: 'health-check'
+      network_name: 'network'
+    test_vars_overrides:
+      # for backward compatible
+      network_name: '"network" + randomSuffix'
+  - name: 'backend_service_tls_settings'
+    primary_resource_id: 'default'
+    vars:
+      backend_service_name: 'backend-service'
+      health_check_name: 'health-check'
+      authentication_name: 'authentication'
+    test_vars_overrides:
+      # for backward compatible
+      authentication_name: '"authentication" + randomSuffix'
+  - name: 'backend_service_dynamic_backends'
+    primary_resource_id: 'default'
+    vars:
+      url_map_name: 'url_map'
+    exclude_test: true
+  - name: 'backend_service_dynamic_forwarding'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      backend_service_name: 'backend-service'
+parameters:
+properties:
+  - name: 'affinityCookieTtlSec'
+    type: Integer
+    description: |
+      Lifetime of cookies in seconds if session_affinity is
+      GENERATED_COOKIE. If set to 0, the cookie is non-persistent and lasts
+      only until the end of the browser session (or equivalent). The
+      maximum allowed value for TTL is one day.
+
+      When the load balancing scheme is INTERNAL, this field is not used.
+    include_empty_value_in_cai: true
+  - name: 'backend'
+    type: Array
+    description: |
+      The set of backends that serve this BackendService.
+    api_name: backends
+    is_set: true
+    set_hash_func: 'resourceGoogleComputeBackendServiceBackendHash'
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'balancingMode'
+          type: Enum
+          description: |
+            Specifies the balancing mode for this backend.
+
+            For global HTTP(S) or TCP/SSL load balancing, the default is
+            UTILIZATION. Valid values are UTILIZATION, RATE (for HTTP(S)),
+            CUSTOM_METRICS (for HTTP(s)) and CONNECTION (for TCP/SSL).
+
+            See the [Backend Services Overview](https://cloud.google.com/load-balancing/docs/backend-service#balancing-mode)
+            for an explanation of load balancing modes.
+          default_value: "UTILIZATION"
+          enum_values:
+            - 'UTILIZATION'
+            - 'RATE'
+            - 'CONNECTION'
+            - 'CUSTOM_METRICS'
+            - 'IN_FLIGHT'
+        - name: 'capacityScaler'
+          type: Double
+          description: |
+            A multiplier applied to the group's maximum servicing capacity
+            (based on UTILIZATION, RATE or CONNECTION).
+
+            Default value is 1, which means the group will serve up to 100%
+            of its configured capacity (depending on balancingMode). A
+            setting of 0 means the group is completely drained, offering
+            0% of its available Capacity. Valid range is [0.0,1.0].
+          send_empty_value: true
+          default_value: 1.0
+        - name: 'preference'
+          type: Enum
+          description: |
+            This field indicates whether this backend should be fully utilized before sending traffic to backends
+            with default preference. This field cannot be set when loadBalancingScheme is set to 'EXTERNAL'. The possible values are:
+              - PREFERRED: Backends with this preference level will be filled up to their capacity limits first,
+                based on RTT.
+              - DEFAULT: If preferred backends don't have enough capacity, backends in this layer would be used and
+                traffic would be assigned based on the load balancing algorithm you use. This is the default
+          enum_values:
+            - 'PREFERRED'
+            - 'DEFAULT'
+        - name: 'description'
+          type: String
+          description: |
+            An optional description of this resource.
+            Provide this property when you create the resource.
+        - name: 'group'
+          type: String
+          description: |
+            The fully-qualified URL of an Instance Group or Network Endpoint
+            Group resource. In case of instance group this defines the list
+            of instances that serve traffic. Member virtual machine
+            instances from each instance group must live in the same zone as
+            the instance group itself. No two backends in a backend service
+            are allowed to use same Instance Group resource.
+
+            For Network Endpoint Groups this defines list of endpoints. All
+            endpoints of Network Endpoint Group must be hosted on instances
+            located in the same zone as the Network Endpoint Group.
+
+            Backend services cannot mix Instance Group and
+            Network Endpoint Group backends.
+
+            Note that you must specify an Instance Group or Network Endpoint
+            Group resource using the fully-qualified URL, rather than a
+            partial URL.
+          required: true
+          diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
+          custom_flatten: 'templates/terraform/custom_flatten/guard_self_link.go.tmpl'
+        - name: 'maxConnections'
+          type: Integer
+          description: |
+            The max number of simultaneous connections for the group. Can
+            be used with either CONNECTION or UTILIZATION balancing modes.
+
+            For CONNECTION mode, either maxConnections or one
+            of maxConnectionsPerInstance or maxConnectionsPerEndpoint,
+            as appropriate for group type, must be set.
+          default_from_api: true
+        - name: 'maxConnectionsPerInstance'
+          type: Integer
+          description: |
+            The max number of simultaneous connections that a single
+            backend instance can handle. This is used to calculate the
+            capacity of the group. Can be used in either CONNECTION or
+            UTILIZATION balancing modes.
+
+            For CONNECTION mode, either maxConnections or
+            maxConnectionsPerInstance must be set.
+          default_from_api: true
+        - name: 'maxConnectionsPerEndpoint'
+          type: Integer
+          description: |
+            The max number of simultaneous connections that a single backend
+            network endpoint can handle. This is used to calculate the
+            capacity of the group. Can be used in either CONNECTION or
+            UTILIZATION balancing modes.
+
+            For CONNECTION mode, either
+            maxConnections or maxConnectionsPerEndpoint must be set.
+          default_from_api: true
+        - name: 'maxRate'
+          type: Integer
+          description: |
+            The max requests per second (RPS) of the group.
+
+            Can be used with either RATE or UTILIZATION balancing modes,
+            but required if RATE mode. For RATE mode, either maxRate or one
+            of maxRatePerInstance or maxRatePerEndpoint, as appropriate for
+            group type, must be set.
+          default_from_api: true
+        - name: 'maxRatePerInstance'
+          type: Double
+          description: |
+            The max requests per second (RPS) that a single backend
+            instance can handle. This is used to calculate the capacity of
+            the group. Can be used in either balancing mode. For RATE mode,
+            either maxRate or maxRatePerInstance must be set.
+          default_from_api: true
+        - name: 'maxRatePerEndpoint'
+          type: Double
+          description: |
+            The max requests per second (RPS) that a single backend network
+            endpoint can handle. This is used to calculate the capacity of
+            the group. Can be used in either balancing mode. For RATE mode,
+            either maxRate or maxRatePerEndpoint must be set.
+          default_from_api: true
+        - name: 'maxUtilization'
+          type: Double
+          description: |
+            Used when balancingMode is UTILIZATION. This ratio defines the
+            CPU utilization target for the group. Valid range is [0.0, 1.0].
+          default_from_api: true
+        - name: 'maxInFlightRequests'
+          type: Integer
+          description: |
+            Defines a maximum number of in-flight requests for the whole NEG
+            or instance group. Not available if backend's balancingMode is RATE
+            or CONNECTION.
+          default_from_api: true
+          min_version: 'beta'
+        - name: 'maxInFlightRequestsPerInstance'
+          type: Integer
+          description: |
+            Defines a maximum number of in-flight requests for a single VM.
+            Not available if backend's balancingMode is RATE or CONNECTION.
+          default_from_api: true
+          min_version: 'beta'
+        - name: 'maxInFlightRequestsPerEndpoint'
+          type: Integer
+          description: |
+            Defines a maximum number of in-flight requests for a single endpoint.
+            Not available if backend's balancingMode is RATE or CONNECTION.
+          default_from_api: true
+          min_version: 'beta'
+        - name: 'trafficDuration'
+          type: Enum
+          description: |
+            This field specifies how long a connection should be kept alive for:
+            - LONG: Most of the requests are expected to take more than multiple
+              seconds to finish.
+            - SHORT: Most requests are expected to finish with a sub-second latency.
+          enum_values:
+            - 'LONG'
+            - 'SHORT'
+          min_version: 'beta'
+        - name: 'customMetrics'
+          type: Array
+          description: |
+            The set of custom metrics that are used for <code>CUSTOM_METRICS</code> BalancingMode.
+          item_type:
+            type: NestedObject
+            properties:
+              - name: 'name'
+                type: String
+                required: true
+                description: |
+                  Name of a custom utilization signal. The name must be 1-64 characters
+                  long and match the regular expression [a-z]([-_.a-z0-9]*[a-z0-9])? which
+                  means the first character must be a lowercase letter, and all following
+                  characters must be a dash, period, underscore, lowercase letter, or
+                  digit, except the last character, which cannot be a dash, period, or
+                  underscore. For usage guidelines, see Custom Metrics balancing mode. This
+                  field can only be used for a global or regional backend service with the
+                  loadBalancingScheme set to <code>EXTERNAL_MANAGED</code>,
+                  <code>INTERNAL_MANAGED</code> <code>INTERNAL_SELF_MANAGED</code>.
+                is_missing_in_cai: true
+              - name: 'dryRun'
+                type: Boolean
+                required: true
+                description: |
+                  If true, the metric data is collected and reported to Cloud
+                  Monitoring, but is not used for load balancing.
+              - name: 'maxUtilization'
+                type: Double
+                description: |
+                  Optional parameter to define a target utilization for the Custom Metrics
+                  balancing mode. The valid range is <code>[0.0, 1.0]</code>.
+                default_value: 0.8
+  - name: 'circuitBreakers'
+    type: NestedObject
+    description: |
+      Settings controlling the volume of connections to a backend service. This field
+      is applicable only when the load_balancing_scheme is set to INTERNAL_SELF_MANAGED.
+    properties:
+      - name: 'connectTimeout'
+        type: NestedObject
+        description: |
+          The timeout for new network connections to hosts.
+        min_version: 'beta'
+        at_least_one_of:
+          - 'circuit_breakers.0.connect_timeout'
+          - 'circuit_breakers.0.max_requests_per_connection'
+          - 'circuit_breakers.0.max_connections'
+          - 'circuit_breakers.0.max_pending_requests'
+          - 'circuit_breakers.0.max_requests'
+          - 'circuit_breakers.0.max_retries'
+        properties:
+          - name: 'seconds'
+            type: Integer
+            description: |
+              Span of time at a resolution of a second.
+              Must be from 0 to 315,576,000,000 inclusive.
+            required: true
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond
+              resolution. Durations less than one second are represented
+              with a 0 seconds field and a positive nanos field. Must
+              be from 0 to 999,999,999 inclusive.
+      - name: 'maxRequestsPerConnection'
+        type: Integer
+        description: |
+          Maximum requests for a single backend connection. This parameter
+          is respected by both the HTTP/1.1 and HTTP/2 implementations. If
+          not specified, there is no limit. Setting this parameter to 1
+          will effectively disable keep alive.
+        at_least_one_of:
+          - 'circuit_breakers.0.connect_timeout'
+          - 'circuit_breakers.0.max_requests_per_connection'
+          - 'circuit_breakers.0.max_connections'
+          - 'circuit_breakers.0.max_pending_requests'
+          - 'circuit_breakers.0.max_requests'
+          - 'circuit_breakers.0.max_retries'
+      - name: 'maxConnections'
+        type: Integer
+        description: |
+          The maximum number of connections to the backend cluster.
+          Defaults to 1024.
+        at_least_one_of:
+          - 'circuit_breakers.0.connect_timeout'
+          - 'circuit_breakers.0.max_requests_per_connection'
+          - 'circuit_breakers.0.max_connections'
+          - 'circuit_breakers.0.max_pending_requests'
+          - 'circuit_breakers.0.max_requests'
+          - 'circuit_breakers.0.max_retries'
+        default_value: 1024
+      - name: 'maxPendingRequests'
+        type: Integer
+        description: |
+          The maximum number of pending requests to the backend cluster.
+          Defaults to 1024.
+        at_least_one_of:
+          - 'circuit_breakers.0.connect_timeout'
+          - 'circuit_breakers.0.max_requests_per_connection'
+          - 'circuit_breakers.0.max_connections'
+          - 'circuit_breakers.0.max_pending_requests'
+          - 'circuit_breakers.0.max_requests'
+          - 'circuit_breakers.0.max_retries'
+        default_value: 1024
+      - name: 'maxRequests'
+        type: Integer
+        description: |
+          The maximum number of parallel requests to the backend cluster.
+          Defaults to 1024.
+        at_least_one_of:
+          - 'circuit_breakers.0.connect_timeout'
+          - 'circuit_breakers.0.max_requests_per_connection'
+          - 'circuit_breakers.0.max_connections'
+          - 'circuit_breakers.0.max_pending_requests'
+          - 'circuit_breakers.0.max_requests'
+          - 'circuit_breakers.0.max_retries'
+        default_value: 1024
+      - name: 'maxRetries'
+        type: Integer
+        description: |
+          The maximum number of parallel retries to the backend cluster.
+          Defaults to 3.
+        at_least_one_of:
+          - 'circuit_breakers.0.connect_timeout'
+          - 'circuit_breakers.0.max_requests_per_connection'
+          - 'circuit_breakers.0.max_connections'
+          - 'circuit_breakers.0.max_pending_requests'
+          - 'circuit_breakers.0.max_requests'
+          - 'circuit_breakers.0.max_retries'
+        default_value: 3
+  - name: 'compressionMode'
+    type: Enum
+    description: |
+      Compress text responses using Brotli or gzip compression, based on the client's Accept-Encoding header.
+    enum_values:
+      - 'AUTOMATIC'
+      - 'DISABLED'
+  - name: 'consistentHash'
+    type: NestedObject
+    description: |
+      Consistent Hash-based load balancing can be used to provide soft session
+      affinity based on HTTP headers, cookies or other properties. This load balancing
+      policy is applicable only for HTTP connections. The affinity to a particular
+      destination host will be lost when one or more hosts are added/removed from the
+      destination service. This field specifies parameters that control consistent
+      hashing. This field only applies if the load_balancing_scheme is set to
+      INTERNAL_SELF_MANAGED. This field is only applicable when locality_lb_policy is
+      set to MAGLEV or RING_HASH.
+    properties:
+      - name: 'httpCookie'
+        type: NestedObject
+        description: |
+          Hash is based on HTTP Cookie. This field describes a HTTP cookie
+          that will be used as the hash key for the consistent hash load
+          balancer. If the cookie is not present, it will be generated.
+          This field is applicable if the sessionAffinity is set to HTTP_COOKIE.
+        at_least_one_of:
+          - 'consistent_hash.0.http_cookie'
+          - 'consistent_hash.0.http_header_name'
+          - 'consistent_hash.0.minimum_ring_size'
+        properties:
+          - name: 'ttl'
+            type: NestedObject
+            description: |
+              Lifetime of the cookie.
+            at_least_one_of:
+              - 'consistent_hash.0.http_cookie.0.ttl'
+              - 'consistent_hash.0.http_cookie.0.name'
+              - 'consistent_hash.0.http_cookie.0.path'
+            properties:
+              - name: 'seconds'
+                type: Integer
+                description: |
+                  Span of time at a resolution of a second.
+                  Must be from 0 to 315,576,000,000 inclusive.
+                required: true
+              - name: 'nanos'
+                type: Integer
+                description: |
+                  Span of time that's a fraction of a second at nanosecond
+                  resolution. Durations less than one second are represented
+                  with a 0 seconds field and a positive nanos field. Must
+                  be from 0 to 999,999,999 inclusive.
+          - name: 'name'
+            type: String
+            description: |
+              Name of the cookie.
+            at_least_one_of:
+              - 'consistent_hash.0.http_cookie.0.ttl'
+              - 'consistent_hash.0.http_cookie.0.name'
+              - 'consistent_hash.0.http_cookie.0.path'
+          - name: 'path'
+            type: String
+            description: |
+              Path to set for the cookie.
+            at_least_one_of:
+              - 'consistent_hash.0.http_cookie.0.ttl'
+              - 'consistent_hash.0.http_cookie.0.name'
+              - 'consistent_hash.0.http_cookie.0.path'
+      - name: 'httpHeaderName'
+        type: String
+        description: |
+          The hash based on the value of the specified header field.
+          This field is applicable if the sessionAffinity is set to HEADER_FIELD.
+        at_least_one_of:
+          - 'consistent_hash.0.http_cookie'
+          - 'consistent_hash.0.http_header_name'
+          - 'consistent_hash.0.minimum_ring_size'
+      - name: 'minimumRingSize'
+        type: Integer
+        description: |
+          The minimum number of virtual nodes to use for the hash ring.
+          Larger ring sizes result in more granular load
+          distributions. If the number of hosts in the load balancing pool
+          is larger than the ring size, each host will be assigned a single
+          virtual node.
+          Defaults to 1024.
+        at_least_one_of:
+          - 'consistent_hash.0.http_cookie'
+          - 'consistent_hash.0.http_header_name'
+          - 'consistent_hash.0.minimum_ring_size'
+        default_value: 1024
+  - name: 'cdnPolicy'
+    type: NestedObject
+    description: 'Cloud CDN configuration for this BackendService.'
+    default_from_api: true
+    is_missing_in_cai: true
+    properties:
+      - name: 'requestCoalescing'
+        type: Boolean
+        description: |
+          If true then Cloud CDN will combine multiple concurrent cache fill requests into a small number of requests
+          to the origin.
+        default_from_api: true
+        send_empty_value: true
+      - name: 'cacheKeyPolicy'
+        type: NestedObject
+        description: 'The CacheKeyPolicy for this CdnPolicy.'
+        at_least_one_of:
+          - 'cdn_policy.0.cache_key_policy'
+          - 'cdn_policy.0.signed_url_cache_max_age_sec'
+        properties:
+          - name: 'includeHost'
+            type: Boolean
+            description: |
+              If true requests to different hosts will be cached separately.
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.include_host'
+              - 'cdn_policy.0.cache_key_policy.0.include_protocol'
+              - 'cdn_policy.0.cache_key_policy.0.include_query_string'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_blacklist'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_http_headers'
+              - 'cdn_policy.0.cache_key_policy.0.include_named_cookies'
+          - name: 'includeProtocol'
+            type: Boolean
+            description: |
+              If true, http and https requests will be cached separately.
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.include_host'
+              - 'cdn_policy.0.cache_key_policy.0.include_protocol'
+              - 'cdn_policy.0.cache_key_policy.0.include_query_string'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_blacklist'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_http_headers'
+              - 'cdn_policy.0.cache_key_policy.0.include_named_cookies'
+          - name: 'includeQueryString'
+            type: Boolean
+            description: |
+              If true, include query string parameters in the cache key
+              according to query_string_whitelist and
+              query_string_blacklist. If neither is set, the entire query
+              string will be included.
+
+              If false, the query string will be excluded from the cache
+              key entirely.
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.include_host'
+              - 'cdn_policy.0.cache_key_policy.0.include_protocol'
+              - 'cdn_policy.0.cache_key_policy.0.include_query_string'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_blacklist'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_http_headers'
+              - 'cdn_policy.0.cache_key_policy.0.include_named_cookies'
+          - name: 'queryStringBlacklist'
+            type: Array
+            description: |
+              Names of query string parameters to exclude in cache keys.
+
+              All other parameters will be included. Either specify
+              query_string_whitelist or query_string_blacklist, not both.
+              '&' and '=' will be percent encoded and not treated as
+              delimiters.
+            is_set: true
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.include_host'
+              - 'cdn_policy.0.cache_key_policy.0.include_protocol'
+              - 'cdn_policy.0.cache_key_policy.0.include_query_string'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_blacklist'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_http_headers'
+              - 'cdn_policy.0.cache_key_policy.0.include_named_cookies'
+            item_type:
+              type: String
+          - name: 'queryStringWhitelist'
+            type: Array
+            description: |
+              Names of query string parameters to include in cache keys.
+
+              All other parameters will be excluded. Either specify
+              query_string_whitelist or query_string_blacklist, not both.
+              '&' and '=' will be percent encoded and not treated as
+              delimiters.
+            is_set: true
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.include_host'
+              - 'cdn_policy.0.cache_key_policy.0.include_protocol'
+              - 'cdn_policy.0.cache_key_policy.0.include_query_string'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_blacklist'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_http_headers'
+              - 'cdn_policy.0.cache_key_policy.0.include_named_cookies'
+            item_type:
+              type: String
+          - name: 'includeHttpHeaders'
+            type: Array
+            description: |
+              Allows HTTP request headers (by name) to be used in the
+              cache key.
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.include_host'
+              - 'cdn_policy.0.cache_key_policy.0.include_protocol'
+              - 'cdn_policy.0.cache_key_policy.0.include_query_string'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_blacklist'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_http_headers'
+              - 'cdn_policy.0.cache_key_policy.0.include_named_cookies'
+            item_type:
+              type: String
+          - name: 'includeNamedCookies'
+            type: Array
+            description: |
+              Names of cookies to include in cache keys.
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.include_host'
+              - 'cdn_policy.0.cache_key_policy.0.include_protocol'
+              - 'cdn_policy.0.cache_key_policy.0.include_query_string'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_blacklist'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_http_headers'
+              - 'cdn_policy.0.cache_key_policy.0.include_named_cookies'
+            item_type:
+              type: String
+      - name: 'signedUrlCacheMaxAgeSec'
+        type: Integer
+        description: |
+          Maximum number of seconds the response to a signed URL request
+          will be considered fresh, defaults to 1hr (3600s). After this
+          time period, the response will be revalidated before
+          being served.
+
+          When serving responses to signed URL requests, Cloud CDN will
+          internally behave as though all responses from this backend had a
+          "Cache-Control: public, max-age=[TTL]" header, regardless of any
+          existing Cache-Control header. The actual headers served in
+          responses will not be altered.
+        at_least_one_of:
+          - 'cdn_policy.0.cache_key_policy'
+          - 'cdn_policy.0.signed_url_cache_max_age_sec'
+        default_value: 3600
+        custom_tgc_flatten: 'templates/tgc_next/custom_flatten/compute_backend_service_signed_url_cache_max_age_sec.go.tmpl'
+      - name: 'defaultTtl'
+        type: Integer
+        description: |
+          Specifies the default TTL for cached content served by this origin for responses
+          that do not have an existing valid TTL (max-age or s-max-age).
+        default_from_api: true
+      - name: 'maxTtl'
+        type: Integer
+        description: |
+          Specifies the maximum allowed TTL for cached content served by this origin.
+        default_from_api: true
+      - name: 'clientTtl'
+        type: Integer
+        description: |
+          Specifies the maximum allowed TTL for cached content served by this origin.
+        default_from_api: true
+      - name: 'negativeCaching'
+        type: Boolean
+        description: |
+          Negative caching allows per-status code TTLs to be set, in order to apply fine-grained caching for common errors or redirects.
+        default_from_api: true
+        send_empty_value: true
+      - name: 'negativeCachingPolicy'
+        type: Array
+        description: |
+          Sets a cache TTL for the specified HTTP status code. negativeCaching must be enabled to configure negativeCachingPolicy.
+          Omitting the policy and leaving negativeCaching enabled will use Cloud CDN's default cache TTLs.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'code'
+              type: Integer
+              description: |
+                The HTTP status code to define a TTL against. Only HTTP status codes 300, 301, 308, 404, 405, 410, 421, 451 and 501
+                can be specified as values, and you cannot specify a status code more than once.
+            - name: 'ttl'
+              type: Integer
+              description: |
+                The TTL (in seconds) for which to cache responses with the corresponding status code. The maximum allowed value is 1800s
+                (30 minutes), noting that infrequently accessed objects may be evicted from the cache before the defined TTL.
+              send_empty_value: true
+      - name: 'cacheMode'
+        type: Enum
+        description: |
+          Specifies the cache setting for all responses from this backend.
+          The possible values are: USE_ORIGIN_HEADERS, FORCE_CACHE_ALL and CACHE_ALL_STATIC
+        default_from_api: true
+        enum_values:
+          - 'USE_ORIGIN_HEADERS'
+          - 'FORCE_CACHE_ALL'
+          - 'CACHE_ALL_STATIC'
+      - name: 'serveWhileStale'
+        type: Integer
+        description: |
+          Serve existing content from the cache (if available) when revalidating content with the origin, or when an error is encountered when refreshing the cache.
+        default_from_api: true
+        send_empty_value: true
+      - name: 'bypassCacheOnRequestHeaders'
+        type: Array
+        description: |
+          Bypass the cache when the specified request headers are matched - e.g. Pragma or Authorization headers. Up to 5 headers can be specified.
+          The cache is bypassed for all cdnPolicy.cacheMode settings.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'headerName'
+              type: String
+              description: |
+                The header field name to match on when bypassing cache. Values are case-insensitive.
+              required: true
+  - name: 'connectionDraining'
+    type: NestedObject
+    description: |
+      Settings for connection draining
+    flatten_object: true
+    properties:
+      - name: 'connection_draining_timeout_sec'
+        type: Integer
+        description: |
+          Time for which instance will be drained (not accept new
+          connections, but still work to finish started).
+        api_name: drainingTimeoutSec
+        default_value: 300
+  - name: 'creationTimestamp'
+    type: Time
+    description: |
+      Creation timestamp in RFC3339 text format.
+    output: true
+  - name: 'customRequestHeaders'
+    type: Array
+    description: |
+      Headers that the HTTP/S load balancer should add to proxied
+      requests.
+    is_set: true
+    item_type:
+      type: String
+  - name: 'customResponseHeaders'
+    type: Array
+    description: |
+      Headers that the HTTP/S load balancer should add to proxied
+      responses.
+    is_set: true
+    item_type:
+      type: String
+  - name: 'fingerprint'
+    type: Fingerprint
+    description: |
+      Fingerprint of this resource. A hash of the contents stored in this
+      object. This field is used in optimistic locking.
+    output: true
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource.
+  - name: 'enableCDN'
+    type: Boolean
+    description: |
+      If true, enable Cloud CDN for this BackendService.
+    include_empty_value_in_cai: true
+  - name: 'healthChecks'
+    type: Array
+    description: |
+      The set of URLs to the HttpHealthCheck or HttpsHealthCheck resource
+      for health checking this BackendService. Currently at most one health
+      check can be specified.
+
+      A health check must be specified unless the backend service uses an internet
+      or serverless NEG as a backend.
+
+      For internal load balancing, a URL to a HealthCheck resource must be specified instead.
+    is_set: true
+    set_hash_func: 'tpgresource.SelfLinkRelativePathHash'
+    custom_flatten: 'templates/terraform/custom_flatten/guard_self_link_array.go.tmpl'
+    item_type:
+      type: String
+    min_size: 1
+    max_size: 1
+  - name: 'generated_id'
+    type: Integer
+    description:
+      'The unique identifier for the resource. This identifier is defined by the
+      server.'
+    api_name: id
+    output: true
+  - name: 'iap'
+    type: NestedObject
+    description: |
+      Settings for enabling Cloud Identity Aware Proxy.
+      If OAuth client is not set, the Google-managed OAuth client is used.
+    default_from_api: true
+    send_empty_value: true
+    properties:
+      - name: 'enabled'
+        type: Boolean
+        description: Whether the serving infrastructure will authenticate and authorize all incoming requests.
+        required: true
+        send_empty_value: true
+      - name: 'oauth2ClientId'
+        type: String
+        description: |
+          OAuth2 Client ID for IAP
+        send_empty_value: true
+        diff_suppress_func: 'tpgresource.EmptyOrDefaultStringSuppress(" ")'
+      - name: 'oauth2ClientSecret'
+        type: String
+        description: |
+          OAuth2 Client Secret for IAP
+        ignore_read: true
+        sensitive: true
+        send_empty_value: true
+        is_missing_in_cai: true
+      - name: 'oauth2ClientSecretSha256'
+        type: String
+        description: |
+          OAuth2 Client Secret SHA-256 for IAP
+        sensitive: true
+        output: true
+  - name: 'ipAddressSelectionPolicy'
+    type: Enum
+    description: |
+      Specifies preference of traffic to the backend (from the proxy and from the client for proxyless gRPC).
+    enum_values:
+      - 'IPV4_ONLY'
+      - 'PREFER_IPV6'
+      - 'IPV6_ONLY'
+  - name: 'loadBalancingScheme'
+    type: Enum
+    description: |
+      Indicates whether the backend service will be used with internal or
+      external load balancing. A backend service created for one type of
+      load balancing cannot be used with the other. For more information, refer to
+      [Choosing a load balancer](https://cloud.google.com/load-balancing/docs/backend-service).
+    default_value: "EXTERNAL"
+    # If you're modifying this value, it probably means Global ILB is now
+    # an option. If that's the case, all of the documentation is based on
+    # this resource supporting external load balancing only.
+    enum_values:
+      - 'EXTERNAL'
+      - 'INTERNAL_SELF_MANAGED'
+      - 'INTERNAL_MANAGED'
+      - 'EXTERNAL_MANAGED'
+  - name: 'externalManagedMigrationState'
+    type: Enum
+    description: |
+      Specifies the canary migration state. Possible values are PREPARE, TEST_BY_PERCENTAGE, and
+      TEST_ALL_TRAFFIC.
+
+      To begin the migration from EXTERNAL to EXTERNAL_MANAGED, the state must be changed to
+      PREPARE. The state must be changed to TEST_ALL_TRAFFIC before the loadBalancingScheme can be
+      changed to EXTERNAL_MANAGED. Optionally, the TEST_BY_PERCENTAGE state can be used to migrate
+      traffic by percentage using externalManagedMigrationTestingPercentage.
+
+      Rolling back a migration requires the states to be set in reverse order. So changing the
+      scheme from EXTERNAL_MANAGED to EXTERNAL requires the state to be set to TEST_ALL_TRAFFIC at
+      the same time. Optionally, the TEST_BY_PERCENTAGE state can be used to migrate some traffic
+      back to EXTERNAL or PREPARE can be used to migrate all traffic back to EXTERNAL.
+    enum_values:
+      - 'PREPARE'
+      - 'TEST_BY_PERCENTAGE'
+      - 'TEST_ALL_TRAFFIC'
+  - name: 'externalManagedMigrationTestingPercentage'
+    type: Double
+    description: |
+      Determines the fraction of requests that should be processed by the Global external
+      Application Load Balancer.
+
+      The value of this field must be in the range [0, 100].
+
+      Session affinity options will slightly affect this routing behavior, for more details,
+      see: Session Affinity.
+
+      This value can only be set if the loadBalancingScheme in the backend service is set to
+      EXTERNAL (when using the Classic ALB) and the migration state is TEST_BY_PERCENTAGE.
+  - name: 'localityLbPolicy'
+    type: Enum
+    description: |
+      The load balancing algorithm used within the scope of the locality.
+      The possible values are:
+
+      * `ROUND_ROBIN`: This is a simple policy in which each healthy backend
+                       is selected in round robin order.
+
+      * `LEAST_REQUEST`: An O(1) algorithm which selects two random healthy
+                         hosts and picks the host which has fewer active requests.
+
+      * `RING_HASH`: The ring/modulo hash load balancer implements consistent
+                     hashing to backends. The algorithm has the property that the
+                     addition/removal of a host from a set of N hosts only affects
+                     1/N of the requests.
+
+      * `RANDOM`: The load balancer selects a random healthy host.
+
+      * `ORIGINAL_DESTINATION`: Backend host is selected based on the client
+                                connection metadata, i.e., connections are opened
+                                to the same address as the destination address of
+                                the incoming connection before the connection
+                                was redirected to the load balancer.
+
+      * `MAGLEV`: used as a drop in replacement for the ring hash load balancer.
+                  Maglev is not as stable as ring hash but has faster table lookup
+                  build times and host selection times. For more information about
+                  Maglev, refer to https://ai.google/research/pubs/pub44824
+
+      * `WEIGHTED_MAGLEV`: Per-instance weighted Load Balancing via health check
+                           reported weights. Only applicable to loadBalancingScheme
+                           EXTERNAL. If set, the Backend Service must
+                           configure a non legacy HTTP-based Health Check, and
+                           health check replies are expected to contain
+                           non-standard HTTP response header field
+                           X-Load-Balancing-Endpoint-Weight to specify the
+                           per-instance weights. If set, Load Balancing is weight
+                           based on the per-instance weights reported in the last
+                           processed health check replies, as long as every
+                           instance either reported a valid weight or had
+                           UNAVAILABLE_WEIGHT. Otherwise, Load Balancing remains
+                           equal-weight.
+
+      * `WEIGHTED_ROUND_ROBIN`: Per-endpoint weighted round-robin Load Balancing using weights computed
+                                from Backend reported Custom Metrics. If set, the Backend Service
+                                responses are expected to contain non-standard HTTP response header field
+                                X-Endpoint-Load-Metrics. The reported metrics
+                                to use for computing the weights are specified via the
+                                backends[].customMetrics fields.
+
+      locality_lb_policy is applicable to either:
+
+      * A regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C,
+        and loadBalancingScheme set to INTERNAL_MANAGED.
+      * A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED.
+      * A regional backend service with loadBalancingScheme set to EXTERNAL (External Network
+        Load Balancing). Only MAGLEV and WEIGHTED_MAGLEV values are possible for External
+        Network Load Balancing. The default is MAGLEV.
+
+      If session_affinity is not NONE, and locality_lb_policy is not set to MAGLEV, WEIGHTED_MAGLEV,
+      or RING_HASH, session affinity settings will not take effect.
+
+      Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced
+      by a URL map that is bound to target gRPC proxy that has validate_for_proxyless
+      field set to true.
+    enum_values:
+      - 'ROUND_ROBIN'
+      - 'LEAST_REQUEST'
+      - 'RING_HASH'
+      - 'RANDOM'
+      - 'ORIGINAL_DESTINATION'
+      - 'MAGLEV'
+      - 'WEIGHTED_MAGLEV'
+      - 'WEIGHTED_ROUND_ROBIN'
+  - name: 'localityLbPolicies'
+    type: Array
+    description: |
+      A list of locality load balancing policies to be used in order of
+      preference. Either the policy or the customPolicy field should be set.
+      Overrides any value set in the localityLbPolicy field.
+
+      localityLbPolicies is only supported when the BackendService is referenced
+      by a URL Map that is referenced by a target gRPC proxy that has the
+      validateForProxyless field set to true.
+    item_type:
+      description: |
+        Container for either a built-in LB policy supported by gRPC or Envoy or
+        a custom one implemented by the end user.
+      type: NestedObject
+      properties:
+        - name: 'policy'
+          type: NestedObject
+          description: |
+            The configuration for a built-in load balancing policy.
+          exactly_one_of:
+            - 'policy'
+            - 'customPolicy'
+          properties:
+            - name: 'name'
+              type: Enum
+              description: |
+                The name of a locality load balancer policy to be used. The value
+                should be one of the predefined ones as supported by localityLbPolicy,
+                although at the moment only ROUND_ROBIN is supported.
+
+                This field should only be populated when the customPolicy field is not
+                used.
+
+                Note that specifying the same policy more than once for a backend is
+                not a valid configuration and will be rejected.
+
+                The possible values are:
+
+                * `ROUND_ROBIN`: This is a simple policy in which each healthy backend
+                                is selected in round robin order.
+
+                * `LEAST_REQUEST`: An O(1) algorithm which selects two random healthy
+                                  hosts and picks the host which has fewer active requests.
+
+                * `RING_HASH`: The ring/modulo hash load balancer implements consistent
+                              hashing to backends. The algorithm has the property that the
+                              addition/removal of a host from a set of N hosts only affects
+                              1/N of the requests.
+
+                * `RANDOM`: The load balancer selects a random healthy host.
+
+                * `ORIGINAL_DESTINATION`: Backend host is selected based on the client
+                                          connection metadata, i.e., connections are opened
+                                          to the same address as the destination address of
+                                          the incoming connection before the connection
+                                          was redirected to the load balancer.
+
+                * `MAGLEV`: used as a drop in replacement for the ring hash load balancer.
+                            Maglev is not as stable as ring hash but has faster table lookup
+                            build times and host selection times. For more information about
+                            Maglev, refer to https://ai.google/research/pubs/pub44824
+              required: true
+              enum_values:
+                - 'ROUND_ROBIN'
+                - 'LEAST_REQUEST'
+                - 'RING_HASH'
+                - 'RANDOM'
+                - 'ORIGINAL_DESTINATION'
+                - 'MAGLEV'
+        - name: 'customPolicy'
+          type: NestedObject
+          description: |
+            The configuration for a custom policy implemented by the user and
+            deployed with the client.
+          exactly_one_of:
+            - 'policy'
+            - 'customPolicy'
+          properties:
+            - name: 'name'
+              type: String
+              description: |
+                Identifies the custom policy.
+
+                The value should match the type the custom implementation is registered
+                with on the gRPC clients. It should follow protocol buffer
+                message naming conventions and include the full path (e.g.
+                myorg.CustomLbPolicy). The maximum length is 256 characters.
+
+                Note that specifying the same custom policy more than once for a
+                backend is not a valid configuration and will be rejected.
+              required: true
+            - name: 'data'
+              type: String
+              description: |
+                An optional, arbitrary JSON object with configuration data, understood
+                by a locally installed custom policy implementation.
+  - name: 'customMetrics'
+    type: Array
+    description: |
+      List of custom metrics that are used for the WEIGHTED_ROUND_ROBIN locality_lb_policy.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          required: true
+          description: |
+            Name of a custom utilization signal. The name must be 1-64 characters
+            long and match the regular expression [a-z]([-_.a-z0-9]*[a-z0-9])? which
+            means the first character must be a lowercase letter, and all following
+            characters must be a dash, period, underscore, lowercase letter, or
+            digit, except the last character, which cannot be a dash, period, or
+            underscore. For usage guidelines, see Custom Metrics balancing mode. This
+            field can only be used for a global or regional backend service with the
+            loadBalancingScheme set to <code>EXTERNAL_MANAGED</code>,
+            <code>INTERNAL_MANAGED</code> <code>INTERNAL_SELF_MANAGED</code>.
+        - name: 'dryRun'
+          type: Boolean
+          required: true
+          description: |
+            If true, the metric data is not used for load balancing.
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    required: true
+    immutable: true
+  - name: 'outlierDetection'
+    type: NestedObject
+    description: |
+      Settings controlling eviction of unhealthy hosts from the load balancing pool.
+      Applicable backend service types can be a global backend service with the
+      loadBalancingScheme set to INTERNAL_SELF_MANAGED or EXTERNAL_MANAGED.
+    properties:
+      - name: 'baseEjectionTime'
+        type: NestedObject
+        description: |
+          The base time that a host is ejected for. The real time is equal to the base
+          time multiplied by the number of times the host has been ejected. Defaults to
+          30000ms or 30s.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+        properties:
+          - name: 'seconds'
+            type: Integer
+            description: |
+              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+              inclusive.
+            required: true
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond resolution. Durations
+              less than one second are represented with a 0 `seconds` field and a positive
+              `nanos` field. Must be from 0 to 999,999,999 inclusive.
+      - name: 'consecutiveErrors'
+        type: Integer
+        description: |
+          Number of errors before a host is ejected from the connection pool. When the
+          backend host is accessed over HTTP, a 5xx return code qualifies as an error.
+          Defaults to 5.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'consecutiveGatewayFailure'
+        type: Integer
+        description: |
+          The number of consecutive gateway failures (502, 503, 504 status or connection
+          errors that are mapped to one of those status codes) before a consecutive
+          gateway failure ejection occurs. Defaults to 5.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'enforcingConsecutiveErrors'
+        type: Integer
+        description: |
+          The percentage chance that a host will be actually ejected when an outlier
+          status is detected through consecutive 5xx. This setting can be used to disable
+          ejection or to ramp it up slowly. Defaults to 100.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'enforcingConsecutiveGatewayFailure'
+        type: Integer
+        description: |
+          The percentage chance that a host will be actually ejected when an outlier
+          status is detected through consecutive gateway failures. This setting can be
+          used to disable ejection or to ramp it up slowly. Defaults to 0.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'enforcingSuccessRate'
+        type: Integer
+        description: |
+          The percentage chance that a host will be actually ejected when an outlier
+          status is detected through success rate statistics. This setting can be used to
+          disable ejection or to ramp it up slowly. Defaults to 100.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'interval'
+        type: NestedObject
+        description: |
+          Time interval between ejection sweep analysis. This can result in both new
+          ejections as well as hosts being returned to service. Defaults to 10 seconds.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+        properties:
+          - name: 'seconds'
+            type: Integer
+            description: |
+              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+              inclusive.
+            required: true
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond resolution. Durations
+              less than one second are represented with a 0 `seconds` field and a positive
+              `nanos` field. Must be from 0 to 999,999,999 inclusive.
+      - name: 'maxEjectionPercent'
+        type: Integer
+        description: |
+          Maximum percentage of hosts in the load balancing pool for the backend service
+          that can be ejected. Defaults to 10%.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'successRateMinimumHosts'
+        type: Integer
+        description: |
+          The number of hosts in a cluster that must have enough request volume to detect
+          success rate outliers. If the number of hosts is less than this setting, outlier
+          detection via success rate statistics is not performed for any host in the
+          cluster. Defaults to 5.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'successRateRequestVolume'
+        type: Integer
+        description: |
+          The minimum number of total requests that must be collected in one interval (as
+          defined by the interval duration above) to include this host in success rate
+          based outlier detection. If the volume is lower than this setting, outlier
+          detection via success rate statistics is not performed for that host. Defaults
+          to 100.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'successRateStdevFactor'
+        type: Integer
+        description: |
+          This factor is used to determine the ejection threshold for success rate outlier
+          ejection. The ejection threshold is the difference between the mean success
+          rate, and the product of this factor and the standard deviation of the mean
+          success rate: mean - (stdev * success_rate_stdev_factor). This factor is divided
+          by a thousand to get a double. That is, if the desired factor is 1.9, the
+          runtime value should be 1900. Defaults to 1900.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+  # 'port' is deprecated
+  - name: 'portName'
+    type: String
+    description: |
+      Name of backend port. The same name should appear in the instance
+      groups referenced by this service. Required when the load balancing
+      scheme is EXTERNAL.
+    default_from_api: true
+  - name: 'protocol'
+    type: Enum
+    description: |
+      The protocol this BackendService uses to communicate with backends.
+      The default is HTTP. Possible values are HTTP, HTTPS, HTTP2, H2C, TCP, SSL, UDP
+      or GRPC. Refer to the documentation for the load balancers or for Traffic Director
+      for more information. Must be set to GRPC when the backend service is referenced
+      by a URL map that is bound to target gRPC proxy.
+    default_from_api: true
+    enum_values:
+      - 'HTTP'
+      - 'HTTPS'
+      - 'HTTP2'
+      - 'TCP'
+      - 'SSL'
+      - 'UDP'
+      - 'GRPC'
+      - 'UNSPECIFIED'
+      - 'H2C'
+  - name: 'securityPolicy'
+    # TODO: make a ResourceRef to Security Policy
+    type: String
+    description: |
+      The security policy associated with this backend service.
+    diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+  - name: 'edgeSecurityPolicy'
+    type: String
+    description: |
+      The resource URL for the edge security policy associated with this backend service.
+    diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+  - name: 'securitySettings'
+    type: NestedObject
+    description: |
+      The security settings that apply to this backend service. This field is applicable to either
+      a regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C, and
+      load_balancing_scheme set to INTERNAL_MANAGED; or a global backend service with the
+      load_balancing_scheme set to INTERNAL_SELF_MANAGED.
+    properties:
+      - name: 'clientTlsPolicy'
+        type: ResourceRef
+        description: |
+          ClientTlsPolicy is a resource that specifies how a client should authenticate
+          connections to backends of a service. This resource itself does not affect
+          configuration unless it is attached to a backend service resource.
+        diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+        resource: 'ClientTlsPolicy'
+        imports: 'name'
+      - name: 'subjectAltNames'
+        type: Array
+        description: |
+          A list of alternate names to verify the subject identity in the certificate.
+          If specified, the client will verify that the server certificate's subject
+          alt name matches one of the specified values.
+        item_type:
+          type: String
+      - name: 'awsV4Authentication'
+        type: NestedObject
+        description: |
+          The configuration needed to generate a signature for access to private storage buckets that support AWS's Signature Version 4 for authentication.
+          Allowed only for INTERNET_IP_PORT and INTERNET_FQDN_PORT NEG backends.
+        properties:
+          - name: 'accessKeyId'
+            type: String
+            description: |
+              The identifier of an access key used for s3 bucket authentication.
+          - name: 'accessKey'
+            type: String
+            description: |
+              The access key used for s3 bucket authentication.
+              Required for updating or creating a backend that uses AWS v4 signature authentication, but will not be returned as part of the configuration when queried with a REST API GET request.
+            ignore_read: true
+            sensitive: true
+            send_empty_value: true
+          - name: 'accessKeyVersion'
+            type: String
+            description: |
+              The optional version identifier for the access key. You can use this to keep track of different iterations of your access key.
+          - name: 'originRegion'
+            type: String
+            description: |
+              The name of the cloud region of your origin. This is a free-form field with the name of the region your cloud uses to host your origin.
+              For example, "us-east-1" for AWS or "us-ashburn-1" for OCI.
+  - name: 'sessionAffinity'
+    type: Enum
+    description: |
+      Type of session affinity to use. The default is NONE. Session affinity is
+      not applicable if the protocol is UDP.
+    default_from_api: true
+    enum_values:
+      - 'NONE'
+      - 'CLIENT_IP'
+      - 'CLIENT_IP_PORT_PROTO'
+      - 'CLIENT_IP_PROTO'
+      - 'GENERATED_COOKIE'
+      - 'HEADER_FIELD'
+      - 'HTTP_COOKIE'
+      - 'STRONG_COOKIE_AFFINITY'
+  - name: 'strongSessionAffinityCookie'
+    type: NestedObject
+    description: |
+      Describes the HTTP cookie used for stateful session affinity. This field is applicable and required if the sessionAffinity is set to STRONG_COOKIE_AFFINITY.
+    properties:
+      - name: 'ttl'
+        type: NestedObject
+        description: |
+          Lifetime of the cookie.
+        at_least_one_of:
+          - 'strong_session_affinity_cookie.0.ttl'
+          - 'strong_session_affinity_cookie.0.name'
+          - 'strong_session_affinity_cookie.0.path'
+        properties:
+          - name: 'seconds'
+            type: Integer
+            description: |
+              Span of time at a resolution of a second.
+              Must be from 0 to 315,576,000,000 inclusive.
+            required: true
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond
+              resolution. Durations less than one second are represented
+              with a 0 seconds field and a positive nanos field. Must
+              be from 0 to 999,999,999 inclusive.
+      - name: 'name'
+        type: String
+        description: |
+          Name of the cookie.
+        at_least_one_of:
+          - 'strong_session_affinity_cookie.0.ttl'
+          - 'strong_session_affinity_cookie.0.name'
+          - 'strong_session_affinity_cookie.0.path'
+      - name: 'path'
+        type: String
+        description: |
+          Path to set for the cookie.
+        at_least_one_of:
+          - 'strong_session_affinity_cookie.0.ttl'
+          - 'strong_session_affinity_cookie.0.name'
+          - 'strong_session_affinity_cookie.0.path'
+  - name: 'timeoutSec'
+    type: Integer
+    description: |
+      The backend service timeout has a different meaning depending on the type of load balancer.
+      For more information see, [Backend service settings](https://cloud.google.com/compute/docs/reference/rest/v1/backendServices).
+      The default is 30 seconds.
+      The full range of timeout values allowed goes from 1 through 2,147,483,647 seconds.
+    default_from_api: true
+  - name: 'logConfig'
+    type: NestedObject
+    description: |
+      This field denotes the logging options for the load balancer traffic served by this backend service.
+      If logging is enabled, logs will be exported to Stackdriver.
+    default_from_api: true
+    properties:
+      - name: 'enable'
+        type: Boolean
+        description: |
+          Whether to enable logging for the load balancer traffic served by this backend service.
+        send_empty_value: true
+        at_least_one_of:
+          - 'log_config.0.enable'
+          - 'log_config.0.sample_rate'
+      - name: 'sampleRate'
+        type: Double
+        description: |
+          This field can only be specified if logging is enabled for this backend service. The value of
+          the field must be in [0, 1]. This configures the sampling rate of requests to the load balancer
+          where 1.0 means all logged requests are reported and 0.0 means no logged requests are reported.
+          The default value is 1.0.
+        at_least_one_of:
+          - 'log_config.0.enable'
+          - 'log_config.0.sample_rate'
+        diff_suppress_func: 'suppressWhenDisabled'
+        default_value: 1.0
+      - name: 'optionalMode'
+        type: Enum
+        description: |
+          Specifies the optional logging mode for the load balancer traffic.
+          Supported values: INCLUDE_ALL_OPTIONAL, EXCLUDE_ALL_OPTIONAL, CUSTOM.
+        enum_values:
+          - 'INCLUDE_ALL_OPTIONAL'
+          - 'EXCLUDE_ALL_OPTIONAL'
+          - 'CUSTOM'
+        at_least_one_of:
+          - 'log_config.0.enable'
+          - 'log_config.0.sample_rate'
+          - 'log_config.0.optional_mode'
+        default_from_api: true
+      - name: 'optionalFields'
+        type: Array
+        description: |
+          This field can only be specified if logging is enabled for this backend service and "logConfig.optionalMode"
+          was set to CUSTOM. Contains a list of optional fields you want to include in the logs.
+          For example: serverInstance, serverGkeDetails.cluster, serverGkeDetails.pod.podNamespace
+          For example: orca_load_report, tls.protocol
+        item_type:
+          type: String
+  - name: 'serviceLbPolicy'
+    type: String
+    description: |
+      URL to networkservices.ServiceLbPolicy resource.
+      Can only be set if load balancing scheme is EXTERNAL, EXTERNAL_MANAGED, INTERNAL_MANAGED or INTERNAL_SELF_MANAGED and the scope is global.
+  - name: 'tlsSettings'
+    type: NestedObject
+    description: |
+      Configuration for Backend Authenticated TLS and mTLS. May only be specified when the backend protocol is SSL, HTTPS or HTTP2.
+    properties:
+      - name: 'sni'
+        type: String
+        description: |
+          Server Name Indication - see RFC3546 section 3.1. If set, the load balancer sends this string as the SNI hostname in the
+          TLS connection to the backend, and requires that this string match a Subject Alternative Name (SAN) in the backend's
+          server certificate. With a Regional Internet NEG backend, if the SNI is specified here, the load balancer uses it
+          regardless of whether the Regional Internet NEG is specified with FQDN or IP address and port.
+      - name: 'subjectAltNames'
+        type: Array
+        description: |
+          A list of Subject Alternative Names (SANs) that the Load Balancer verifies during a TLS handshake with the backend.
+          When the server presents its X.509 certificate to the Load Balancer, the Load Balancer inspects the certificate's SAN field,
+          and requires that at least one SAN match one of the subjectAltNames in the list. This field is limited to 5 entries.
+          When both sni and subjectAltNames are specified, the load balancer matches the backend certificate's SAN only to
+          subjectAltNames.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'dnsName'
+              type: String
+              description: The SAN specified as a DNS Name.
+              exactly_one_of:
+                - tlsSettings.0.uniform_resource_identifier
+                - tlsSettings.0.dns_name
+            - name: 'uniformResourceIdentifier'
+              type: String
+              description: The SAN specified as a URI.
+              exactly_one_of:
+                - tlsSettings.0.uniform_resource_identifier
+                - tlsSettings.0.dns_name
+      - name: 'authenticationConfig'
+        type: String
+        description: |
+          Reference to the BackendAuthenticationConfig resource from the networksecurity.googleapis.com namespace.
+          Can be used in authenticating TLS connections to the backend, as specified by the authenticationMode field.
+          Can only be specified if authenticationMode is not NONE.
+  - name: 'maxStreamDuration'
+    type: NestedObject
+    description: |
+      Specifies the default maximum duration (timeout) for streams to this service. Duration is computed from the
+      beginning of the stream until the response has been completely processed, including all retries. A stream that
+      does not complete in this duration is closed.
+      If not specified, there will be no timeout limit, i.e. the maximum duration is infinite.
+      This value can be overridden in the PathMatcher configuration of the UrlMap that references this backend service.
+      This field is only allowed when the loadBalancingScheme of the backend service is INTERNAL_SELF_MANAGED.
+    properties:
+      - name: 'seconds'
+        type: String
+        description: |
+          Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive. (int64 format)
+        required: true
+      - name: 'nanos'
+        type: Integer
+        description: |
+          Span of time that's a fraction of a second at nanosecond resolution.
+          Durations less than one second are represented with a 0 seconds field and a positive nanos field.
+          Must be from 0 to 999,999,999 inclusive.
+  - name: 'networkPassThroughLbTrafficPolicy'
+    type: NestedObject
+    description: |
+      Configures traffic steering properties of internal passthrough Network Load Balancers.
+    min_version: beta
+    properties:
+      - name: 'zonalAffinity'
+        type: NestedObject
+        description: |
+          When configured, new connections are load balanced across healthy backend endpoints in the local zone.
+        properties:
+          - name: 'spillover'
+            type: Enum
+            description: |
+              This field indicates whether zonal affinity is enabled or not.
+            enum_values:
+              - 'ZONAL_AFFINITY_DISABLED'
+              - 'ZONAL_AFFINITY_SPILL_CROSS_ZONE'
+              - 'ZONAL_AFFINITY_STAY_WITHIN_ZONE'
+            default_value: 'ZONAL_AFFINITY_DISABLED'
+            min_version: beta
+          - name: 'spilloverRatio'
+            type: Double
+            description: |
+              The value of the field must be in [0, 1]. When the ratio of the count of healthy backend endpoints in a zone
+              to the count of backend endpoints in that same zone is equal to or above this threshold, the load balancer
+              distributes new connections to all healthy endpoints in the local zone only. When the ratio of the count
+              of healthy backend endpoints in a zone to the count of backend endpoints in that same zone is below this
+              threshold, the load balancer distributes all new connections to all healthy endpoints across all zones.
+            min_version: beta
+  - name: 'dynamicForwarding'
+    type: NestedObject
+    description: |
+      Dynamic forwarding configuration. This field is used to configure the backend service with dynamic forwarding
+      feature which together with Service Extension allows customized and complex routing logic.
+    min_version: beta
+    is_missing_in_cai: true
+    properties:
+      - name: 'ipPortSelection'
+        type: NestedObject
+        description: |
+          IP:PORT based dynamic forwarding configuration.
+        min_version: beta
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            min_version: beta
+            description: |
+              A boolean flag enabling IP:PORT based dynamic forwarding.
+            immutable: true
+  - name: 'params'
+    type: NestedObject
+    ignore_read: true
+    immutable: true
+    description: |
+      Additional params passed with the request, but not persisted as part of resource payload
+    properties:
+      - name: 'resourceManagerTags'
+        type: KeyValuePairs
+        description: |
+          Resource manager tags to be bound to the backend service. Tag keys and values have the
+          same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id},
+          and values are in the format tagValues/456.
+        api_name: resourceManagerTags
+        ignore_read: true
+        immutable: true

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_forwarding_rule.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_forwarding_rule.yaml
@@ -1,0 +1,701 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'ForwardingRule'
+api_variant_patterns:
+  - 'projects/{project}/regions/{region}/forwardingRules/{forwardingRule}'
+kind: 'compute#forwardingRule'
+description: |
+  A ForwardingRule resource. A ForwardingRule resource specifies which pool
+  of target virtual machines to forward a packet to if it matches the given
+  [IPAddress, IPProtocol, portRange] tuple.
+# Has a separate endpoint for labels
+exclude_attribution_label: true
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules'
+  api: 'https://cloud.google.com/compute/docs/reference/v1/forwardingRules'
+docs:
+base_url: 'projects/{{project}}/regions/{{region}}/forwardingRules'
+has_self_link: true
+immutable: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+tgc_tests:
+  - name: 'TestAccComputeForwardingRule_allowGlobalAccessUpdate_Internal'
+    skip: 'Test data issue'
+custom_code:
+  constants: 'templates/terraform/constants/compute_forwarding_rule.go.tmpl'
+  pre_create: 'templates/terraform/pre_create/compute_forwarding_rule.go.tmpl'
+  post_create: 'templates/terraform/post_create/labels.tmpl'
+custom_diff:
+  - 'forwardingRuleCustomizeDiff'
+legacy_long_form_project: true
+sweeper:
+  dependencies:
+    - "google_network_connectivity_service_connection_policy"
+  url_substitutions:
+    - region: "us-west2"
+    - region: "us-central1"
+    - region: "europe-west4"
+    - region: "europe-west1"
+    - region: "us-west1"
+examples:
+  - name: 'internal_http_lb_with_mig_backend'
+    primary_resource_id: 'google_compute_forwarding_rule'
+    min_version: 'beta'
+    vars:
+      ilb_network_name: 'l7-ilb-network'
+      proxy_subnet_name: 'l7-ilb-proxy-subnet'
+      backend_subnet_name: 'l7-ilb-subnet'
+      forwarding_rule_name: 'l7-ilb-forwarding-rule'
+      target_http_proxy_name: 'l7-ilb-target-http-proxy'
+      regional_url_map_name: 'l7-ilb-regional-url-map'
+      backend_service_name: 'l7-ilb-backend-subnet'
+      mig_template_name: 'l7-ilb-mig-template'
+      hc_name: 'l7-ilb-hc'
+      mig_name: 'l7-ilb-mig1'
+      fw_allow_iap_hc_name: 'l7-ilb-fw-allow-iap-hc'
+      fw_allow_ilb_to_backends_name: 'l7-ilb-fw-allow-ilb-to-backends'
+      vm_test_name: 'l7-ilb-test-vm'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+  - name: 'internal_tcp_udp_lb_with_mig_backend'
+    primary_resource_id: 'google_compute_forwarding_rule'
+    min_version: 'beta'
+    vars:
+      ilb_network_name: 'l4-ilb-network'
+      backend_subnet_name: 'l4-ilb-subnet'
+      forwarding_rule_name: 'l4-ilb-forwarding-rule'
+      backend_service_name: 'l4-ilb-backend-subnet'
+      mig_template_name: 'l4-ilb-mig-template'
+      hc_name: 'l4-ilb-hc'
+      mig_name: 'l4-ilb-mig1'
+      fw_allow_hc_name: 'l4-ilb-fw-allow-hc'
+      fw_allow_ilb_to_backends_name: 'l4-ilb-fw-allow-ilb-to-backends'
+      fw_allow_ilb_ssh_name: 'l4-ilb-fw-ssh'
+      vm_test_name: 'l4-ilb-test-vm'
+  - name: 'forwarding_rule_externallb'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      forwarding_rule_name: 'website-forwarding-rule'
+      backend_name: 'website-backend'
+      network_name: 'website-net'
+    ignore_read_extra:
+      - 'port_range'
+  - name: 'forwarding_rule_externallb_byoipv6'
+    primary_resource_id: 'default'
+    vars:
+      forwarding_rule_name: 'byoipv6-forwarding-rule'
+      backend_name: 'website-backend'
+      network_name: 'website-net'
+      ip_address: '"2600:1901:4457:1::/96"'
+      ip_collection_url: '"projects/tf-static-byoip/regions/us-central1/publicDelegatedPrefixes/tf-test-forwarding-rule-mode-pdp"'
+    test_vars_overrides:
+      ip_address: 'fmt.Sprintf("2600:1901:4457:1:%d:%d::/96", acctest.RandIntRange(t, 0, 9999), acctest.RandIntRange(t, 0, 9999))'
+      ip_collection_url: '"projects/tf-static-byoip/regions/us-central1/publicDelegatedPrefixes/tf-test-forwarding-rule-mode-pdp"'
+    ignore_read_extra:
+      - 'port_range'
+  - name: 'forwarding_rule_global_internallb'
+    primary_resource_id: 'default'
+    vars:
+      forwarding_rule_name: 'website-forwarding-rule'
+      backend_name: 'website-backend'
+      network_name: 'website-net'
+  - name: 'forwarding_rule_basic'
+    primary_resource_id: 'default'
+    vars:
+      forwarding_rule_name: 'website-forwarding-rule'
+      target_pool_name: 'website-target-pool'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+  - name: 'forwarding_rule_l3_default'
+    primary_resource_id: 'fwd_rule'
+    min_version: 'beta'
+    vars:
+      forwarding_rule_name: 'l3-forwarding-rule'
+      service_name: 'service'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      service_name: '"service" + randomSuffix'
+  - name: 'forwarding_rule_internallb'
+    primary_resource_id: 'default'
+    vars:
+      forwarding_rule_name: 'website-forwarding-rule'
+      backend_name: 'website-backend'
+      network_name: 'website-net'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+  - name: 'forwarding_rule_http_lb'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      forwarding_rule_name: 'website-forwarding-rule'
+      region_target_http_proxy_name: 'website-proxy'
+      region_url_map_name: 'website-map'
+      region_backend_service_name: 'website-backend'
+      region_health_check_name: 'website-hc'
+      rigm_name: 'website-rigm'
+      network_name: 'website-net'
+      fw_name: 'website-fw'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+  - name: 'forwarding_rule_regional_http_xlb'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      forwarding_rule_name: 'website-forwarding-rule'
+      region_target_http_proxy_name: 'website-proxy'
+      region_url_map_name: 'website-map'
+      region_backend_service_name: 'website-backend'
+      region_health_check_name: 'website-hc'
+      rigm_name: 'website-rigm'
+      network_name: 'website-net'
+      fw_name: 'website-fw'
+      ip_name: 'website-ip'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+      - 'ip_address'
+  - name: 'forwarding_rule_vpc_psc'
+    primary_resource_id: 'default'
+    vars:
+      forwarding_rule_name: 'psc-endpoint'
+      consumer_network_name: 'consumer-net'
+      ip_name: 'website-ip'
+      producer_network_name: 'producer-net'
+      producer_psc_network_name: 'producer-psc-net'
+      service_attachment_name: 'producer-service'
+      producer_forwarding_rule_name: 'producer-forwarding-rule'
+      producer_backend_name: 'producer-service-backend'
+      producer_healthcheck_name: 'producer-service-health-check'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+      - 'ip_address'
+  - name: 'forwarding_rule_vpc_psc_no_automate_dns'
+    primary_resource_id: 'default'
+    vars:
+      forwarding_rule_name: 'psc-endpoint'
+      consumer_network_name: 'consumer-net'
+      ip_name: 'website-ip'
+      producer_network_name: 'producer-net'
+      producer_psc_network_name: 'producer-psc-net'
+      service_attachment_name: 'producer-service'
+      producer_forwarding_rule_name: 'producer-forwarding-rule'
+      producer_backend_name: 'producer-service-backend'
+      producer_healthcheck_name: 'producer-service-health-check'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+      - 'ip_address'
+  - name: 'forwarding_rule_regional_steering'
+    primary_resource_id: 'steering'
+    vars:
+      forwarding_rule_name: 'steering-rule'
+      ip_name: 'website-ip'
+      backend_name: 'service-backend'
+      external_forwarding_rule_name: 'external-forwarding-rule'
+  - name: 'forwarding_rule_internallb_ipv6'
+    primary_resource_id: 'default'
+    vars:
+      forwarding_rule_name: 'ilb-ipv6-forwarding-rule'
+      backend_name: 'ilb-ipv6-backend'
+      network_name: 'net-ipv6'
+      subnet_name: 'subnet-internal-ipv6'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+virtual_fields:
+  - name: 'recreate_closed_psc'
+    description:
+      This is used in PSC consumer ForwardingRule to make terraform recreate the ForwardingRule when the status is closed
+    type: Boolean
+    default_value: false
+parameters:
+  - name: 'region'
+    type: ResourceRef
+    description: |
+      A reference to the region where the regional forwarding rule resides.
+
+      This field is not applicable to global forwarding rules.
+    required: false
+    default_from_api: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Region'
+    imports: 'name'
+properties:
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'isMirroringCollector'
+    type: Boolean
+    description: |
+      Indicates whether or not this load balancer can be used as a collector for
+      packet mirroring. To prevent mirroring loops, instances behind this
+      load balancer will not have their traffic mirrored even if a
+      `PacketMirroring` rule applies to them.
+
+      This can only be set to true for load balancers that have their
+      `loadBalancingScheme` set to `INTERNAL`.
+  - name: 'forwardingRuleId'
+    type: Integer
+    description: |
+      The unique identifier number for the resource. This identifier is defined by the server.
+    api_name: id
+    output: true
+  - name: 'pscConnectionId'
+    type: String
+    description: 'The PSC connection id of the PSC Forwarding Rule.'
+    output: true
+  - name: 'pscConnectionStatus'
+    type: String
+    description:
+      'The PSC connection status of the PSC Forwarding Rule. Possible values:
+      `STATUS_UNSPECIFIED`, `PENDING`, `ACCEPTED`, `REJECTED`, `CLOSED`'
+    output: true
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource. Provide this property when
+      you create the resource.
+  # This is a multi-resource resource reference (Address, GlobalAddress)
+  - name: 'IPAddress'
+    type: String
+    description: |
+      IP address for which this forwarding rule accepts traffic. When a client
+      sends traffic to this IP address, the forwarding rule directs the traffic
+      to the referenced `target` or `backendService`.
+
+      While creating a forwarding rule, specifying an `IPAddress` is
+      required under the following circumstances:
+
+      * When the `target` is set to `targetGrpcProxy` and
+      `validateForProxyless` is set to `true`, the
+      `IPAddress` should be set to `0.0.0.0`.
+      * When the `target` is a Private Service Connect Google APIs
+      bundle, you must specify an `IPAddress`.
+
+      Otherwise, you can optionally specify an IP address that references an
+      existing static (reserved) IP address resource. When omitted, Google Cloud
+      assigns an ephemeral IP address.
+
+      Use one of the following formats to specify an IP address while creating a
+      forwarding rule:
+
+      * IP address number, as in `100.1.2.3`
+      * IPv6 address range, as in `2600:1234::/96`
+      * Full resource URL, as in
+      `https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name`
+      * Partial URL or by name, as in:
+        * `projects/project_id/regions/region/addresses/address-name`
+        * `regions/region/addresses/address-name`
+        * `global/addresses/address-name`
+        * `address-name`
+
+      The forwarding rule's `target` or `backendService`,
+      and in most cases, also the `loadBalancingScheme`, determine the
+      type of IP address that you can use. For detailed information, see
+      [IP address
+      specifications](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+      When reading an `IPAddress`, the API always returns the IP
+      address number.
+    default_from_api: true
+    diff_suppress_func: 'InternalIpDiffSuppress'
+  - name: 'IPProtocol'
+    type: Enum
+    description: |
+      The IP protocol to which this rule applies.
+
+      For protocol forwarding, valid
+      options are `TCP`, `UDP`, `ESP`,
+      `AH`, `SCTP`, `ICMP` and
+      `L3_DEFAULT`.
+
+      The valid IP protocols are different for different load balancing products
+      as described in [Load balancing
+      features](https://cloud.google.com/load-balancing/docs/features#protocols_from_the_load_balancer_to_the_backends).
+
+      A Forwarding Rule with protocol L3_DEFAULT can attach with target instance or
+      backend service with UNSPECIFIED protocol.
+      A forwarding rule with "L3_DEFAULT" IPProtocal cannot be attached to a backend service with TCP or UDP.
+    default_from_api: true
+    diff_suppress_func: 'tpgresource.CaseDiffSuppress'
+    enum_values:
+      - 'TCP'
+      - 'UDP'
+      - 'ESP'
+      - 'AH'
+      - 'SCTP'
+      - 'ICMP'
+      - 'L3_DEFAULT'
+  # This is a multi-resource resource reference (BackendService (global), RegionBackendService)
+  # We have custom expands that manage this.
+  - name: 'backendService'
+    type: ResourceRef
+    description: |
+      Identifies the backend service to which the forwarding rule sends traffic.
+
+      Required for Internal TCP/UDP Load Balancing and Network Load Balancing;
+      must be omitted for all other load balancer types.
+    custom_expand: 'templates/terraform/custom_expand/self_link_from_name.tmpl'
+    resource: 'BackendService'
+    imports: 'selfLink'
+  - name: 'loadBalancingScheme'
+    type: Enum
+    description: |
+      Specifies the forwarding rule type.
+
+      Note that an empty string value (`""`) is also supported for some use
+      cases, for example PSC (private service connection) regional forwarding
+      rules.
+
+      For more information about forwarding rules, refer to
+      [Forwarding rule concepts](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts).
+    default_value: "EXTERNAL"
+    enum_values:
+      - 'EXTERNAL'
+      - 'EXTERNAL_MANAGED'
+      - 'INTERNAL'
+      - 'INTERNAL_MANAGED'
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource; provided by the client when the resource is created.
+      The name must be 1-63 characters long, and comply with
+      [RFC1035](https://www.ietf.org/rfc/rfc1035.txt).
+
+      Specifically, the name must be 1-63 characters long and match the regular
+      expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first
+      character must be a lowercase letter, and all following characters must
+      be a dash, lowercase letter, or digit, except the last character, which
+      cannot be a dash.
+
+      For Private Service Connect forwarding rules that forward traffic to Google
+      APIs, the forwarding rule name must be a 1-20 characters string with
+      lowercase letters and numbers and must start with a letter.
+    required: true
+  - name: 'network'
+    type: ResourceRef
+    description: |
+      This field is not used for external load balancing.
+
+      For Internal TCP/UDP Load Balancing, this field identifies the network that
+      the load balanced IP should belong to for this Forwarding Rule.
+      If the subnetwork is specified, the network of the subnetwork will be used.
+      If neither subnetwork nor this field is specified, the default network will
+      be used.
+
+      For Private Service Connect forwarding rules that forward traffic to Google
+      APIs, a network must be provided.
+    default_from_api: true
+    # TODO: When implementing new types enable converting the
+    # manifest input from a single value to a range of form NN-NN. The API
+    # accepts a single value, e.g. '80', but the API stores and returns
+    # '80-80'. This causes idempotency false positive.
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Network'
+    imports: 'selfLink'
+  - name: 'portRange'
+    type: String
+    description: |
+      The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
+      Only packets addressed to ports in the specified range will be forwarded
+      to the backends configured with this forwarding rule.
+
+      The `portRange` field has the following limitations:
+      * It requires that the forwarding rule `IPProtocol` be TCP, UDP, or SCTP,
+      and
+      * It's applicable only to the following products: external passthrough
+      Network Load Balancers, internal and external proxy Network Load
+      Balancers, internal and external Application Load Balancers, external
+      protocol forwarding, and Classic VPN.
+      * Some products have restrictions on what ports can be used. See
+      [port specifications](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#port_specifications)
+      for details.
+
+      For external forwarding rules, two or more forwarding rules cannot use the
+      same `[IPAddress, IPProtocol]` pair, and cannot have overlapping
+      `portRange`s.
+
+      For internal forwarding rules within the same VPC network, two or more
+      forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
+      cannot have overlapping `portRange`s.
+
+      @pattern: \d+(?:-\d+)?
+    default_from_api: true
+    diff_suppress_func: 'PortRangeDiffSuppress'
+  - name: 'ports'
+    type: Array
+    description: |
+      The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
+      Only packets addressed to ports in the specified range will be forwarded
+      to the backends configured with this forwarding rule.
+
+      The `ports` field has the following limitations:
+      * It requires that the forwarding rule `IPProtocol` be TCP, UDP, or SCTP,
+      and
+      * It's applicable only to the following products: internal passthrough
+      Network Load Balancers, backend service-based external passthrough Network
+      Load Balancers, and internal protocol forwarding.
+      * You can specify a list of up to five ports by number, separated by
+      commas. The ports can be contiguous or discontiguous.
+
+      For external forwarding rules, two or more forwarding rules cannot use the
+      same `[IPAddress, IPProtocol]` pair if they share at least one port
+      number.
+
+      For internal forwarding rules within the same VPC network, two or more
+      forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
+      they share at least one port number.
+
+      @pattern: \d+(?:-\d+)?
+    is_set: true
+    custom_expand: 'templates/terraform/custom_expand/set_to_list.tmpl'
+    item_type:
+      type: String
+    max_size: 5
+  - name: 'subnetwork'
+    type: ResourceRef
+    description: |
+      This field identifies the subnetwork that the load balanced IP should
+      belong to for this Forwarding Rule, used in internal load balancing and
+      network load balancing with IPv6.
+
+      If the network specified is in auto subnet mode, this field is optional.
+      However, a subnetwork must be specified if the network is in custom subnet
+      mode or when creating external forwarding rule with IPv6.
+    # This is a multi-resource resource reference (TargetHttp(s)Proxy,
+    # TargetSslProxy, TargetTcpProxy, TargetVpnGateway, TargetPool,
+    # TargetInstance)
+    default_from_api: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Subnetwork'
+    imports: 'selfLink'
+  - name: 'target'
+    type: String
+    description: |
+      The URL of the target resource to receive the matched traffic.  For
+      regional forwarding rules, this target must be in the same region as the
+      forwarding rule. For global forwarding rules, this target must be a global
+      load balancing resource.
+
+      The forwarded traffic must be of a type appropriate to the target object.
+      *  For load balancers, see the "Target" column in [Port specifications](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+      For Private Service Connect forwarding rules that forward traffic to managed services, the target must be a service attachment.
+    update_url: 'projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}/setTarget'
+    update_verb: 'POST'
+    diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePathsIgnoreProjectId'
+    custom_expand: 'templates/terraform/custom_expand/self_link_from_name.tmpl'
+  - name: 'labelFingerprint'
+    type: Fingerprint
+    description: |
+      The fingerprint used for optimistic locking of this resource.  Used
+      internally during updates.
+    output: true
+    update_url: 'projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}/setLabels'
+    update_verb: 'POST'
+    key_expander: ''
+  - name: 'allowGlobalAccess'
+    type: Boolean
+    description: |
+      This field is used along with the `backend_service` field for
+      internal load balancing or with the `target` field for internal
+      TargetInstance.
+
+      If the field is set to `TRUE`, clients can access ILB from all
+      regions.
+
+      Otherwise only allows access from clients in the same region as the
+      internal load balancer.
+    send_empty_value: true
+    update_url: 'projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}'
+    update_verb: 'PATCH'
+  - name: 'labels'
+    type: KeyValueLabels
+    description: |
+      Labels to apply to this forwarding rule.  A list of key->value pairs.
+    update_url: 'projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}/setLabels'
+    update_verb: 'POST'
+  - name: 'allPorts'
+    type: Boolean
+    description: |
+      The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
+      Only packets addressed to ports in the specified range will be forwarded
+      to the backends configured with this forwarding rule.
+
+      The `allPorts` field has the following limitations:
+      * It requires that the forwarding rule `IPProtocol` be TCP, UDP, SCTP, or
+      L3_DEFAULT.
+      * It's applicable only to the following products: internal passthrough
+      Network Load Balancers, backend service-based external passthrough Network
+      Load Balancers, and internal and external protocol forwarding.
+      * Set this field to true to allow packets addressed to any port or packets
+      lacking destination port information (for example, UDP fragments after the
+      first fragment) to be forwarded to the backends configured with this
+      forwarding rule. The L3_DEFAULT protocol requires `allPorts` be set to
+      true.
+  - name: 'networkTier'
+    type: Enum
+    description: |
+      This signifies the networking tier used for configuring
+      this load balancer and can only take the following values:
+      `PREMIUM`, `STANDARD`.
+
+      For regional ForwardingRule, the valid values are `PREMIUM` and
+      `STANDARD`. For GlobalForwardingRule, the valid value is
+      `PREMIUM`.
+
+      If this field is not specified, it is assumed to be `PREMIUM`.
+      If `IPAddress` is specified, this value must be equal to the
+      networkTier of the Address.
+    immutable: true
+    default_from_api: true
+    enum_values:
+      - 'PREMIUM'
+      - 'STANDARD'
+  - name: 'serviceDirectoryRegistrations'
+    type: Array
+    description: |
+      Service Directory resources to register this forwarding rule with.
+
+      Currently, only supports a single Service Directory resource.
+    immutable: true
+    default_from_api: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'namespace'
+          type: String
+          description: |
+            Service Directory namespace to register the forwarding rule under.
+          immutable: true
+          default_from_api: true
+        - name: 'service'
+          type: String
+          description: |
+            Service Directory service to register the forwarding rule under.
+          immutable: true
+    min_size: 0
+    max_size: 1
+  - name: 'serviceLabel'
+    type: String
+    description: |
+      An optional prefix to the service name for this Forwarding Rule.
+      If specified, will be the first label of the fully qualified service
+      name.
+
+      The label must be 1-63 characters long, and comply with RFC1035.
+      Specifically, the label must be 1-63 characters long and match the
+      regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first
+      character must be a lowercase letter, and all following characters
+      must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+
+      This field is only used for INTERNAL load balancing.
+    validation:
+      function: 'verify.ValidateGCEName'
+  - name: 'serviceName'
+    type: String
+    description: |
+      The internal fully qualified service name for this Forwarding Rule.
+
+      This field is only used for INTERNAL load balancing.
+    output: true
+  - name: 'sourceIpRanges'
+    type: Array
+    description:
+      If not empty, this Forwarding Rule will only forward the traffic when the
+      source IP address matches one of the IP addresses or CIDR ranges set here.
+      Note that a Forwarding Rule can only have up to 64 source IP ranges, and
+      this field can only be used with a regional Forwarding Rule whose scheme
+      is EXTERNAL. Each sourceIpRange entry should be either an IP address (for
+      example, 1.2.3.4) or a CIDR range (for example, 1.2.3.0/24).
+    immutable: true
+    item_type:
+      type: String
+  - name: 'baseForwardingRule'
+    type: String
+    description:
+      '[Output Only] The URL for the corresponding base Forwarding Rule. By base
+      Forwarding Rule, we mean the Forwarding Rule that has the same IP address,
+      protocol, and port settings with the current Forwarding Rule, but without
+      sourceIPRanges specified. Always empty if the current Forwarding Rule does
+      not have sourceIPRanges specified.'
+    output: true
+  - name: 'allowPscGlobalAccess'
+    type: Boolean
+    description:
+      This is used in PSC consumer ForwardingRule to control whether the PSC
+      endpoint can be accessed from another region.
+    send_empty_value: true
+    update_url: 'projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}'
+    update_verb: 'PATCH'
+    update_id: 'allowPscGlobalAccess'
+    fingerprint_name: 'fingerprint'
+  - name: 'noAutomateDnsZone'
+    type: Boolean
+    description:
+      This is used in PSC consumer ForwardingRule to control whether it should try to auto-generate a DNS zone or not.
+      Non-PSC forwarding rules do not use this field.
+    immutable: true
+    ignore_read: true
+    send_empty_value: true
+  - name: 'ipVersion'
+    type: Enum
+    description: |
+      The IP address version that will be used by this forwarding rule.
+      Valid options are IPV4 and IPV6.
+
+      If not set, the IPv4 address will be used by default.
+    immutable: true
+    default_from_api: true
+    enum_values:
+      - 'IPV4'
+      - 'IPV6'
+  - name: ipCollection
+    type: String
+    is_missing_in_cai: true
+    diff_suppress_func: 'IpCollectionDiffSuppress'
+    description: |
+      Resource reference of a PublicDelegatedPrefix. The PDP must be a sub-PDP
+      in EXTERNAL_IPV6_FORWARDING_RULE_CREATION mode.
+      Use one of the following formats to specify a sub-PDP when creating an
+      IPv6 NetLB forwarding rule using BYOIP:
+      Full resource URL, as in:
+        * `https://www.googleapis.com/compute/v1/projects/{{projectId}}/regions/{{region}}/publicDelegatedPrefixes/{{sub-pdp-name}}`
+      Partial URL, as in:
+        * `projects/{{projectId}}/regions/region/publicDelegatedPrefixes/{{sub-pdp-name}}`
+        * `regions/{{region}}/publicDelegatedPrefixes/{{sub-pdp-name}}`

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_global_forwarding_rule.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_global_forwarding_rule.yaml
@@ -1,0 +1,605 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'GlobalForwardingRule'
+api_resource_type_kind: ForwardingRule
+api_variant_patterns:
+  - 'projects/{project}/global/forwardingRules/{forwardingRule}'
+kind: 'compute#forwardingRule'
+cai_resource_kind: 'GlobalForwardingRule'
+description: |
+  Represents a GlobalForwardingRule resource. Global forwarding rules are
+  used to forward traffic to the correct load balancer for HTTP load
+  balancing. Global forwarding rules can only be used for HTTP load
+  balancing.
+
+  For more information, see https://cloud.google.com/compute/docs/load-balancing/http/
+# Has a separate endpoint for labels
+exclude_attribution_label: true
+docs:
+base_url: 'projects/{{project}}/global/forwardingRules'
+has_self_link: true
+immutable: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+custom_code:
+  pre_create: 'templates/terraform/pre_create/compute_global_forwarding_rule.go.tmpl'
+  post_create: 'templates/terraform/post_create/labels.tmpl'
+legacy_long_form_project: true
+examples:
+  - name: 'external_ssl_proxy_lb_mig_backend'
+    primary_resource_id: 'default'
+    vars:
+      ssl_proxy_xlb_network: 'ssl-proxy-xlb-network'
+      ssl_proxy_xlb_subnet: 'ssl-proxy-xlb-subnet'
+      ssl_proxy_xlb_ip: 'ssl-proxy-xlb-ip'
+      default_cert: 'default-cert'
+      test_proxy: 'test-proxy'
+      ssl_proxy_xlb_forwarding_rule: 'ssl-proxy-xlb-forwarding-rule'
+      ssl_proxy_xlb_backend_service: 'ssl-proxy-xlb-backend-service'
+      ssl_proxy_health_check: 'ssl-proxy-health-check'
+      ssl_proxy_xlb_mig_template: 'ssl-proxy-xlb-mig-template'
+      ssl_proxy_xlb_mig1: 'ssl-proxy-xlb-mig1'
+      ssl_proxy_xlb_fw_allow_hc: 'ssl-proxy-xlb-fw-allow-hc'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+      - 'ip_address'
+    exclude_test: true
+  - name: 'external_tcp_proxy_lb_mig_backend'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      tcp_proxy_xlb_network: 'tcp-proxy-xlb-network'
+      tcp_proxy_xlb_subnet: 'tcp-proxy-xlb-subnet'
+      tcp_proxy_xlb_ip: 'tcp-proxy-xlb-ip'
+      tcp_proxy_xlb_forwarding_rule: 'tcp-proxy-xlb-forwarding-rule'
+      test_proxy_health_check: 'test-proxy-health-check'
+      tcp_proxy_xlb_backend_service: 'tcp-proxy-xlb-backend-service'
+      tcp_proxy_health_check: 'tcp-proxy-health-check'
+      tcp_proxy_xlb_mig_template: 'tcp-proxy-xlb-mig-template'
+      tcp_proxy_xlb_mig1: 'tcp-proxy-xlb-mig1'
+      tcp_proxy_xlb_fw_allow_hc: 'tcp-proxy-xlb-fw-allow-hc'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+      - 'ip_address'
+  - name: 'external_http_lb_mig_backend_custom_header'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      xlb_network_name: 'l7-xlb-network'
+      backend_subnet_name: 'l7-xlb-subnet'
+      address_name: 'l7-xlb-static-ip'
+      forwarding_rule_name: 'l7-xlb-forwarding-rule'
+      target_http_proxy_name: 'l7-xlb-target-http-proxy'
+      url_map_name: 'l7-xlb-url-map'
+      backend_service_name: 'l7-xlb-backend-service'
+      mig_template_name: 'l7-xlb-mig-template'
+      hc_name: 'l7-xlb-hc'
+      mig_name: 'l7-xlb-mig1'
+      fw_allow_hc_name: 'l7-xlb-fw-allow-hc'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+      - 'ip_address'
+  - name: 'global_forwarding_rule_http'
+    primary_resource_id: 'default'
+    vars:
+      forwarding_rule_name: 'global-rule'
+      http_proxy_name: 'target-proxy'
+      backend_service_name: 'backend'
+    test_vars_overrides:
+      # for backward compatible
+      backend_service_name: '"backend" + randomSuffix'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+  - name: 'global_forwarding_rule_internal'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      forwarding_rule_name: 'global-rule'
+      http_proxy_name: 'target-proxy'
+      backend_service_name: 'backend'
+      igm_name: 'igm-internal'
+    test_vars_overrides:
+      # for backward compatible
+      backend_service_name: '"backend" + randomSuffix'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+  - name: 'global_forwarding_rule_external_managed'
+    primary_resource_id: 'default'
+    vars:
+      forwarding_rule_name: 'global-rule'
+      http_proxy_name: 'target-proxy'
+      backend_service_name: 'backend'
+    test_vars_overrides:
+      # for backward compatible
+      backend_service_name: '"backend" + randomSuffix'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+  - name: 'global_forwarding_rule_hybrid'
+    primary_resource_id: 'default'
+    vars:
+      forwarding_rule_name: 'global-rule'
+      http_proxy_name: 'target-proxy'
+      network_name: 'my-network'
+      internal_network_name: 'my-internal-network'
+      subnetwork_name: 'my-subnetwork'
+      default_backend_service_name: 'backend-default'
+      hybrid_backend_service_name: 'backend-hybrid'
+      internal_backend_service_name: 'backend-internal'
+      default_neg_name: 'default-neg'
+      hybrid_neg_name: 'hybrid-neg'
+      internal_neg_name: 'internal-neg'
+      health_check_name: 'health-check'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+  - name: 'global_internal_http_lb_with_mig_backend'
+    primary_resource_id: 'google_compute_forwarding_rule'
+    min_version: 'beta'
+    vars:
+      gilb_network_name: 'l7-gilb-network'
+      proxy_subnet_name: 'l7-gilb-proxy-subnet'
+      backend_subnet_name: 'l7-gilb-subnet'
+      forwarding_rule_name: 'l7-gilb-forwarding-rule'
+      target_http_proxy_name: 'l7-gilb-target-http-proxy'
+      url_map_name: 'l7-gilb-url-map'
+      backend_service_name: 'l7-gilb-backend-subnet'
+      mig_template_name: 'l7-gilb-mig-template'
+      hc_name: 'l7-gilb-hc'
+      mig_name: 'l7-gilb-mig1'
+      fw_allow_iap_hc_name: 'l7-gilb-fw-allow-iap-hc'
+      fw_allow_gilb_to_backends_name: 'l7-gilb-fw-allow-gilb-to-backends'
+      vm_test_name: 'l7-gilb-test-vm'
+    ignore_read_extra:
+      - 'port_range'
+      - 'target'
+  - name: 'private_service_connect_google_apis'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      network_name: 'my-network'
+      subnetwork_name: 'my-subnetwork'
+      global_address_name: 'global-psconnect-ip'
+      forwarding_rule_name: 'globalrule'
+    test_vars_overrides:
+      # for backward compatible
+      forwarding_rule_name: '"globalrule" + randomSuffix'
+    test_env_vars:
+      project: 'PROJECT_NAME'
+    ignore_read_extra:
+      - 'ip_address'
+  - name: 'private_service_connect_google_apis_no_automate_dns'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      network_name: 'my-network'
+      subnetwork_name: 'my-subnetwork'
+      global_address_name: 'global-psconnect-ip'
+      forwarding_rule_name: 'globalrule'
+    test_vars_overrides:
+      # for backward compatible
+      forwarding_rule_name: '"globalrule" + randomSuffix'
+    test_env_vars:
+      project: 'PROJECT_NAME'
+    ignore_read_extra:
+      - 'ip_address'
+parameters:
+properties:
+  - name: 'pscConnectionId'
+    type: String
+    description: 'The PSC connection id of the PSC Forwarding Rule.'
+    output: true
+  - name: 'pscConnectionStatus'
+    type: String
+    description:
+      'The PSC connection status of the PSC Forwarding Rule. Possible values:
+      `STATUS_UNSPECIFIED`, `PENDING`, `ACCEPTED`, `REJECTED`, `CLOSED`'
+    output: true
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource. Provide this property when
+      you create the resource.
+  - name: 'forwardingRuleId'
+    type: Integer
+    description: |
+      The unique identifier number for the resource. This identifier is defined by the server.
+    api_name: id
+    output: true
+  # This is a multi-resource resource reference (Address, GlobalAddress)
+  - name: 'IPAddress'
+    type: String
+    description: |
+      IP address for which this forwarding rule accepts traffic. When a client
+      sends traffic to this IP address, the forwarding rule directs the traffic
+      to the referenced `target`.
+
+      While creating a forwarding rule, specifying an `IPAddress` is
+      required under the following circumstances:
+
+      * When the `target` is set to `targetGrpcProxy` and
+      `validateForProxyless` is set to `true`, the
+      `IPAddress` should be set to `0.0.0.0`.
+      * When the `target` is a Private Service Connect Google APIs
+      bundle, you must specify an `IPAddress`.
+
+      Otherwise, you can optionally specify an IP address that references an
+      existing static (reserved) IP address resource. When omitted, Google Cloud
+      assigns an ephemeral IP address.
+
+      Use one of the following formats to specify an IP address while creating a
+      forwarding rule:
+
+      * IP address number, as in `100.1.2.3`
+      * IPv6 address range, as in `2600:1234::/96`
+      * Full resource URL, as in
+      `https://www.googleapis.com/compute/v1/projects/project_id/regions/region/addresses/address-name`
+      * Partial URL or by name, as in:
+        * `projects/project_id/regions/region/addresses/address-name`
+        * `regions/region/addresses/address-name`
+        * `global/addresses/address-name`
+        * `address-name`
+
+      The forwarding rule's `target`,
+      and in most cases, also the `loadBalancingScheme`, determine the
+      type of IP address that you can use. For detailed information, see
+      [IP address
+      specifications](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+
+      When reading an `IPAddress`, the API always returns the IP
+      address number.
+    default_from_api: true
+    diff_suppress_func: 'InternalIpDiffSuppress'
+  - name: 'IPProtocol'
+    type: Enum
+    description: |
+      The IP protocol to which this rule applies.
+
+      For protocol forwarding, valid
+      options are `TCP`, `UDP`, `ESP`,
+      `AH`, `SCTP`, `ICMP` and
+      `L3_DEFAULT`.
+
+      The valid IP protocols are different for different load balancing products
+      as described in [Load balancing
+      features](https://cloud.google.com/load-balancing/docs/features#protocols_from_the_load_balancer_to_the_backends).
+    default_from_api: true
+    diff_suppress_func: 'tpgresource.CaseDiffSuppress'
+    enum_values:
+      - 'TCP'
+      - 'UDP'
+      - 'ESP'
+      - 'AH'
+      - 'SCTP'
+      - 'ICMP'
+  - name: 'ipVersion'
+    type: Enum
+    description: |
+      The IP Version that will be used by this global forwarding rule.
+    enum_values:
+      - 'IPV4'
+      - 'IPV6'
+  - name: 'labels'
+    type: KeyValueLabels
+    description: |
+      Labels to apply to this forwarding rule.  A list of key->value pairs.
+    update_url: 'projects/{{project}}/global/forwardingRules/{{name}}/setLabels'
+    update_verb: 'POST'
+  - name: 'labelFingerprint'
+    type: Fingerprint
+    description: |
+      The fingerprint used for optimistic locking of this resource.  Used
+      internally during updates.
+    output: true
+    update_url: 'projects/{{project}}/global/forwardingRules/{{name}}/setLabels'
+    update_verb: 'POST'
+    key_expander: ''
+  - name: 'loadBalancingScheme'
+    type: Enum
+    description: |
+      Specifies the forwarding rule type.
+
+      For more information about forwarding rules, refer to
+      [Forwarding rule concepts](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts).
+    default_value: "EXTERNAL"
+    enum_values:
+      - 'EXTERNAL'
+      - 'EXTERNAL_MANAGED'
+      - 'INTERNAL_MANAGED'
+      - 'INTERNAL_SELF_MANAGED'
+    update_url: 'projects/{{project}}/global/forwardingRules/{{name}}'
+    update_verb: 'PATCH'
+  - name: 'metadataFilters'
+    type: Array
+    description: |
+      Opaque filter criteria used by Loadbalancer to restrict routing
+      configuration to a limited set xDS compliant clients. In their xDS
+      requests to Loadbalancer, xDS clients present node metadata. If a
+      match takes place, the relevant routing configuration is made available
+      to those proxies.
+
+      For each metadataFilter in this list, if its filterMatchCriteria is set
+      to MATCH_ANY, at least one of the filterLabels must match the
+      corresponding label provided in the metadata. If its filterMatchCriteria
+      is set to MATCH_ALL, then all of its filterLabels must match with
+      corresponding labels in the provided metadata.
+
+      metadataFilters specified here can be overridden by those specified in
+      the UrlMap that this ForwardingRule references.
+
+      metadataFilters only applies to Loadbalancers that have their
+      loadBalancingScheme set to INTERNAL_SELF_MANAGED.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'filterMatchCriteria'
+          type: Enum
+          description: |
+            Specifies how individual filterLabel matches within the list of
+            filterLabels contribute towards the overall metadataFilter match.
+
+            MATCH_ANY - At least one of the filterLabels must have a matching
+            label in the provided metadata.
+            MATCH_ALL - All filterLabels must have matching labels in the
+            provided metadata.
+          required: true
+          enum_values:
+            - 'MATCH_ANY'
+            - 'MATCH_ALL'
+        - name: 'filterLabels'
+          type: Array
+          description: |
+            The list of label value pairs that must match labels in the
+            provided metadata based on filterMatchCriteria
+
+            This list must not be empty and can have at the most 64 entries.
+          required: true
+          item_type:
+            type: NestedObject
+            properties:
+              - name: 'name'
+                type: String
+                description: |
+                  Name of the metadata label. The length must be between
+                  1 and 1024 characters, inclusive.
+                required: true
+              - name: 'value'
+                type: String
+                description: |
+                  The value that the label must match. The value has a maximum
+                  length of 1024 characters.
+                required: true
+          min_size: 1
+          max_size: 64
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource; provided by the client when the resource is created.
+      The name must be 1-63 characters long, and comply with
+      [RFC1035](https://www.ietf.org/rfc/rfc1035.txt).
+
+      Specifically, the name must be 1-63 characters long and match the regular
+      expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first
+      character must be a lowercase letter, and all following characters must
+      be a dash, lowercase letter, or digit, except the last character, which
+      cannot be a dash.
+
+      For Private Service Connect forwarding rules that forward traffic to Google
+      APIs, the forwarding rule name must be a 1-20 characters string with
+      lowercase letters and numbers and must start with a letter.
+    required: true
+  - name: 'network'
+    type: ResourceRef
+    description: |
+      This field is not used for external load balancing.
+
+      For Internal TCP/UDP Load Balancing, this field identifies the network that
+      the load balanced IP should belong to for this Forwarding Rule.
+      If the subnetwork is specified, the network of the subnetwork will be used.
+      If neither subnetwork nor this field is specified, the default network will
+      be used.
+
+      For Private Service Connect forwarding rules that forward traffic to Google
+      APIs, a network must be provided.
+    default_from_api: true
+  # TODO: When implementing new types enable converting the
+  # manifest input from a single value to a range of form NN-NN. The API
+  # accepts a single value, e.g. '80', but the API stores and returns
+  # '80-80'. This causes idempotency false positive.
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Network'
+    imports: 'selfLink'
+  - name: 'portRange'
+    type: String
+    description: |
+      The `portRange` field has the following limitations:
+      * It requires that the forwarding rule `IPProtocol` be TCP, UDP, or SCTP,
+      and
+      * It's applicable only to the following products: external passthrough
+      Network Load Balancers, internal and external proxy Network Load
+      Balancers, internal and external Application Load Balancers, external
+      protocol forwarding, and Classic VPN.
+      * Some products have restrictions on what ports can be used. See
+      [port specifications](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#port_specifications)
+      for details.
+
+      For external forwarding rules, two or more forwarding rules cannot use the
+      same `[IPAddress, IPProtocol]` pair, and cannot have overlapping
+      `portRange`s.
+
+      For internal forwarding rules within the same VPC network, two or more
+      forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
+      cannot have overlapping `portRange`s.
+
+      @pattern: \d+(?:-\d+)?
+    diff_suppress_func: 'PortRangeDiffSuppress'
+    # This is a multi-resource resource reference (TargetHttp(s)Proxy,
+    # TargetSslProxy, TargetTcpProxy, TargetVpnGateway, TargetPool,
+    # TargetInstance)
+  - name: 'subnetwork'
+    type: ResourceRef
+    description: |
+      This field identifies the subnetwork that the load balanced IP should
+      belong to for this Forwarding Rule, used in internal load balancing and
+      network load balancing with IPv6.
+
+      If the network specified is in auto subnet mode, this field is optional.
+      However, a subnetwork must be specified if the network is in custom subnet
+      mode or when creating external forwarding rule with IPv6.
+    # This is a multi-resource resource reference (TargetHttp(s)Proxy,
+    # TargetSslProxy, TargetTcpProxy, TargetVpnGateway, TargetPool,
+    # TargetInstance)
+    default_from_api: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Subnetwork'
+    imports: 'selfLink'
+  - name: 'target'
+    type: String
+    description: |
+      The URL of the target resource to receive the matched traffic.  For
+      regional forwarding rules, this target must be in the same region as the
+      forwarding rule. For global forwarding rules, this target must be a global
+      load balancing resource.
+
+      The forwarded traffic must be of a type appropriate to the target object.
+      *  For load balancers, see the "Target" column in [Port specifications](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
+      *  For Private Service Connect forwarding rules that forward traffic to Google APIs, provide the name of a supported Google API bundle:
+        *  `vpc-sc` - [ APIs that support VPC Service Controls](https://cloud.google.com/vpc-service-controls/docs/supported-products).
+        *  `all-apis` - [All supported Google APIs](https://cloud.google.com/vpc/docs/private-service-connect#supported-apis).
+
+      For Private Service Connect forwarding rules that forward traffic to managed services, the target must be a service attachment.
+    required: true
+    update_url: 'projects/{{project}}/global/forwardingRules/{{name}}/setTarget'
+    update_verb: 'POST'
+    diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
+  - name: 'networkTier'
+    type: Enum
+    description: |
+      This signifies the networking tier used for configuring
+      this load balancer and can only take the following values:
+      `PREMIUM`, `STANDARD`.
+
+      For regional ForwardingRule, the valid values are `PREMIUM` and
+      `STANDARD`. For GlobalForwardingRule, the valid value is
+      `PREMIUM`.
+
+      If this field is not specified, it is assumed to be `PREMIUM`.
+      If `IPAddress` is specified, this value must be equal to the
+      networkTier of the Address.
+    immutable: true
+    default_from_api: true
+    custom_tgc_flatten: 'templates/tgc_next/custom_flatten/global_forwarding_rule_network_tier.go.tmpl'
+    enum_values:
+      - 'PREMIUM'
+      - 'STANDARD'
+  - name: 'externalManagedBackendBucketMigrationState'
+    type: Enum
+    description: |
+      Specifies the canary migration state for the backend buckets attached to this forwarding rule.
+      Possible values are PREPARE, TEST_BY_PERCENTAGE, and TEST_ALL_TRAFFIC.
+
+      To begin the migration from EXTERNAL to EXTERNAL_MANAGED, the state must be changed to
+      PREPARE. The state must be changed to TEST_ALL_TRAFFIC before the loadBalancingScheme can be
+      changed to EXTERNAL_MANAGED. Optionally, the TEST_BY_PERCENTAGE state can be used to migrate
+      traffic to backend buckets attached to this forwarding rule by percentage using
+      externalManagedBackendBucketMigrationTestingPercentage.
+
+      Rolling back a migration requires the states to be set in reverse order. So changing the
+      scheme from EXTERNAL_MANAGED to EXTERNAL requires the state to be set to TEST_ALL_TRAFFIC at
+      the same time. Optionally, the TEST_BY_PERCENTAGE state can be used to migrate some traffic
+      back to EXTERNAL or PREPARE can be used to migrate all traffic back to EXTERNAL.
+    enum_values:
+      - 'PREPARE'
+      - 'TEST_BY_PERCENTAGE'
+      - 'TEST_ALL_TRAFFIC'
+    update_url: 'projects/{{project}}/global/forwardingRules/{{name}}'
+    update_verb: 'PATCH'
+  - name: 'externalManagedBackendBucketMigrationTestingPercentage'
+    type: Double
+    description: |
+      Determines the fraction of requests to backend buckets that should be processed by the Global
+      external Application Load Balancer.
+
+      The value of this field must be in the range [0, 100].
+
+      This value can only be set if the loadBalancingScheme in the forwarding rule is set to
+      EXTERNAL (when using the Classic ALB) and the migration state is TEST_BY_PERCENTAGE.
+    update_url: 'projects/{{project}}/global/forwardingRules/{{name}}'
+    update_verb: 'PATCH'
+  - name: 'serviceDirectoryRegistrations'
+    type: Array
+    description: |
+      Service Directory resources to register this forwarding rule with.
+
+      Currently, only supports a single Service Directory resource.
+    immutable: true
+    default_from_api: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'namespace'
+          type: String
+          description: |
+            Service Directory namespace to register the forwarding rule under.
+          immutable: true
+          default_from_api: true
+        - name: 'serviceDirectoryRegion'
+          type: String
+          description: |
+            [Optional] Service Directory region to register this global forwarding rule under.
+            Default to "us-central1". Only used for PSC for Google APIs. All PSC for
+            Google APIs Forwarding Rules on the same network should use the same Service
+            Directory region.
+          immutable: true
+    min_size: 0
+    max_size: 1
+  - name: 'sourceIpRanges'
+    type: Array
+    description: If not empty, this Forwarding Rule will only forward the traffic when the source IP address matches one of the IP addresses or CIDR ranges set here. Note that a Forwarding Rule can only have up to 64 source IP ranges, and this field can only be used with a regional Forwarding Rule whose scheme is EXTERNAL. Each sourceIpRange entry should be either an IP address (for example, 1.2.3.4) or a CIDR range (for example, 1.2.3.0/24).
+    immutable: true
+    item_type:
+      type: String
+  - name: 'baseForwardingRule'
+    type: String
+    description: '[Output Only] The URL for the corresponding base Forwarding Rule. By base Forwarding Rule, we mean the Forwarding Rule that has the same IP address, protocol, and port settings with the current Forwarding Rule, but without sourceIPRanges specified. Always empty if the current Forwarding Rule does not have sourceIPRanges specified.'
+    output: true
+  - name: 'allowPscGlobalAccess'
+    type: Boolean
+    description: This is used in PSC consumer ForwardingRule to control whether the PSC endpoint can be accessed from another region.
+    min_version: 'beta'
+  - name: 'noAutomateDnsZone'
+    type: Boolean
+    description:
+      This is used in PSC consumer ForwardingRule to control whether it should try to auto-generate a DNS zone or not.
+      Non-PSC forwarding rules do not use this field.
+    immutable: true
+    ignore_read: true
+    send_empty_value: true

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_global_network_endpoint_group.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_global_network_endpoint_group.yaml
@@ -1,0 +1,88 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'GlobalNetworkEndpointGroup'
+api_resource_type_kind: NetworkEndpointGroup
+kind: 'compute#networkEndpointGroup'
+description: |
+  A global network endpoint group contains endpoints that reside outside of Google Cloud.
+  Currently a global network endpoint group can only support a single endpoint.
+
+  Recreating a global network endpoint group that's in use by another resource will give a
+  `resourceInUseByAnotherResource` error. Use `lifecycle.create_before_destroy`
+  to avoid this type of error.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/load-balancing/docs/negs/internet-neg-concepts'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/beta/networkEndpointGroups'
+docs:
+base_url: 'projects/{{project}}/global/networkEndpointGroups'
+has_self_link: true
+immutable: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+custom_code:
+examples:
+  - name: 'global_network_endpoint_group'
+    primary_resource_id: 'neg'
+    vars:
+      neg_name: 'my-lb-neg'
+  - name: 'global_network_endpoint_group_ip_address'
+    primary_resource_id: 'neg'
+    vars:
+      neg_name: 'my-lb-neg'
+parameters:
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource; provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    required: true
+    validation:
+      function: 'verify.ValidateGCEName'
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource. Provide this property when
+      you create the resource.
+  - name: 'networkEndpointType'
+    type: Enum
+    description: |
+      Type of network endpoints in this network endpoint group.
+    required: true
+    enum_values:
+      - 'INTERNET_IP_PORT'
+      - 'INTERNET_FQDN_PORT'
+  - name: 'defaultPort'
+    type: Integer
+    description: |
+      The default port used if the port number is not specified in the
+      network endpoint.

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_health_check.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_health_check.yaml
@@ -1,0 +1,963 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'HealthCheck'
+api_variant_patterns:
+  - 'projects/{project}/global/healthChecks/{healthCheck}'
+kind: 'compute#healthCheck'
+description: |
+  Health Checks determine whether instances are responsive and able to do work.
+  They are an important part of a comprehensive load balancing configuration,
+  as they enable monitoring instances behind load balancers.
+
+  Health Checks poll instances at a specified interval. Instances that
+  do not respond successfully to some number of probes in a row are marked
+  as unhealthy. No new connections are sent to unhealthy instances,
+  though existing connections will continue. The health check will
+  continue to poll unhealthy instances. If an instance later responds
+  successfully to some number of consecutive probes, it is marked
+  healthy again and can receive new connections.
+
+  ~>**NOTE**: Legacy HTTP(S) health checks must be used for target pool-based network
+  load balancers. See the [official guide](https://cloud.google.com/load-balancing/docs/health-check-concepts#selecting_hc)
+  for choosing a type of health check.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/load-balancing/docs/health-checks'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks'
+docs:
+base_url: 'projects/{{project}}/global/healthChecks'
+has_self_link: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+custom_code:
+  constants: 'templates/terraform/constants/health_check.tmpl'
+  encoder: 'templates/terraform/encoders/health_check_type.tmpl'
+custom_diff:
+  - 'healthCheckCustomizeDiff'
+sweeper:
+  dependencies:
+    - "google_compute_subnetwork"
+tgc_tests:
+  - name: 'TestAccComputeHealthCheck_grpcWithTls_create'
+    skip: 'grpcTlsHealthCheck is not in CAI asset, but is required in this test.'
+  - name: 'TestAccComputeHealthCheck_grpcWithTls_update'
+    skip: 'grpcTlsHealthCheck is not in CAI asset, but is required in this test.'
+examples:
+  - name: 'health_check_tcp'
+    primary_resource_id: 'tcp-health-check'
+    vars:
+      health_check_name: 'tcp-health-check'
+  - name: 'health_check_tcp_full'
+    primary_resource_id: 'tcp-health-check'
+    vars:
+      health_check_name: 'tcp-health-check'
+  - name: 'health_check_ssl'
+    primary_resource_id: 'ssl-health-check'
+    vars:
+      health_check_name: 'ssl-health-check'
+  - name: 'health_check_ssl_full'
+    primary_resource_id: 'ssl-health-check'
+    vars:
+      health_check_name: 'ssl-health-check'
+  - name: 'health_check_http'
+    primary_resource_id: 'http-health-check'
+    vars:
+      health_check_name: 'http-health-check'
+  - name: 'health_check_http_full'
+    primary_resource_id: 'http-health-check'
+    vars:
+      health_check_name: 'http-health-check'
+  - name: 'health_check_https'
+    primary_resource_id: 'https-health-check'
+    vars:
+      health_check_name: 'https-health-check'
+  - name: 'health_check_https_full'
+    primary_resource_id: 'https-health-check'
+    vars:
+      health_check_name: 'https-health-check'
+  - name: 'health_check_http2'
+    primary_resource_id: 'http2-health-check'
+    vars:
+      health_check_name: 'http2-health-check'
+  - name: 'health_check_http2_full'
+    primary_resource_id: 'http2-health-check'
+    vars:
+      health_check_name: 'http2-health-check'
+  - name: 'health_check_grpc'
+    primary_resource_id: 'grpc-health-check'
+    vars:
+      health_check_name: 'grpc-health-check'
+  - name: 'health_check_grpc_full'
+    primary_resource_id: 'grpc-health-check'
+    vars:
+      health_check_name: 'grpc-health-check'
+  - name: 'health_check_grpc_with_tls'
+    primary_resource_id: 'grpc-with-tls-health-check'
+    vars:
+      health_check_name: 'grpc-with-tls-health-check'
+    tgc_skip_test: 'grpcTlsHealthCheck is not in CAI asset, but is required in this test.'
+  - name: 'health_check_grpc_with_tls_full'
+    primary_resource_id: 'grpc-with-tls-health-check'
+    vars:
+      health_check_name: 'grpc-with-tls-health-check'
+    tgc_skip_test: 'grpcTlsHealthCheck is not in CAI asset, but is required in this test.'
+  - name: 'health_check_with_logging'
+    primary_resource_id: 'health-check-with-logging'
+    min_version: 'beta'
+    vars:
+      health_check_name: 'tcp-health-check'
+  - name: 'compute_health_check_http_source_regions'
+    primary_resource_id: 'http-health-check-with-source-regions'
+    vars:
+      health_check_name: 'http-health-check'
+  - name: 'compute_health_check_https_source_regions'
+    primary_resource_id: 'https-health-check-with-source-regions'
+    vars:
+      health_check_name: 'https-health-check'
+  - name: 'compute_health_check_tcp_source_regions'
+    primary_resource_id: 'tcp-health-check-with-source-regions'
+    vars:
+      health_check_name: 'tcp-health-check'
+parameters:
+properties:
+  - name: 'checkIntervalSec'
+    type: Integer
+    description: |
+      How often (in seconds) to send a health check. The default value is 5
+      seconds.
+    default_value: 5
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource. Provide this property when
+      you create the resource.
+    send_empty_value: true
+  - name: 'healthyThreshold'
+    type: Integer
+    description: |
+      A so-far unhealthy instance will be marked healthy after this many
+      consecutive successes. The default value is 2.
+    default_value: 2
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035.  Specifically, the name must be 1-63 characters long and
+      match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means
+      the first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the
+      last character, which cannot be a dash.
+    required: true
+    immutable: true
+  - name: 'timeoutSec'
+    type: Integer
+    description: |
+      How long (in seconds) to wait before claiming failure.
+      The default value is 5 seconds.  It is invalid for timeoutSec to have
+      greater value than checkIntervalSec.
+    default_value: 5
+  - name: 'sourceRegions'
+    type: Array
+    description: |
+      The list of cloud regions from which health checks are performed. If
+      any regions are specified, then exactly 3 regions should be specified.
+      The region names must be valid names of Google Cloud regions. This can
+      only be set for global health check. If this list is non-empty, then
+      there are restrictions on what other health check fields are supported
+      and what other resources can use this health check:
+
+      * SSL, HTTP2, and GRPC protocols are not supported.
+
+      * The TCP request field is not supported.
+
+      * The proxyHeader field for HTTP, HTTPS, and TCP is not supported.
+
+      * The checkIntervalSec field must be at least 30.
+
+      * The health check cannot be used with BackendService nor with managed
+      instance group auto-healing.
+    item_type:
+      type: String
+    min_size: 3
+    max_size: 3
+    is_missing_in_cai: true
+  - name: 'unhealthyThreshold'
+    type: Integer
+    description: |
+      A so-far healthy instance will be marked unhealthy after this many
+      consecutive failures. The default value is 2.
+    default_value: 2
+  - name: 'type'
+    type: Enum
+    description: |-
+      The type of the health check. One of HTTP, HTTPS, TCP, or SSL.
+    output: true
+    enum_values:
+      - 'TCP'
+      - 'SSL'
+      - 'HTTP'
+      - 'HTTPS'
+      - 'HTTP2'
+  - name: 'httpHealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    properties:
+      - name: 'host'
+        type: String
+        description: |
+          The value of the host header in the HTTP health check request.
+          If left empty (default value), the public IP on behalf of which this health
+          check is performed will be used.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+      - name: 'requestPath'
+        type: String
+        description: |
+          The request path of the HTTP health check request.
+          The default value is /.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+        default_value: "/"
+      - name: 'response'
+        type: String
+        description: |
+          The bytes to match against the beginning of the response data. If left empty
+          (the default value), any response will indicate health. The response data
+          can only be ASCII.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+      - name: 'port'
+        type: Integer
+        description: |
+          The TCP port number for the HTTP health check request.
+          The default value is 80.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+      - name: 'portName'
+        type: String
+        description: |
+          Port name as defined in InstanceGroup#NamedPort#name. If both port and
+          port_name are defined, port takes precedence.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+      - name: 'proxyHeader'
+        type: Enum
+        description: |
+          Specifies the type of proxy header to append before sending data to the
+          backend.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+        default_value: "NONE"
+        enum_values:
+          - 'NONE'
+          - 'PROXY_V1'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: The `portName` is used for health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, HTTP health check follows behavior specified in `port` and
+          `portName` fields.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+  - name: 'httpsHealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    properties:
+      - name: 'host'
+        type: String
+        description: |
+          The value of the host header in the HTTPS health check request.
+          If left empty (default value), the public IP on behalf of which this health
+          check is performed will be used.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+      - name: 'requestPath'
+        type: String
+        description: |
+          The request path of the HTTPS health check request.
+          The default value is /.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+        default_value: "/"
+      - name: 'response'
+        type: String
+        description: |
+          The bytes to match against the beginning of the response data. If left empty
+          (the default value), any response will indicate health. The response data
+          can only be ASCII.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+      - name: 'port'
+        type: Integer
+        description: |
+          The TCP port number for the HTTPS health check request.
+          The default value is 443.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+      - name: 'portName'
+        type: String
+        description: |
+          Port name as defined in InstanceGroup#NamedPort#name. If both port and
+          port_name are defined, port takes precedence.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+      - name: 'proxyHeader'
+        type: Enum
+        description: |
+          Specifies the type of proxy header to append before sending data to the
+          backend.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+        default_value: "NONE"
+        enum_values:
+          - 'NONE'
+          - 'PROXY_V1'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: The `portName` is used for health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, HTTPS health check follows behavior specified in `port` and
+          `portName` fields.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+  - name: 'tcpHealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    properties:
+      - name: 'request'
+        type: String
+        description: |
+          The application data to send once the TCP connection has been
+          established (default value is empty). If both request and response are
+          empty, the connection establishment alone will indicate health. The request
+          data can only be ASCII.
+        at_least_one_of:
+          - 'tcp_health_check.0.request'
+          - 'tcp_health_check.0.response'
+          - 'tcp_health_check.0.port'
+          - 'tcp_health_check.0.port_name'
+          - 'tcp_health_check.0.proxy_header'
+          - 'tcp_health_check.0.port_specification'
+      - name: 'response'
+        type: String
+        description: |
+          The bytes to match against the beginning of the response data. If left empty
+          (the default value), any response will indicate health. The response data
+          can only be ASCII.
+        at_least_one_of:
+          - 'tcp_health_check.0.request'
+          - 'tcp_health_check.0.response'
+          - 'tcp_health_check.0.port'
+          - 'tcp_health_check.0.port_name'
+          - 'tcp_health_check.0.proxy_header'
+          - 'tcp_health_check.0.port_specification'
+      - name: 'port'
+        type: Integer
+        description: |
+          The TCP port number for the TCP health check request.
+          The default value is 443.
+        at_least_one_of:
+          - 'tcp_health_check.0.request'
+          - 'tcp_health_check.0.response'
+          - 'tcp_health_check.0.port'
+          - 'tcp_health_check.0.port_name'
+          - 'tcp_health_check.0.proxy_header'
+          - 'tcp_health_check.0.port_specification'
+      - name: 'portName'
+        type: String
+        description: |
+          Port name as defined in InstanceGroup#NamedPort#name. If both port and
+          port_name are defined, port takes precedence.
+        at_least_one_of:
+          - 'tcp_health_check.0.request'
+          - 'tcp_health_check.0.response'
+          - 'tcp_health_check.0.port'
+          - 'tcp_health_check.0.port_name'
+          - 'tcp_health_check.0.proxy_header'
+          - 'tcp_health_check.0.port_specification'
+      - name: 'proxyHeader'
+        type: Enum
+        description: |
+          Specifies the type of proxy header to append before sending data to the
+          backend.
+        at_least_one_of:
+          - 'tcp_health_check.0.request'
+          - 'tcp_health_check.0.response'
+          - 'tcp_health_check.0.port'
+          - 'tcp_health_check.0.port_name'
+          - 'tcp_health_check.0.proxy_header'
+          - 'tcp_health_check.0.port_specification'
+        default_value: "NONE"
+        enum_values:
+          - 'NONE'
+          - 'PROXY_V1'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: The `portName` is used for health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, TCP health check follows behavior specified in `port` and
+          `portName` fields.
+        at_least_one_of:
+          - 'tcp_health_check.0.request'
+          - 'tcp_health_check.0.response'
+          - 'tcp_health_check.0.port'
+          - 'tcp_health_check.0.port_name'
+          - 'tcp_health_check.0.proxy_header'
+          - 'tcp_health_check.0.port_specification'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+  - name: 'sslHealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    properties:
+      - name: 'request'
+        type: String
+        description: |
+          The application data to send once the SSL connection has been
+          established (default value is empty). If both request and response are
+          empty, the connection establishment alone will indicate health. The request
+          data can only be ASCII.
+        at_least_one_of:
+          - 'ssl_health_check.0.request'
+          - 'ssl_health_check.0.response'
+          - 'ssl_health_check.0.port'
+          - 'ssl_health_check.0.port_name'
+          - 'ssl_health_check.0.proxy_header'
+          - 'ssl_health_check.0.port_specification'
+      - name: 'response'
+        type: String
+        description: |
+          The bytes to match against the beginning of the response data. If left empty
+          (the default value), any response will indicate health. The response data
+          can only be ASCII.
+        at_least_one_of:
+          - 'ssl_health_check.0.request'
+          - 'ssl_health_check.0.response'
+          - 'ssl_health_check.0.port'
+          - 'ssl_health_check.0.port_name'
+          - 'ssl_health_check.0.proxy_header'
+          - 'ssl_health_check.0.port_specification'
+      - name: 'port'
+        type: Integer
+        description: |
+          The TCP port number for the SSL health check request.
+          The default value is 443.
+        at_least_one_of:
+          - 'ssl_health_check.0.request'
+          - 'ssl_health_check.0.response'
+          - 'ssl_health_check.0.port'
+          - 'ssl_health_check.0.port_name'
+          - 'ssl_health_check.0.proxy_header'
+          - 'ssl_health_check.0.port_specification'
+      - name: 'portName'
+        type: String
+        description: |
+          Port name as defined in InstanceGroup#NamedPort#name. If both port and
+          port_name are defined, port takes precedence.
+        at_least_one_of:
+          - 'ssl_health_check.0.request'
+          - 'ssl_health_check.0.response'
+          - 'ssl_health_check.0.port'
+          - 'ssl_health_check.0.port_name'
+          - 'ssl_health_check.0.proxy_header'
+          - 'ssl_health_check.0.port_specification'
+      - name: 'proxyHeader'
+        type: Enum
+        description: |
+          Specifies the type of proxy header to append before sending data to the
+          backend.
+        at_least_one_of:
+          - 'ssl_health_check.0.request'
+          - 'ssl_health_check.0.response'
+          - 'ssl_health_check.0.port'
+          - 'ssl_health_check.0.port_name'
+          - 'ssl_health_check.0.proxy_header'
+          - 'ssl_health_check.0.port_specification'
+        default_value: "NONE"
+        enum_values:
+          - 'NONE'
+          - 'PROXY_V1'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: The `portName` is used for health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, SSL health check follows behavior specified in `port` and
+          `portName` fields.
+        at_least_one_of:
+          - 'ssl_health_check.0.request'
+          - 'ssl_health_check.0.response'
+          - 'ssl_health_check.0.port'
+          - 'ssl_health_check.0.port_name'
+          - 'ssl_health_check.0.proxy_header'
+          - 'ssl_health_check.0.port_specification'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+  - name: 'http2HealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    properties:
+      - name: 'host'
+        type: String
+        description: |
+          The value of the host header in the HTTP2 health check request.
+          If left empty (default value), the public IP on behalf of which this health
+          check is performed will be used.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+      - name: 'requestPath'
+        type: String
+        description: |
+          The request path of the HTTP2 health check request.
+          The default value is /.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+        default_value: "/"
+      - name: 'response'
+        type: String
+        description: |
+          The bytes to match against the beginning of the response data. If left empty
+          (the default value), any response will indicate health. The response data
+          can only be ASCII.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+      - name: 'port'
+        type: Integer
+        description: |
+          The TCP port number for the HTTP2 health check request.
+          The default value is 443.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+      - name: 'portName'
+        type: String
+        description: |
+          Port name as defined in InstanceGroup#NamedPort#name. If both port and
+          port_name are defined, port takes precedence.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+      - name: 'proxyHeader'
+        type: Enum
+        description: |
+          Specifies the type of proxy header to append before sending data to the
+          backend.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+        default_value: "NONE"
+        enum_values:
+          - 'NONE'
+          - 'PROXY_V1'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: The `portName` is used for health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, HTTP2 health check follows behavior specified in `port` and
+          `portName` fields.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+  - name: 'grpcHealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    properties:
+      - name: 'port'
+        type: Integer
+        description: |
+          The port number for the health check request.
+          Must be specified if portName and portSpecification are not set
+          or if port_specification is USE_FIXED_PORT. Valid values are 1 through 65535.
+        at_least_one_of:
+          - 'grpc_health_check.0.port'
+          - 'grpc_health_check.0.port_name'
+          - 'grpc_health_check.0.port_specification'
+          - 'grpc_health_check.0.grpc_service_name'
+      - name: 'portName'
+        type: String
+        description: |
+          Port name as defined in InstanceGroup#NamedPort#name. If both port and
+          port_name are defined, port takes precedence.
+        at_least_one_of:
+          - 'grpc_health_check.0.port'
+          - 'grpc_health_check.0.port_name'
+          - 'grpc_health_check.0.port_specification'
+          - 'grpc_health_check.0.grpc_service_name'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: The `portName` is used for health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, gRPC health check follows behavior specified in `port` and
+          `portName` fields.
+        at_least_one_of:
+          - 'grpc_health_check.0.port'
+          - 'grpc_health_check.0.port_name'
+          - 'grpc_health_check.0.port_specification'
+          - 'grpc_health_check.0.grpc_service_name'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+      - name: 'grpcServiceName'
+        type: String
+        description: |
+          The gRPC service name for the health check.
+          The value of grpcServiceName has the following meanings by convention:
+            - Empty serviceName means the overall status of all services at the backend.
+            - Non-empty serviceName means the health of that gRPC service, as defined by the owner of the service.
+          The grpcServiceName can only be ASCII.
+        at_least_one_of:
+          - 'grpc_health_check.0.port'
+          - 'grpc_health_check.0.port_name'
+          - 'grpc_health_check.0.port_specification'
+          - 'grpc_health_check.0.grpc_service_name'
+  - name: 'grpcTlsHealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    is_missing_in_cai: true
+    properties:
+      - name: 'port'
+        type: Integer
+        description: |
+          The port number for the health check request.
+          Must be specified if port_specification is USE_FIXED_PORT. Valid values are 1 through 65535.
+        at_least_one_of:
+          - 'grpc_tls_health_check.0.port'
+          - 'grpc_tls_health_check.0.port_specification'
+          - 'grpc_tls_health_check.0.grpc_service_name'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: Not supported for GRPC with TLS health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, gRPC with TLS health check follows behavior specified in the `port` field.
+        at_least_one_of:
+          - 'grpc_tls_health_check.0.port'
+          - 'grpc_tls_health_check.0.port_specification'
+          - 'grpc_tls_health_check.0.grpc_service_name'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+      - name: 'grpcServiceName'
+        type: String
+        description: |
+          The gRPC service name for the health check.
+          The value of grpcServiceName has the following meanings by convention:
+            - Empty serviceName means the overall status of all services at the backend.
+            - Non-empty serviceName means the health of that gRPC service, as defined by the owner of the service.
+          The grpcServiceName can only be ASCII.
+        at_least_one_of:
+          - 'grpc_tls_health_check.0.port'
+          - 'grpc_tls_health_check.0.port_specification'
+          - 'grpc_tls_health_check.0.grpc_service_name'
+  - name: 'logConfig'
+    type: NestedObject
+    description: |
+      Configure logging on this health check.
+    default_from_api: true
+    custom_flatten: 'templates/terraform/custom_flatten/health_check_log_config.go.tmpl'
+    properties:
+      - name: 'enable'
+        type: Boolean
+        description: |
+          Indicates whether or not to export logs. This is false by default,
+          which means no health check logging will be done.
+        default_value: false

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_instance_group_manager.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_instance_group_manager.yaml
@@ -1,0 +1,222 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'InstanceGroupManager'
+kind: 'compute#instanceGroupManager'
+description: |
+  Creates a managed instance group using the information that you specify in
+  the request. After the group is created, it schedules an action to create
+  instances in the group using the specified instance template. This
+  operation is marked as DONE when the group is created even if the
+  instances in the group have not yet been created. You must separately
+  verify the status of the individual instances.
+
+  A managed instance group can have up to 1000 VM instances per group.
+# Used as a resource reference
+exclude: true
+docs:
+base_url: 'projects/{{project}}/zones/{{zone}}/instanceGroupManagers'
+has_self_link: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+custom_code:
+parameters:
+  - name: 'zone'
+    type: ResourceRef
+    description: 'The zone the managed instance group resides.'
+    required: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Zone'
+    imports: 'name'
+properties:
+  - name: 'baseInstanceName'
+    type: String
+    description: |
+      The base instance name to use for instances in this group. The value
+      must be 1-58 characters long. Instances are named by appending a
+      hyphen and a random four-character string to the base instance name.
+      The base instance name must comply with RFC1035.
+    required: true
+  - name: 'instanceGroupManagerId'
+    type: Integer
+    description: |
+      The unique identifier number for the resource. This identifier is defined by the server.
+    api_name: id
+    output: true
+  - name: 'creationTimestamp'
+    type: Time
+    description: |
+      The creation timestamp for this managed instance group in RFC3339
+      text format.
+    output: true
+  - name: 'currentActions'
+    type: NestedObject
+    description: |
+      The list of instance actions and the number of instances in this
+      managed instance group that are scheduled for each of those actions.
+    output: true
+    properties:
+      - name: 'abandoning'
+        type: Integer
+        description: |
+          The total number of instances in the managed instance group that
+          are scheduled to be abandoned. Abandoning an instance removes it
+          from the managed instance group without deleting it.
+        output: true
+      - name: 'creating'
+        type: Integer
+        description: |
+          The number of instances in the managed instance group that are
+          scheduled to be created or are currently being created. If the
+          group fails to create any of these instances, it tries again until
+          it creates the instance successfully.
+
+          If you have disabled creation retries, this field will not be
+          populated; instead, the creatingWithoutRetries field will be
+          populated.
+        output: true
+      - name: 'creatingWithoutRetries'
+        type: Integer
+        description: |
+          The number of instances that the managed instance group will
+          attempt to create. The group attempts to create each instance only
+          once. If the group fails to create any of these instances, it
+          decreases the group's targetSize value accordingly.
+        output: true
+      - name: 'deleting'
+        type: Integer
+        description: |
+          The number of instances in the managed instance group that are
+          scheduled to be deleted or are currently being deleted.
+        output: true
+      - name: 'none'
+        type: Integer
+        description: |
+          The number of instances in the managed instance group that are
+          running and have no scheduled actions.
+        output: true
+      - name: 'recreating'
+        type: Integer
+        description: |
+          The number of instances in the managed instance group that are
+          scheduled to be recreated or are currently being being recreated.
+          Recreating an instance deletes the existing root persistent disk
+          and creates a new disk from the image that is defined in the
+          instance template.
+        output: true
+      - name: 'refreshing'
+        type: Integer
+        description: |
+          The number of instances in the managed instance group that are
+          being reconfigured with properties that do not require a restart
+          or a recreate action. For example, setting or removing target
+          pools for the instance.
+        output: true
+      - name: 'restarting'
+        type: Integer
+        description: |
+          The number of instances in the managed instance group that are
+          scheduled to be restarted or are currently being restarted.
+        output: true
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource. Provide this property when
+      you create the resource.
+    immutable: true
+  # fingerprint ignored as it is an internal locking detail
+  - name: 'id'
+    type: Integer
+    description: 'A unique identifier for this resource'
+    output: true
+  - name: 'instanceGroup'
+    type: ResourceRef
+    description: 'The instance group being managed'
+    output: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'InstanceGroup'
+    imports: 'selfLink'
+  - name: 'instanceTemplate'
+    type: ResourceRef
+    description: |
+      The instance template that is specified for this managed instance
+      group. The group uses this template to create all new instances in the
+      managed instance group.
+    required: true
+  # kind is internal transport detail
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'InstanceTemplate'
+    imports: 'selfLink'
+  - name: 'name'
+    type: String
+    description: |
+      The name of the managed instance group. The name must be 1-63
+      characters long, and comply with RFC1035.
+    required: true
+  # TODO: Make namedPorts a NameValue(name[string], port[integer])
+  - name: 'namedPorts'
+    type: Array
+    description:
+      Named ports configured for the Instance Groups complementary to this
+      Instance Group Manager.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          description: |
+            The name for this named port. The name must be 1-63 characters
+            long, and comply with RFC1035.
+        - name: 'port'
+          type: Integer
+          description:
+            The port number, which can be a value between 1 and 65535.
+  - name: 'region'
+    type: ResourceRef
+    description: |
+      The region this managed instance group resides
+      (for regional resources).
+    output: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Region'
+    imports: 'selfLink'
+  - name: 'targetPools'
+    type: Array
+    description: |
+      TargetPool resources to which instances in the instanceGroup field are
+      added. The target pools automatically apply to all of the instances in
+      the managed instance group.
+    custom_expand: 'templates/terraform/custom_expand/array_resourceref_with_validation.go.tmpl'
+    item_type:
+      name: 'targetPool'
+      type: ResourceRef
+      description: 'The targetPool to receive managed instances.'
+      resource: 'TargetPool'
+      imports: 'selfLink'
+  - name: 'targetSize'
+    type: Integer
+    description: |
+      The target number of running instances for this managed instance
+      group. Deleting or abandoning instances reduces this number. Resizing
+      the group changes this number.

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_instance_template.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_instance_template.yaml
@@ -1,0 +1,27 @@
+---
+name: 'InstanceTemplate'
+kind: 'compute#instanceTemplate'
+description: |
+  Resource that enables a convenient way to save a virtual machine (VM) instance's configuration
+  that includes all of its properties and allows you to create a new instance from it.
+base_url: 'projects/{{project}}/global/instanceTemplates'
+has_self_link: true
+exclude_resource: true
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource.
+    required: true
+    immutable: true
+iam_policy:
+  parent_resource_attribute: 'name'
+  base_url: 'projects/{{project}}/global/instanceTemplates/{{name}}'
+  iam_conditions_request_type: 'QUERY_PARAM'
+  allowed_iam_role: 'roles/compute.instanceAdmin'
+custom_code:
+examples:
+  - name: 'instance_template_basic'
+    primary_resource_id: 'default'
+    vars:
+      instance_name: 'my-instance-template'

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_managed_ssl_certificate.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_managed_ssl_certificate.yaml
@@ -1,0 +1,149 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'ManagedSslCertificate'
+api_resource_type_kind: SslCertificate
+kind: 'compute#sslCertificate'
+description: |
+  An SslCertificate resource, used for HTTPS load balancing.  This resource
+  represents a certificate for which the certificate secrets are created and
+  managed by Google.
+
+  For a resource where you provide the key, see the
+  SSL Certificate resource.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/load-balancing/docs/ssl-certificates'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates'
+docs:
+  warning: |
+    This resource should be used with extreme caution!  Provisioning an SSL
+    certificate is complex.  Ensure that you understand the lifecycle of a
+    certificate before attempting complex tasks like cert rotation automatically.
+    This resource will "return" as soon as the certificate object is created,
+    but post-creation the certificate object will go through a "provisioning"
+    process.  The provisioning process can complete only when the domain name
+    for which the certificate is created points to a target pool which, itself,
+    points at the certificate.  Depending on your DNS provider, this may take
+    some time, and migrating from self-managed certificates to Google-managed
+    certificates may entail some downtime while the certificate provisions.
+
+    In conclusion: Be extremely cautious.
+base_url: 'projects/{{project}}/global/sslCertificates'
+has_self_link: true
+immutable: true
+timeouts:
+  insert_minutes: 30
+  update_minutes: 30
+    # Deletes can take 20-30 minutes to complete, since they depend
+    # on the provisioning process either succeeding or failing completely.
+  delete_minutes: 30
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    timeouts:
+      insert_minutes: 30
+      update_minutes: 30
+      # Deletes can take 20-30 minutes to complete, since they depend
+      # on the provisioning process either succeeding or failing completely.
+      delete_minutes: 30
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+custom_code:
+  constants: 'templates/terraform/constants/compute_managed_ssl_certificate.go.tmpl'
+include_in_tgc_next: true
+examples:
+  - name: 'managed_ssl_certificate_basic'
+    primary_resource_id: 'default'
+    vars:
+      cert_name: 'test-cert'
+      proxy_name: 'test-proxy'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      dns_zone_name: 'dnszone'
+      forwarding_rule_name: 'forwarding-rule'
+      http_health_check_name: 'http-health-check'
+    test_vars_overrides:
+      # for backward compatible
+      dns_zone_name: '"dnszone" + randomSuffix'
+  - name: 'managed_ssl_certificate_recreation'
+    primary_resource_id: 'cert'
+    external_providers: ["random", "time"]
+      # Random provider
+    skip_vcr: true
+parameters:
+properties:
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'description'
+    type: String
+    description: 'An optional description of this resource.'
+  - name: 'certificate_id'
+    type: Integer
+    description: 'The unique identifier for the resource.'
+    api_name: id
+    output: true
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+
+      These are in the same namespace as the managed SSL certificates.
+  - name: 'managed'
+    type: NestedObject
+    description: |
+      Properties relevant to a managed certificate.  These will be used if the
+      certificate is managed (as indicated by a value of `MANAGED` in `type`).
+    properties:
+      - name: 'domains'
+        type: Array
+        description: |
+          Domains for which a managed SSL certificate will be valid.  Currently,
+          there can be up to 100 domains in this list.
+        required: true
+        diff_suppress_func: 'AbsoluteDomainSuppress'
+        item_type:
+          type: String
+        max_size: 100
+  - name: 'type'
+    type: Enum
+    description: |
+      Enum field whose value is always `MANAGED` - used to signal to the API
+      which type this is.
+    default_value: "MANAGED"
+    enum_values:
+      - 'MANAGED'
+  - name: 'subjectAlternativeNames'
+    type: Array
+    description: |
+      Domains associated with the certificate via Subject Alternative Name.
+    output: true
+    item_type:
+      type: String
+  - name: 'expireTime'
+    type: Time
+    description: |
+      Expire time of the certificate in RFC3339 text format.
+    output: true

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_network_endpoint_group.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_network_endpoint_group.yaml
@@ -1,0 +1,153 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'NetworkEndpointGroup'
+kind: 'compute#networkEndpointGroup'
+description: |
+  Network endpoint groups (NEGs) are zonal resources that represent
+  collections of IP address and port combinations for GCP resources within a
+  single subnet. Each IP address and port combination is called a network
+  endpoint.
+
+  Network endpoint groups can be used as backends in backend services for
+  HTTP(S), TCP proxy, and SSL proxy load balancers. You cannot use NEGs as a
+  backend with internal load balancers. Because NEG backends allow you to
+  specify IP addresses and ports, you can distribute traffic in a granular
+  fashion among applications or containers running within VM instances.
+
+  Recreating a network endpoint group that's in use by another resource will give a
+  `resourceInUseByAnotherResource` error. Use `lifecycle.create_before_destroy`
+  to avoid this type of error.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/load-balancing/docs/negs/'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/beta/networkEndpointGroups'
+docs:
+base_url: 'projects/{{project}}/zones/{{zone}}/networkEndpointGroups'
+has_self_link: true
+immutable: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+custom_code:
+  constants: 'templates/terraform/constants/compute_network_endpoint_group.go.tmpl'
+sweeper:
+  url_substitutions:
+    - zone: "us-central1-a"
+include_in_tgc_next: true
+examples:
+  - name: 'network_endpoint_group'
+    primary_resource_id: 'neg'
+    vars:
+      neg_name: 'my-lb-neg'
+      network_name: 'neg-network'
+      subnetwork_name: 'neg-subnetwork'
+  - name: 'network_endpoint_group_non_gcp'
+    primary_resource_id: 'neg'
+    vars:
+      neg_name: 'my-lb-neg'
+      network_name: 'neg-network'
+parameters:
+  - name: 'zone'
+    type: ResourceRef
+    description: |
+      Zone where the network endpoint group is located.
+    required: false
+    ignore_read: true
+    default_from_api: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Zone'
+    imports: 'name'
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource; provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    required: true
+    validation:
+      function: 'verify.ValidateGCEName'
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource. Provide this property when
+      you create the resource.
+  - name: 'networkEndpointType'
+    type: Enum
+    description: |
+      Type of network endpoints in this network endpoint group.
+      NON_GCP_PRIVATE_IP_PORT is used for hybrid connectivity network
+      endpoint groups (see https://cloud.google.com/load-balancing/docs/hybrid).
+      Note that NON_GCP_PRIVATE_IP_PORT can only be used with Backend Services
+      that 1) have the following load balancing schemes: EXTERNAL, EXTERNAL_MANAGED,
+      INTERNAL_MANAGED, and INTERNAL_SELF_MANAGED and 2) support the RATE or
+      CONNECTION balancing modes.
+
+      Possible values include: GCE_VM_IP, GCE_VM_IP_PORT, NON_GCP_PRIVATE_IP_PORT, INTERNET_IP_PORT, INTERNET_FQDN_PORT, SERVERLESS, and PRIVATE_SERVICE_CONNECT.
+    default_value: "GCE_VM_IP_PORT"
+    enum_values:
+      - 'GCE_VM_IP'
+      - 'GCE_VM_IP_PORT'
+      - 'NON_GCP_PRIVATE_IP_PORT'
+      - 'INTERNET_IP_PORT'
+      - 'INTERNET_FQDN_PORT'
+      - 'SERVERLESS'
+      - 'PRIVATE_SERVICE_CONNECT'
+      - 'GCE_VM_IP_DEDICATED_BACKEND'
+  - name: 'size'
+    type: Integer
+    description: Number of network endpoints in the network endpoint group.
+    output: true
+  - name: 'network'
+    type: ResourceRef
+    description: |
+      The network to which all network endpoints in the NEG belong.
+      Uses "default" project network if unspecified.
+    required: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Network'
+    imports: 'selfLink'
+  - name: 'subnetwork'
+    type: ResourceRef
+    description: |
+      Optional subnetwork to which all network endpoints in the NEG belong.
+    diff_suppress_func: 'compareOptionalSubnet'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Subnetwork'
+    imports: 'selfLink'
+  - name: 'defaultPort'
+    type: Integer
+    description: |
+      The default port used if the port number is not specified in the
+      network endpoint.
+  - name: 'generated_id'
+    type: Integer
+    api_name: 'id'
+    output: true
+    description: |
+      The uniquely generated identifier for the resource. This identifier is defined by the server.

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_autoscaler.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_autoscaler.yaml
@@ -1,0 +1,412 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'RegionAutoscaler'
+api_resource_type_kind: Autoscaler
+api_variant_patterns:
+  - 'projects/{project}/regions/{region}/autoscalers/{autoscaler}'
+kind: 'compute#autoscaler'
+description: |
+  Represents an Autoscaler resource.
+
+  Autoscalers allow you to automatically scale virtual machine instances in
+  managed instance groups according to an autoscaling policy that you
+  define.
+references:
+  guides:
+    'Autoscaling Groups of Instances': 'https://cloud.google.com/compute/docs/autoscaler/'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/regionAutoscalers'
+docs:
+base_url: 'projects/{{project}}/regions/{{region}}/autoscalers'
+has_self_link: true
+update_url: 'projects/{{project}}/regions/{{region}}/autoscalers?autoscaler={{name}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+custom_code:
+examples:
+  - name: 'region_autoscaler_basic'
+    primary_resource_id: 'foobar'
+    vars:
+      region_autoscaler_name: 'my-region-autoscaler'
+      instance_template_name: 'my-instance-template'
+      target_pool_name: 'my-target-pool'
+      rigm_name: 'my-region-igm'
+parameters:
+  - name: 'region'
+    type: ResourceRef
+    description: |
+      URL of the region where the instance group resides.
+    required: false
+    immutable: true
+    ignore_read: true
+    default_from_api: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Region'
+    imports: 'name'
+properties:
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. The name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    required: true
+    immutable: true
+    validation:
+      function: 'verify.ValidateGCEName'
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource.
+  - name: 'autoscalingPolicy'
+    type: NestedObject
+    description: |
+      The configuration parameters for the autoscaling algorithm. You can
+      define one or more of the policies for an autoscaler: cpuUtilization,
+      customMetricUtilizations, and loadBalancingUtilization.
+
+      If none of these are specified, the default will be to autoscale based
+      on cpuUtilization to 0.6 or 60%.
+    required: true
+    properties:
+      - name: 'minReplicas'
+        type: Integer
+        description: |
+          The minimum number of replicas that the autoscaler can scale down
+          to. This cannot be less than 0. If not provided, autoscaler will
+          choose a default value depending on maximum number of instances
+          allowed.
+        api_name: minNumReplicas
+        required: true
+        send_empty_value: true
+      - name: 'maxReplicas'
+        type: Integer
+        description: |
+          The maximum number of instances that the autoscaler can scale up
+          to. This is required when creating or updating an autoscaler. The
+          maximum number of replicas should not be lower than minimal number
+          of replicas.
+        api_name: maxNumReplicas
+        required: true
+        send_empty_value: true
+      - name: 'cooldownPeriod'
+        type: Integer
+        description: |
+          The number of seconds that the autoscaler should wait before it
+          starts collecting information from a new instance. This prevents
+          the autoscaler from collecting information when the instance is
+          initializing, during which the collected usage would not be
+          reliable. The default time autoscaler waits is 60 seconds.
+
+          Virtual machine initialization times might vary because of
+          numerous factors. We recommend that you test how long an
+          instance may take to initialize. To do this, create an instance
+          and time the startup process.
+        api_name: coolDownPeriodSec
+        default_value: 60
+      - name: 'stabilizationPeriod'
+        type: Integer
+        description: |
+          The number of seconds that the autoscaler waits for load stabilization
+          before making scale-in decisions.
+
+          This might appear as a delay in scaling in but it is an important mechanism
+          for your application to not have fluctuating size due to short term load
+          fluctuations.
+        api_name: stabilizationPeriodSec
+      - name: 'mode'
+        type: String
+        description: |
+          Defines operating mode for this policy.
+        default_value: "ON"
+      - name: 'scaleDownControl'
+        type: NestedObject
+        description: |
+          Defines scale down controls to reduce the risk of response latency
+          and outages due to abrupt scale-in events
+        min_version: 'beta'
+        properties:
+          - name: 'maxScaledDownReplicas'
+            type: NestedObject
+            at_least_one_of:
+              - 'autoscaling_policy.0.scale_down_control.0.max_scaled_down_replicas'
+              - 'autoscaling_policy.0.scale_down_control.0.time_window_sec'
+            properties:
+              - name: 'fixed'
+                type: Integer
+                description: |
+                  Specifies a fixed number of VM instances. This must be a positive
+                  integer.
+                at_least_one_of:
+                  - 'autoscaling_policy.0.scale_down_control.0.max_scaled_down_replicas.0.fixed'
+                  - 'autoscaling_policy.0.scale_down_control.0.max_scaled_down_replicas.0.percent'
+              - name: 'percent'
+                type: Integer
+                description: |
+                  Specifies a percentage of instances between 0 to 100%, inclusive.
+                  For example, specify 80 for 80%.
+                at_least_one_of:
+                  - 'autoscaling_policy.0.scale_down_control.0.max_scaled_down_replicas.0.fixed'
+                  - 'autoscaling_policy.0.scale_down_control.0.max_scaled_down_replicas.0.percent'
+          - name: 'timeWindowSec'
+            type: Integer
+            description: |
+              How long back autoscaling should look when computing recommendations
+              to include directives regarding slower scale down, as described above.
+            at_least_one_of:
+              - 'autoscaling_policy.0.scale_down_control.0.max_scaled_down_replicas'
+              - 'autoscaling_policy.0.scale_down_control.0.time_window_sec'
+      - name: 'scaleInControl'
+        type: NestedObject
+        description: |
+          Defines scale in controls to reduce the risk of response latency
+          and outages due to abrupt scale-in events
+        properties:
+          - name: 'maxScaledInReplicas'
+            type: NestedObject
+            at_least_one_of:
+              - 'autoscaling_policy.0.scale_in_control.0.max_scaled_in_replicas'
+              - 'autoscaling_policy.0.scale_in_control.0.time_window_sec'
+            properties:
+              - name: 'fixed'
+                type: Integer
+                description: |
+                  Specifies a fixed number of VM instances. This must be a positive
+                  integer.
+                at_least_one_of:
+                  - 'autoscaling_policy.0.scale_in_control.0.max_scaled_in_replicas.0.fixed'
+                  - 'autoscaling_policy.0.scale_in_control.0.max_scaled_in_replicas.0.percent'
+              - name: 'percent'
+                type: Integer
+                description: |
+                  Specifies a percentage of instances between 0 to 100%, inclusive.
+                  For example, specify 80 for 80%.
+                at_least_one_of:
+                  - 'autoscaling_policy.0.scale_in_control.0.max_scaled_in_replicas.0.fixed'
+                  - 'autoscaling_policy.0.scale_in_control.0.max_scaled_in_replicas.0.percent'
+          - name: 'timeWindowSec'
+            type: Integer
+            description: |
+              How long back autoscaling should look when computing recommendations
+              to include directives regarding slower scale down, as described above.
+            at_least_one_of:
+              - 'autoscaling_policy.0.scale_in_control.0.max_scaled_in_replicas'
+              - 'autoscaling_policy.0.scale_in_control.0.time_window_sec'
+      - name: 'cpuUtilization'
+        type: NestedObject
+        description: |
+          Defines the CPU utilization policy that allows the autoscaler to
+          scale based on the average CPU utilization of a managed instance
+          group.
+        default_from_api: true
+        properties:
+          - name: 'target'
+            type: Double
+            description: |
+              The target CPU utilization that the autoscaler should maintain.
+              Must be a float value in the range (0, 1]. If not specified, the
+              default is 0.6.
+
+              If the CPU level is below the target utilization, the autoscaler
+              scales down the number of instances until it reaches the minimum
+              number of instances you specified or until the average CPU of
+              your instances reaches the target utilization.
+
+              If the average CPU is above the target utilization, the autoscaler
+              scales up until it reaches the maximum number of instances you
+              specified or until the average utilization reaches the target
+              utilization.
+            api_name: utilizationTarget
+            required: true
+          - name: 'predictiveMethod'
+            type: String
+            description: |
+              Indicates whether predictive autoscaling based on CPU metric is enabled. Valid values are:
+
+              - NONE (default). No predictive method is used. The autoscaler scales the group to meet current demand based on real-time metrics.
+
+              - OPTIMIZE_AVAILABILITY. Predictive autoscaling improves availability by monitoring daily and weekly load patterns and scaling out ahead of anticipated demand.
+            custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.tmpl'
+            default_value: "NONE"
+      - name: 'metric'
+        type: Array
+        description: |
+          Configuration parameters of autoscaling based on a custom metric.
+        api_name: customMetricUtilizations
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'name'
+              type: String
+              description: |
+                The identifier (type) of the Stackdriver Monitoring metric.
+                The metric cannot have negative values.
+
+                The metric must have a value type of INT64 or DOUBLE.
+              api_name: metric
+              required: true
+            - name: 'singleInstanceAssignment'
+              type: Double
+              description: |
+                If scaling is based on a per-group metric value that represents the
+                total amount of work to be done or resource usage, set this value to
+                an amount assigned for a single instance of the scaled group.
+                The autoscaler will keep the number of instances proportional to the
+                value of this metric, the metric itself should not change value due
+                to group resizing.
+
+                For example, a good metric to use with the target is
+                `pubsub.googleapis.com/subscription/num_undelivered_messages`
+                or a custom metric exporting the total number of requests coming to
+                your instances.
+
+                A bad example would be a metric exporting an average or median
+                latency, since this value can't include a chunk assignable to a
+                single instance, it could be better used with utilization_target
+                instead.
+            - name: 'target'
+              type: Double
+              description: |
+                The target value of the metric that autoscaler should
+                maintain. This must be a positive value. A utilization
+                metric scales number of virtual machines handling requests
+                to increase or decrease proportionally to the metric.
+
+                For example, a good metric to use as a utilizationTarget is
+                www.googleapis.com/compute/instance/network/received_bytes_count.
+                The autoscaler will work to keep this value constant for each
+                of the instances.
+              api_name: utilizationTarget
+            - name: 'type'
+              type: Enum
+              description: |
+                Defines how target utilization value is expressed for a
+                Stackdriver Monitoring metric.
+              api_name: utilizationTargetType
+              enum_values:
+                - 'GAUGE'
+                - 'DELTA_PER_SECOND'
+                - 'DELTA_PER_MINUTE'
+            - name: 'filter'
+              type: String
+              description: |
+                A filter string to be used as the filter string for
+                a Stackdriver Monitoring TimeSeries.list API call.
+                This filter is used to select a specific TimeSeries for
+                the purpose of autoscaling and to determine whether the metric
+                is exporting per-instance or per-group data.
+
+                You can only use the AND operator for joining selectors.
+                You can only use direct equality comparison operator (=) without
+                any functions for each selector.
+                You can specify the metric in both the filter string and in the
+                metric field. However, if specified in both places, the metric must
+                be identical.
+
+                The monitored resource type determines what kind of values are
+                expected for the metric. If it is a gce_instance, the autoscaler
+                expects the metric to include a separate TimeSeries for each
+                instance in a group. In such a case, you cannot filter on resource
+                labels.
+
+                If the resource type is any other value, the autoscaler expects
+                this metric to contain values that apply to the entire autoscaled
+                instance group and resource label filtering can be performed to
+                point autoscaler at the correct TimeSeries to scale upon.
+                This is called a per-group metric for the purpose of autoscaling.
+
+                If not specified, the type defaults to gce_instance.
+
+                You should provide a filter that is selective enough to pick just
+                one TimeSeries for the autoscaled group or for each of the instances
+                (if you are using gce_instance resource type). If multiple
+                TimeSeries are returned upon the query execution, the autoscaler
+                will sum their respective values to obtain its scaling value.
+      - name: 'loadBalancingUtilization'
+        type: NestedObject
+        description: |
+          Configuration parameters of autoscaling based on a load balancer.
+        properties:
+          - name: 'target'
+            type: Double
+            description: |
+              Fraction of backend capacity utilization (set in HTTP(s) load
+              balancing configuration) that autoscaler should maintain. Must
+              be a positive float value. If not defined, the default is 0.8.
+            api_name: utilizationTarget
+            required: true
+      - name: 'scalingSchedules'
+        type: Map
+        description: |
+          Scaling schedules defined for an autoscaler. Multiple schedules can be set on an autoscaler and they can overlap.
+        key_name: 'name'
+        value_type:
+          type: NestedObject
+          properties:
+            - name: 'minRequiredReplicas'
+              type: Integer
+              description: |
+                Minimum number of VM instances that autoscaler will recommend in time intervals starting according to schedule.
+              required: true
+              send_empty_value: true
+            - name: 'schedule'
+              type: String
+              description: |
+                The start timestamps of time intervals when this scaling schedule should provide a scaling signal. This field uses the extended cron format (with an optional year field).
+              required: true
+            - name: 'timeZone'
+              type: String
+              description: |
+                The time zone to be used when interpreting the schedule. The value of this field must be a time zone name from the tz database: http://en.wikipedia.org/wiki/Tz_database.
+              default_value: "UTC"
+            - name: 'durationSec'
+              type: Integer
+              description: |
+                The duration of time intervals (in seconds) for which this scaling schedule will be running. The minimum allowed value is 300.
+              required: true
+            - name: 'disabled'
+              type: Boolean
+              description: |
+                A boolean value that specifies if a scaling schedule can influence autoscaler recommendations. If set to true, then a scaling schedule has no effect.
+              default_value: false
+            - name: 'description'
+              type: String
+              description: |
+                A description of a scaling schedule.
+  - name: 'target'
+    type: String
+    # TODO: #303 resourceref once RegionIGM exists
+    # resource: 'RegionInstanceGroupManager'
+    # imports: 'selfLink'
+    description: |
+      URL of the managed instance group that this autoscaler will scale.
+    required: true
+    diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_backend_service.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_backend_service.yaml
@@ -1,0 +1,1710 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'RegionBackendService'
+api_resource_type_kind: BackendService
+kind: 'compute#backendService'
+description: |
+  A Region Backend Service defines a regionally-scoped group of virtual
+  machines that will serve traffic for load balancing.
+
+  ~> **Note:** Recreating a `google_compute_region_backend_service` that references other dependent resources like `google_compute_instance_group` will give a `resourceInUseByAnotherResource` error, when decreasing the number of other dependent resources.
+  Use `lifecycle.create_before_destroy` on the dependent resources to avoid this type of error as shown in the Dynamic Backend Count example.
+references:
+  guides:
+    'Internal TCP/UDP Load Balancing': 'https://cloud.google.com/compute/docs/load-balancing/internal/'
+  api: 'https://cloud.google.com/compute/docs/reference/latest/regionBackendServices'
+docs:
+cai_resource_kind: 'RegionBackendService'
+base_url: 'projects/{{project}}/regions/{{region}}/backendServices'
+has_self_link: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+iam_policy:
+  allowed_iam_role: 'roles/compute.admin'
+  parent_resource_attribute: 'name'
+  iam_conditions_request_type: 'QUERY_PARAM'
+  min_version: 'beta'
+include_in_tgc_next: true
+custom_code:
+  constants: 'templates/terraform/constants/region_backend_service.go.tmpl'
+  encoder: 'templates/terraform/encoders/region_backend_service.go.tmpl'
+  decoder: 'templates/terraform/decoders/region_backend_service.go.tmpl'
+  post_create: 'templates/terraform/post_create/compute_region_backend_service_security_policy.go.tmpl'
+  tgc_decoder: 'templates/tgc_next/decoders/compute_region_backend_service.go.tmpl'
+custom_diff:
+  - 'customDiffRegionBackendService'
+schema_version: 1
+migrate_state: 'tpgresource.MigrateStateNoop'
+sweeper:
+  url_substitutions:
+    - region: "us-west2"
+    - region: "us-central1"
+    - region: "europe-west4"
+    - region: "europe-west1"
+    - region: "us-west1"
+examples:
+  - name: 'region_backend_service_basic'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'region-service'
+      health_check_name: 'rbs-health-check'
+  - name: 'region_backend_service_external_iap'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'tf-test-region-service-external'
+  - name: 'region_backend_service_ilb_round_robin'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'region-service'
+      health_check_name: 'rbs-health-check'
+  - name: 'region_backend_service_external'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      region_backend_service_name: 'region-service'
+      health_check_name: 'rbs-health-check'
+  - name: 'region_backend_service_external_weighted'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'region-service'
+      health_check_name: 'rbs-health-check'
+  - name: 'region_backend_service_ilb_ring_hash'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'region-service'
+      health_check_name: 'rbs-health-check'
+  - name: 'region_backend_service_ilb_stateful_session_affinity'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      region_backend_service_name: 'region-service'
+      health_check_name: 'rbs-health-check'
+  - name: 'region_backend_service_balancing_mode'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'region-service'
+      rigm_name: 'rbs-rigm'
+      region_health_check_name: 'rbs-health-check'
+      network_name: 'rbs-net'
+  - name: 'region_backend_service_connection_tracking'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'region-service'
+      health_check_name: 'rbs-health-check'
+  - name: 'region_backend_service_ip_address_selection_policy'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'region-service'
+      health_check_name: 'rbs-health-check'
+  - name: 'region_backend_service_ilb_custom_metrics'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'region-service'
+      default_neg_name: 'network-endpoint'
+      health_check_name: 'rbs-health-check'
+      network_name: 'network'
+    test_vars_overrides:
+      # for backward compatible
+      network_name: '"network" + randomSuffix'
+  - name: 'region_backend_service_dynamic_backend_count'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'region-service'
+      health_check_name: 'health-check'
+      instance_group_name: 'instance_group'
+      network_name: 'network'
+    test_vars_overrides:
+      # for backward compatible
+      network_name: '"network" + randomSuffix'
+    exclude_test: true
+  - name: 'region_backend_service_dynamic_forwarding'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      region_backend_service_name: 'region-service'
+  - name: 'region_backend_service_dynamic_forwarding_forward_proxy_cloud_run'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      region_backend_service_name: 'region-service'
+  - name: 'region_backend_service_dynamic_forwarding_forward_proxy_direct_forwarding'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      region_backend_service_name: 'region-service'
+  - name: 'region_backend_service_ha_policy'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'region-service'
+      network_name: 'rbs-net'
+  - name: 'region_backend_service_ha_policy_manual_leader'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'region-service'
+      network_name: 'rbs-net'
+      subnetwork_name: 'rbs-subnet'
+      instance_name: 'rbs-instance'
+      neg_name: 'rbs-neg'
+  - name: 'region_backend_service_tls_settings'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'region-service'
+      health_check_name: 'health-check'
+      authentication_name: 'authentication'
+    test_vars_overrides:
+      # for backward compatible
+      authentication_name: '"authentication" + randomSuffix'
+parameters:
+  - name: 'region'
+    type: ResourceRef
+    description: |
+      The Region in which the created backend service should reside.
+      If it is not provided, the provider region is used.
+    required: false
+    default_from_api: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Region'
+    imports: 'name'
+properties:
+  - name: 'affinityCookieTtlSec'
+    type: Integer
+    description: |
+      Lifetime of cookies in seconds if session_affinity is
+      GENERATED_COOKIE. If set to 0, the cookie is non-persistent and lasts
+      only until the end of the browser session (or equivalent). The
+      maximum allowed value for TTL is one day.
+
+      When the load balancing scheme is INTERNAL, this field is not used.
+  - name: 'backend'
+    type: Array
+    description: |
+      The set of backends that serve this RegionBackendService.
+    api_name: backends
+    is_set: true
+    set_hash_func: 'resourceGoogleComputeBackendServiceBackendHash'
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'balancingMode'
+          type: Enum
+          description: |
+            Specifies the balancing mode for this backend.
+
+            See the [Backend Services Overview](https://cloud.google.com/load-balancing/docs/backend-service#balancing-mode)
+            for an explanation of load balancing modes.
+          default_value: "UTILIZATION"
+          enum_values:
+            - 'UTILIZATION'
+            - 'RATE'
+            - 'CONNECTION'
+            - 'CUSTOM_METRICS'
+        - name: 'capacityScaler'
+          type: Double
+          description: |
+            A multiplier applied to the group's maximum servicing capacity
+            (based on UTILIZATION, RATE or CONNECTION).
+
+            ~>**NOTE**: This field cannot be set for
+            INTERNAL region backend services (default loadBalancingScheme),
+            but is required for non-INTERNAL backend service. The total
+            capacity_scaler for all backends must be non-zero.
+
+            A setting of 0 means the group is completely drained, offering
+            0% of its available Capacity. Valid range is [0.0,1.0].
+          send_empty_value: true
+        - name: 'description'
+          type: String
+          description: |
+            An optional description of this resource.
+            Provide this property when you create the resource.
+        - name: 'failover'
+          type: Boolean
+          description: |
+            This field designates whether this is a failover backend. More
+            than one failover backend can be configured for a given RegionBackendService.
+          default_from_api: true
+        - name: 'group'
+          type: String
+          description: |
+            The fully-qualified URL of an Instance Group or Network Endpoint
+            Group resource. In case of instance group this defines the list
+            of instances that serve traffic. Member virtual machine
+            instances from each instance group must live in the same zone as
+            the instance group itself. No two backends in a backend service
+            are allowed to use same Instance Group resource.
+
+            For Network Endpoint Groups this defines list of endpoints. All
+            endpoints of Network Endpoint Group must be hosted on instances
+            located in the same zone as the Network Endpoint Group.
+
+            Backend services cannot mix Instance Group and
+            Network Endpoint Group backends.
+
+            When the `load_balancing_scheme` is INTERNAL, only instance groups
+            are supported.
+
+            Note that you must specify an Instance Group or Network Endpoint
+            Group resource using the fully-qualified URL, rather than a
+            partial URL.
+          required: true
+          diff_suppress_func: 'tpgresource.CompareSelfLinkCanonicalPaths'
+          custom_flatten: 'templates/terraform/custom_flatten/guard_self_link.go.tmpl'
+        - name: 'maxConnections'
+          type: Integer
+          description: |
+            The max number of simultaneous connections for the group. Can
+            be used with either CONNECTION or UTILIZATION balancing modes.
+            Cannot be set for INTERNAL backend services.
+
+            For CONNECTION mode, either maxConnections or one
+            of maxConnectionsPerInstance or maxConnectionsPerEndpoint,
+            as appropriate for group type, must be set.
+        - name: 'maxConnectionsPerInstance'
+          type: Integer
+          description: |
+            The max number of simultaneous connections that a single
+            backend instance can handle. Cannot be set for INTERNAL backend
+            services.
+
+            This is used to calculate the capacity of the group.
+            Can be used in either CONNECTION or UTILIZATION balancing modes.
+            For CONNECTION mode, either maxConnections or
+            maxConnectionsPerInstance must be set.
+        - name: 'maxConnectionsPerEndpoint'
+          type: Integer
+          description: |
+            The max number of simultaneous connections that a single backend
+            network endpoint can handle. Cannot be set
+            for INTERNAL backend services.
+
+            This is used to calculate the capacity of the group. Can be
+            used in either CONNECTION or UTILIZATION balancing modes. For
+            CONNECTION mode, either maxConnections or
+            maxConnectionsPerEndpoint must be set.
+        - name: 'maxRate'
+          type: Integer
+          description: |
+            The max requests per second (RPS) of the group. Cannot be set
+            for INTERNAL backend services.
+
+            Can be used with either RATE or UTILIZATION balancing modes,
+            but required if RATE mode. Either maxRate or one
+            of maxRatePerInstance or maxRatePerEndpoint, as appropriate for
+            group type, must be set.
+        - name: 'maxRatePerInstance'
+          type: Double
+          description: |
+            The max requests per second (RPS) that a single backend
+            instance can handle. This is used to calculate the capacity of
+            the group. Can be used in either balancing mode. For RATE mode,
+            either maxRate or maxRatePerInstance must be set. Cannot be set
+            for INTERNAL backend services.
+        - name: 'maxRatePerEndpoint'
+          type: Double
+          description: |
+            The max requests per second (RPS) that a single backend network
+            endpoint can handle. This is used to calculate the capacity of
+            the group. Can be used in either balancing mode. For RATE mode,
+            either maxRate or maxRatePerEndpoint must be set. Cannot be set
+            for INTERNAL backend services.
+        - name: 'maxUtilization'
+          type: Double
+          description: |
+            Used when balancingMode is UTILIZATION. This ratio defines the
+            CPU utilization target for the group. Valid range is [0.0, 1.0].
+            Cannot be set for INTERNAL backend services.
+        - name: 'maxInFlightRequests'
+          type: Integer
+          description: |
+            Defines a maximum number of in-flight requests for the whole NEG
+            or instance group. Not available if backend's balancingMode is RATE
+            or CONNECTION.
+          default_from_api: true
+          min_version: 'beta'
+        - name: 'maxInFlightRequestsPerInstance'
+          type: Integer
+          description: |
+            Defines a maximum number of in-flight requests for a single VM.
+            Not available if backend's balancingMode is RATE or CONNECTION.
+          default_from_api: true
+          min_version: 'beta'
+        - name: 'maxInFlightRequestsPerEndpoint'
+          type: Integer
+          description: |
+            Defines a maximum number of in-flight requests for a single endpoint.
+            Not available if backend's balancingMode is RATE or CONNECTION.
+          default_from_api: true
+          min_version: 'beta'
+        - name: 'trafficDuration'
+          type: Enum
+          description: |
+            This field specifies how long a connection should be kept alive for:
+            - LONG: Most of the requests are expected to take more than multiple
+              seconds to finish.
+            - SHORT: Most requests are expected to finish with a sub-second latency.
+          enum_values:
+            - 'LONG'
+            - 'SHORT'
+          min_version: 'beta'
+        - name: 'customMetrics'
+          type: Array
+          description: |
+            The set of custom metrics that are used for <code>CUSTOM_METRICS</code> BalancingMode.
+          item_type:
+            type: NestedObject
+            properties:
+              - name: 'name'
+                type: String
+                required: true
+                description: |
+                  Name of a custom utilization signal. The name must be 1-64 characters
+                  long and match the regular expression [a-z]([-_.a-z0-9]*[a-z0-9])? which
+                  means the first character must be a lowercase letter, and all following
+                  characters must be a dash, period, underscore, lowercase letter, or
+                  digit, except the last character, which cannot be a dash, period, or
+                  underscore. For usage guidelines, see Custom Metrics balancing mode. This
+                  field can only be used for a global or regional backend service with the
+                  loadBalancingScheme set to <code>EXTERNAL_MANAGED</code>,
+                  <code>INTERNAL_MANAGED</code> <code>INTERNAL_SELF_MANAGED</code>.
+              - name: 'dryRun'
+                type: Boolean
+                required: true
+                description: |
+                  If true, the metric data is collected and reported to Cloud
+                  Monitoring, but is not used for load balancing.
+              - name: 'maxUtilization'
+                type: Double
+                description: |
+                  Optional parameter to define a target utilization for the Custom Metrics
+                  balancing mode. The valid range is <code>[0.0, 1.0]</code>.
+                default_value: 0.8
+  - name: 'circuitBreakers'
+    type: NestedObject
+    description: |
+      Settings controlling the volume of connections to a backend service. This field
+      is applicable only when the `load_balancing_scheme` is set to INTERNAL_MANAGED
+      and the `protocol` is set to HTTP, HTTPS, HTTP2 or H2C.
+    properties:
+      - name: 'connectTimeout'
+        type: NestedObject
+        description: |
+          The timeout for new network connections to hosts.
+        min_version: 'beta'
+        at_least_one_of:
+          - 'circuit_breakers.0.connect_timeout'
+          - 'circuit_breakers.0.max_requests_per_connection'
+          - 'circuit_breakers.0.max_connections'
+          - 'circuit_breakers.0.max_pending_requests'
+          - 'circuit_breakers.0.max_requests'
+          - 'circuit_breakers.0.max_retries'
+        properties:
+          - name: 'seconds'
+            type: Integer
+            description: |
+              Span of time at a resolution of a second.
+              Must be from 0 to 315,576,000,000 inclusive.
+            required: true
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond
+              resolution. Durations less than one second are represented
+              with a 0 seconds field and a positive nanos field. Must
+              be from 0 to 999,999,999 inclusive.
+      - name: 'maxRequestsPerConnection'
+        type: Integer
+        description: |
+          Maximum requests for a single backend connection. This parameter
+          is respected by both the HTTP/1.1 and HTTP/2 implementations. If
+          not specified, there is no limit. Setting this parameter to 1
+          will effectively disable keep alive.
+        at_least_one_of:
+          - 'circuit_breakers.0.connect_timeout'
+          - 'circuit_breakers.0.max_requests_per_connection'
+          - 'circuit_breakers.0.max_connections'
+          - 'circuit_breakers.0.max_pending_requests'
+          - 'circuit_breakers.0.max_requests'
+          - 'circuit_breakers.0.max_retries'
+      - name: 'maxConnections'
+        type: Integer
+        description: |
+          The maximum number of connections to the backend cluster.
+          Defaults to 1024.
+        at_least_one_of:
+          - 'circuit_breakers.0.connect_timeout'
+          - 'circuit_breakers.0.max_requests_per_connection'
+          - 'circuit_breakers.0.max_connections'
+          - 'circuit_breakers.0.max_pending_requests'
+          - 'circuit_breakers.0.max_requests'
+          - 'circuit_breakers.0.max_retries'
+        default_value: 1024
+      - name: 'maxPendingRequests'
+        type: Integer
+        description: |
+          The maximum number of pending requests to the backend cluster.
+          Defaults to 1024.
+        at_least_one_of:
+          - 'circuit_breakers.0.connect_timeout'
+          - 'circuit_breakers.0.max_requests_per_connection'
+          - 'circuit_breakers.0.max_connections'
+          - 'circuit_breakers.0.max_pending_requests'
+          - 'circuit_breakers.0.max_requests'
+          - 'circuit_breakers.0.max_retries'
+        default_value: 1024
+      - name: 'maxRequests'
+        type: Integer
+        description: |
+          The maximum number of parallel requests to the backend cluster.
+          Defaults to 1024.
+        at_least_one_of:
+          - 'circuit_breakers.0.connect_timeout'
+          - 'circuit_breakers.0.max_requests_per_connection'
+          - 'circuit_breakers.0.max_connections'
+          - 'circuit_breakers.0.max_pending_requests'
+          - 'circuit_breakers.0.max_requests'
+          - 'circuit_breakers.0.max_retries'
+        default_value: 1024
+      - name: 'maxRetries'
+        type: Integer
+        description: |
+          The maximum number of parallel retries to the backend cluster.
+          Defaults to 3.
+        at_least_one_of:
+          - 'circuit_breakers.0.connect_timeout'
+          - 'circuit_breakers.0.max_requests_per_connection'
+          - 'circuit_breakers.0.max_connections'
+          - 'circuit_breakers.0.max_pending_requests'
+          - 'circuit_breakers.0.max_requests'
+          - 'circuit_breakers.0.max_retries'
+        default_value: 3
+  - name: 'consistentHash'
+    type: NestedObject
+    description: |
+      Consistent Hash-based load balancing can be used to provide soft session
+      affinity based on HTTP headers, cookies or other properties. This load balancing
+      policy is applicable only for HTTP connections. The affinity to a particular
+      destination host will be lost when one or more hosts are added/removed from the
+      destination service. This field specifies parameters that control consistent
+      hashing.
+      This field only applies when all of the following are true -
+        * `load_balancing_scheme` is set to INTERNAL_MANAGED
+        * `protocol` is set to HTTP, HTTPS, HTTP2 or H2C
+        * `locality_lb_policy` is set to MAGLEV or RING_HASH
+    properties:
+      - name: 'httpCookie'
+        type: NestedObject
+        description: |
+          Hash is based on HTTP Cookie. This field describes a HTTP cookie
+          that will be used as the hash key for the consistent hash load
+          balancer. If the cookie is not present, it will be generated.
+          This field is applicable if the sessionAffinity is set to HTTP_COOKIE.
+        at_least_one_of:
+          - 'consistent_hash.0.http_cookie'
+          - 'consistent_hash.0.http_header_name'
+          - 'consistent_hash.0.minimum_ring_size'
+        properties:
+          - name: 'ttl'
+            type: NestedObject
+            description: |
+              Lifetime of the cookie.
+            at_least_one_of:
+              - 'consistent_hash.0.http_cookie.0.ttl'
+              - 'consistent_hash.0.http_cookie.0.name'
+              - 'consistent_hash.0.http_cookie.0.path'
+            properties:
+              - name: 'seconds'
+                type: Integer
+                description: |
+                  Span of time at a resolution of a second.
+                  Must be from 0 to 315,576,000,000 inclusive.
+                required: true
+              - name: 'nanos'
+                type: Integer
+                description: |
+                  Span of time that's a fraction of a second at nanosecond
+                  resolution. Durations less than one second are represented
+                  with a 0 seconds field and a positive nanos field. Must
+                  be from 0 to 999,999,999 inclusive.
+          - name: 'name'
+            type: String
+            description: |
+              Name of the cookie.
+            at_least_one_of:
+              - 'consistent_hash.0.http_cookie.0.ttl'
+              - 'consistent_hash.0.http_cookie.0.name'
+              - 'consistent_hash.0.http_cookie.0.path'
+          - name: 'path'
+            type: String
+            description: |
+              Path to set for the cookie.
+            at_least_one_of:
+              - 'consistent_hash.0.http_cookie.0.ttl'
+              - 'consistent_hash.0.http_cookie.0.name'
+              - 'consistent_hash.0.http_cookie.0.path'
+      - name: 'httpHeaderName'
+        type: String
+        description: |
+          The hash based on the value of the specified header field.
+          This field is applicable if the sessionAffinity is set to HEADER_FIELD.
+        at_least_one_of:
+          - 'consistent_hash.0.http_cookie'
+          - 'consistent_hash.0.http_header_name'
+          - 'consistent_hash.0.minimum_ring_size'
+      - name: 'minimumRingSize'
+        type: Integer
+        description: |
+          The minimum number of virtual nodes to use for the hash ring.
+          Larger ring sizes result in more granular load
+          distributions. If the number of hosts in the load balancing pool
+          is larger than the ring size, each host will be assigned a single
+          virtual node.
+          Defaults to 1024.
+        at_least_one_of:
+          - 'consistent_hash.0.http_cookie'
+          - 'consistent_hash.0.http_header_name'
+          - 'consistent_hash.0.minimum_ring_size'
+        default_value: 1024
+  - name: 'cdnPolicy'
+    type: NestedObject
+    description: 'Cloud CDN configuration for this BackendService.'
+    default_from_api: true
+    properties:
+      - name: 'cacheKeyPolicy'
+        type: NestedObject
+        description: 'The CacheKeyPolicy for this CdnPolicy.'
+        at_least_one_of:
+          - 'cdn_policy.0.cache_key_policy'
+          - 'cdn_policy.0.signed_url_cache_max_age_sec'
+        properties:
+          - name: 'includeHost'
+            type: Boolean
+            description: |
+              If true requests to different hosts will be cached separately.
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.include_host'
+              - 'cdn_policy.0.cache_key_policy.0.include_protocol'
+              - 'cdn_policy.0.cache_key_policy.0.include_query_string'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_blacklist'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_named_cookies'
+          - name: 'includeProtocol'
+            type: Boolean
+            description: |
+              If true, http and https requests will be cached separately.
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.include_host'
+              - 'cdn_policy.0.cache_key_policy.0.include_protocol'
+              - 'cdn_policy.0.cache_key_policy.0.include_query_string'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_blacklist'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_named_cookies'
+          - name: 'includeQueryString'
+            type: Boolean
+            description: |
+              If true, include query string parameters in the cache key
+              according to query_string_whitelist and
+              query_string_blacklist. If neither is set, the entire query
+              string will be included.
+
+              If false, the query string will be excluded from the cache
+              key entirely.
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.include_host'
+              - 'cdn_policy.0.cache_key_policy.0.include_protocol'
+              - 'cdn_policy.0.cache_key_policy.0.include_query_string'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_blacklist'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_named_cookies'
+          - name: 'queryStringBlacklist'
+            type: Array
+            description: |
+              Names of query string parameters to exclude in cache keys.
+
+              All other parameters will be included. Either specify
+              query_string_whitelist or query_string_blacklist, not both.
+              '&' and '=' will be percent encoded and not treated as
+              delimiters.
+            is_set: true
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.include_host'
+              - 'cdn_policy.0.cache_key_policy.0.include_protocol'
+              - 'cdn_policy.0.cache_key_policy.0.include_query_string'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_blacklist'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_named_cookies'
+            item_type:
+              type: String
+          - name: 'queryStringWhitelist'
+            type: Array
+            description: |
+              Names of query string parameters to include in cache keys.
+
+              All other parameters will be excluded. Either specify
+              query_string_whitelist or query_string_blacklist, not both.
+              '&' and '=' will be percent encoded and not treated as
+              delimiters.
+            is_set: true
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.include_host'
+              - 'cdn_policy.0.cache_key_policy.0.include_protocol'
+              - 'cdn_policy.0.cache_key_policy.0.include_query_string'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_blacklist'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_named_cookies'
+            item_type:
+              type: String
+          - name: 'includeNamedCookies'
+            type: Array
+            description: |
+              Names of cookies to include in cache keys.
+            send_empty_value: true
+            at_least_one_of:
+              - 'cdn_policy.0.cache_key_policy.0.include_host'
+              - 'cdn_policy.0.cache_key_policy.0.include_protocol'
+              - 'cdn_policy.0.cache_key_policy.0.include_query_string'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_blacklist'
+              - 'cdn_policy.0.cache_key_policy.0.query_string_whitelist'
+              - 'cdn_policy.0.cache_key_policy.0.include_named_cookies'
+            item_type:
+              type: String
+      - name: 'signedUrlCacheMaxAgeSec'
+        type: Integer
+        description: |
+          Maximum number of seconds the response to a signed URL request
+          will be considered fresh, defaults to 1hr (3600s). After this
+          time period, the response will be revalidated before
+          being served.
+
+          When serving responses to signed URL requests, Cloud CDN will
+          internally behave as though all responses from this backend had a
+          "Cache-Control: public, max-age=[TTL]" header, regardless of any
+          existing Cache-Control header. The actual headers served in
+          responses will not be altered.
+        at_least_one_of:
+          - 'cdn_policy.0.cache_key_policy'
+          - 'cdn_policy.0.signed_url_cache_max_age_sec'
+        default_value: 3600
+      - name: 'defaultTtl'
+        type: Integer
+        description: |
+          Specifies the default TTL for cached content served by this origin for responses
+          that do not have an existing valid TTL (max-age or s-max-age).
+        default_from_api: true
+      - name: 'maxTtl'
+        type: Integer
+        description: |
+          Specifies the maximum allowed TTL for cached content served by this origin.
+        default_from_api: true
+      - name: 'clientTtl'
+        type: Integer
+        description: |
+          Specifies the maximum allowed TTL for cached content served by this origin.
+        default_from_api: true
+      - name: 'negativeCaching'
+        type: Boolean
+        description: |
+          Negative caching allows per-status code TTLs to be set, in order to apply fine-grained caching for common errors or redirects.
+        default_from_api: true
+        send_empty_value: true
+      - name: 'negativeCachingPolicy'
+        type: Array
+        description: |
+          Sets a cache TTL for the specified HTTP status code. negativeCaching must be enabled to configure negativeCachingPolicy.
+          Omitting the policy and leaving negativeCaching enabled will use Cloud CDN's default cache TTLs.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'code'
+              type: Integer
+              description: |
+                The HTTP status code to define a TTL against. Only HTTP status codes 300, 301, 308, 404, 405, 410, 421, 451 and 501
+                can be specified as values, and you cannot specify a status code more than once.
+            - name: 'ttl'
+              type: Integer
+              description: |
+                The TTL (in seconds) for which to cache responses with the corresponding status code. The maximum allowed value is 1800s
+                (30 minutes), noting that infrequently accessed objects may be evicted from the cache before the defined TTL.
+              min_version: 'beta'
+      - name: 'cacheMode'
+        type: Enum
+        description: |
+          Specifies the cache setting for all responses from this backend.
+          The possible values are: USE_ORIGIN_HEADERS, FORCE_CACHE_ALL and CACHE_ALL_STATIC
+        default_from_api: true
+        enum_values:
+          - 'USE_ORIGIN_HEADERS'
+          - 'FORCE_CACHE_ALL'
+          - 'CACHE_ALL_STATIC'
+      - name: 'serveWhileStale'
+        type: Integer
+        description: |
+          Serve existing content from the cache (if available) when revalidating content with the origin, or when an error is encountered when refreshing the cache.
+
+        default_from_api: true
+        send_empty_value: true
+  - name: 'connectionDraining'
+    type: NestedObject
+    description: |
+      Settings for connection draining
+    flatten_object: true
+    properties:
+      - name: 'connection_draining_timeout_sec'
+        type: Integer
+        description: |
+          Time for which instance will be drained (not accept new
+          connections, but still work to finish started).
+        api_name: drainingTimeoutSec
+        send_empty_value: true
+        default_value: 300
+  - name: 'creationTimestamp'
+    type: Time
+    description: |
+      Creation timestamp in RFC3339 text format.
+    output: true
+  # customRequestHeaders only supported for EXTERNAL load balancing
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource.
+  - name: 'failoverPolicy'
+    type: NestedObject
+    description: |
+      Policy for failovers.
+    properties:
+      - name: 'disableConnectionDrainOnFailover'
+        type: Boolean
+        description: |
+          On failover or failback, this field indicates whether connection drain
+          will be honored. Setting this to true has the following effect: connections
+          to the old active pool are not drained. Connections to the new active pool
+          use the timeout of 10 min (currently fixed). Setting to false has the
+          following effect: both old and new connections will have a drain timeout
+          of 10 min.
+          This can be set to true only if the protocol is TCP.
+          The default is false.
+        default_from_api: true
+        at_least_one_of:
+          - 'failover_policy.0.disable_connection_drain_on_failover'
+          - 'failover_policy.0.drop_traffic_if_unhealthy'
+          - 'failover_policy.0.failover_ratio'
+      - name: 'dropTrafficIfUnhealthy'
+        type: Boolean
+        description: |
+          This option is used only when no healthy VMs are detected in the primary
+          and backup instance groups. When set to true, traffic is dropped. When
+          set to false, new connections are sent across all VMs in the primary group.
+          The default is false.
+        default_from_api: true
+        send_empty_value: true
+        at_least_one_of:
+          - 'failover_policy.0.disable_connection_drain_on_failover'
+          - 'failover_policy.0.drop_traffic_if_unhealthy'
+          - 'failover_policy.0.failover_ratio'
+      - name: 'failoverRatio'
+        type: Double
+        description: |
+          The value of the field must be in [0, 1]. If the ratio of the healthy
+          VMs in the primary backend is at or below this number, traffic arriving
+          at the load-balanced IP will be directed to the failover backend.
+          In case where 'failoverRatio' is not set or all the VMs in the backup
+          backend are unhealthy, the traffic will be directed back to the primary
+          backend in the "force" mode, where traffic will be spread to the healthy
+          VMs with the best effort, or to all VMs when no VM is healthy.
+          This field is only used with l4 load balancing.
+        at_least_one_of:
+          - 'failover_policy.0.disable_connection_drain_on_failover'
+          - 'failover_policy.0.drop_traffic_if_unhealthy'
+          - 'failover_policy.0.failover_ratio'
+  - name: 'enableCDN'
+    type: Boolean
+    description: |
+      If true, enable Cloud CDN for this RegionBackendService.
+  - name: 'fingerprint'
+    type: Fingerprint
+    description: |
+      Fingerprint of this resource. A hash of the contents stored in this
+      object. This field is used in optimistic locking.
+    output: true
+  - name: 'healthChecks'
+    type: Array
+    description: |
+      The set of URLs to HealthCheck resources for health checking
+      this RegionBackendService. Currently at most one health
+      check can be specified.
+
+      A health check must be specified unless the backend service uses an internet
+      or serverless NEG as a backend.
+    is_set: true
+    set_hash_func: 'tpgresource.SelfLinkRelativePathHash'
+    custom_flatten: 'templates/terraform/custom_flatten/guard_self_link_array.go.tmpl'
+    item_type:
+      type: String
+    min_size: 1
+    max_size: 1
+  - name: 'generated_id'
+    type: Integer
+    description:
+      'The unique identifier for the resource. This identifier is defined by the
+      server.'
+    api_name: id
+    output: true
+  - name: 'iap'
+    type: NestedObject
+    description: |
+      Settings for enabling Cloud Identity Aware Proxy.
+      If OAuth client is not set, Google-managed OAuth client is used.
+    default_from_api: true
+    send_empty_value: true
+    properties:
+      - name: 'enabled'
+        type: Boolean
+        description: Whether the serving infrastructure will authenticate and authorize all incoming requests.
+        required: true
+        send_empty_value: true
+      - name: 'oauth2ClientId'
+        type: String
+        description: |
+          OAuth2 Client ID for IAP
+        send_empty_value: true
+        diff_suppress_func: 'tpgresource.EmptyOrDefaultStringSuppress(" ")'
+      - name: 'oauth2ClientSecret'
+        type: String
+        description: |
+          OAuth2 Client Secret for IAP
+        ignore_read: true
+        sensitive: true
+        send_empty_value: true
+      - name: 'oauth2ClientSecretSha256'
+        type: String
+        description: |
+          OAuth2 Client Secret SHA-256 for IAP
+        sensitive: true
+        output: true
+  - name: 'ipAddressSelectionPolicy'
+    type: Enum
+    description: |
+      Specifies preference of traffic to the backend (from the proxy and from the client for proxyless gRPC).
+    enum_values:
+      - 'IPV4_ONLY'
+      - 'PREFER_IPV6'
+      - 'IPV6_ONLY'
+  - name: 'loadBalancingScheme'
+    type: Enum
+    description: |
+      Indicates what kind of load balancing this regional backend service
+      will be used for. A backend service created for one type of load
+      balancing cannot be used with the other(s). For more information, refer to
+      [Choosing a load balancer](https://cloud.google.com/load-balancing/docs/backend-service).
+    immutable: true
+    default_value: "INTERNAL"
+    enum_values:
+      - 'EXTERNAL'
+      - 'EXTERNAL_MANAGED'
+      - 'INTERNAL'
+      - 'INTERNAL_MANAGED'
+      - 'INTERNAL_SELF_MANAGED'
+  - name: 'localityLbPolicy'
+    type: Enum
+    description: |
+      The load balancing algorithm used within the scope of the locality.
+      The possible values are:
+
+      * `ROUND_ROBIN`: This is a simple policy in which each healthy backend
+                       is selected in round robin order.
+
+      * `LEAST_REQUEST`: An O(1) algorithm which selects two random healthy
+                         hosts and picks the host which has fewer active requests.
+
+      * `RING_HASH`: The ring/modulo hash load balancer implements consistent
+                     hashing to backends. The algorithm has the property that the
+                     addition/removal of a host from a set of N hosts only affects
+                     1/N of the requests.
+
+      * `RANDOM`: The load balancer selects a random healthy host.
+
+      * `ORIGINAL_DESTINATION`: Backend host is selected based on the client
+                                connection metadata, i.e., connections are opened
+                                to the same address as the destination address of
+                                the incoming connection before the connection
+                                was redirected to the load balancer.
+
+      * `MAGLEV`: used as a drop in replacement for the ring hash load balancer.
+                  Maglev is not as stable as ring hash but has faster table lookup
+                  build times and host selection times. For more information about
+                  Maglev, refer to https://ai.google/research/pubs/pub44824
+
+      * `WEIGHTED_MAGLEV`: Per-instance weighted Load Balancing via health check
+                           reported weights. Only applicable to loadBalancingScheme
+                           EXTERNAL. If set, the Backend Service must
+                           configure a non legacy HTTP-based Health Check, and
+                           health check replies are expected to contain
+                           non-standard HTTP response header field
+                           X-Load-Balancing-Endpoint-Weight to specify the
+                           per-instance weights. If set, Load Balancing is weight
+                           based on the per-instance weights reported in the last
+                           processed health check replies, as long as every
+                           instance either reported a valid weight or had
+                           UNAVAILABLE_WEIGHT. Otherwise, Load Balancing remains
+                           equal-weight.
+
+      * `WEIGHTED_ROUND_ROBIN`: Per-endpoint weighted round-robin Load Balancing using weights computed
+                                from Backend reported Custom Metrics. If set, the Backend Service
+                                responses are expected to contain non-standard HTTP response header field
+                                X-Endpoint-Load-Metrics. The reported metrics
+                                to use for computing the weights are specified via the
+                                backends[].customMetrics fields.
+
+      locality_lb_policy is applicable to either:
+
+      * A regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C,
+        and loadBalancingScheme set to INTERNAL_MANAGED.
+      * A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED.
+      * A regional backend service with loadBalancingScheme set to EXTERNAL (External Network
+        Load Balancing). Only MAGLEV and WEIGHTED_MAGLEV values are possible for External
+        Network Load Balancing. The default is MAGLEV.
+
+      If session_affinity is not NONE, and locality_lb_policy is not set to MAGLEV, WEIGHTED_MAGLEV,
+      or RING_HASH, session affinity settings will not take effect.
+
+      Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced
+      by a URL map that is bound to target gRPC proxy that has validate_for_proxyless
+      field set to true.
+    enum_values:
+      - 'ROUND_ROBIN'
+      - 'LEAST_REQUEST'
+      - 'RING_HASH'
+      - 'RANDOM'
+      - 'ORIGINAL_DESTINATION'
+      - 'MAGLEV'
+      - 'WEIGHTED_MAGLEV'
+      - 'WEIGHTED_ROUND_ROBIN'
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    required: true
+    immutable: true
+  - name: 'customMetrics'
+    type: Array
+    description: |
+      List of custom metrics that are used for the WEIGHTED_ROUND_ROBIN locality_lb_policy.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          required: true
+          description: |
+            Name of a custom utilization signal. The name must be 1-64 characters
+            long and match the regular expression [a-z]([-_.a-z0-9]*[a-z0-9])? which
+            means the first character must be a lowercase letter, and all following
+            characters must be a dash, period, underscore, lowercase letter, or
+            digit, except the last character, which cannot be a dash, period, or
+            underscore. For usage guidelines, see Custom Metrics balancing mode. This
+            field can only be used for a global or regional backend service with the
+            loadBalancingScheme set to <code>EXTERNAL_MANAGED</code>,
+            <code>INTERNAL_MANAGED</code> <code>INTERNAL_SELF_MANAGED</code>.
+        - name: 'dryRun'
+          type: Boolean
+          required: true
+          description: |
+            If true, the metric data is not used for load balancing.
+  - name: 'networkPassThroughLbTrafficPolicy'
+    type: NestedObject
+    description: |
+      Configures traffic steering properties of internal passthrough Network Load Balancers.
+    properties:
+      - name: 'zonalAffinity'
+        type: NestedObject
+        description: |
+          When configured, new connections are load balanced across healthy backend endpoints in the local zone.
+        properties:
+          - name: 'spillover'
+            type: Enum
+            description: |
+              This field indicates whether zonal affinity is enabled or not.
+            enum_values:
+              - 'ZONAL_AFFINITY_DISABLED'
+              - 'ZONAL_AFFINITY_SPILL_CROSS_ZONE'
+              - 'ZONAL_AFFINITY_STAY_WITHIN_ZONE'
+            default_value: 'ZONAL_AFFINITY_DISABLED'
+          - name: 'spilloverRatio'
+            type: Double
+            description: |
+              The value of the field must be in [0, 1]. When the ratio of the count of healthy backend endpoints in a zone
+              to the count of backend endpoints in that same zone is equal to or above this threshold, the load balancer
+              distributes new connections to all healthy endpoints in the local zone only. When the ratio of the count
+              of healthy backend endpoints in a zone to the count of backend endpoints in that same zone is below this
+              threshold, the load balancer distributes all new connections to all healthy endpoints across all zones.
+  - name: 'outlierDetection'
+    type: NestedObject
+    description: |
+      Settings controlling eviction of unhealthy hosts from the load balancing pool.
+      This field is applicable only when the `load_balancing_scheme` is set
+      to INTERNAL_MANAGED and the `protocol` is set to HTTP, HTTPS, HTTP2 or H2C.
+    properties:
+      - name: 'baseEjectionTime'
+        type: NestedObject
+        description: |
+          The base time that a host is ejected for. The real time is equal to the base
+          time multiplied by the number of times the host has been ejected. Defaults to
+          30000ms or 30s.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+        properties:
+          - name: 'seconds'
+            type: Integer
+            description: |
+              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+              inclusive.
+            required: true
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond resolution. Durations
+              less than one second are represented with a 0 `seconds` field and a positive
+              `nanos` field. Must be from 0 to 999,999,999 inclusive.
+      - name: 'consecutiveErrors'
+        type: Integer
+        description: |
+          Number of errors before a host is ejected from the connection pool. When the
+          backend host is accessed over HTTP, a 5xx return code qualifies as an error.
+          Defaults to 5.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'consecutiveGatewayFailure'
+        type: Integer
+        description: |
+          The number of consecutive gateway failures (502, 503, 504 status or connection
+          errors that are mapped to one of those status codes) before a consecutive
+          gateway failure ejection occurs. Defaults to 5.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'enforcingConsecutiveErrors'
+        type: Integer
+        description: |
+          The percentage chance that a host will be actually ejected when an outlier
+          status is detected through consecutive 5xx. This setting can be used to disable
+          ejection or to ramp it up slowly. Defaults to 100.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'enforcingConsecutiveGatewayFailure'
+        type: Integer
+        description: |
+          The percentage chance that a host will be actually ejected when an outlier
+          status is detected through consecutive gateway failures. This setting can be
+          used to disable ejection or to ramp it up slowly. Defaults to 0.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'enforcingSuccessRate'
+        type: Integer
+        description: |
+          The percentage chance that a host will be actually ejected when an outlier
+          status is detected through success rate statistics. This setting can be used to
+          disable ejection or to ramp it up slowly. Defaults to 100.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'interval'
+        type: NestedObject
+        description: |
+          Time interval between ejection sweep analysis. This can result in both new
+          ejections as well as hosts being returned to service. Defaults to 10 seconds.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+        properties:
+          - name: 'seconds'
+            type: Integer
+            description: |
+              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+              inclusive.
+            required: true
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond resolution. Durations
+              less than one second are represented with a 0 `seconds` field and a positive
+              `nanos` field. Must be from 0 to 999,999,999 inclusive.
+      - name: 'maxEjectionPercent'
+        type: Integer
+        description: |
+          Maximum percentage of hosts in the load balancing pool for the backend service
+          that can be ejected. Defaults to 10%.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'successRateMinimumHosts'
+        type: Integer
+        description: |
+          The number of hosts in a cluster that must have enough request volume to detect
+          success rate outliers. If the number of hosts is less than this setting, outlier
+          detection via success rate statistics is not performed for any host in the
+          cluster. Defaults to 5.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'successRateRequestVolume'
+        type: Integer
+        description: |
+          The minimum number of total requests that must be collected in one interval (as
+          defined by the interval duration above) to include this host in success rate
+          based outlier detection. If the volume is lower than this setting, outlier
+          detection via success rate statistics is not performed for that host. Defaults
+          to 100.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+      - name: 'successRateStdevFactor'
+        type: Integer
+        description: |
+          This factor is used to determine the ejection threshold for success rate outlier
+          ejection. The ejection threshold is the difference between the mean success
+          rate, and the product of this factor and the standard deviation of the mean
+          success rate: mean - (stdev * success_rate_stdev_factor). This factor is divided
+          by a thousand to get a double. That is, if the desired factor is 1.9, the
+          runtime value should be 1900. Defaults to 1900.
+        at_least_one_of:
+          - 'outlier_detection.0.base_ejection_time'
+          - 'outlier_detection.0.consecutive_errors'
+          - 'outlier_detection.0.consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_consecutive_errors'
+          - 'outlier_detection.0.enforcing_consecutive_gateway_failure'
+          - 'outlier_detection.0.enforcing_success_rate'
+          - 'outlier_detection.0.interval'
+          - 'outlier_detection.0.max_ejection_percent'
+          - 'outlier_detection.0.success_rate_minimum_hosts'
+          - 'outlier_detection.0.success_rate_request_volume'
+          - 'outlier_detection.0.success_rate_stdev_factor'
+  - name: 'portName'
+    type: String
+    description: |
+      A named port on a backend instance group representing the port for
+      communication to the backend VMs in that group. Required when the
+      loadBalancingScheme is EXTERNAL, EXTERNAL_MANAGED, INTERNAL_MANAGED, or INTERNAL_SELF_MANAGED
+      and the backends are instance groups. The named port must be defined on each
+      backend instance group. This parameter has no meaning if the backends are NEGs. API sets a
+      default of "http" if not given.
+      Must be omitted when the loadBalancingScheme is INTERNAL (Internal TCP/UDP Load Balancing).
+    default_from_api: true
+  - name: 'protocol'
+    type: Enum
+    description: |
+      The protocol this BackendService uses to communicate with backends.
+      The default is HTTP. Possible values are HTTP, HTTPS, HTTP2, H2C, TCP, SSL, UDP
+      or GRPC. Refer to the documentation for the load balancers or for Traffic Director
+      for more information.
+    default_from_api: true
+    enum_values:
+      - 'HTTP'
+      - 'HTTPS'
+      - 'HTTP2'
+      - 'TCP'
+      - 'SSL'
+      - 'UDP'
+      - 'GRPC'
+      - 'UNSPECIFIED'
+      - 'H2C'
+  - name: 'securityPolicy'
+    type: String
+    description: |
+      The security policy associated with this backend service.
+    update_url: 'projects/{{project}}/regions/{{region}}/backendServices/{{name}}/setSecurityPolicy'
+    update_verb: 'POST'
+    diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+  - name: 'sessionAffinity'
+    type: Enum
+    description: |
+      Type of session affinity to use. The default is NONE. Session affinity is
+      not applicable if the protocol is UDP.
+    default_from_api: true
+    enum_values:
+      - 'NONE'
+      - 'CLIENT_IP'
+      - 'CLIENT_IP_PORT_PROTO'
+      - 'CLIENT_IP_PROTO'
+      - 'GENERATED_COOKIE'
+      - 'HEADER_FIELD'
+      - 'HTTP_COOKIE'
+      - 'CLIENT_IP_NO_DESTINATION'
+      - 'STRONG_COOKIE_AFFINITY'
+  - name: 'strongSessionAffinityCookie'
+    type: NestedObject
+    description: |
+      Describes the HTTP cookie used for stateful session affinity. This field is applicable and required if the sessionAffinity is set to STRONG_COOKIE_AFFINITY.
+    properties:
+      - name: 'ttl'
+        type: NestedObject
+        description: |
+          Lifetime of the cookie.
+        at_least_one_of:
+          - 'strong_session_affinity_cookie.0.ttl'
+          - 'strong_session_affinity_cookie.0.name'
+          - 'strong_session_affinity_cookie.0.path'
+        properties:
+          - name: 'seconds'
+            type: Integer
+            description: |
+              Span of time at a resolution of a second.
+              Must be from 0 to 315,576,000,000 inclusive.
+            required: true
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond
+              resolution. Durations less than one second are represented
+              with a 0 seconds field and a positive nanos field. Must
+              be from 0 to 999,999,999 inclusive.
+      - name: 'name'
+        type: String
+        description: |
+          Name of the cookie.
+        at_least_one_of:
+          - 'strong_session_affinity_cookie.0.ttl'
+          - 'strong_session_affinity_cookie.0.name'
+          - 'strong_session_affinity_cookie.0.path'
+      - name: 'path'
+        type: String
+        description: |
+          Path to set for the cookie.
+        at_least_one_of:
+          - 'strong_session_affinity_cookie.0.ttl'
+          - 'strong_session_affinity_cookie.0.name'
+          - 'strong_session_affinity_cookie.0.path'
+  - name: 'connectionTrackingPolicy'
+    type: NestedObject
+    description: |
+      Connection Tracking configuration for this BackendService.
+      This is available only for Layer 4 Internal Load Balancing and
+      Network Load Balancing.
+    properties:
+      - name: 'idleTimeoutSec'
+        type: Integer
+        description: |
+          Specifies how long to keep a Connection Tracking entry while there is
+          no matching traffic (in seconds).
+
+          For L4 ILB the minimum(default) is 10 minutes and maximum is 16 hours.
+
+          For NLB the minimum(default) is 60 seconds and the maximum is 16 hours.
+        default_from_api: true
+      - name: 'trackingMode'
+        type: Enum
+        description: |
+          Specifies the key used for connection tracking. There are two options:
+          `PER_CONNECTION`: The Connection Tracking is performed as per the
+          Connection Key (default Hash Method) for the specific protocol.
+
+          `PER_SESSION`: The Connection Tracking is performed as per the
+          configured Session Affinity. It matches the configured Session Affinity.
+        default_value: "PER_CONNECTION"
+        enum_values:
+          - 'PER_CONNECTION'
+          - 'PER_SESSION'
+      - name: 'connectionPersistenceOnUnhealthyBackends'
+        type: Enum
+        description: |
+          Specifies connection persistence when backends are unhealthy.
+
+          If set to `DEFAULT_FOR_PROTOCOL`, the existing connections persist on
+          unhealthy backends only for connection-oriented protocols (TCP and SCTP)
+          and only if the Tracking Mode is PER_CONNECTION (default tracking mode)
+          or the Session Affinity is configured for 5-tuple. They do not persist
+          for UDP.
+
+          If set to `NEVER_PERSIST`, after a backend becomes unhealthy, the existing
+          connections on the unhealthy backend are never persisted on the unhealthy
+          backend. They are always diverted to newly selected healthy backends
+          (unless all backends are unhealthy).
+
+          If set to `ALWAYS_PERSIST`, existing connections always persist on
+          unhealthy backends regardless of protocol and session affinity. It is
+          generally not recommended to use this mode overriding the default.
+        default_value: "DEFAULT_FOR_PROTOCOL"
+        enum_values:
+          - 'DEFAULT_FOR_PROTOCOL'
+          - 'NEVER_PERSIST'
+          - 'ALWAYS_PERSIST'
+      - name: 'enableStrongAffinity'
+        type: Boolean
+        description: Enable Strong Session Affinity for Network Load Balancing. This option is not available publicly.
+  - name: 'timeoutSec'
+    type: Integer
+    description: |
+      The backend service timeout has a different meaning depending on the type of load balancer.
+      For more information see, [Backend service settings](https://cloud.google.com/compute/docs/reference/rest/v1/backendServices).
+      The default is 30 seconds.
+      The full range of timeout values allowed goes from 1 through 2,147,483,647 seconds.
+    default_from_api: true
+  - name: 'logConfig'
+    type: NestedObject
+    description: |
+      This field denotes the logging options for the load balancer traffic served by this backend service.
+      If logging is enabled, logs will be exported to Stackdriver.
+    default_from_api: true
+    properties:
+      - name: 'enable'
+        type: Boolean
+        description: |
+          Whether to enable logging for the load balancer traffic served by this backend service.
+        send_empty_value: true
+        at_least_one_of:
+          - 'log_config.0.enable'
+          - 'log_config.0.sample_rate'
+          - 'log_config.0.optional_mode'
+      - name: 'sampleRate'
+        type: Double
+        description: |
+          This field can only be specified if logging is enabled for this backend service. The value of
+          the field must be in [0, 1]. This configures the sampling rate of requests to the load balancer
+          where 1.0 means all logged requests are reported and 0.0 means no logged requests are reported.
+          The default value is 1.0.
+        at_least_one_of:
+          - 'log_config.0.enable'
+          - 'log_config.0.sample_rate'
+          - 'log_config.0.optional_mode'
+        diff_suppress_func: 'suppressWhenDisabled'
+        default_value: 1.0
+      - name: 'optionalMode'
+        type: Enum
+        description: |
+          Specifies the optional logging mode for the load balancer traffic.
+          Supported values: INCLUDE_ALL_OPTIONAL, EXCLUDE_ALL_OPTIONAL, CUSTOM.
+        enum_values:
+          - 'INCLUDE_ALL_OPTIONAL'
+          - 'EXCLUDE_ALL_OPTIONAL'
+          - 'CUSTOM'
+        at_least_one_of:
+          - 'log_config.0.enable'
+          - 'log_config.0.sample_rate'
+          - 'log_config.0.optional_mode'
+        default_from_api: true
+      - name: 'optionalFields'
+        type: Array
+        description: |
+          Specifies the fields to include in logging. This field can only be specified if logging is enabled for this backend service.
+        item_type:
+          type: String
+        default_from_api: true
+  - name: 'network'
+    type: ResourceRef
+    description: |
+      The URL of the network to which this backend service belongs.
+      This field must be set for Internal Passthrough Network Load Balancers when the haPolicy is enabled, and for External Passthrough Network Load Balancers when the haPolicy fastIpMove is enabled.
+      This field can only be specified when the load balancing scheme is set to INTERNAL, or when the load balancing scheme is set to EXTERNAL and haPolicy fastIpMove is enabled.
+      Changes to this field force recreation of the resource.
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Network'
+    imports: 'selfLink'
+    immutable: true
+  - name: 'subsetting'
+    type: NestedObject
+    description: |
+      Subsetting configuration for this BackendService. Currently this is applicable only for Internal TCP/UDP load balancing and Internal HTTP(S) load balancing.
+    min_version: 'beta'
+    properties:
+      - name: 'policy'
+        type: Enum
+        description: |
+          The algorithm used for subsetting.
+        required: true
+        enum_values:
+          - 'CONSISTENT_HASH_SUBSETTING'
+      - name: 'subsetSize'
+        type: Integer
+        description: |
+          The number of backends per backend group assigned to each proxy instance or each service mesh client.
+          An input parameter to the CONSISTENT_HASH_SUBSETTING algorithm. Can only be set if policy is set to
+          CONSISTENT_HASH_SUBSETTING. Can only be set if load balancing scheme is INTERNAL_MANAGED or INTERNAL_SELF_MANAGED.
+          subsetSize is optional for Internal HTTP(S) load balancing and required for Traffic Director.
+          If you do not provide this value, Cloud Load Balancing will calculate it dynamically to optimize the number
+          of proxies/clients visible to each backend and vice versa.
+          Must be greater than 0. If subsetSize is larger than the number of backends/endpoints, then subsetting is disabled.
+  - name: 'dynamicForwarding'
+    type: NestedObject
+    description: |
+      Dynamic forwarding configuration. This field is used to configure the backend service with dynamic forwarding
+      feature which together with Service Extension allows customized and complex routing logic.
+    min_version: beta
+    properties:
+      - name: 'ipPortSelection'
+        type: NestedObject
+        description: |
+          IP:PORT based dynamic forwarding configuration.
+        min_version: beta
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            min_version: beta
+            description: |
+              A boolean flag enabling IP:PORT based dynamic forwarding.
+            immutable: true
+      - name: 'forwardProxy'
+        type: NestedObject
+        description: |
+          Dynamic Forwarding Proxy configuration.
+        min_version: beta
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            min_version: beta
+            description: |
+              A boolean flag enabling dynamic forwarding proxy.
+            immutable: true
+            required: true
+          - name: 'proxyMode'
+            type: Enum
+            min_version: beta
+            description: |
+              Determines the dynamic forwarding proxy mode
+            enum_values:
+              - 'DIRECT_FORWARDING'
+              - 'CLOUD_RUN'
+            required: true
+  - name: 'haPolicy'
+    type: NestedObject
+    description: |
+      Configures self-managed High Availability (HA) for External and Internal Protocol Forwarding.
+      The backends of this regional backend service must only specify zonal network endpoint groups
+      (NEGs) of type GCE_VM_IP. Note that haPolicy is not for load balancing, and therefore cannot
+      be specified with sessionAffinity, connectionTrackingPolicy, and failoverPolicy. haPolicy
+      requires customers to be responsible for tracking backend endpoint health and electing a
+      leader among the healthy endpoints. Therefore, haPolicy cannot be specified with healthChecks.
+      haPolicy can only be specified for External Passthrough Network Load Balancers and Internal
+      Passthrough Network Load Balancers.
+    conflicts:
+      - sessionAffinity
+      - connectionTrackingPolicy
+      - failoverPolicy
+      - healthChecks
+    properties:
+      - name: 'fastIPMove'
+        type: Enum
+        is_missing_in_cai: true
+        description: |
+          Specifies whether fast IP move is enabled, and if so, the mechanism to achieve it.
+          Supported values are:
+
+          * `DISABLED`: Fast IP Move is disabled. You can only use the haPolicy.leader API to
+                        update the leader.
+
+          * `GARP_RA`: Provides a method to very quickly define a new network endpoint as the
+                       leader. This method is faster than updating the leader using the
+                       haPolicy.leader API. Fast IP move works as follows: The VM hosting the
+                       network endpoint that should become the new leader sends either a
+                       Gratuitous ARP (GARP) packet (IPv4) or an ICMPv6 Router Advertisement(RA)
+                       packet (IPv6). Google Cloud immediately but temporarily associates the
+                       forwarding rule IP address with that VM, and both new and in-flight packets
+                       are quickly delivered to that VM.
+        immutable: true
+        enum_values:
+          - 'DISABLED'
+          - 'GARP_RA'
+      - name: 'leader'
+        type: NestedObject
+        description: |
+          Selects one of the network endpoints attached to the backend NEGs of this service as the
+          active endpoint (the leader) that receives all traffic.
+        properties:
+          - name: 'backendGroup'
+            type: ResourceRef
+            is_missing_in_cai: true
+            description: |
+              A fully-qualified URL of the zonal Network Endpoint Group (NEG) that the leader is
+              attached to.
+          - name: 'networkEndpoint'
+            type: NestedObject
+            description: |
+              The network endpoint within the leader.backendGroup that is designated as the leader.
+            properties:
+              - name: 'instance'
+                type: String
+                description: |
+                  The name of the VM instance of the leader network endpoint. The instance must
+                  already be attached to the NEG specified in the haPolicy.leader.backendGroup.
+  - name: 'params'
+    type: NestedObject
+    ignore_read: true
+    immutable: true
+    description: |
+      Additional params passed with the request, but not persisted as part of resource payload
+    properties:
+      - name: 'resourceManagerTags'
+        type: KeyValuePairs
+        description: |
+          Resource manager tags to be bound to the region backend service. Tag keys and values have the
+          same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id},
+          and values are in the format tagValues/456.
+        api_name: resourceManagerTags
+        ignore_read: true
+        immutable: true
+  - name: 'tlsSettings'
+    type: NestedObject
+    description: |
+      Configuration for Backend Authenticated TLS and mTLS. May only be specified when the backend protocol is SSL, HTTPS or HTTP2.
+    properties:
+      - name: 'sni'
+        type: String
+        description: |
+          Server Name Indication - see RFC3546 section 3.1. If set, the load balancer sends this string as the SNI hostname in the
+          TLS connection to the backend, and requires that this string match a Subject Alternative Name (SAN) in the backend's
+          server certificate. With a Regional Internet NEG backend, if the SNI is specified here, the load balancer uses it
+          regardless of whether the Regional Internet NEG is specified with FQDN or IP address and port.
+      - name: 'subjectAltNames'
+        type: Array
+        description: |
+          A list of Subject Alternative Names (SANs) that the Load Balancer verifies during a TLS handshake with the backend.
+          When the server presents its X.509 certificate to the Load Balancer, the Load Balancer inspects the certificate's SAN field,
+          and requires that at least one SAN match one of the subjectAltNames in the list. This field is limited to 5 entries.
+          When both sni and subjectAltNames are specified, the load balancer matches the backend certificate's SAN only to
+          subjectAltNames.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'dnsName'
+              type: String
+              description: The SAN specified as a DNS Name.
+              exactly_one_of:
+                - tlsSettings.0.uniform_resource_identifier
+                - tlsSettings.0.dns_name
+            - name: 'uniformResourceIdentifier'
+              type: String
+              description: The SAN specified as a URI.
+              exactly_one_of:
+                - tlsSettings.0.uniform_resource_identifier
+                - tlsSettings.0.dns_name
+      - name: 'authenticationConfig'
+        type: String
+        description: |
+          Reference to the BackendAuthenticationConfig resource from the networksecurity.googleapis.com namespace.
+          Can be used in authenticating TLS connections to the backend, as specified by the authenticationMode field.
+          Can only be specified if authenticationMode is not NONE.

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_health_check.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_health_check.yaml
@@ -1,0 +1,949 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'RegionHealthCheck'
+api_resource_type_kind: HealthCheck
+api_variant_patterns:
+  - 'projects/{project}/regions/{region}/healthChecks/{healthCheck}'
+kind: 'compute#healthCheck'
+description: |
+  Health Checks determine whether instances are responsive and able to do work.
+  They are an important part of a comprehensive load balancing configuration,
+  as they enable monitoring instances behind load balancers.
+
+  Health Checks poll instances at a specified interval. Instances that
+  do not respond successfully to some number of probes in a row are marked
+  as unhealthy. No new connections are sent to unhealthy instances,
+  though existing connections will continue. The health check will
+  continue to poll unhealthy instances. If an instance later responds
+  successfully to some number of consecutive probes, it is marked
+  healthy again and can receive new connections.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/load-balancing/docs/health-checks'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/regionHealthChecks'
+docs:
+base_url: 'projects/{{project}}/regions/{{region}}/healthChecks'
+has_self_link: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+custom_code:
+  encoder: 'templates/terraform/encoders/health_check_type.tmpl'
+custom_diff:
+  - 'healthCheckCustomizeDiff'
+tgc_tests:
+  - name: 'TestAccComputeRegionHealthCheck_typeTransition'
+    skip: 'Test data has mismatched steps'
+  - name: 'TestAccComputeRegionHealthCheck_grpcWithTls_create'
+    skip: 'grpcTlsHealthCheck is not in CAI asset, but is required in this test.'
+  - name: 'TestAccComputeRegionHealthCheck_grpcWithTls_update'
+    skip: 'grpcTlsHealthCheck is not in CAI asset, but is required in this test.'
+sweeper:
+  url_substitutions:
+    - region: "us-central1"
+    - region: "europe-west4"
+    - region: "europe-west1"
+    - region: "us-west1"
+examples:
+  - name: 'region_health_check_tcp'
+    primary_resource_id: 'tcp-region-health-check'
+    vars:
+      health_check_name: 'tcp-region-health-check'
+  - name: 'region_health_check_tcp_full'
+    primary_resource_id: 'tcp-region-health-check'
+    vars:
+      health_check_name: 'tcp-region-health-check'
+  - name: 'region_health_check_ssl'
+    primary_resource_id: 'ssl-region-health-check'
+    vars:
+      health_check_name: 'ssl-region-health-check'
+  - name: 'region_health_check_ssl_full'
+    primary_resource_id: 'ssl-region-health-check'
+    vars:
+      health_check_name: 'ssl-region-health-check'
+  - name: 'region_health_check_http'
+    primary_resource_id: 'http-region-health-check'
+    vars:
+      health_check_name: 'http-region-health-check'
+  - name: 'region_health_check_http_logs'
+    primary_resource_id: 'http-region-health-check'
+    min_version: 'beta'
+    vars:
+      health_check_name: 'http-region-health-check'
+  - name: 'region_health_check_http_full'
+    primary_resource_id: 'http-region-health-check'
+    vars:
+      health_check_name: 'http-region-health-check'
+  - name: 'region_health_check_https'
+    primary_resource_id: 'https-region-health-check'
+    vars:
+      health_check_name: 'https-region-health-check'
+  - name: 'region_health_check_https_full'
+    primary_resource_id: 'https-region-health-check'
+    vars:
+      health_check_name: 'https-region-health-check'
+  - name: 'region_health_check_http2'
+    primary_resource_id: 'http2-region-health-check'
+    vars:
+      health_check_name: 'http2-region-health-check'
+  - name: 'region_health_check_http2_full'
+    primary_resource_id: 'http2-region-health-check'
+    vars:
+      health_check_name: 'http2-region-health-check'
+  - name: 'region_health_check_grpc'
+    primary_resource_id: 'grpc-region-health-check'
+    vars:
+      health_check_name: 'grpc-region-health-check'
+  - name: 'region_health_check_grpc_full'
+    primary_resource_id: 'grpc-region-health-check'
+    vars:
+      health_check_name: 'grpc-region-health-check'
+  - name: 'region_health_check_grpc_with_tls'
+    primary_resource_id: 'grpc-with-tls-region-health-check'
+    vars:
+      health_check_name: 'grpc-with-tls-region-health-check'
+    tgc_skip_test: 'grpcTlsHealthCheck is not in CAI asset, but is required in this test.'
+  - name: 'region_health_check_grpc_with_tls_full'
+    primary_resource_id: 'grpc-with-tls-region-health-check'
+    vars:
+      health_check_name: 'grpc-with-tls-region-health-check'
+    tgc_skip_test: 'grpcTlsHealthCheck is not in CAI asset, but is required in this test.'
+parameters:
+  - name: 'region'
+    type: ResourceRef
+    description: |
+      The Region in which the created health check should reside.
+      If it is not provided, the provider region is used.
+    required: false
+    immutable: true
+    default_from_api: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Region'
+    imports: 'selfLink'
+properties:
+  - name: 'checkIntervalSec'
+    type: Integer
+    description: |
+      How often (in seconds) to send a health check. The default value is 5
+      seconds.
+    default_value: 5
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource. Provide this property when
+      you create the resource.
+    send_empty_value: true
+  - name: 'healthCheckId'
+    type: Integer
+    description: |
+      The unique identifier number for the resource. This identifier is defined by the server.
+    api_name: id
+    output: true
+  - name: 'healthyThreshold'
+    type: Integer
+    description: |
+      A so-far unhealthy instance will be marked healthy after this many
+      consecutive successes. The default value is 2.
+    default_value: 2
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035.  Specifically, the name must be 1-63 characters long and
+      match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means
+      the first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the
+      last character, which cannot be a dash.
+    required: true
+    immutable: true
+  - name: 'unhealthyThreshold'
+    type: Integer
+    description: |
+      A so-far healthy instance will be marked unhealthy after this many
+      consecutive failures. The default value is 2.
+    default_value: 2
+  - name: 'timeoutSec'
+    type: Integer
+    description: |
+      How long (in seconds) to wait before claiming failure.
+      The default value is 5 seconds.  It is invalid for timeoutSec to have
+      greater value than checkIntervalSec.
+    default_value: 5
+  - name: 'type'
+    type: Enum
+    description: |-
+      The type of the health check. One of HTTP, HTTP2, HTTPS, TCP, or SSL.
+    output: true
+    enum_values:
+      - 'TCP'
+      - 'SSL'
+      - 'HTTP'
+      - 'HTTPS'
+      - 'HTTP2'
+  - name: 'httpHealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    properties:
+      - name: 'host'
+        type: String
+        description: |
+          The value of the host header in the HTTP health check request.
+          If left empty (default value), the public IP on behalf of which this health
+          check is performed will be used.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+      - name: 'requestPath'
+        type: String
+        description: |
+          The request path of the HTTP health check request.
+          The default value is /.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+        default_value: "/"
+      - name: 'response'
+        type: String
+        description: |
+          The bytes to match against the beginning of the response data. If left empty
+          (the default value), any response will indicate health. The response data
+          can only be ASCII.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+      - name: 'port'
+        type: Integer
+        description: |
+          The TCP port number for the HTTP health check request.
+          The default value is 80.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+      - name: 'portName'
+        type: String
+        description: |
+          Port name as defined in InstanceGroup#NamedPort#name. If both port and
+          port_name are defined, port takes precedence.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+      - name: 'proxyHeader'
+        type: Enum
+        description: |
+          Specifies the type of proxy header to append before sending data to the
+          backend.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+        default_value: "NONE"
+        enum_values:
+          - 'NONE'
+          - 'PROXY_V1'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: The `portName` is used for health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, HTTP health check follows behavior specified in `port` and
+          `portName` fields.
+        at_least_one_of:
+          - 'http_health_check.0.host'
+          - 'http_health_check.0.request_path'
+          - 'http_health_check.0.response'
+          - 'http_health_check.0.port'
+          - 'http_health_check.0.port_name'
+          - 'http_health_check.0.proxy_header'
+          - 'http_health_check.0.port_specification'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+  - name: 'httpsHealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    properties:
+      - name: 'host'
+        type: String
+        description: |
+          The value of the host header in the HTTPS health check request.
+          If left empty (default value), the public IP on behalf of which this health
+          check is performed will be used.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+      - name: 'requestPath'
+        type: String
+        description: |
+          The request path of the HTTPS health check request.
+          The default value is /.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+        default_value: "/"
+      - name: 'response'
+        type: String
+        description: |
+          The bytes to match against the beginning of the response data. If left empty
+          (the default value), any response will indicate health. The response data
+          can only be ASCII.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+      - name: 'port'
+        type: Integer
+        description: |
+          The TCP port number for the HTTPS health check request.
+          The default value is 443.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+      - name: 'portName'
+        type: String
+        description: |
+          Port name as defined in InstanceGroup#NamedPort#name. If both port and
+          port_name are defined, port takes precedence.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+      - name: 'proxyHeader'
+        type: Enum
+        description: |
+          Specifies the type of proxy header to append before sending data to the
+          backend.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+        default_value: "NONE"
+        enum_values:
+          - 'NONE'
+          - 'PROXY_V1'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: The `portName` is used for health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, HTTPS health check follows behavior specified in `port` and
+          `portName` fields.
+        at_least_one_of:
+          - 'https_health_check.0.host'
+          - 'https_health_check.0.request_path'
+          - 'https_health_check.0.response'
+          - 'https_health_check.0.port'
+          - 'https_health_check.0.port_name'
+          - 'https_health_check.0.proxy_header'
+          - 'https_health_check.0.port_specification'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+  - name: 'tcpHealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    properties:
+      - name: 'request'
+        type: String
+        description: |
+          The application data to send once the TCP connection has been
+          established (default value is empty). If both request and response are
+          empty, the connection establishment alone will indicate health. The request
+          data can only be ASCII.
+        at_least_one_of:
+          - 'tcp_health_check.0.request'
+          - 'tcp_health_check.0.response'
+          - 'tcp_health_check.0.port'
+          - 'tcp_health_check.0.port_name'
+          - 'tcp_health_check.0.proxy_header'
+          - 'tcp_health_check.0.port_specification'
+      - name: 'response'
+        type: String
+        description: |
+          The bytes to match against the beginning of the response data. If left empty
+          (the default value), any response will indicate health. The response data
+          can only be ASCII.
+        at_least_one_of:
+          - 'tcp_health_check.0.request'
+          - 'tcp_health_check.0.response'
+          - 'tcp_health_check.0.port'
+          - 'tcp_health_check.0.port_name'
+          - 'tcp_health_check.0.proxy_header'
+          - 'tcp_health_check.0.port_specification'
+      - name: 'port'
+        type: Integer
+        description: |
+          The TCP port number for the TCP health check request.
+          The default value is 80.
+        at_least_one_of:
+          - 'tcp_health_check.0.request'
+          - 'tcp_health_check.0.response'
+          - 'tcp_health_check.0.port'
+          - 'tcp_health_check.0.port_name'
+          - 'tcp_health_check.0.proxy_header'
+          - 'tcp_health_check.0.port_specification'
+      - name: 'portName'
+        type: String
+        description: |
+          Port name as defined in InstanceGroup#NamedPort#name. If both port and
+          port_name are defined, port takes precedence.
+        at_least_one_of:
+          - 'tcp_health_check.0.request'
+          - 'tcp_health_check.0.response'
+          - 'tcp_health_check.0.port'
+          - 'tcp_health_check.0.port_name'
+          - 'tcp_health_check.0.proxy_header'
+          - 'tcp_health_check.0.port_specification'
+      - name: 'proxyHeader'
+        type: Enum
+        description: |
+          Specifies the type of proxy header to append before sending data to the
+          backend.
+        at_least_one_of:
+          - 'tcp_health_check.0.request'
+          - 'tcp_health_check.0.response'
+          - 'tcp_health_check.0.port'
+          - 'tcp_health_check.0.port_name'
+          - 'tcp_health_check.0.proxy_header'
+          - 'tcp_health_check.0.port_specification'
+        default_value: "NONE"
+        enum_values:
+          - 'NONE'
+          - 'PROXY_V1'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: The `portName` is used for health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, TCP health check follows behavior specified in `port` and
+          `portName` fields.
+        at_least_one_of:
+          - 'tcp_health_check.0.request'
+          - 'tcp_health_check.0.response'
+          - 'tcp_health_check.0.port'
+          - 'tcp_health_check.0.port_name'
+          - 'tcp_health_check.0.proxy_header'
+          - 'tcp_health_check.0.port_specification'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+  - name: 'sslHealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    properties:
+      - name: 'request'
+        type: String
+        description: |
+          The application data to send once the SSL connection has been
+          established (default value is empty). If both request and response are
+          empty, the connection establishment alone will indicate health. The request
+          data can only be ASCII.
+        at_least_one_of:
+          - 'ssl_health_check.0.request'
+          - 'ssl_health_check.0.response'
+          - 'ssl_health_check.0.port'
+          - 'ssl_health_check.0.port_name'
+          - 'ssl_health_check.0.proxy_header'
+          - 'ssl_health_check.0.port_specification'
+      - name: 'response'
+        type: String
+        description: |
+          The bytes to match against the beginning of the response data. If left empty
+          (the default value), any response will indicate health. The response data
+          can only be ASCII.
+        at_least_one_of:
+          - 'ssl_health_check.0.request'
+          - 'ssl_health_check.0.response'
+          - 'ssl_health_check.0.port'
+          - 'ssl_health_check.0.port_name'
+          - 'ssl_health_check.0.proxy_header'
+          - 'ssl_health_check.0.port_specification'
+      - name: 'port'
+        type: Integer
+        description: |
+          The TCP port number for the SSL health check request.
+          The default value is 443.
+        at_least_one_of:
+          - 'ssl_health_check.0.request'
+          - 'ssl_health_check.0.response'
+          - 'ssl_health_check.0.port'
+          - 'ssl_health_check.0.port_name'
+          - 'ssl_health_check.0.proxy_header'
+          - 'ssl_health_check.0.port_specification'
+      - name: 'portName'
+        type: String
+        description: |
+          Port name as defined in InstanceGroup#NamedPort#name. If both port and
+          port_name are defined, port takes precedence.
+        at_least_one_of:
+          - 'ssl_health_check.0.request'
+          - 'ssl_health_check.0.response'
+          - 'ssl_health_check.0.port'
+          - 'ssl_health_check.0.port_name'
+          - 'ssl_health_check.0.proxy_header'
+          - 'ssl_health_check.0.port_specification'
+      - name: 'proxyHeader'
+        type: Enum
+        description: |
+          Specifies the type of proxy header to append before sending data to the
+          backend.
+        at_least_one_of:
+          - 'ssl_health_check.0.request'
+          - 'ssl_health_check.0.response'
+          - 'ssl_health_check.0.port'
+          - 'ssl_health_check.0.port_name'
+          - 'ssl_health_check.0.proxy_header'
+          - 'ssl_health_check.0.port_specification'
+        default_value: "NONE"
+        enum_values:
+          - 'NONE'
+          - 'PROXY_V1'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: The `portName` is used for health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, SSL health check follows behavior specified in `port` and
+          `portName` fields.
+        at_least_one_of:
+          - 'ssl_health_check.0.request'
+          - 'ssl_health_check.0.response'
+          - 'ssl_health_check.0.port'
+          - 'ssl_health_check.0.port_name'
+          - 'ssl_health_check.0.proxy_header'
+          - 'ssl_health_check.0.port_specification'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+  - name: 'http2HealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    properties:
+      - name: 'host'
+        type: String
+        description: |
+          The value of the host header in the HTTP2 health check request.
+          If left empty (default value), the public IP on behalf of which this health
+          check is performed will be used.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+      - name: 'requestPath'
+        type: String
+        description: |
+          The request path of the HTTP2 health check request.
+          The default value is /.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+        default_value: "/"
+      - name: 'response'
+        type: String
+        description: |
+          The bytes to match against the beginning of the response data. If left empty
+          (the default value), any response will indicate health. The response data
+          can only be ASCII.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+      - name: 'port'
+        type: Integer
+        description: |
+          The TCP port number for the HTTP2 health check request.
+          The default value is 443.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+      - name: 'portName'
+        type: String
+        description: |
+          Port name as defined in InstanceGroup#NamedPort#name. If both port and
+          port_name are defined, port takes precedence.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+      - name: 'proxyHeader'
+        type: Enum
+        description: |
+          Specifies the type of proxy header to append before sending data to the
+          backend.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+        default_value: "NONE"
+        enum_values:
+          - 'NONE'
+          - 'PROXY_V1'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: The `portName` is used for health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, HTTP2 health check follows behavior specified in `port` and
+          `portName` fields.
+        at_least_one_of:
+          - 'http2_health_check.0.host'
+          - 'http2_health_check.0.request_path'
+          - 'http2_health_check.0.response'
+          - 'http2_health_check.0.port'
+          - 'http2_health_check.0.port_name'
+          - 'http2_health_check.0.proxy_header'
+          - 'http2_health_check.0.port_specification'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+  - name: 'grpcHealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    properties:
+      - name: 'port'
+        type: Integer
+        description: |
+          The port number for the health check request.
+          Must be specified if portName and portSpecification are not set
+          or if port_specification is USE_FIXED_PORT. Valid values are 1 through 65535.
+        at_least_one_of:
+          - 'grpc_health_check.0.port'
+          - 'grpc_health_check.0.port_name'
+          - 'grpc_health_check.0.port_specification'
+          - 'grpc_health_check.0.grpc_service_name'
+      - name: 'portName'
+        type: String
+        description: |
+          Port name as defined in InstanceGroup#NamedPort#name. If both port and
+          port_name are defined, port takes precedence.
+        at_least_one_of:
+          - 'grpc_health_check.0.port'
+          - 'grpc_health_check.0.port_name'
+          - 'grpc_health_check.0.port_specification'
+          - 'grpc_health_check.0.grpc_service_name'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: The `portName` is used for health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, gRPC health check follows behavior specified in `port` and
+          `portName` fields.
+        at_least_one_of:
+          - 'grpc_health_check.0.port'
+          - 'grpc_health_check.0.port_name'
+          - 'grpc_health_check.0.port_specification'
+          - 'grpc_health_check.0.grpc_service_name'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+      - name: 'grpcServiceName'
+        type: String
+        description: |
+          The gRPC service name for the health check.
+          The value of grpcServiceName has the following meanings by convention:
+
+          * Empty serviceName means the overall status of all services at the backend.
+          * Non-empty serviceName means the health of that gRPC service, as defined by the owner of the service.
+
+          The grpcServiceName can only be ASCII.
+        at_least_one_of:
+          - 'grpc_health_check.0.port'
+          - 'grpc_health_check.0.port_name'
+          - 'grpc_health_check.0.port_specification'
+          - 'grpc_health_check.0.grpc_service_name'
+  - name: 'grpcTlsHealthCheck'
+    type: NestedObject
+    exactly_one_of:
+      - 'http_health_check'
+      - 'https_health_check'
+      - 'http2_health_check'
+      - 'tcp_health_check'
+      - 'ssl_health_check'
+      - 'grpc_health_check'
+      - 'grpc_tls_health_check'
+    diff_suppress_func: 'portDiffSuppress'
+    is_missing_in_cai: true
+    properties:
+      - name: 'port'
+        type: Integer
+        description: |
+          The port number for the health check request.
+          Must be specified if port_specification is USE_FIXED_PORT. Valid values are 1 through 65535.
+        at_least_one_of:
+          - 'grpc_tls_health_check.0.port'
+          - 'grpc_tls_health_check.0.port_specification'
+          - 'grpc_tls_health_check.0.grpc_service_name'
+      - name: 'portSpecification'
+        type: Enum
+        description: |
+          Specifies how port is selected for health checking, can be one of the
+          following values:
+
+            * `USE_FIXED_PORT`: The port number in `port` is used for health checking.
+
+            * `USE_NAMED_PORT`: Not supported for GRPC with TLS health checking.
+
+            * `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+            network endpoint is used for health checking. For other backends, the
+            port or named port specified in the Backend Service is used for health
+            checking.
+
+          If not specified, gRPC health check follows behavior specified in the `port` field.
+        at_least_one_of:
+          - 'grpc_tls_health_check.0.port'
+          - 'grpc_tls_health_check.0.port_specification'
+          - 'grpc_tls_health_check.0.grpc_service_name'
+        enum_values:
+          - 'USE_FIXED_PORT'
+          - 'USE_NAMED_PORT'
+          - 'USE_SERVING_PORT'
+      - name: 'grpcServiceName'
+        type: String
+        description: |
+          The gRPC service name for the health check.
+          The value of grpcServiceName has the following meanings by convention:
+
+          * Empty serviceName means the overall status of all services at the backend.
+          * Non-empty serviceName means the health of that gRPC service, as defined by the owner of the service.
+
+          The grpcServiceName can only be ASCII.
+        at_least_one_of:
+          - 'grpc_tls_health_check.0.port'
+          - 'grpc_tls_health_check.0.port_specification'
+          - 'grpc_tls_health_check.0.grpc_service_name'
+  - name: 'logConfig'
+    type: NestedObject
+    description: |
+      Configure logging on this health check.
+    default_from_api: true
+    custom_flatten: 'templates/terraform/custom_flatten/health_check_log_config.go.tmpl'
+    properties:
+      - name: 'enable'
+        type: Boolean
+        description: |
+          Indicates whether or not to export logs. This is false by default,
+          which means no health check logging will be done.
+        default_value: false

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_instance_group_manager.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_instance_group_manager.yaml
@@ -1,0 +1,234 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'RegionInstanceGroupManager'
+api_variant_patterns:
+  - 'projects/{project}/regions/{region}/instanceGroupManagers/{instanceGroupManager}'
+kind: 'compute#instanceGroupManager'
+description: |
+  Creates a managed instance group using the information that you specify in
+  the request. After the group is created, it schedules an action to create
+  instances in the group using the specified instance template. This
+  operation is marked as DONE when the group is created even if the
+  instances in the group have not yet been created. You must separately
+  verify the status of the individual instances.
+
+  A managed instance group can have up to 1000 VM instances per group.
+exclude: true
+references:
+  guides:
+    'Creating Regional Managed Instance Groups': 'https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/regionInstanceGroupManagers'
+docs:
+base_url: 'projects/{{project}}/regions/{{region}}/instanceGroupManagers'
+has_self_link: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+custom_code:
+parameters:
+  - name: 'region'
+    type: ResourceRef
+    description: 'The region the managed instance group resides.'
+    required: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Region'
+    imports: 'name'
+properties:
+  - name: 'baseInstanceName'
+    type: String
+    description: |
+      The base instance name to use for instances in this group. The value
+      must be 1-58 characters long. Instances are named by appending a
+      hyphen and a random four-character string to the base instance name.
+      The base instance name must comply with RFC1035.
+    required: true
+  - name: 'instanceGroupManagerId'
+    type: Integer
+    description: |
+      The unique identifier number for the resource. This identifier is defined by the server.
+    api_name: id
+    output: true
+  - name: 'creationTimestamp'
+    type: Time
+    description: |
+      The creation timestamp for this managed instance group in RFC3339
+      text format.
+    output: true
+  - name: 'currentActions'
+    type: NestedObject
+    description: |
+      The list of instance actions and the number of instances in this
+      managed instance group that are scheduled for each of those actions.
+    output: true
+    properties:
+      - name: 'abandoning'
+        type: Integer
+        description: |
+          The total number of instances in the managed instance group that
+          are scheduled to be abandoned. Abandoning an instance removes it
+          from the managed instance group without deleting it.
+        output: true
+      - name: 'creating'
+        type: Integer
+        description: |
+          The number of instances in the managed instance group that are
+          scheduled to be created or are currently being created. If the
+          group fails to create any of these instances, it tries again until
+          it creates the instance successfully.
+
+          If you have disabled creation retries, this field will not be
+          populated; instead, the creatingWithoutRetries field will be
+          populated.
+        output: true
+      - name: 'creatingWithoutRetries'
+        type: Integer
+        description: |
+          The number of instances that the managed instance group will
+          attempt to create. The group attempts to create each instance only
+          once. If the group fails to create any of these instances, it
+          decreases the group's targetSize value accordingly.
+        output: true
+      - name: 'deleting'
+        type: Integer
+        description: |
+          The number of instances in the managed instance group that are
+          scheduled to be deleted or are currently being deleted.
+        output: true
+      - name: 'none'
+        type: Integer
+        description: |
+          The number of instances in the managed instance group that are
+          running and have no scheduled actions.
+        output: true
+      - name: 'recreating'
+        type: Integer
+        description: |
+          The number of instances in the managed instance group that are
+          scheduled to be recreated or are currently being being recreated.
+          Recreating an instance deletes the existing root persistent disk
+          and creates a new disk from the image that is defined in the
+          instance template.
+        output: true
+      - name: 'refreshing'
+        type: Integer
+        description: |
+          The number of instances in the managed instance group that are
+          being reconfigured with properties that do not require a restart
+          or a recreate action. For example, setting or removing target
+          pools for the instance.
+        output: true
+      - name: 'restarting'
+        type: Integer
+        description: |
+          The number of instances in the managed instance group that are
+          scheduled to be restarted or are currently being restarted.
+        output: true
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource. Provide this property when
+      you create the resource.
+    immutable: true
+  # fingerprint ignored as it is an internal locking detail
+  - name: 'id'
+    type: Integer
+    description: 'A unique identifier for this resource'
+    output: true
+  - name: 'instanceGroup'
+    type: ResourceRef
+    description: 'The instance group being managed'
+    output: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'InstanceGroup'
+    imports: 'selfLink'
+  - name: 'instanceTemplate'
+    type: ResourceRef
+    description: |
+      The instance template that is specified for this managed instance
+      group. The group uses this template to create all new instances in the
+      managed instance group.
+    required: true
+  # kind is internal transport detail
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'InstanceTemplate'
+    imports: 'selfLink'
+  - name: 'name'
+    type: String
+    description: |
+      The name of the managed instance group. The name must be 1-63
+      characters long, and comply with RFC1035.
+    required: true
+  # TODO: Make namedPorts a NameValue(name[string], port[integer])
+  - name: 'namedPorts'
+    type: Array
+    description:
+      Named ports configured for the Instance Groups complementary to this
+      Instance Group Manager.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          description: |
+            The name for this named port. The name must be 1-63 characters
+            long, and comply with RFC1035.
+        - name: 'port'
+          type: Integer
+          description:
+            The port number, which can be a value between 1 and 65535.
+  - name: 'targetPools'
+    type: Array
+    description: |
+      TargetPool resources to which instances in the instanceGroup field are
+      added. The target pools automatically apply to all of the instances in
+      the managed instance group.
+    custom_expand: 'templates/terraform/custom_expand/array_resourceref_with_validation.go.tmpl'
+    item_type:
+      name: 'targetPool'
+      type: ResourceRef
+      description: 'The targetPool to receive managed instances.'
+      resource: 'TargetPool'
+      imports: 'selfLink'
+  - name: 'targetSize'
+    type: Integer
+    description: |
+      The target number of running instances for this managed instance
+      group. Deleting or abandoning instances reduces this number. Resizing
+      the group changes this number.
+  - name: 'autoHealingPolicies'
+    type: Array
+    description: |
+      The autohealing policy for this managed instance group
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'healthCheck'
+          type: String
+          description: |
+            The URL for the health check that signals autohealing.
+        - name: 'initialDelaySec'
+          type: Integer
+          description: |
+            The number of seconds that the managed instance group waits
+            before it applies autohealing policies to new instances or recently recreated instances

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_network_endpoint_group.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_network_endpoint_group.yaml
@@ -1,0 +1,354 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'RegionNetworkEndpointGroup'
+api_resource_type_kind: NetworkEndpointGroup
+kind: 'compute#networkEndpointGroup'
+description: |
+  A regional NEG that can support Serverless Products, proxying traffic to
+  external backends and providing traffic to the PSC port mapping endpoints.
+
+  When in use by a resource that can be updated, recreating a RegionNetworkEndpointGroup
+  will give a `resourceInUseByAnotherResource` error because Terraform will attempt to
+  delete the  RegionNetworkEndpointGroup first, but an in-use RegionNetworkEndpointGroup
+  can't be deleted in the API. Use `lifecycle.create_before_destroy` to reorder the plan
+  and create the new resource first, allowing the deletion to go through successfully.
+  This is only recommended when strictly necessary, as the `create_before_destroy`
+  directive can be passed onto further dependencies, creating unexpected plans.
+references:
+  guides:
+    'Serverless NEGs Official Documentation': 'https://cloud.google.com/load-balancing/docs/negs/serverless-neg-concepts'
+    'Internet NEGs Official Documentation': 'https://cloud.google.com/load-balancing/docs/negs/internet-neg-concepts'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/beta/regionNetworkEndpointGroups'
+docs:
+base_url: 'projects/{{project}}/regions/{{region}}/networkEndpointGroups'
+has_self_link: true
+immutable: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+custom_code:
+sweeper:
+  url_substitutions:
+    - region: "us-central1"
+    - region: "europe-west4"
+    - region: "asia-northeast3"
+examples:
+  - name: 'region_network_endpoint_group_functions'
+    primary_resource_id: 'function_neg'
+    vars:
+      neg_name: 'function-neg'
+      function_name: 'function-neg'
+      bucket_name: 'cloudfunctions-function-example-bucket'
+      zip_path: 'path/to/index.zip'
+    test_vars_overrides:
+      'zip_path': 'acctest.CreateZIPArchiveForCloudFunctionSource(t, "./test-fixtures/http_trigger.js")'
+  - name: 'region_network_endpoint_group_cloudrun'
+    primary_resource_id: 'cloudrun_neg'
+    vars:
+      neg_name: 'cloudrun-neg'
+  - name: 'region_network_endpoint_group_appengine'
+    primary_resource_id: 'appengine_neg'
+    vars:
+      neg_name: 'appengine-neg'
+  - name: 'region_network_endpoint_group_appengine_empty'
+    primary_resource_id: 'appengine_neg'
+    vars:
+      neg_name: 'appengine-neg'
+  - name: 'region_network_endpoint_group_psc'
+    primary_resource_id: 'psc_neg'
+    vars:
+      neg_name: 'psc-neg'
+  - name: 'region_network_endpoint_group_psc_service_attachment'
+    primary_resource_id: 'psc_neg_service_attachment'
+    vars:
+      neg_name: 'psc-neg'
+      network_name: 'psc-network'
+      subnetwork_name: 'psc-subnetwork'
+      psc_subnetwork_name: 'psc-subnetwork-nat'
+      backend_service_name: 'psc-backend'
+      forwarding_rule_name: 'psc-forwarding-rule'
+      service_attachment_name: 'psc-service-attachment'
+      health_check_name: 'psc-healthcheck'
+  - name: 'region_network_endpoint_group_internet_ip_port'
+    primary_resource_id: 'region_network_endpoint_group_internet_ip_port'
+    vars:
+      neg_name: 'ip-port-neg'
+      network_name: 'network'
+    test_vars_overrides:
+      # for backward compatible
+      network_name: '"network" + randomSuffix'
+  - name: 'region_network_endpoint_group_internet_fqdn_port'
+    primary_resource_id: 'region_network_endpoint_group_internet_fqdn_port'
+    vars:
+      neg_name: 'ip-port-neg'
+      network_name: 'network'
+    test_vars_overrides:
+      # for backward compatible
+      network_name: '"network" + randomSuffix'
+  - name: 'region_network_endpoint_group_portmap'
+    primary_resource_id: 'region_network_endpoint_group_portmap'
+    min_version: 'beta'
+    vars:
+      network_name: 'network'
+      subnetwork_name: 'subnetwork'
+      neg_name: 'portmap-neg'
+    test_vars_overrides:
+      # for backward compatible
+      network_name: '"network" + randomSuffix'
+      # for backward compatible
+      subnetwork_name: '"subnetwork" + randomSuffix'
+parameters:
+  - name: 'region'
+    type: ResourceRef
+    description: |
+      A reference to the region where the regional NEGs reside.
+    required: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Region'
+    imports: 'name'
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource; provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    required: true
+    validation:
+      function: 'verify.ValidateGCEName'
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource. Provide this property when
+      you create the resource.
+  - name: 'networkEndpointType'
+    type: Enum
+    description: |
+      Type of network endpoints in this network endpoint group. Defaults to SERVERLESS.
+    default_value: "SERVERLESS"
+    enum_values:
+      - 'SERVERLESS'
+      - 'PRIVATE_SERVICE_CONNECT'
+      - 'INTERNET_IP_PORT'
+      - 'INTERNET_FQDN_PORT'
+      - 'GCE_VM_IP_PORTMAP'
+  - name: 'pscTargetService'
+    type: String
+    description: |
+      This field is only used for PSC and INTERNET NEGs.
+
+      The target service url used to set up private service connection to
+      a Google API or a PSC Producer Service Attachment.
+  - name: 'network'
+    type: ResourceRef
+    description: |
+      This field is only used for PSC and INTERNET NEGs.
+
+      The URL of the network to which all network endpoints in the NEG belong. Uses
+      "default" project network if unspecified.
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Network'
+    imports: 'selfLink'
+    default_from_api: true
+  - name: 'subnetwork'
+    type: ResourceRef
+    description: |
+      This field is only used for PSC NEGs.
+
+      Optional URL of the subnetwork to which all network endpoints in the NEG belong.
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Subnetwork'
+    imports: 'selfLink'
+  - name: 'pscData'
+    type: NestedObject
+    description: |
+      This field is only used for PSC NEGs.
+    default_from_api: true
+    properties:
+      - name: 'producerPort'
+        type: String
+        ignore_read: true
+        description: |
+          The PSC producer port to use when consumer PSC NEG connects to a producer. If
+          this flag isn't specified for a PSC NEG with endpoint type
+          private-service-connect, then PSC NEG will be connected to a first port in the
+          available PSC producer port range.
+  - name: 'cloudRun'
+    type: NestedObject
+    description: |
+      This field is only used for SERVERLESS NEGs.
+
+      Only one of cloud_run, app_engine, cloud_function or serverless_deployment may be set.
+    conflicts:
+      - cloud_function
+      - app_engine
+      - serverless_deployment
+    properties:
+      - name: 'service'
+        type: String
+        description: |
+          Cloud Run service is the main resource of Cloud Run.
+          The service must be 1-63 characters long, and comply with RFC1035.
+          Example value: "run-service".
+        at_least_one_of:
+          - 'cloud_run.0.service'
+          - 'cloud_run.0.url_mask'
+      - name: 'tag'
+        type: String
+        description: |
+          Cloud Run tag represents the "named-revision" to provide
+          additional fine-grained traffic routing information.
+          The tag must be 1-63 characters long, and comply with RFC1035.
+          Example value: "revision-0010".
+      - name: 'urlMask'
+        type: String
+        description: |
+          A template to parse service and tag fields from a request URL.
+          URL mask allows for routing to multiple Run services without having
+          to create multiple network endpoint groups and backend services.
+
+          For example, request URLs "foo1.domain.com/bar1" and "foo1.domain.com/bar2"
+          an be backed by the same Serverless Network Endpoint Group (NEG) with
+          URL mask ".domain.com/". The URL mask will parse them to { service="bar1", tag="foo1" }
+          and { service="bar2", tag="foo2" } respectively.
+        at_least_one_of:
+          - 'cloud_run.0.service'
+          - 'cloud_run.0.url_mask'
+  - name: 'appEngine'
+    type: NestedObject
+    description: |
+      This field is only used for SERVERLESS NEGs.
+
+      Only one of cloud_run, app_engine, cloud_function or serverless_deployment may be set.
+    send_empty_value: true
+    allow_empty_object: true
+    conflicts:
+      - cloud_run
+      - cloud_function
+      - serverless_deployment
+    properties:
+      - name: 'service'
+        type: String
+        description: |
+          Optional serving service.
+          The service name must be 1-63 characters long, and comply with RFC1035.
+          Example value: "default", "my-service".
+      - name: 'version'
+        type: String
+        description: |
+          Optional serving version.
+          The version must be 1-63 characters long, and comply with RFC1035.
+          Example value: "v1", "v2".
+      - name: 'urlMask'
+        type: String
+        description: |
+          A template to parse service and version fields from a request URL.
+          URL mask allows for routing to multiple App Engine services without
+          having to create multiple Network Endpoint Groups and backend services.
+
+          For example, the request URLs "foo1-dot-appname.appspot.com/v1" and
+          "foo1-dot-appname.appspot.com/v2" can be backed by the same Serverless NEG with
+          URL mask "-dot-appname.appspot.com/". The URL mask will parse
+          them to { service = "foo1", version = "v1" } and { service = "foo1", version = "v2" } respectively.
+  - name: 'cloudFunction'
+    type: NestedObject
+    description: |
+      This field is only used for SERVERLESS NEGs.
+
+      Only one of cloud_run, app_engine, cloud_function or serverless_deployment may be set.
+    conflicts:
+      - cloud_run
+      - app_engine
+      - serverless_deployment
+    properties:
+      - name: 'function'
+        type: String
+        description: |
+          A user-defined name of the Cloud Function.
+          The function name is case-sensitive and must be 1-63 characters long.
+          Example value: "func1".
+        at_least_one_of:
+          - 'cloud_function.0.function'
+          - 'cloud_function.0.url_mask'
+      - name: 'urlMask'
+        type: String
+        description: |
+          A template to parse function field from a request URL. URL mask allows
+          for routing to multiple Cloud Functions without having to create
+          multiple Network Endpoint Groups and backend services.
+
+          For example, request URLs "mydomain.com/function1" and "mydomain.com/function2"
+          can be backed by the same Serverless NEG with URL mask "/". The URL mask
+          will parse them to { function = "function1" } and { function = "function2" } respectively.
+        at_least_one_of:
+          - 'cloud_function.0.function'
+          - 'cloud_function.0.url_mask'
+  - name: 'serverlessDeployment'
+    type: NestedObject
+    description: |
+      This field is only used for SERVERLESS NEGs.
+
+      Only one of cloudRun, appEngine, cloudFunction or serverlessDeployment may be set.
+    min_version: 'beta'
+    send_empty_value: true
+    allow_empty_object: true
+    conflicts:
+      - cloud_run
+      - cloud_function
+      - app_engine
+    properties:
+      - name: 'platform'
+        type: String
+        # Docs (https://cloud.google.com/compute/docs/reference/rest/beta/regionNetworkEndpointGroups) say support is offered for:
+        # API Gateway: apigateway.googleapis.com, App Engine: appengine.googleapis.com,
+        # Cloud Functions: cloudfunctions.googleapis.com, Cloud Run: run.googleapis.com
+        # However, only API Gateway is currently supported
+        description: |
+          The platform of the NEG backend target(s). Possible values:
+          API Gateway: apigateway.googleapis.com
+        required: true
+      - name: 'resource'
+        type: String
+        description: |
+          The user-defined name of the workload/instance. This value must be provided explicitly or in the urlMask.
+          The resource identified by this value is platform-specific and is as follows: API Gateway: The gateway ID, App Engine: The service name,
+          Cloud Functions: The function name, Cloud Run: The service name
+      - name: 'version'
+        type: String
+        description: |
+          The optional resource version. The version identified by this value is platform-specific and is follows:
+          API Gateway: Unused, App Engine: The service version, Cloud Functions: Unused, Cloud Run: The service tag
+      - name: 'urlMask'
+        type: String
+        description: |
+          A template to parse platform-specific fields from a request URL. URL mask allows for routing to multiple resources
+          on the same serverless platform without having to create multiple Network Endpoint Groups and backend resources.
+          The fields parsed by this template are platform-specific and are as follows: API Gateway: The gateway ID,
+          App Engine: The service and version, Cloud Functions: The function name, Cloud Run: The service and tag
+        required: false

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_target_http_proxy.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_target_http_proxy.yaml
@@ -1,0 +1,121 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'RegionTargetHttpProxy'
+api_resource_type_kind: TargetHttpProxy
+description: |
+  Represents a RegionTargetHttpProxy resource, which is used by one or more
+  forwarding rules to route incoming HTTP requests to a URL map.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/compute/docs/load-balancing/http/target-proxies'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/regionTargetHttpProxies'
+docs:
+base_url: 'projects/{{project}}/regions/{{region}}/targetHttpProxies'
+has_self_link: true
+immutable: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+include_in_tgc_next: true
+custom_code:
+sweeper:
+  url_substitutions:
+    - region: "us-central1"
+    - region: "europe-west1"
+    - region: "us-west1"
+examples:
+  - name: 'region_target_http_proxy_basic'
+    primary_resource_id: 'default'
+    vars:
+      region_target_http_proxy_name: 'test-proxy'
+      region_url_map_name: 'url-map'
+      region_backend_service_name: 'backend-service'
+      region_health_check_name: 'http-health-check'
+  - name: 'region_target_http_proxy_http_keep_alive_timeout'
+    primary_resource_id: 'default'
+    vars:
+      region_target_http_proxy_name: 'test-http-keep-alive-timeout-proxy'
+      region_url_map_name: 'url-map'
+      region_backend_service_name: 'backend-service'
+      region_health_check_name: 'http-health-check'
+  - name: 'region_target_http_proxy_https_redirect'
+    primary_resource_id: 'default'
+    vars:
+      region_target_http_proxy_name: 'test-https-redirect-proxy'
+      region_url_map_name: 'url-map'
+parameters:
+  - name: 'region'
+    type: ResourceRef
+    description: |
+      The Region in which the created target https proxy should reside.
+      If it is not provided, the provider region is used.
+    required: false
+    immutable: true
+    default_from_api: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Region'
+    imports: 'name'
+properties:
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'description'
+    type: String
+    description: 'An optional description of this resource.'
+  - name: 'proxyId'
+    type: Integer
+    description: 'The unique identifier for the resource.'
+    api_name: id
+    output: true
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    required: true
+  - name: 'urlMap'
+    type: ResourceRef
+    description: |
+      A reference to the RegionUrlMap resource that defines the mapping from URL
+      to the BackendService.
+    required: true
+    update_url: 'projects/{{project}}/regions/{{region}}/targetHttpProxies/{{name}}/setUrlMap'
+    update_verb: 'POST'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'RegionUrlMap'
+    imports: 'selfLink'
+  - name: 'httpKeepAliveTimeoutSec'
+    type: Integer
+    description: |
+      Specifies how long to keep a connection open, after completing a response,
+      while there is no matching traffic (in seconds). If an HTTP keepalive is
+      not specified, a default value (600 seconds) will be used. For Regional
+      HTTP(S) load balancer, the minimum allowed value is 5 seconds and the
+      maximum allowed value is 600 seconds.

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_target_https_proxy.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_target_https_proxy.yaml
@@ -1,0 +1,225 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'RegionTargetHttpsProxy'
+api_resource_type_kind: TargetHttpsProxy
+description: |
+  Represents a RegionTargetHttpsProxy resource, which is used by one or more
+  forwarding rules to route incoming HTTPS requests to a URL map.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/compute/docs/load-balancing/http/target-proxies'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/regionTargetHttpsProxies'
+docs:
+base_url: 'projects/{{project}}/regions/{{region}}/targetHttpsProxies'
+has_self_link: true
+immutable: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+include_in_tgc_next: true
+custom_code:
+  encoder: 'templates/terraform/encoders/compute_region_target_https_proxy.go.tmpl'
+  # update_encoder is usually the same as encoder by default. This resource is an uncommon case where the whole resource
+  # is marked to be immutable, but we have a field specific update that overrides it (e.g certifiacteManagerCertificates).
+  # This causes the encoder logic to not be applied during update.
+  update_encoder: 'templates/terraform/encoders/compute_region_target_https_proxy.go.tmpl'
+  decoder: 'templates/terraform/decoders/compute_region_target_https_proxy.go.tmpl'
+examples:
+  - name: 'region_target_https_proxy_basic'
+    primary_resource_id: 'default'
+    vars:
+      region_target_https_proxy_name: 'test-proxy'
+      region_ssl_certificate_name: 'my-certificate'
+      region_url_map_name: 'url-map'
+      region_backend_service_name: 'backend-service'
+      region_health_check_name: 'http-health-check'
+  - name: 'region_target_https_proxy_http_keep_alive_timeout'
+    primary_resource_id: 'default'
+    vars:
+      region_target_https_proxy_name: 'test-http-keep-alive-timeout-proxy'
+      region_ssl_certificate_name: 'my-certificate'
+      region_url_map_name: 'url-map'
+      region_backend_service_name: 'backend-service'
+      region_health_check_name: 'http-health-check'
+  - name: 'region_target_https_proxy_mtls'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      target_https_proxy_name: 'test-mtls-proxy'
+      ssl_certificate_name: 'my-certificate'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'http-health-check'
+      server_tls_policy_name: 'my-tls-policy'
+      trust_config_name: 'my-trust-config'
+  - name: 'region_target_https_proxy_certificate_manager_certificate'
+    primary_resource_id: 'default'
+    vars:
+      region_target_https_proxy_name: 'target-http-proxy'
+      certificate_manager_certificate_name: 'my-certificate'
+      region_url_map_name: 'url-map'
+      region_backend_service_name: 'backend-service'
+parameters:
+  - name: 'region'
+    type: ResourceRef
+    description: |
+      The Region in which the created target https proxy should reside.
+      If it is not provided, the provider region is used.
+    required: false
+    immutable: true
+    default_from_api: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Region'
+    imports: 'name'
+properties:
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'description'
+    type: String
+    description: 'An optional description of this resource.'
+    immutable: true
+  - name: 'proxyId'
+    type: Integer
+    description: 'The unique identifier for the resource.'
+    api_name: id
+    output: true
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    required: true
+    immutable: true
+  # This field is present in the schema but as of 2019 Sep 23 attempting to set it fails with
+  # a 400 "QUIC override is supported only with global TargetHttpsProxy". jamessynge@ said in an
+  # email sent on 2019 Sep 20 that support for this "is probably far in the future."
+  #   name: 'quicOverride'
+  #   type: Enum
+  #   description: |
+  #     Specifies the QUIC override policy for this resource. This determines
+  #     whether the load balancer will attempt to negotiate QUIC with clients
+  #     or not. Can specify one of NONE, ENABLE, or DISABLE. If NONE is
+  #     specified, uses the QUIC policy with no user overrides, which is
+  #     equivalent to DISABLE. Not specifying this field is equivalent to
+  #     specifying NONE.
+  #   enum_values:
+  #     - 'NONE'
+  #     - 'ENABLE'
+  #     - 'DISABLE'
+  #   update_verb: :POST
+  #   update_url:
+  #     'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}/setQuicOverride'
+  - name: 'certificateManagerCertificates'
+    type: Array
+    description: |
+      URLs to certificate manager certificate resources that are used to authenticate connections between users and the load balancer.
+      sslCertificates and certificateManagerCertificates can't be defined together.
+      Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificates/{resourceName}` or just the self_link `projects/{project}/locations/{location}/certificates/{resourceName}`
+    update_url: 'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}/setSslCertificates'
+    update_verb: 'POST'
+    conflicts:
+      - ssl_certificates
+    diff_suppress_func: 'tpgresource.CompareResourceNames'
+    custom_expand: 'templates/terraform/custom_expand/certificate_manager_certificate_construct_full_url.go.tmpl'
+    item_type:
+      type: String
+  - name: 'sslCertificates'
+    type: Array
+    description: |
+      URLs to SslCertificate resources that are used to authenticate connections between users and the load balancer.
+      At least one SSL certificate must be specified. Currently, you may specify up to 15 SSL certificates.
+      sslCertificates do not apply when the load balancing scheme is set to INTERNAL_SELF_MANAGED.
+    update_url: 'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}/setSslCertificates'
+    update_verb: 'POST'
+    conflicts:
+      - certificate_manager_certificates
+    custom_expand: 'templates/terraform/custom_expand/array_resourceref_with_validation.go.tmpl'
+    item_type:
+      name: 'sslCertificate'
+      type: ResourceRef
+      description: 'The SSL certificates used by this TargetHttpsProxy'
+      resource: 'RegionSslCertificate'
+      imports: 'selfLink'
+  - name: 'sslPolicy'
+    type: ResourceRef
+    description: |
+      A reference to the Region SslPolicy resource that will be associated with
+      the TargetHttpsProxy resource. If not set, the TargetHttpsProxy
+      resource will not have any SSL policy configured.
+    update_url: 'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}'
+    update_verb: 'PATCH'
+    update_id: 'sslPolicy'
+    fingerprint_name: 'fingerprint'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'RegionSslPolicy'
+    imports: 'selfLink'
+  - name: 'urlMap'
+    type: ResourceRef
+    description: |
+      A reference to the RegionUrlMap resource that defines the mapping from URL
+      to the RegionBackendService.
+    required: true
+    update_url: 'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}/setUrlMap'
+    update_verb: 'POST'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'RegionUrlMap'
+    imports: 'selfLink'
+  - name: 'httpKeepAliveTimeoutSec'
+    type: Integer
+    description: |
+      Specifies how long to keep a connection open, after completing a response,
+      while there is no matching traffic (in seconds). If an HTTP keepalive is
+      not specified, a default value (600 seconds) will be used. For Regioanl
+      HTTP(S) load balancer, the minimum allowed value is 5 seconds and the
+      maximum allowed value is 600 seconds.
+  - name: 'serverTlsPolicy'
+    type: ResourceRef
+    description: |
+      A URL referring to a networksecurity.ServerTlsPolicy
+      resource that describes how the proxy should authenticate inbound
+      traffic. serverTlsPolicy only applies to a global TargetHttpsProxy
+      attached to globalForwardingRules with the loadBalancingScheme
+      set to INTERNAL_SELF_MANAGED or EXTERNAL or EXTERNAL_MANAGED.
+      For details which ServerTlsPolicy resources are accepted with
+      INTERNAL_SELF_MANAGED and which with EXTERNAL, EXTERNAL_MANAGED
+      loadBalancingScheme consult ServerTlsPolicy documentation.
+      If left blank, communications are not encrypted.
+
+      If you remove this field from your configuration at the same time as
+      deleting or recreating a referenced ServerTlsPolicy resource, you will
+      receive a resourceInUseByAnotherResource error. Use lifecycle.create_before_destroy
+      within the ServerTlsPolicy resource to avoid this.
+    update_url: 'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}'
+    update_verb: 'PATCH'
+    update_id: 'serverTlsPolicy'
+    fingerprint_name: 'fingerprint'
+    resource: 'SslPolicy'
+    imports: 'selfLink'

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_url_map.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_region_url_map.yaml
@@ -1,0 +1,2762 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'RegionUrlMap'
+api_resource_type_kind: UrlMap
+kind: 'compute#urlMap'
+description: |
+  UrlMaps are used to route requests to a backend service based on rules
+  that you define for the host and path of an incoming URL.
+docs:
+base_url: 'projects/{{project}}/regions/{{region}}/urlMaps'
+has_self_link: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+custom_code:
+sweeper:
+  url_substitutions:
+    - region: 'us-central1'
+    - region: 'europe-west1'
+    - region: 'us-west1'
+examples:
+  - name: 'region_url_map_basic'
+    primary_resource_id: 'regionurlmap'
+    vars:
+      region_url_map_name: 'regionurlmap'
+      login_region_backend_service_name: 'login'
+      home_region_backend_service_name: 'home'
+      region_health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      region_url_map_name: '"regionurlmap" + randomSuffix'
+      # for backward compatible
+      login_region_backend_service_name: '"login" + randomSuffix'
+      # for backward compatible
+      home_region_backend_service_name: '"home" + randomSuffix'
+  - name: 'region_url_map_default_route_action'
+    primary_resource_id: 'regionurlmap'
+    vars:
+      region_url_map_name: 'regionurlmap'
+      login_region_backend_service_name: 'login'
+      home_region_backend_service_name: 'home'
+      region_health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      region_url_map_name: '"regionurlmap" + randomSuffix'
+      # for backward compatible
+      login_region_backend_service_name: '"login" + randomSuffix'
+      # for backward compatible
+      home_region_backend_service_name: '"home" + randomSuffix'
+  - name: 'region_url_map_l7_ilb_path'
+    primary_resource_id: 'regionurlmap'
+    vars:
+      region_url_map_name: 'regionurlmap'
+      home_region_backend_service_name: 'home'
+      region_health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      region_url_map_name: '"regionurlmap" + randomSuffix'
+      # for backward compatible
+      home_region_backend_service_name: '"home" + randomSuffix'
+  - name: 'region_url_map_l7_ilb_path_partial'
+    primary_resource_id: 'regionurlmap'
+    vars:
+      region_url_map_name: 'regionurlmap'
+      home_region_backend_service_name: 'home'
+      region_health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      region_url_map_name: '"regionurlmap" + randomSuffix'
+      # for backward compatible
+      home_region_backend_service_name: '"home" + randomSuffix'
+  - name: 'region_url_map_l7_ilb_route'
+    primary_resource_id: 'regionurlmap'
+    vars:
+      region_url_map_name: 'regionurlmap'
+      home_region_backend_service_name: 'home'
+      region_health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      region_url_map_name: '"regionurlmap" + randomSuffix'
+      # for backward compatible
+      home_region_backend_service_name: '"home" + randomSuffix'
+  - name: 'region_url_map_l7_ilb_route_partial'
+    primary_resource_id: 'regionurlmap'
+    vars:
+      region_url_map_name: 'regionurlmap'
+      home_region_backend_service_name: 'home'
+      region_health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      region_url_map_name: '"regionurlmap" + randomSuffix'
+      # for backward compatible
+      home_region_backend_service_name: '"home" + randomSuffix'
+  - name: 'int_https_lb_https_redirect'
+    primary_resource_id: 'redirect'
+    min_version: 'beta'
+    vars:
+      l7_ilb_network: 'l7-ilb-network'
+      l7_ilb_proxy_subnet: 'l7-ilb-proxy-subnet'
+      l7_ilb_subnet: 'l7-ilb-subnet'
+      l7_ilb_ip: 'l7-ilb-ip'
+      l7_ilb_forwarding_rule: 'l7-ilb-forwarding-rule'
+      l7_ilb_target_https_proxy: 'l7-ilb-target-https-proxy'
+      l7_ilb_regional_url_map: 'l7-ilb-regional-url-map'
+      l7_ilb_backend_service: 'l7-ilb-backend-service'
+      l7_ilb_mig_template: 'l7-ilb-mig-template'
+      l7_ilb_hc: 'l7-ilb-hc'
+      l7_ilb_mig1: 'l7-ilb-mig1'
+      l7_ilb_fw_allow_hc: 'l7-ilb-fw-allow-hc'
+      l7_ilb_fw_allow_ilb_to_backends: 'l7-ilb-fw-allow-ilb-to-backends'
+      l7_ilb_test_vm: 'l7-ilb-test-vm'
+      l7_ilb_redirect: 'l7-ilb-redirect'
+      l7_ilb_target_http_proxy: 'l7-ilb-target-http-proxy'
+      l7_ilb_redirect_url_map: 'l7-ilb-redirect-url-map'
+    ignore_read_extra:
+      - 'target'
+      - 'ip_address'
+    exclude_test: true
+  - name: 'regional_external_http_load_balancer'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      lb_network: 'lb-network'
+      backend_subnet: 'backend-subnet'
+      proxy_only_subnet: 'proxy-only-subnet'
+      fw_allow_health_check: 'fw-allow-health-check'
+      fw_allow_proxies: 'fw-allow-proxies'
+      l7_xlb_backend_template: 'l7-xlb-backend-template'
+      l7_xlb_backend_example: 'l7-xlb-backend-example'
+      address_name: 'address-name'
+      l7_xlb_basic_check: 'l7-xlb-basic-check'
+      l7_xlb_backend_service: 'l7-xlb-backend-service'
+      regional_l7_xlb_map: 'regional-l7-xlb-map'
+      l7_xlb_proxy: 'l7-xlb-proxy'
+      l7_xlb_forwarding_rule: 'l7-xlb-forwarding-rule'
+    # Similar to other samples
+    exclude_test: true
+    exclude_docs: true
+  - name: 'region_url_map_path_template_match'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      home_backend_service_name: 'home-service'
+      cart_backend_service_name: 'cart-service'
+      user_backend_service_name: 'user-service'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+  - name: 'region_url_map_path_matcher_default_route_action'
+    primary_resource_id: 'regionurlmap'
+    vars:
+      region_url_map_name: 'regionurlmap'
+      login_region_backend_service_name: 'login'
+      home_region_backend_service_name: 'home'
+      region_health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      region_url_map_name: '"regionurlmap" + randomSuffix'
+      # for backward compatible
+      login_region_backend_service_name: '"login" + randomSuffix'
+      # for backward compatible
+      home_region_backend_service_name: '"home" + randomSuffix'
+  - name: 'region_url_map_default_mirror_percent'
+    primary_resource_id: 'regionurlmap'
+    min_version: 'beta'
+    vars:
+      region_url_map_name: 'regionurlmap'
+      home_backend_service_name: 'home'
+      mirror_backend_service_name: 'mirror'
+      region_health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      region_url_map_name: '"regionurlmap" + randomSuffix'
+      # for backward compatible
+      home_backend_service_name: '"home" + randomSuffix'
+      # for backward compatible
+      mirror_backend_service_name: '"mirror" + randomSuffix'
+  - name: 'region_url_map_path_matcher_default_mirror_percent'
+    primary_resource_id: 'regionurlmap'
+    min_version: 'beta'
+    vars:
+      region_url_map_name: 'regionurlmap'
+      home_backend_service_name: 'home'
+      mirror_backend_service_name: 'mirror'
+      region_health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      region_url_map_name: '"regionurlmap" + randomSuffix'
+      # for backward compatible
+      home_backend_service_name: '"home" + randomSuffix'
+      # for backward compatible
+      mirror_backend_service_name: '"mirror" + randomSuffix'
+  - name: 'region_url_map_path_rule_mirror_percent'
+    primary_resource_id: 'regionurlmap'
+    min_version: 'beta'
+    vars:
+      region_url_map_name: 'regionurlmap'
+      home_backend_service_name: 'home'
+      mirror_backend_service_name: 'mirror'
+      region_health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      region_url_map_name: '"regionurlmap" + randomSuffix'
+      # for backward compatible
+      home_backend_service_name: '"home" + randomSuffix'
+      # for backward compatible
+      mirror_backend_service_name: '"mirror" + randomSuffix'
+  - name: 'region_url_map_route_rule_mirror_percent'
+    primary_resource_id: 'regionurlmap'
+    min_version: 'beta'
+    vars:
+      region_url_map_name: 'regionurlmap'
+      home_backend_service_name: 'home'
+      mirror_backend_service_name: 'mirror'
+      region_health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      region_url_map_name: '"regionurlmap" + randomSuffix'
+      # for backward compatible
+      home_backend_service_name: '"home" + randomSuffix'
+      # for backward compatible
+      mirror_backend_service_name: '"mirror" + randomSuffix'
+parameters:
+  - name: 'region'
+    type: ResourceRef
+    description: |
+      The Region in which the url map should reside.
+      If it is not provided, the provider region is used.
+    required: false
+    default_from_api: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Region'
+    imports: 'name'
+properties:
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'defaultService'
+    type: ResourceRef
+    description: |
+      The full or partial URL of the defaultService resource to which traffic is directed if
+      none of the hostRules match. If defaultRouteAction is additionally specified, advanced
+      routing actions like URL Rewrites, etc. take effect prior to sending the request to the
+      backend. However, if defaultService is specified, defaultRouteAction cannot contain any
+      weightedBackendServices. Conversely, if routeAction specifies any
+      weightedBackendServices, service must not be specified.  Only one of defaultService,
+      defaultUrlRedirect or defaultRouteAction.weightedBackendService must be set.
+    exactly_one_of:
+      - 'default_service'
+      - 'default_url_redirect'
+      - 'default_route_action.0.weighted_backend_services'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'RegionBackendService'
+    imports: 'selfLink'
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource. Provide this property when
+      you create the resource.
+  # 'fingerprint' used internally for object consistency.
+  - name: 'host_rule'
+    type: Array
+    description: 'The list of HostRules to use against the URL.'
+    api_name: hostRules
+    is_set: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'description'
+          type: String
+          description: |
+            An optional description of this HostRule. Provide this property
+            when you create the resource.
+        - name: 'hosts'
+          type: Array
+          description: |
+            The list of host patterns to match. They must be valid
+            hostnames, except * will match any string of ([a-z0-9-.]*). In
+            that case, * must be the first character and must be followed in
+            the pattern by either - or ..
+          is_set: true
+          required: true
+          item_type:
+            type: String
+        - name: 'pathMatcher'
+          type: String
+          description: |
+            The name of the PathMatcher to use to match the path portion of
+            the URL if the hostRule matches the URL's host portion.
+          required: true
+  - name: 'map_id'
+    type: Integer
+    description: 'The unique identifier for the resource.'
+    api_name: id
+    output: true
+  - name: 'fingerprint'
+    type: Fingerprint
+    description: |
+      Fingerprint of this resource. This field is used internally during
+      updates of this resource.
+    output: true
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    required: true
+    immutable: true
+  - name: 'path_matcher'
+    type: Array
+    description: 'The list of named PathMatchers to use against the URL.'
+    api_name: pathMatchers
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'headerAction'
+          type: NestedObject
+          description: |
+            Specifies changes to request and response headers that need to take effect for the selected backendService.
+            headerAction specified here take effect before headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap.
+            headerAction is not supported for load balancers that have their loadBalancingScheme set to EXTERNAL.
+            Not supported when the URL map is bound to a target gRPC proxy that has validateForProxyless field set to true.
+          properties:
+            - name: 'requestHeadersToRemove'
+              type: Array
+              description: |
+                A list of header names for headers that need to be removed from the request before forwarding the request to the backendService.
+              item_type:
+                type: String
+            - name: 'requestHeadersToAdd'
+              type: Array
+              description: |
+                Headers to add to a matching request before forwarding the request to the backendService.
+              item_type:
+                type: NestedObject
+                properties:
+                  - name: 'headerName'
+                    type: String
+                    description: 'The name of the header.'
+                  - name: 'headerValue'
+                    type: String
+                    description: 'The value of the header to add.'
+                  - name: 'replace'
+                    type: Boolean
+                    description: |
+                      If false, headerValue is appended to any values that already exist for the header. If true, headerValue is set for the header, discarding any values that were set for that header.
+                      The default value is false.
+                    default_value: false
+            - name: 'responseHeadersToRemove'
+              type: Array
+              description: |
+                A list of header names for headers that need to be removed from the response before sending the response back to the client.
+              item_type:
+                type: String
+            - name: 'responseHeadersToAdd'
+              type: Array
+              description: |
+                Headers to add the response before sending the response back to the client.
+              item_type:
+                type: NestedObject
+                properties:
+                  - name: 'headerName'
+                    type: String
+                    description: 'The name of the header.'
+                  - name: 'headerValue'
+                    type: String
+                    description: 'The value of the header to add.'
+                  - name: 'replace'
+                    type: Boolean
+                    description: |
+                      If false, headerValue is appended to any values that already exist for the header. If true, headerValue is set for the header, discarding any values that were set for that header.
+                      The default value is false.
+                    default_value: false
+        - name: 'defaultService'
+          type: ResourceRef
+          description: |
+            A reference to a RegionBackendService resource. This will be used if
+            none of the pathRules defined by this PathMatcher is matched by
+            the URL's path portion.
+          custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+          # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.
+          # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
+          # TODO: add defaultRouteAction.weightedBackendService here once they are supported.
+          # exactly_one_of:
+          #   - path_matchers.0.default_service
+          #   - path_matchers.0.default_url_redirect
+          #   - path_matchers.0.default_route_action.0.weighted_backend_services
+          resource: 'RegionBackendService'
+          imports: 'selfLink'
+        - name: 'description'
+          type: String
+          description: 'An optional description of this resource.'
+        - name: 'name'
+          type: String
+          description: |
+            The name to which this PathMatcher is referred by the HostRule.
+          required: true
+        - name: 'routeRules'
+          type: Array
+          description: |
+            The list of ordered HTTP route rules. Use this list instead of pathRules when
+            advanced route matching and routing actions are desired. The order of specifying
+            routeRules matters: the first rule that matches will cause its specified routing
+            action to take effect. Within a given pathMatcher, only one of pathRules or
+            routeRules must be set. routeRules are not supported in UrlMaps intended for
+            External load balancers.
+          item_type:
+            type: NestedObject
+            properties:
+              - name: 'priority'
+                type: Integer
+                description: |
+                  For routeRules within a given pathMatcher, priority determines the order
+                  in which load balancer will interpret routeRules. RouteRules are evaluated
+                  in order of priority, from the lowest to highest number. The priority of
+                  a rule decreases as its number increases (1, 2, 3, N+1). The first rule
+                  that matches the request is applied.
+
+                  You cannot configure two or more routeRules with the same priority.
+                  Priority for each rule must be set to a number between 0 and
+                  2147483647 inclusive.
+
+                  Priority numbers can have gaps, which enable you to add or remove rules
+                  in the future without affecting the rest of the rules. For example,
+                  1, 2, 3, 4, 5, 9, 12, 16 is a valid series of priority numbers to which
+                  you could add rules numbered from 6 to 8, 10 to 11, and 13 to 15 in the
+                  future without any impact on existing rules.
+                required: true
+              - name: 'service'
+                type: ResourceRef
+                description: |
+                  The region backend service resource to which traffic is
+                  directed if this rule is matched. If routeAction is additionally specified,
+                  advanced routing actions like URL Rewrites, etc. take effect prior to sending
+                  the request to the backend. However, if service is specified, routeAction cannot
+                  contain any weightedBackendService s. Conversely, if routeAction specifies any
+                  weightedBackendServices, service must not be specified. Only one of urlRedirect,
+                  service or routeAction.weightedBackendService must be set.
+                custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                resource: 'RegionBackendService'
+                imports: 'selfLink'
+              - name: 'headerAction'
+                type: NestedObject
+                description: |
+                  Specifies changes to request and response headers that need to take effect for
+                  the selected backendService. The headerAction specified here are applied before
+                  the matching pathMatchers[].headerAction and after pathMatchers[].routeRules[].r
+                  outeAction.weightedBackendService.backendServiceWeightAction[].headerAction
+                properties:
+                  - name: 'requestHeadersToAdd'
+                    type: Array
+                    description: |
+                      Headers to add to a matching request prior to forwarding the request to the
+                      backendService.
+                    item_type:
+                      type: NestedObject
+                      properties:
+                        - name: 'headerName'
+                          type: String
+                          description: |
+                            The name of the header.
+                          required: true
+                        - name: 'headerValue'
+                          type: String
+                          description: |
+                            The value of the header to add.
+                          required: true
+                        - name: 'replace'
+                          type: Boolean
+                          description: |
+                            If false, headerValue is appended to any values that already exist for the
+                            header. If true, headerValue is set for the header, discarding any values that
+                            were set for that header.
+                          required: true
+                  - name: 'requestHeadersToRemove'
+                    type: Array
+                    description: |
+                      A list of header names for headers that need to be removed from the request
+                      prior to forwarding the request to the backendService.
+                    item_type:
+                      type: String
+                  - name: 'responseHeadersToAdd'
+                    type: Array
+                    description: |
+                      Headers to add the response prior to sending the response back to the client.
+                    item_type:
+                      type: NestedObject
+                      properties:
+                        - name: 'headerName'
+                          type: String
+                          description: |
+                            The name of the header.
+                          required: true
+                        - name: 'headerValue'
+                          type: String
+                          description: |
+                            The value of the header to add.
+                          required: true
+                        - name: 'replace'
+                          type: Boolean
+                          description: |
+                            If false, headerValue is appended to any values that already exist for the
+                            header. If true, headerValue is set for the header, discarding any values that
+                            were set for that header.
+                          required: true
+                  - name: 'responseHeadersToRemove'
+                    type: Array
+                    description: |
+                      A list of header names for headers that need to be removed from the response
+                      prior to sending the response back to the client.
+                    item_type:
+                      type: String
+              - name: 'matchRules'
+                type: Array
+                description: |
+                  The rules for determining a match.
+                item_type:
+                  type: NestedObject
+                  properties:
+                    - name: 'fullPathMatch'
+                      type: String
+                      description: |
+                        For satisfying the matchRule condition, the path of the request must exactly
+                        match the value specified in fullPathMatch after removing any query parameters
+                        and anchor that may be part of the original URL. FullPathMatch must be between 1
+                        and 1024 characters. Only one of prefixMatch, fullPathMatch or regexMatch must
+                        be specified.
+                    - name: 'headerMatches'
+                      type: Array
+                      description: |
+                        Specifies a list of header match criteria, all of which must match corresponding
+                        headers in the request.
+                      item_type:
+                        type: NestedObject
+                        properties:
+                          - name: 'exactMatch'
+                            type: String
+                            description: |
+                              The value should exactly match contents of exactMatch. Only one of exactMatch,
+                              prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch must be set.
+                          - name: 'headerName'
+                            type: String
+                            description: |
+                              The name of the HTTP header to match. For matching against the HTTP request's
+                              authority, use a headerMatch with the header name ":authority". For matching a
+                              request's method, use the headerName ":method".
+                            required: true
+                          - name: 'invertMatch'
+                            type: Boolean
+                            description: |
+                              If set to false, the headerMatch is considered a match if the match criteria
+                              above are met. If set to true, the headerMatch is considered a match if the
+                              match criteria above are NOT met. Defaults to false.
+                            default_value: false
+                          - name: 'prefixMatch'
+                            type: String
+                            description: |
+                              The value of the header must start with the contents of prefixMatch. Only one of
+                              exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch
+                              must be set.
+                          - name: 'presentMatch'
+                            type: Boolean
+                            description: |
+                              A header with the contents of headerName must exist. The match takes place
+                              whether or not the request's header has a value or not. Only one of exactMatch,
+                              prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch must be set.
+                          - name: 'rangeMatch'
+                            type: NestedObject
+                            description: |
+                              The header value must be an integer and its value must be in the range specified
+                              in rangeMatch. If the header does not contain an integer, number or is empty,
+                              the match fails. For example for a range [-5, 0]
+
+                              * -3 will match
+                              * 0 will not match
+                              * 0.25 will not match
+                              * -3someString will not match.
+
+                              Only one of exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or
+                              rangeMatch must be set.
+                            properties:
+                              - name: 'rangeEnd'
+                                type: Integer
+                                description: |
+                                  The end of the range (exclusive).
+                                required: true
+                              - name: 'rangeStart'
+                                type: Integer
+                                description: |
+                                  The start of the range (inclusive).
+                                required: true
+                          - name: 'regexMatch'
+                            type: String
+                            description: |
+                              The value of the header must match the regular expression specified in
+                              regexMatch. For regular expression grammar, please see:
+                              en.cppreference.com/w/cpp/regex/ecmascript  For matching against a port
+                              specified in the HTTP request, use a headerMatch with headerName set to PORT and
+                              a regular expression that satisfies the RFC2616 Host header's port specifier.
+                              Only one of exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or
+                              rangeMatch must be set.
+                          - name: 'suffixMatch'
+                            type: String
+                            description: |
+                              The value of the header must end with the contents of suffixMatch. Only one of
+                              exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch
+                              must be set.
+                    - name: 'ignoreCase'
+                      type: Boolean
+                      description: |
+                        Specifies that prefixMatch and fullPathMatch matches are case sensitive.
+                        Defaults to false.
+                      default_value: false
+                    - name: 'metadataFilters'
+                      type: Array
+                      description: |
+                        Opaque filter criteria used by Loadbalancer to restrict routing configuration to
+                        a limited set xDS compliant clients. In their xDS requests to Loadbalancer, xDS
+                        clients present node metadata. If a match takes place, the relevant routing
+                        configuration is made available to those proxies. For each metadataFilter in
+                        this list, if its filterMatchCriteria is set to MATCH_ANY, at least one of the
+                        filterLabels must match the corresponding label provided in the metadata. If its
+                        filterMatchCriteria is set to MATCH_ALL, then all of its filterLabels must match
+                        with corresponding labels in the provided metadata. metadataFilters specified
+                        here can be overrides those specified in ForwardingRule that refers to this
+                        UrlMap. metadataFilters only applies to Loadbalancers that have their
+                        loadBalancingScheme set to INTERNAL_SELF_MANAGED.
+                      item_type:
+                        type: NestedObject
+                        properties:
+                          - name: 'filterLabels'
+                            type: Array
+                            description: |
+                              The list of label value pairs that must match labels in the provided metadata
+                              based on filterMatchCriteria  This list must not be empty and can have at the
+                              most 64 entries.
+                            required: true
+                            item_type:
+                              type: NestedObject
+                              properties:
+                                - name: 'name'
+                                  type: String
+                                  description: |
+                                    Name of metadata label. The name can have a maximum length of 1024 characters
+                                    and must be at least 1 character long.
+                                  required: true
+                                - name: 'value'
+                                  type: String
+                                  description: |
+                                    The value of the label must match the specified value. value can have a maximum
+                                    length of 1024 characters.
+                                  required: true
+                            min_size: 1
+                            max_size: 64
+                          - name: 'filterMatchCriteria'
+                            type: Enum
+                            description: |
+                              Specifies how individual filterLabel matches within the list of filterLabels
+                              contribute towards the overall metadataFilter match. Supported values are:
+
+                              * MATCH_ANY: At least one of the filterLabels must have a matching label in the
+                              provided metadata.
+                              * MATCH_ALL: All filterLabels must have matching labels in
+                              the provided metadata.
+                            required: true
+                            enum_values:
+                              - 'MATCH_ALL'
+                              - 'MATCH_ANY'
+                    - name: 'prefixMatch'
+                      type: String
+                      description: |
+                        For satisfying the matchRule condition, the request's path must begin with the
+                        specified prefixMatch. prefixMatch must begin with a /. The value must be
+                        between 1 and 1024 characters. Only one of prefixMatch, fullPathMatch or
+                        regexMatch must be specified.
+                    - name: 'queryParameterMatches'
+                      type: Array
+                      description: |
+                        Specifies a list of query parameter match criteria, all of which must match
+                        corresponding query parameters in the request.
+                      item_type:
+                        type: NestedObject
+                        properties:
+                          - name: 'exactMatch'
+                            type: String
+                            description: |
+                              The queryParameterMatch matches if the value of the parameter exactly matches
+                              the contents of exactMatch. Only one of presentMatch, exactMatch and regexMatch
+                              must be set.
+                          - name: 'name'
+                            type: String
+                            description: |
+                              The name of the query parameter to match. The query parameter must exist in the
+                              request, in the absence of which the request match fails.
+                            required: true
+                          - name: 'presentMatch'
+                            type: Boolean
+                            description: |
+                              Specifies that the queryParameterMatch matches if the request contains the query
+                              parameter, irrespective of whether the parameter has a value or not. Only one of
+                              presentMatch, exactMatch and regexMatch must be set.
+                          - name: 'regexMatch'
+                            type: String
+                            description: |
+                              The queryParameterMatch matches if the value of the parameter matches the
+                              regular expression specified by regexMatch. For the regular expression grammar,
+                              please see en.cppreference.com/w/cpp/regex/ecmascript  Only one of presentMatch,
+                              exactMatch and regexMatch must be set.
+                    - name: 'regexMatch'
+                      type: String
+                      description: |
+                        For satisfying the matchRule condition, the path of the request must satisfy the
+                        regular expression specified in regexMatch after removing any query parameters
+                        and anchor supplied with the original URL. For regular expression grammar please
+                        see en.cppreference.com/w/cpp/regex/ecmascript  Only one of prefixMatch,
+                        fullPathMatch or regexMatch must be specified.
+                    - name: 'pathTemplateMatch'
+                      type: String
+                      description: |
+                        For satisfying the matchRule condition, the path of the request
+                        must match the wildcard pattern specified in pathTemplateMatch
+                        after removing any query parameters and anchor that may be part
+                        of the original URL.
+
+                        pathTemplateMatch must be between 1 and 255 characters
+                        (inclusive).  The pattern specified by pathTemplateMatch may
+                        have at most 5 wildcard operators and at most 5 variable
+                        captures in total.
+              - name: 'routeAction'
+                type: NestedObject
+                description: |
+                  In response to a matching matchRule, the load balancer performs advanced routing
+                  actions like URL rewrites, header transformations, etc. prior to forwarding the
+                  request to the selected backend. If  routeAction specifies any
+                  weightedBackendServices, service must not be set. Conversely if service is set,
+                  routeAction cannot contain any  weightedBackendServices. Only one of routeAction
+                  or urlRedirect must be set.
+                properties:
+                  - name: 'corsPolicy'
+                    type: NestedObject
+                    description: |
+                      The specification for allowing client side cross-origin requests. Please see W3C
+                      Recommendation for Cross Origin Resource Sharing
+                    properties:
+                      - name: 'allowCredentials'
+                        type: Boolean
+                        description: |
+                          In response to a preflight request, setting this to true indicates that the
+                          actual request can include user credentials. This translates to the Access-
+                          Control-Allow-Credentials header. Defaults to false.
+                        default_value: false
+                      - name: 'allowHeaders'
+                        type: Array
+                        description: |
+                          Specifies the content for the Access-Control-Allow-Headers header.
+                        item_type:
+                          type: String
+                      - name: 'allowMethods'
+                        type: Array
+                        description: |
+                          Specifies the content for the Access-Control-Allow-Methods header.
+                        item_type:
+                          type: String
+                      - name: 'allowOriginRegexes'
+                        type: Array
+                        description: |
+                          Specifies the regular expression patterns that match allowed origins. For
+                          regular expression grammar please see en.cppreference.com/w/cpp/regex/ecmascript
+                          An origin is allowed if it matches either allow_origins or allow_origin_regex.
+                        item_type:
+                          type: String
+                      - name: 'allowOrigins'
+                        type: Array
+                        description: |
+                          Specifies the list of origins that will be allowed to do CORS requests. An
+                          origin is allowed if it matches either allow_origins or allow_origin_regex.
+                        item_type:
+                          type: String
+                      - name: 'disabled'
+                        type: Boolean
+                        description: |
+                          If true, specifies the CORS policy is disabled.
+                          which indicates that the CORS policy is in effect. Defaults to false.
+                        default_value: false
+                      - name: 'exposeHeaders'
+                        type: Array
+                        description: |
+                          Specifies the content for the Access-Control-Expose-Headers header.
+                        item_type:
+                          type: String
+                      - name: 'maxAge'
+                        type: Integer
+                        description: |
+                          Specifies how long the results of a preflight request can be cached. This
+                          translates to the content for the Access-Control-Max-Age header.
+                  - name: 'faultInjectionPolicy'
+                    type: NestedObject
+                    description: |
+                      The specification for fault injection introduced into traffic to test the
+                      resiliency of clients to backend service failure. As part of fault injection,
+                      when clients send requests to a backend service, delays can be introduced by
+                      Loadbalancer on a percentage of requests before sending those request to the
+                      backend service. Similarly requests from clients can be aborted by the
+                      Loadbalancer for a percentage of requests. timeout and retry_policy will be
+                      ignored by clients that are configured with a fault_injection_policy.
+                    properties:
+                      - name: 'abort'
+                        type: NestedObject
+                        description: |
+                          The specification for how client requests are aborted as part of fault
+                          injection.
+                        properties:
+                          - name: 'httpStatus'
+                            type: Integer
+                            description: |
+                              The HTTP status code used to abort the request. The value must be between 200
+                              and 599 inclusive.
+                          - name: 'percentage'
+                            type: Double
+                            description: |
+                              The percentage of traffic (connections/operations/requests) which will be
+                              aborted as part of fault injection. The value must be between 0.0 and 100.0
+                              inclusive.
+                      - name: 'delay'
+                        type: NestedObject
+                        description: |
+                          The specification for how client requests are delayed as part of fault
+                          injection, before being sent to a backend service.
+                        properties:
+                          - name: 'fixedDelay'
+                            type: NestedObject
+                            description: |
+                              Specifies the value of the fixed delay interval.
+                            properties:
+                              - name: 'nanos'
+                                type: Integer
+                                description: |
+                                  Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                  less than one second are represented with a 0 `seconds` field and a positive
+                                  `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                              - name: 'seconds'
+                                type: String
+                                description: |
+                                  Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                  inclusive.
+                                required: true
+                          - name: 'percentage'
+                            type: Double
+                            description: |
+                              The percentage of traffic (connections/operations/requests) on which delay will
+                              be introduced as part of fault injection. The value must be between 0.0 and
+                              100.0 inclusive.
+                  - name: 'requestMirrorPolicy'
+                    type: NestedObject
+                    description: |
+                      Specifies the policy on how requests intended for the route's backends are
+                      shadowed to a separate mirrored backend service. Loadbalancer does not wait for
+                      responses from the shadow service. Prior to sending traffic to the shadow
+                      service, the host / authority header is suffixed with -shadow.
+                    properties:
+                      - name: 'backendService'
+                        type: ResourceRef
+                        description: |
+                          The RegionBackendService resource being mirrored to.
+                        required: true
+                        custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                        resource: 'RegionBackendService'
+                        imports: 'selfLink'
+                      - name: 'mirrorPercent'
+                        min_version: beta
+                        type: Double
+                        description: |
+                          The percentage of requests to be mirrored to backendService.
+                          The value must be between 0.0 and 100.0 inclusive.
+                        validation:
+                          function: 'validation.FloatBetween(0, 100)'
+                  - name: 'retryPolicy'
+                    type: NestedObject
+                    description: |
+                      Specifies the retry policy associated with this route.
+                    properties:
+                      - name: 'numRetries'
+                        type: Integer
+                        description: |
+                          Specifies the allowed number retries. This number must be > 0.
+                        required: true
+                      - name: 'perTryTimeout'
+                        type: NestedObject
+                        description: |
+                          Specifies a non-zero timeout per retry attempt.
+                        properties:
+                          - name: 'nanos'
+                            type: Integer
+                            description: |
+                              Span of time that's a fraction of a second at nanosecond resolution. Durations
+                              less than one second are represented with a 0 `seconds` field and a positive
+                              `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                          - name: 'seconds'
+                            type: String
+                            description: |
+                              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                              inclusive.
+                            required: true
+                      - name: 'retryConditions'
+                        type: Array
+                        description: |
+                          Specifies one or more conditions when this retry rule applies. Valid values are:
+
+                          * 5xx: Loadbalancer will attempt a retry if the backend service responds with
+                            any 5xx response code, or if the backend service does not respond at all,
+                            for example: disconnects, reset, read timeout, connection failure, and refused
+                            streams.
+                          * gateway-error: Similar to 5xx, but only applies to response codes
+                            502, 503 or 504.
+                          * connect-failure: Loadbalancer will retry on failures
+                            connecting to backend services, for example due to connection timeouts.
+                          * retriable-4xx: Loadbalancer will retry for retriable 4xx response codes.
+                            Currently the only retriable error supported is 409.
+                          * refused-stream: Loadbalancer will retry if the backend service resets the stream with a
+                            REFUSED_STREAM error code. This reset type indicates that it is safe to retry.
+                          * cancelled: Loadbalancer will retry if the gRPC status code in the response
+                            header is set to cancelled
+                          * deadline-exceeded: Loadbalancer will retry if the
+                            gRPC status code in the response header is set to deadline-exceeded
+                          * resource-exhausted: Loadbalancer will retry if the gRPC status code in the response
+                            header is set to resource-exhausted
+                          * unavailable: Loadbalancer will retry if the gRPC status code in
+                            the response header is set to unavailable
+                        item_type:
+                          type: String
+                  - name: 'timeout'
+                    type: NestedObject
+                    description: |
+                      Specifies the timeout for the selected route. Timeout is computed from the time
+                      the request is has been fully processed (i.e. end-of-stream) up until the
+                      response has been completely processed. Timeout includes all retries. If not
+                      specified, the default value is 15 seconds.
+                    properties:
+                      - name: 'nanos'
+                        type: Integer
+                        description: |
+                          Span of time that's a fraction of a second at nanosecond resolution. Durations
+                          less than one second are represented with a 0 `seconds` field and a positive
+                          `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                      - name: 'seconds'
+                        type: String
+                        description: |
+                          Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                          inclusive.
+                        required: true
+                  - name: 'urlRewrite'
+                    type: NestedObject
+                    description: |
+                      The spec to modify the URL of the request, prior to forwarding the request to
+                      the matched service
+                    properties:
+                      - name: 'hostRewrite'
+                        type: String
+                        description: |
+                          Prior to forwarding the request to the selected service, the request's host
+                          header is replaced with contents of hostRewrite. The value must be between 1 and
+                          255 characters.
+                      - name: 'pathPrefixRewrite'
+                        type: String
+                        description: |
+                          Prior to forwarding the request to the selected backend service, the matching
+                          portion of the request's path is replaced by pathPrefixRewrite. The value must
+                          be between 1 and 1024 characters.
+                      - name: 'pathTemplateRewrite'
+                        type: String
+                        description: |
+                          Prior to forwarding the request to the selected origin, if the
+                          request matched a pathTemplateMatch, the matching portion of the
+                          request's path is replaced re-written using the pattern specified
+                          by pathTemplateRewrite.
+
+                          pathTemplateRewrite must be between 1 and 255 characters
+                          (inclusive), must start with a '/', and must only use variables
+                          captured by the route's pathTemplate matchers.
+
+                          pathTemplateRewrite may only be used when all of a route's
+                          MatchRules specify pathTemplate.
+
+                          Only one of pathPrefixRewrite and pathTemplateRewrite may be
+                          specified.
+                  - name: 'weightedBackendServices'
+                    type: Array
+                    description: |
+                      A list of weighted backend services to send traffic to when a route match
+                      occurs. The weights determine the fraction of traffic that flows to their
+                      corresponding backend service. If all traffic needs to go to a single backend
+                      service, there must be one  weightedBackendService with weight set to a non 0
+                      number. Once a backendService is identified and before forwarding the request to
+                      the backend service, advanced routing actions like Url rewrites and header
+                      transformations are applied depending on additional settings specified in this
+                      HttpRouteAction.
+                    item_type:
+                      type: NestedObject
+                      properties:
+                        - name: 'backendService'
+                          type: ResourceRef
+                          description: |
+                            The default RegionBackendService resource. Before
+                            forwarding the request to backendService, the loadbalancer applies any relevant
+                            headerActions specified as part of this backendServiceWeight.
+                          required: true
+                          custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                          resource: 'RegionBackendService'
+                          imports: 'selfLink'
+                        - name: 'headerAction'
+                          type: NestedObject
+                          description: |
+                            Specifies changes to request and response headers that need to take effect for
+                            the selected backendService. headerAction specified here take effect before
+                            headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap.
+                          properties:
+                            - name: 'requestHeadersToAdd'
+                              type: Array
+                              description: |
+                                Headers to add to a matching request prior to forwarding the request to the
+                                backendService.
+                              item_type:
+                                type: NestedObject
+                                properties:
+                                  - name: 'headerName'
+                                    type: String
+                                    description: |
+                                      The name of the header.
+                                    required: true
+                                  - name: 'headerValue'
+                                    type: String
+                                    description: |
+                                      The value of the header to add.
+                                    required: true
+                                  - name: 'replace'
+                                    type: Boolean
+                                    description: |
+                                      If false, headerValue is appended to any values that already exist for the
+                                      header. If true, headerValue is set for the header, discarding any values that
+                                      were set for that header.
+                                    required: true
+                            - name: 'requestHeadersToRemove'
+                              type: Array
+                              description: |
+                                A list of header names for headers that need to be removed from the request
+                                prior to forwarding the request to the backendService.
+                              item_type:
+                                type: String
+                            - name: 'responseHeadersToAdd'
+                              type: Array
+                              description: |
+                                Headers to add the response prior to sending the response back to the client.
+                              item_type:
+                                type: NestedObject
+                                properties:
+                                  - name: 'headerName'
+                                    type: String
+                                    description: |
+                                      The name of the header.
+                                    required: true
+                                  - name: 'headerValue'
+                                    type: String
+                                    description: |
+                                      The value of the header to add.
+                                    required: true
+                                  - name: 'replace'
+                                    type: Boolean
+                                    description: |
+                                      If false, headerValue is appended to any values that already exist for the
+                                      header. If true, headerValue is set for the header, discarding any values that
+                                      were set for that header.
+                                    required: true
+                            - name: 'responseHeadersToRemove'
+                              type: Array
+                              description: |
+                                A list of header names for headers that need to be removed from the response
+                                prior to sending the response back to the client.
+                              item_type:
+                                type: String
+                        - name: 'weight'
+                          type: Integer
+                          description: |
+                            Specifies the fraction of traffic sent to backendService, computed as weight /
+                            (sum of all weightedBackendService weights in routeAction) . The selection of a
+                            backend service is determined only for new traffic. Once a user's request has
+                            been directed to a backendService, subsequent requests will be sent to the same
+                            backendService as determined by the BackendService's session affinity policy.
+                            The value must be between 0 and 1000
+                          required: true
+              - name: 'urlRedirect'
+                type: NestedObject
+                description: |
+                  When this rule is matched, the request is redirected to a URL specified by
+                  urlRedirect. If urlRedirect is specified, service or routeAction must not be
+                  set.
+                properties:
+                  - name: 'hostRedirect'
+                    type: String
+                    description: |
+                      The host that will be used in the redirect response instead of the one
+                      that was supplied in the request. The value must be between 1 and 255
+                      characters.
+                  - name: 'httpsRedirect'
+                    type: Boolean
+                    description: |
+                      If set to true, the URL scheme in the redirected request is set to https.
+                      If set to false, the URL scheme of the redirected request will remain the
+                      same as that of the request. This must only be set for UrlMaps used in
+                      TargetHttpProxys. Setting this true for TargetHttpsProxy is not
+                      permitted. The default is set to false.
+                    default_value: false
+                  - name: 'pathRedirect'
+                    type: String
+                    description: |
+                      The path that will be used in the redirect response instead of the one
+                      that was supplied in the request. pathRedirect cannot be supplied
+                      together with prefixRedirect. Supply one alone or neither. If neither is
+                      supplied, the path of the original request will be used for the redirect.
+                      The value must be between 1 and 1024 characters.
+                  - name: 'prefixRedirect'
+                    type: String
+                    description: |
+                      The prefix that replaces the prefixMatch specified in the
+                      HttpRouteRuleMatch, retaining the remaining portion of the URL before
+                      redirecting the request. prefixRedirect cannot be supplied together with
+                      pathRedirect. Supply one alone or neither. If neither is supplied, the
+                      path of the original request will be used for the redirect. The value
+                      must be between 1 and 1024 characters.
+                  - name: 'redirectResponseCode'
+                    type: Enum
+                    description: |
+                      The HTTP Status code to use for this RedirectAction. Supported values are:
+
+                      * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+
+                      * FOUND, which corresponds to 302.
+
+                      * SEE_OTHER which corresponds to 303.
+
+                      * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+                      will be retained.
+
+                      * PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                      the request method will be retained.
+                    enum_values:
+                      - 'FOUND'
+                      - 'MOVED_PERMANENTLY_DEFAULT'
+                      - 'PERMANENT_REDIRECT'
+                      - 'SEE_OTHER'
+                      - 'TEMPORARY_REDIRECT'
+                    exclude_docs_values: true
+                  - name: 'stripQuery'
+                    type: Boolean
+                    description: |
+                      If set to true, any accompanying query portion of the original URL is
+                      removed prior to redirecting the request. If set to false, the query
+                      portion of the original URL is retained. The default value is false.
+                    default_value: false
+        - name: 'pathRule'
+          type: Array
+          description: |
+            The list of path rules. Use this list instead of routeRules when routing based
+            on simple path matching is all that's required. The order by which path rules
+            are specified does not matter. Matches are always done on the longest-path-first
+            basis. For example: a pathRule with a path /a/b/c/* will match before /a/b/*
+            irrespective of the order in which those paths appear in this list. Within a
+            given pathMatcher, only one of pathRules or routeRules must be set.
+          api_name: pathRules
+          item_type:
+            type: NestedObject
+            properties:
+              - name: 'service'
+                type: ResourceRef
+                description: |
+                  The region backend service resource to which traffic is
+                  directed if this rule is matched. If routeAction is additionally specified,
+                  advanced routing actions like URL Rewrites, etc. take effect prior to sending
+                  the request to the backend. However, if service is specified, routeAction cannot
+                  contain any weightedBackendService s. Conversely, if routeAction specifies any
+                  weightedBackendServices, service must not be specified. Only one of urlRedirect,
+                  service or routeAction.weightedBackendService must be set.
+                custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                resource: 'RegionBackendService'
+                imports: 'selfLink'
+              - name: 'paths'
+                type: Array
+                description: |
+                  The list of path patterns to match. Each must start with / and the only place a
+                  \* is allowed is at the end following a /. The string fed to the path matcher
+                  does not include any text after the first ? or #, and those chars are not
+                  allowed here.
+                is_set: true
+                required: true
+                item_type:
+                  type: String
+              - name: 'routeAction'
+                type: NestedObject
+                description: |
+                  In response to a matching path, the load balancer performs advanced routing
+                  actions like URL rewrites, header transformations, etc. prior to forwarding the
+                  request to the selected backend. If routeAction specifies any
+                  weightedBackendServices, service must not be set. Conversely if service is set,
+                  routeAction cannot contain any  weightedBackendServices. Only one of routeAction
+                  or urlRedirect must be set.
+                properties:
+                  - name: 'corsPolicy'
+                    type: NestedObject
+                    description: |
+                      The specification for allowing client side cross-origin requests. Please see W3C
+                      Recommendation for Cross Origin Resource Sharing
+                    properties:
+                      - name: 'allowCredentials'
+                        type: Boolean
+                        description: |
+                          In response to a preflight request, setting this to true indicates that the
+                          actual request can include user credentials. This translates to the Access-
+                          Control-Allow-Credentials header. Defaults to false.
+                        default_value: false
+                      - name: 'allowHeaders'
+                        type: Array
+                        description: |
+                          Specifies the content for the Access-Control-Allow-Headers header.
+                        item_type:
+                          type: String
+                      - name: 'allowMethods'
+                        type: Array
+                        description: |
+                          Specifies the content for the Access-Control-Allow-Methods header.
+                        item_type:
+                          type: String
+                      - name: 'allowOriginRegexes'
+                        type: Array
+                        description: |
+                          Specifies the regular expression patterns that match allowed origins. For
+                          regular expression grammar please see en.cppreference.com/w/cpp/regex/ecmascript
+                          An origin is allowed if it matches either allow_origins or allow_origin_regex.
+                        item_type:
+                          type: String
+                      - name: 'allowOrigins'
+                        type: Array
+                        description: |
+                          Specifies the list of origins that will be allowed to do CORS requests. An
+                          origin is allowed if it matches either allow_origins or allow_origin_regex.
+                        item_type:
+                          type: String
+                      - name: 'disabled'
+                        type: Boolean
+                        description: |
+                          If true, specifies the CORS policy is disabled.
+                        required: true
+                      - name: 'exposeHeaders'
+                        type: Array
+                        description: |
+                          Specifies the content for the Access-Control-Expose-Headers header.
+                        item_type:
+                          type: String
+                      - name: 'maxAge'
+                        type: Integer
+                        description: |
+                          Specifies how long the results of a preflight request can be cached. This
+                          translates to the content for the Access-Control-Max-Age header.
+                  - name: 'faultInjectionPolicy'
+                    type: NestedObject
+                    description: |
+                      The specification for fault injection introduced into traffic to test the
+                      resiliency of clients to backend service failure. As part of fault injection,
+                      when clients send requests to a backend service, delays can be introduced by
+                      Loadbalancer on a percentage of requests before sending those request to the
+                      backend service. Similarly requests from clients can be aborted by the
+                      Loadbalancer for a percentage of requests. timeout and retry_policy will be
+                      ignored by clients that are configured with a fault_injection_policy.
+                    properties:
+                      - name: 'abort'
+                        type: NestedObject
+                        description: |
+                          The specification for how client requests are aborted as part of fault
+                          injection.
+                        properties:
+                          - name: 'httpStatus'
+                            type: Integer
+                            description: |
+                              The HTTP status code used to abort the request. The value must be between 200
+                              and 599 inclusive.
+                            required: true
+                          - name: 'percentage'
+                            type: Double
+                            description: |
+                              The percentage of traffic (connections/operations/requests) which will be
+                              aborted as part of fault injection. The value must be between 0.0 and 100.0
+                              inclusive.
+                            required: true
+                      - name: 'delay'
+                        type: NestedObject
+                        description: |
+                          The specification for how client requests are delayed as part of fault
+                          injection, before being sent to a backend service.
+                        properties:
+                          - name: 'fixedDelay'
+                            type: NestedObject
+                            description: |
+                              Specifies the value of the fixed delay interval.
+                            required: true
+                            properties:
+                              - name: 'nanos'
+                                type: Integer
+                                description: |
+                                  Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                  less than one second are represented with a 0 `seconds` field and a positive
+                                  `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                              - name: 'seconds'
+                                type: String
+                                description: |
+                                  Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                  inclusive.
+                                required: true
+                          - name: 'percentage'
+                            type: Double
+                            description: |
+                              The percentage of traffic (connections/operations/requests) on which delay will
+                              be introduced as part of fault injection. The value must be between 0.0 and
+                              100.0 inclusive.
+                            required: true
+                  - name: 'requestMirrorPolicy'
+                    type: NestedObject
+                    description: |
+                      Specifies the policy on how requests intended for the route's backends are
+                      shadowed to a separate mirrored backend service. Loadbalancer does not wait for
+                      responses from the shadow service. Prior to sending traffic to the shadow
+                      service, the host / authority header is suffixed with -shadow.
+                    properties:
+                      - name: 'backendService'
+                        type: ResourceRef
+                        description: |
+                          The RegionBackendService resource being mirrored to.
+                        required: true
+                        custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                        resource: 'RegionBackendService'
+                        imports: 'selfLink'
+                      - name: 'mirrorPercent'
+                        min_version: beta
+                        type: Double
+                        description: |
+                          The percentage of requests to be mirrored to backendService.
+                          The value must be between 0.0 and 100.0 inclusive.
+                        validation:
+                          function: 'validation.FloatBetween(0, 100)'
+                  - name: 'retryPolicy'
+                    type: NestedObject
+                    description: |
+                      Specifies the retry policy associated with this route.
+                    properties:
+                      - name: 'numRetries'
+                        type: Integer
+                        description: |
+                          Specifies the allowed number retries. This number must be > 0.
+                      - name: 'perTryTimeout'
+                        type: NestedObject
+                        description: |
+                          Specifies a non-zero timeout per retry attempt.
+                        properties:
+                          - name: 'nanos'
+                            type: Integer
+                            description: |
+                              Span of time that's a fraction of a second at nanosecond resolution. Durations
+                              less than one second are represented with a 0 `seconds` field and a positive
+                              `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                          - name: 'seconds'
+                            type: String
+                            description: |
+                              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                              inclusive.
+                            required: true
+                      - name: 'retryConditions'
+                        type: Array
+                        description: |
+                          Specifies one or more conditions when this retry rule applies. Valid values are:
+
+                          - 5xx: Loadbalancer will attempt a retry if the backend service responds with
+                          any 5xx response code, or if the backend service does not respond at all,
+                          for example: disconnects, reset, read timeout, connection failure, and refused
+                          streams.
+                          - gateway-error: Similar to 5xx, but only applies to response codes
+                          502, 503 or 504.
+                          - connect-failure: Loadbalancer will retry on failures
+                          connecting to backend services, for example due to connection timeouts.
+                          - retriable-4xx: Loadbalancer will retry for retriable 4xx response codes.
+                          Currently the only retriable error supported is 409.
+                          - refused-stream: Loadbalancer will retry if the backend service resets the stream with a
+                          REFUSED_STREAM error code. This reset type indicates that it is safe to retry.
+                          - cancelled: Loadbalancer will retry if the gRPC status code in the response
+                          header is set to cancelled
+                          - deadline-exceeded: Loadbalancer will retry if the
+                          gRPC status code in the response header is set to deadline-exceeded
+                          - resource-exhausted: Loadbalancer will retry if the gRPC status code in the response
+                          header is set to resource-exhausted
+                          - unavailable: Loadbalancer will retry if
+                          the gRPC status code in the response header is set to unavailable
+                        item_type:
+                          type: String
+                  - name: 'timeout'
+                    type: NestedObject
+                    description: |
+                      Specifies the timeout for the selected route. Timeout is computed from the time
+                      the request is has been fully processed (i.e. end-of-stream) up until the
+                      response has been completely processed. Timeout includes all retries. If not
+                      specified, the default value is 15 seconds.
+                    properties:
+                      - name: 'nanos'
+                        type: Integer
+                        description: |
+                          Span of time that's a fraction of a second at nanosecond resolution. Durations
+                          less than one second are represented with a 0 `seconds` field and a positive
+                          `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                      - name: 'seconds'
+                        type: String
+                        description: |
+                          Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                          inclusive.
+                        required: true
+                  - name: 'urlRewrite'
+                    type: NestedObject
+                    description: |
+                      The spec to modify the URL of the request, prior to forwarding the request to
+                      the matched service
+                    properties:
+                      - name: 'hostRewrite'
+                        type: String
+                        description: |
+                          Prior to forwarding the request to the selected service, the request's host
+                          header is replaced with contents of hostRewrite. The value must be between 1 and
+                          255 characters.
+                      - name: 'pathPrefixRewrite'
+                        type: String
+                        description: |
+                          Prior to forwarding the request to the selected backend service, the matching
+                          portion of the request's path is replaced by pathPrefixRewrite. The value must
+                          be between 1 and 1024 characters.
+                  - name: 'weightedBackendServices'
+                    type: Array
+                    description: |
+                      A list of weighted backend services to send traffic to when a route match
+                      occurs. The weights determine the fraction of traffic that flows to their
+                      corresponding backend service. If all traffic needs to go to a single backend
+                      service, there must be one  weightedBackendService with weight set to a non 0
+                      number. Once a backendService is identified and before forwarding the request to
+                      the backend service, advanced routing actions like Url rewrites and header
+                      transformations are applied depending on additional settings specified in this
+                      HttpRouteAction.
+                    item_type:
+                      type: NestedObject
+                      properties:
+                        - name: 'backendService'
+                          type: ResourceRef
+                          description: |
+                            The default RegionBackendService resource. Before
+                            forwarding the request to backendService, the loadbalancer applies any relevant
+                            headerActions specified as part of this backendServiceWeight.
+                          required: true
+                          custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                          resource: 'RegionBackendService'
+                          imports: 'selfLink'
+                        - name: 'headerAction'
+                          type: NestedObject
+                          description: |
+                            Specifies changes to request and response headers that need to take effect for
+                            the selected backendService. headerAction specified here take effect before
+                            headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap.
+                          properties:
+                            - name: 'requestHeadersToAdd'
+                              type: Array
+                              description: |
+                                Headers to add to a matching request prior to forwarding the request to the
+                                backendService.
+                              item_type:
+                                type: NestedObject
+                                properties:
+                                  - name: 'headerName'
+                                    type: String
+                                    description: |
+                                      The name of the header.
+                                    required: true
+                                  - name: 'headerValue'
+                                    type: String
+                                    description: |
+                                      The value of the header to add.
+                                    required: true
+                                  - name: 'replace'
+                                    type: Boolean
+                                    description: |
+                                      If false, headerValue is appended to any values that already exist for the
+                                      header. If true, headerValue is set for the header, discarding any values that
+                                      were set for that header.
+                                    required: true
+                            - name: 'requestHeadersToRemove'
+                              type: Array
+                              description: |
+                                A list of header names for headers that need to be removed from the request
+                                prior to forwarding the request to the backendService.
+                              item_type:
+                                type: String
+                            - name: 'responseHeadersToAdd'
+                              type: Array
+                              description: |
+                                Headers to add the response prior to sending the response back to the client.
+                              item_type:
+                                type: NestedObject
+                                properties:
+                                  - name: 'headerName'
+                                    type: String
+                                    description: |
+                                      The name of the header.
+                                    required: true
+                                  - name: 'headerValue'
+                                    type: String
+                                    description: |
+                                      The value of the header to add.
+                                    required: true
+                                  - name: 'replace'
+                                    type: Boolean
+                                    description: |
+                                      If false, headerValue is appended to any values that already exist for the
+                                      header. If true, headerValue is set for the header, discarding any values that
+                                      were set for that header.
+                                    required: true
+                            - name: 'responseHeadersToRemove'
+                              type: Array
+                              description: |
+                                A list of header names for headers that need to be removed from the response
+                                prior to sending the response back to the client.
+                              item_type:
+                                type: String
+                        - name: 'weight'
+                          type: Integer
+                          description: |
+                            Specifies the fraction of traffic sent to backendService, computed as weight /
+                            (sum of all weightedBackendService weights in routeAction) . The selection of a
+                            backend service is determined only for new traffic. Once a user's request has
+                            been directed to a backendService, subsequent requests will be sent to the same
+                            backendService as determined by the BackendService's session affinity policy.
+                            The value must be between 0 and 1000
+                          required: true
+              - name: 'urlRedirect'
+                type: NestedObject
+                description: |
+                  When a path pattern is matched, the request is redirected to a URL specified
+                  by urlRedirect. If urlRedirect is specified, service or routeAction must not
+                  be set.
+                properties:
+                  - name: 'hostRedirect'
+                    type: String
+                    description: |
+                      The host that will be used in the redirect response instead of the one
+                      that was supplied in the request. The value must be between 1 and 255
+                      characters.
+                  - name: 'httpsRedirect'
+                    type: Boolean
+                    description: |
+                      If set to true, the URL scheme in the redirected request is set to https.
+                      If set to false, the URL scheme of the redirected request will remain the
+                      same as that of the request. This must only be set for UrlMaps used in
+                      TargetHttpProxys. Setting this true for TargetHttpsProxy is not
+                      permitted. The default is set to false.
+                    default_value: false
+                  - name: 'pathRedirect'
+                    type: String
+                    description: |
+                      The path that will be used in the redirect response instead of the one
+                      that was supplied in the request. pathRedirect cannot be supplied
+                      together with prefixRedirect. Supply one alone or neither. If neither is
+                      supplied, the path of the original request will be used for the redirect.
+                      The value must be between 1 and 1024 characters.
+                  - name: 'prefixRedirect'
+                    type: String
+                    description: |
+                      The prefix that replaces the prefixMatch specified in the
+                      HttpRouteRuleMatch, retaining the remaining portion of the URL before
+                      redirecting the request. prefixRedirect cannot be supplied together with
+                      pathRedirect. Supply one alone or neither. If neither is supplied, the
+                      path of the original request will be used for the redirect. The value
+                      must be between 1 and 1024 characters.
+                  - name: 'redirectResponseCode'
+                    type: Enum
+                    description: |
+                      The HTTP Status code to use for this RedirectAction. Supported values are:
+
+                      * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+
+                      * FOUND, which corresponds to 302.
+
+                      * SEE_OTHER which corresponds to 303.
+
+                      * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+                      will be retained.
+
+                      * PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                      the request method will be retained.
+                    enum_values:
+                      - 'FOUND'
+                      - 'MOVED_PERMANENTLY_DEFAULT'
+                      - 'PERMANENT_REDIRECT'
+                      - 'SEE_OTHER'
+                      - 'TEMPORARY_REDIRECT'
+                    exclude_docs_values: true
+                  - name: 'stripQuery'
+                    type: Boolean
+                    description: |
+                      If set to true, any accompanying query portion of the original URL is removed
+                      prior to redirecting the request. If set to false, the query portion of the
+                      original URL is retained.
+                       This field is required to ensure an empty block is not set. The normal default value is false.
+                    required: true
+        - name: 'defaultUrlRedirect'
+          type: NestedObject
+          # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.
+          # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
+          # TODO: add defaultRouteAction.weightedBackendService here once they are supported.
+          # exactly_one_of:
+          #   - path_matchers.0.default_service
+          #   - path_matchers.0.default_url_redirect
+          #   - path_matchers.0.default_route_action.0.weighted_backend_services
+          description: |
+            When none of the specified hostRules match, the request is redirected to a URL specified
+            by defaultUrlRedirect. If defaultUrlRedirect is specified, defaultService or
+            defaultRouteAction must not be set.
+          properties:
+            - name: 'hostRedirect'
+              type: String
+              description: |
+                The host that will be used in the redirect response instead of the one that was
+                supplied in the request. The value must be between 1 and 255 characters.
+            - name: 'httpsRedirect'
+              type: Boolean
+              description: |
+                If set to true, the URL scheme in the redirected request is set to https. If set to
+                false, the URL scheme of the redirected request will remain the same as that of the
+                request. This must only be set for UrlMaps used in TargetHttpProxys. Setting this
+                true for TargetHttpsProxy is not permitted. The default is set to false.
+              default_value: false
+            - name: 'pathRedirect'
+              type: String
+              description: |
+                The path that will be used in the redirect response instead of the one that was
+                supplied in the request. pathRedirect cannot be supplied together with
+                prefixRedirect. Supply one alone or neither. If neither is supplied, the path of the
+                original request will be used for the redirect. The value must be between 1 and 1024
+                characters.
+            - name: 'prefixRedirect'
+              type: String
+              description: |
+                The prefix that replaces the prefixMatch specified in the HttpRouteRuleMatch,
+                retaining the remaining portion of the URL before redirecting the request.
+                prefixRedirect cannot be supplied together with pathRedirect. Supply one alone or
+                neither. If neither is supplied, the path of the original request will be used for
+                the redirect. The value must be between 1 and 1024 characters.
+            - name: 'redirectResponseCode'
+              type: Enum
+              description: |
+                The HTTP Status code to use for this RedirectAction. Supported values are:
+
+                * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+
+                * FOUND, which corresponds to 302.
+
+                * SEE_OTHER which corresponds to 303.
+
+                * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+                will be retained.
+
+                * PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                the request method will be retained.
+              enum_values:
+                - 'FOUND'
+                - 'MOVED_PERMANENTLY_DEFAULT'
+                - 'PERMANENT_REDIRECT'
+                - 'SEE_OTHER'
+                - 'TEMPORARY_REDIRECT'
+              exclude_docs_values: true
+            - name: 'stripQuery'
+              type: Boolean
+              description: |
+                If set to true, any accompanying query portion of the original URL is removed prior
+                to redirecting the request. If set to false, the query portion of the original URL is
+                retained.
+                 This field is required to ensure an empty block is not set. The normal default value is false.
+              required: true
+        - name: 'defaultRouteAction'
+          type: NestedObject
+          # TODO: (mbang) conflicts also won't work for array path matchers yet, uncomment here once supported.
+          # conflicts:
+          #   - path_matcher.path_matcher.default_url_redirect
+          description: |
+            defaultRouteAction takes effect when none of the pathRules or routeRules match. The load balancer performs
+            advanced routing actions like URL rewrites, header transformations, etc. prior to forwarding the request
+            to the selected backend. If defaultRouteAction specifies any weightedBackendServices, defaultService must not be set.
+            Conversely if defaultService is set, defaultRouteAction cannot contain any weightedBackendServices.
+
+            Only one of defaultRouteAction or defaultUrlRedirect must be set.
+          properties:
+            - name: 'weightedBackendServices'
+              type: Array
+              # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.
+              # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
+              # exactly_one_of:
+              #   - path_matchers.0.default_service
+              #   - path_matchers.0.default_url_redirect
+              #   - path_matchers.0.default_route_action.0.weighted_backend_services
+              description: |
+                A list of weighted backend services to send traffic to when a route match occurs.
+                The weights determine the fraction of traffic that flows to their corresponding backend service.
+                If all traffic needs to go to a single backend service, there must be one weightedBackendService
+                with weight set to a non-zero number.
+
+                Once a backendService is identified and before forwarding the request to the backend service,
+                advanced routing actions like Url rewrites and header transformations are applied depending on
+                additional settings specified in this HttpRouteAction.
+              item_type:
+                type: NestedObject
+                properties:
+                  - name: 'backendService'
+                    type: ResourceRef
+                    description: |
+                      The full or partial URL to the default BackendService resource. Before forwarding the
+                      request to backendService, the loadbalancer applies any relevant headerActions
+                      specified as part of this backendServiceWeight.
+                    custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+                    resource: 'BackendService'
+                    imports: 'selfLink'
+                  - name: 'weight'
+                    type: Integer
+                    description: |
+                      Specifies the fraction of traffic sent to backendService, computed as
+                      weight / (sum of all weightedBackendService weights in routeAction) .
+
+                      The selection of a backend service is determined only for new traffic. Once a user's request
+                      has been directed to a backendService, subsequent requests will be sent to the same backendService
+                      as determined by the BackendService's session affinity policy.
+
+                      The value must be between 0 and 1000
+                    validation:
+                      function: 'validation.IntBetween(0, 1000)'
+                  - name: 'headerAction'
+                    type: NestedObject
+                    description: |
+                      Specifies changes to request and response headers that need to take effect for
+                      the selected backendService.
+
+                      headerAction specified here take effect before headerAction in the enclosing
+                      HttpRouteRule, PathMatcher and UrlMap.
+                    properties:
+                      - name: 'requestHeadersToRemove'
+                        type: Array
+                        description: |
+                          A list of header names for headers that need to be removed from the request prior to
+                          forwarding the request to the backendService.
+                        item_type:
+                          type: String
+                      - name: 'requestHeadersToAdd'
+                        type: Array
+                        description: |
+                          Headers to add to a matching request prior to forwarding the request to the backendService.
+                        item_type:
+                          type: NestedObject
+                          properties:
+                            - name: 'headerName'
+                              type: String
+                              description: |
+                                The name of the header to add.
+                            - name: 'headerValue'
+                              type: String
+                              description: |
+                                The value of the header to add.
+                            - name: 'replace'
+                              type: Boolean
+                              description: |
+                                If false, headerValue is appended to any values that already exist for the header.
+                                If true, headerValue is set for the header, discarding any values that were set for that header.
+                              default_value: false
+                      - name: 'responseHeadersToRemove'
+                        type: Array
+                        description: |
+                          A list of header names for headers that need to be removed from the response prior to sending the
+                          response back to the client.
+                        item_type:
+                          type: String
+                      - name: 'responseHeadersToAdd'
+                        type: Array
+                        description: |
+                          Headers to add the response prior to sending the response back to the client.
+                        item_type:
+                          type: NestedObject
+                          properties:
+                            - name: 'headerName'
+                              type: String
+                              description: |
+                                The name of the header to add.
+                            - name: 'headerValue'
+                              type: String
+                              description: |
+                                The value of the header to add.
+                            - name: 'replace'
+                              type: Boolean
+                              description: |
+                                If false, headerValue is appended to any values that already exist for the header.
+                                If true, headerValue is set for the header, discarding any values that were set for that header.
+                              default_value: false
+            - name: 'urlRewrite'
+              type: NestedObject
+              description: |
+                The spec to modify the URL of the request, prior to forwarding the request to the matched service.
+              properties:
+                - name: 'pathPrefixRewrite'
+                  type: String
+                  description: |
+                    Prior to forwarding the request to the selected backend service, the matching portion of the
+                    request's path is replaced by pathPrefixRewrite.
+
+                    The value must be between 1 and 1024 characters.
+                - name: 'hostRewrite'
+                  type: String
+                  description: |
+                    Prior to forwarding the request to the selected service, the request's host header is replaced
+                    with contents of hostRewrite.
+
+                    The value must be between 1 and 255 characters.
+                - name: 'pathTemplateRewrite'
+                  type: String
+                  description: |
+                    If specified, the pattern rewrites the URL path (based on the :path header) using the HTTP template syntax.
+
+                    A corresponding pathTemplateMatch must be specified. Any template variables must exist in the pathTemplateMatch field.
+
+                    * At least one variable must be specified in the pathTemplateMatch field
+                    * You can omit variables from the rewritten URL
+                    * The * and ** operators cannot be matched unless they have a corresponding variable name - e.g. {format=*} or {var=**}.
+
+                    For example, a pathTemplateMatch of /static/{format=**} could be rewritten as /static/content/{format} to prefix
+                    /content to the URL. Variables can also be re-ordered in a rewrite, so that /{country}/{format}/{suffix=**} can be
+                    rewritten as /content/{format}/{country}/{suffix}.
+
+                    At least one non-empty routeRules[].matchRules[].path_template_match is required.
+
+                    Only one of pathPrefixRewrite or pathTemplateRewrite may be specified.
+                  # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.
+                  # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
+                  # exactly_one_of:
+                  #   - path_matchers.0.default_route_action.0.url_rewrite.path_prefix_rewrite
+                  #   - path_matchers.0.default_route_action.0.url_rewrite.path_template_rewrite
+            - name: 'timeout'
+              type: NestedObject
+              description: |
+                Specifies the timeout for the selected route. Timeout is computed from the time the request has been
+                fully processed (i.e. end-of-stream) up until the response has been completely processed. Timeout includes all retries.
+
+                If not specified, will use the largest timeout among all backend services associated with the route.
+              default_from_api: true
+              properties:
+                - name: 'seconds'
+                  type: String
+                  description: |
+                    Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                    Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                - name: 'nanos'
+                  type: Integer
+                  description: |
+                    Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented
+                    with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+            - name: 'maxStreamDuration'
+              type: NestedObject
+              description: |
+                Specifies the maximum duration (timeout) for streams on the selected route.
+                Unlike the `Timeout` field where the timeout duration starts from the time the request
+                has been fully processed (known as end-of-stream), the duration in this field
+                is computed from the beginning of the stream until the response has been processed,
+                including all retries. A stream that does not complete in this duration is closed.
+              default_from_api: true
+              properties:
+                - name: 'nanos'
+                  type: Integer
+                  description: |
+                    Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented
+                    with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                - name: 'seconds'
+                  type: String
+                  description: |
+                    Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                    Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                  required: true
+            - name: 'retryPolicy'
+              type: NestedObject
+              description: |
+                Specifies the retry policy associated with this route.
+              properties:
+                - name: 'retryConditions'
+                  type: Array
+                  description: |
+                    Specfies one or more conditions when this retry rule applies. Valid values are:
+
+                    * 5xx: Loadbalancer will attempt a retry if the backend service responds with any 5xx response code,
+                      or if the backend service does not respond at all, example: disconnects, reset, read timeout,
+                    * connection failure, and refused streams.
+                    * gateway-error: Similar to 5xx, but only applies to response codes 502, 503 or 504.
+                    * connect-failure: Loadbalancer will retry on failures connecting to backend services,
+                      for example due to connection timeouts.
+                    * retriable-4xx: Loadbalancer will retry for retriable 4xx response codes.
+                      Currently the only retriable error supported is 409.
+                    * refused-stream:Loadbalancer will retry if the backend service resets the stream with a REFUSED_STREAM error code.
+                      This reset type indicates that it is safe to retry.
+                    * cancelled: Loadbalancer will retry if the gRPC status code in the response header is set to cancelled
+                    * deadline-exceeded: Loadbalancer will retry if the gRPC status code in the response header is set to deadline-exceeded
+                    * resource-exhausted: Loadbalancer will retry if the gRPC status code in the response header is set to resource-exhausted
+                    * unavailable: Loadbalancer will retry if the gRPC status code in the response header is set to unavailable
+                  item_type:
+                    type: String
+                - name: 'numRetries'
+                  type: Integer
+                  description: |
+                    Specifies the allowed number retries. This number must be > 0. If not specified, defaults to 1.
+                  validation:
+                    function: 'validation.IntAtLeast(1)'
+                  default_value: 1
+                - name: 'perTryTimeout'
+                  type: NestedObject
+                  description: |
+                    Specifies a non-zero timeout per retry attempt.
+
+                    If not specified, will use the timeout set in HttpRouteAction. If timeout in HttpRouteAction is not set,
+                    will use the largest timeout among all backend services associated with the route.
+                  properties:
+                    - name: 'seconds'
+                      type: String
+                      description: |
+                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                        Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                    - name: 'nanos'
+                      type: Integer
+                      description: |
+                        Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are
+                        represented with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+            - name: 'requestMirrorPolicy'
+              type: NestedObject
+              description: |
+                Specifies the policy on how requests intended for the route's backends are shadowed to a separate mirrored backend service.
+                Loadbalancer does not wait for responses from the shadow service. Prior to sending traffic to the shadow service,
+                the host / authority header is suffixed with -shadow.
+              properties:
+                - name: 'backendService'
+                  type: ResourceRef
+                  description: |
+                    The full or partial URL to the BackendService resource being mirrored to.
+                  required: true
+                  custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+                  resource: 'BackendService'
+                  imports: 'selfLink'
+                - name: 'mirrorPercent'
+                  min_version: beta
+                  type: Double
+                  description: |
+                    The percentage of requests to be mirrored to backendService.
+                    The value must be between 0.0 and 100.0 inclusive.
+                  validation:
+                    function: 'validation.FloatBetween(0, 100)'
+            - name: 'corsPolicy'
+              type: NestedObject
+              description: |
+                The specification for allowing client side cross-origin requests. Please see
+                [W3C Recommendation for Cross Origin Resource Sharing](https://www.w3.org/TR/cors/)
+              properties:
+                - name: 'allowOrigins'
+                  type: Array
+                  description: |
+                    Specifies the list of origins that will be allowed to do CORS requests.
+                    An origin is allowed if it matches either an item in allowOrigins or an item in allowOriginRegexes.
+                  item_type:
+                    type: String
+                - name: 'allowOriginRegexes'
+                  type: Array
+                  description: |
+                    Specifies the regular expression patterns that match allowed origins. For regular expression grammar
+                    please see en.cppreference.com/w/cpp/regex/ecmascript
+                    An origin is allowed if it matches either an item in allowOrigins or an item in allowOriginRegexes.
+                  item_type:
+                    type: String
+                - name: 'allowMethods'
+                  type: Array
+                  description: |
+                    Specifies the content for the Access-Control-Allow-Methods header.
+                  item_type:
+                    type: String
+                - name: 'allowHeaders'
+                  type: Array
+                  description: |
+                    Specifies the content for the Access-Control-Allow-Headers header.
+                  item_type:
+                    type: String
+                - name: 'exposeHeaders'
+                  type: Array
+                  description: |
+                    Specifies the content for the Access-Control-Expose-Headers header.
+                  item_type:
+                    type: String
+                - name: 'maxAge'
+                  type: Integer
+                  description: |
+                    Specifies how long results of a preflight request can be cached in seconds.
+                    This translates to the Access-Control-Max-Age header.
+                - name: 'allowCredentials'
+                  type: Boolean
+                  description: |
+                    In response to a preflight request, setting this to true indicates that the actual request can include user credentials.
+                    This translates to the Access-Control-Allow-Credentials header.
+                  default_value: false
+                - name: 'disabled'
+                  type: Boolean
+                  description: |
+                    If true, specifies the CORS policy is disabled. The default value is false, which indicates that the CORS policy is in effect.
+                  default_value: false
+            - name: 'faultInjectionPolicy'
+              type: NestedObject
+              description: |
+                The specification for fault injection introduced into traffic to test the resiliency of clients to backend service failure.
+                As part of fault injection, when clients send requests to a backend service, delays can be introduced by Loadbalancer on a
+                percentage of requests before sending those request to the backend service. Similarly requests from clients can be aborted
+                by the Loadbalancer for a percentage of requests.
+
+                timeout and retryPolicy will be ignored by clients that are configured with a faultInjectionPolicy.
+              properties:
+                - name: 'delay'
+                  type: NestedObject
+                  description: |
+                    The specification for how client requests are delayed as part of fault injection, before being sent to a backend service.
+                  properties:
+                    - name: 'fixedDelay'
+                      type: NestedObject
+                      description: |
+                        Specifies the value of the fixed delay interval.
+                      properties:
+                        - name: 'seconds'
+                          type: String
+                          description: |
+                            Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                            Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                        - name: 'nanos'
+                          type: Integer
+                          description: |
+                            Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are
+                            represented with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                    - name: 'percentage'
+                      type: Double
+                      description: |
+                        The percentage of traffic (connections/operations/requests) on which delay will be introduced as part of fault injection.
+                        The value must be between 0.0 and 100.0 inclusive.
+                      validation:
+                        function: 'validation.FloatBetween(0, 100)'
+                - name: 'abort'
+                  type: NestedObject
+                  description: |
+                    The specification for how client requests are aborted as part of fault injection.
+                  properties:
+                    - name: 'httpStatus'
+                      type: Integer
+                      description: |
+                        The HTTP status code used to abort the request.
+                        The value must be between 200 and 599 inclusive.
+                      validation:
+                        function: 'validation.IntBetween(200, 599)'
+                    - name: 'percentage'
+                      type: Double
+                      description: |
+                        The percentage of traffic (connections/operations/requests) which will be aborted as part of fault injection.
+                        The value must be between 0.0 and 100.0 inclusive.
+                      validation:
+                        function: 'validation.FloatBetween(0, 100)'
+  - name: 'test'
+    type: Array
+    description: |
+      The list of expected URL mappings. Requests to update this UrlMap will
+      succeed only if all of the test cases pass.
+    api_name: tests
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'description'
+          type: String
+          description: 'Description of this test case.'
+        - name: 'host'
+          type: String
+          description: 'Host portion of the URL.'
+          required: true
+        - name: 'path'
+          type: String
+          description: 'Path portion of the URL.'
+          required: true
+        - name: 'service'
+          type: ResourceRef
+          description:
+            A reference to expected RegionBackendService resource the given URL
+            should be mapped to.
+          required: true
+          custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+          resource: 'RegionBackendService'
+          imports: 'selfLink'
+  - name: 'defaultUrlRedirect'
+    type: NestedObject
+    description: |
+      When none of the specified hostRules match, the request is redirected to a URL specified
+      by defaultUrlRedirect. If defaultUrlRedirect is specified, defaultService or
+      defaultRouteAction must not be set.
+    conflicts:
+      - default_route_action
+    exactly_one_of:
+      - 'default_service'
+      - 'default_url_redirect'
+      - 'default_route_action.0.weighted_backend_services'
+    properties:
+      - name: 'hostRedirect'
+        type: String
+        description: |
+          The host that will be used in the redirect response instead of the one that was
+          supplied in the request. The value must be between 1 and 255 characters.
+      - name: 'httpsRedirect'
+        type: Boolean
+        description: |
+          If set to true, the URL scheme in the redirected request is set to https. If set to
+          false, the URL scheme of the redirected request will remain the same as that of the
+          request. This must only be set for UrlMaps used in TargetHttpProxys. Setting this
+          true for TargetHttpsProxy is not permitted. The default is set to false.
+        default_value: false
+      - name: 'pathRedirect'
+        type: String
+        description: |
+          The path that will be used in the redirect response instead of the one that was
+          supplied in the request. pathRedirect cannot be supplied together with
+          prefixRedirect. Supply one alone or neither. If neither is supplied, the path of the
+          original request will be used for the redirect. The value must be between 1 and 1024
+          characters.
+      - name: 'prefixRedirect'
+        type: String
+        description: |
+          The prefix that replaces the prefixMatch specified in the HttpRouteRuleMatch,
+          retaining the remaining portion of the URL before redirecting the request.
+          prefixRedirect cannot be supplied together with pathRedirect. Supply one alone or
+          neither. If neither is supplied, the path of the original request will be used for
+          the redirect. The value must be between 1 and 1024 characters.
+      - name: 'redirectResponseCode'
+        type: Enum
+        description: |
+          The HTTP Status code to use for this RedirectAction. Supported values are:
+
+          * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+
+          * FOUND, which corresponds to 302.
+
+          * SEE_OTHER which corresponds to 303.
+
+          * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+          will be retained.
+
+          * PERMANENT_REDIRECT, which corresponds to 308. In this case,
+          the request method will be retained.
+        enum_values:
+          - 'FOUND'
+          - 'MOVED_PERMANENTLY_DEFAULT'
+          - 'PERMANENT_REDIRECT'
+          - 'SEE_OTHER'
+          - 'TEMPORARY_REDIRECT'
+        exclude_docs_values: true
+      - name: 'stripQuery'
+        type: Boolean
+        description: |
+          If set to true, any accompanying query portion of the original URL is removed prior
+          to redirecting the request. If set to false, the query portion of the original URL is
+          retained.
+           This field is required to ensure an empty block is not set. The normal default value is false.
+        required: true
+  - name: 'defaultRouteAction'
+    type: NestedObject
+    description: |
+      defaultRouteAction takes effect when none of the hostRules match. The load balancer performs advanced routing actions, such as URL rewrites and header transformations, before forwarding the request to the selected backend. If defaultRouteAction specifies any weightedBackendServices, defaultService must not be set. Conversely if defaultService is set, defaultRouteAction cannot contain any weightedBackendServices.
+      Only one of defaultRouteAction or defaultUrlRedirect must be set.
+      URL maps for Classic external HTTP(S) load balancers only support the urlRewrite action within defaultRouteAction.
+      defaultRouteAction has no effect when the URL map is bound to a target gRPC proxy that has the validateForProxyless field set to true.
+    conflicts:
+      - default_url_redirect
+    properties:
+      - name: 'weightedBackendServices'
+        type: Array
+        description: |
+          A list of weighted backend services to send traffic to when a route match occurs. The weights determine the fraction of traffic that flows to their corresponding backend service. If all traffic needs to go to a single backend service, there must be one weightedBackendService with weight set to a non-zero number.
+          After a backend service is identified and before forwarding the request to the backend service, advanced routing actions such as URL rewrites and header transformations are applied depending on additional settings specified in this HttpRouteAction.
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+        exactly_one_of:
+          - 'default_service'
+          - 'default_url_redirect'
+          - 'default_route_action.0.weighted_backend_services'
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'backendService'
+              type: ResourceRef
+              description: |
+                The full or partial URL to the default BackendService resource. Before forwarding the request to backendService, the load balancer applies any relevant headerActions specified as part of this backendServiceWeight.
+              custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+              resource: 'RegionBackendService'
+              imports: 'selfLink'
+            - name: 'weight'
+              type: Integer
+              description: |
+                Specifies the fraction of traffic sent to a backend service, computed as weight / (sum of all weightedBackendService weights in routeAction) .
+                The selection of a backend service is determined only for new traffic. Once a user's request has been directed to a backend service, subsequent requests are sent to the same backend service as determined by the backend service's session affinity policy.
+                The value must be from 0 to 1000.
+              validation:
+                function: 'validation.IntBetween(0, 1000)'
+            - name: 'headerAction'
+              type: NestedObject
+              description: |
+                Specifies changes to request and response headers that need to take effect for the selected backendService.
+                headerAction specified here take effect before headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap.
+                headerAction is not supported for load balancers that have their loadBalancingScheme set to EXTERNAL.
+                Not supported when the URL map is bound to a target gRPC proxy that has validateForProxyless field set to true.
+              properties:
+                - name: 'requestHeadersToRemove'
+                  type: Array
+                  description: |
+                    A list of header names for headers that need to be removed from the request before forwarding the request to the backendService.
+                  item_type:
+                    type: String
+                - name: 'requestHeadersToAdd'
+                  type: Array
+                  description: |
+                    Headers to add to a matching request before forwarding the request to the backendService.
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: 'headerName'
+                        type: String
+                        description: 'The name of the header.'
+                      - name: 'headerValue'
+                        type: String
+                        description: 'The value of the header to add.'
+                      - name: 'replace'
+                        type: Boolean
+                        description: |
+                          If false, headerValue is appended to any values that already exist for the header. If true, headerValue is set for the header, discarding any values that were set for that header.
+                          The default value is false.
+                        default_value: false
+                - name: 'responseHeadersToRemove'
+                  type: Array
+                  description: |
+                    A list of header names for headers that need to be removed from the response before sending the response back to the client.
+                  item_type:
+                    type: String
+                - name: 'responseHeadersToAdd'
+                  type: Array
+                  description: |
+                    Headers to add the response before sending the response back to the client.
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: 'headerName'
+                        type: String
+                        description: 'The name of the header.'
+                      - name: 'headerValue'
+                        type: String
+                        description: 'The value of the header to add.'
+                      - name: 'replace'
+                        type: Boolean
+                        description: |
+                          If false, headerValue is appended to any values that already exist for the header. If true, headerValue is set for the header, discarding any values that were set for that header.
+                          The default value is false.
+                        default_value: false
+      - name: 'urlRewrite'
+        type: NestedObject
+        description: |
+          The spec to modify the URL of the request, before forwarding the request to the matched service.
+          urlRewrite is the only action supported in UrlMaps for external HTTP(S) load balancers.
+          Not supported when the URL map is bound to a target gRPC proxy that has the validateForProxyless field set to true.
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+        properties:
+          - name: 'pathPrefixRewrite'
+            type: String
+            description: |
+              Before forwarding the request to the selected backend service, the matching portion of the request's path is replaced by pathPrefixRewrite.
+              The value must be from 1 to 1024 characters.
+            at_least_one_of:
+              - 'default_route_action.0.url_rewrite.0.path_prefix_rewrite'
+              - 'default_route_action.0.url_rewrite.0.host_rewrite'
+            validation:
+              function: 'validation.StringLenBetween(1, 1024)'
+          - name: 'hostRewrite'
+            type: String
+            description: |
+              Before forwarding the request to the selected service, the request's host header is replaced with contents of hostRewrite.
+              The value must be from 1 to 255 characters.
+            at_least_one_of:
+              - 'default_route_action.0.url_rewrite.0.path_prefix_rewrite'
+              - 'default_route_action.0.url_rewrite.0.host_rewrite'
+            validation:
+              function: 'validation.StringLenBetween(1, 255)'
+      - name: 'timeout'
+        type: NestedObject
+        description: |
+          Specifies the timeout for the selected route. Timeout is computed from the time the request has been fully processed (known as end-of-stream) up until the response has been processed. Timeout includes all retries.
+          If not specified, this field uses the largest timeout among all backend services associated with the route.
+          Not supported when the URL map is bound to a target gRPC proxy that has validateForProxyless field set to true.
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+        properties:
+          - name: 'seconds'
+            type: String
+            description: |
+              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+            at_least_one_of:
+              - 'default_route_action.0.timeout.0.seconds'
+              - 'default_route_action.0.timeout.0.nanos'
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+            at_least_one_of:
+              - 'default_route_action.0.timeout.0.seconds'
+              - 'default_route_action.0.timeout.0.nanos'
+            validation:
+              function: 'validation.IntBetween(0, 999999999)'
+      - name: 'retryPolicy'
+        type: NestedObject
+        description: |
+          Specifies the retry policy associated with this route.
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+        properties:
+          - name: 'retryConditions'
+            type: Array
+            description: |
+              Specifies one or more conditions when this retry policy applies.
+              Valid values are listed below. Only the following codes are supported when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true: cancelled, deadline-exceeded, internal, resource-exhausted, unavailable.
+                - 5xx : retry is attempted if the instance or endpoint responds with any 5xx response code, or if the instance or endpoint does not respond at all. For example, disconnects, reset, read timeout, connection failure, and refused streams.
+                - gateway-error : Similar to 5xx, but only applies to response codes 502, 503 or 504.
+                - connect-failure : a retry is attempted on failures connecting to the instance or endpoint. For example, connection timeouts.
+                - retriable-4xx : a retry is attempted if the instance or endpoint responds with a 4xx response code. The only error that you can retry is error code 409.
+                - refused-stream : a retry is attempted if the instance or endpoint resets the stream with a REFUSED_STREAM error code. This reset type indicates that it is safe to retry.
+                - cancelled : a retry is attempted if the gRPC status code in the response header is set to cancelled.
+                - deadline-exceeded : a retry is attempted if the gRPC status code in the response header is set to deadline-exceeded.
+                - internal :  a retry is attempted if the gRPC status code in the response header is set to internal.
+                - resource-exhausted : a retry is attempted if the gRPC status code in the response header is set to resource-exhausted.
+                - unavailable : a retry is attempted if the gRPC status code in the response header is set to unavailable.
+            at_least_one_of:
+              - 'default_route_action.0.retry_policy.0.retry_conditions'
+              - 'default_route_action.0.retry_policy.0.num_retries'
+              - 'default_route_action.0.retry_policy.0.per_try_timeout'
+            item_type:
+              type: String
+          - name: 'numRetries'
+            type: Integer
+            description: |
+              Specifies the allowed number retries. This number must be > 0. If not specified, defaults to 1.
+            at_least_one_of:
+              - 'default_route_action.0.retry_policy.0.retry_conditions'
+              - 'default_route_action.0.retry_policy.0.num_retries'
+              - 'default_route_action.0.retry_policy.0.per_try_timeout'
+            validation:
+              function: 'validation.IntAtLeast(1)'
+            default_value: 1
+          - name: 'perTryTimeout'
+            type: NestedObject
+            description: |
+              Specifies a non-zero timeout per retry attempt.
+
+              If not specified, will use the timeout set in HttpRouteAction. If timeout in HttpRouteAction is not set,
+              will use the largest timeout among all backend services associated with the route.
+            at_least_one_of:
+              - 'default_route_action.0.retry_policy.0.retry_conditions'
+              - 'default_route_action.0.retry_policy.0.num_retries'
+              - 'default_route_action.0.retry_policy.0.per_try_timeout'
+            properties:
+              - name: 'seconds'
+                type: String
+                description: |
+                  Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                  Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                at_least_one_of:
+                  - 'default_route_action.0.retry_policy.0.per_try_timeout.0.seconds'
+                  - 'default_route_action.0.retry_policy.0.per_try_timeout.0.nanos'
+              - name: 'nanos'
+                type: Integer
+                description: |
+                  Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are
+                  represented with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                at_least_one_of:
+                  - 'default_route_action.0.retry_policy.0.per_try_timeout.0.seconds'
+                  - 'default_route_action.0.retry_policy.0.per_try_timeout.0.nanos'
+                validation:
+                  function: 'validation.IntBetween(0, 999999999)'
+      - name: 'requestMirrorPolicy'
+        type: NestedObject
+        description: |
+          Specifies the policy on how requests intended for the route's backends are shadowed to a separate mirrored backend service.
+          The load balancer does not wait for responses from the shadow service. Before sending traffic to the shadow service, the host / authority header is suffixed with -shadow.
+          Not supported when the URL map is bound to a target gRPC proxy that has the validateForProxyless field set to true.
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+        properties:
+          - name: 'backendService'
+            type: ResourceRef
+            description: |
+              The full or partial URL to the RegionBackendService resource being mirrored to.
+              The backend service configured for a mirroring policy must reference backends that are of the same type as the original backend service matched in the URL map.
+              Serverless NEG backends are not currently supported as a mirrored backend service.
+            custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+            resource: 'RegionBackendService'
+            imports: 'selfLink'
+          - name: 'mirrorPercent'
+            min_version: beta
+            type: Double
+            description: |
+              The percentage of requests to be mirrored to backendService.
+              The value must be between 0.0 and 100.0 inclusive.
+            validation:
+              function: 'validation.FloatBetween(0, 100)'
+      - name: 'corsPolicy'
+        type: NestedObject
+        description: |
+          The specification for allowing client side cross-origin requests. Please see
+          [W3C Recommendation for Cross Origin Resource Sharing](https://www.w3.org/TR/cors/)
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+        properties:
+          - name: 'allowOrigins'
+            type: Array
+            description: |
+              Specifies the list of origins that will be allowed to do CORS requests.
+              An origin is allowed if it matches either an item in allowOrigins or an item in allowOriginRegexes.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            item_type:
+              type: String
+          - name: 'allowOriginRegexes'
+            type: Array
+            description: |
+              Specifies the regualar expression patterns that match allowed origins. For regular expression grammar
+              please see en.cppreference.com/w/cpp/regex/ecmascript
+              An origin is allowed if it matches either an item in allowOrigins or an item in allowOriginRegexes.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            item_type:
+              type: String
+          - name: 'allowMethods'
+            type: Array
+            description: |
+              Specifies the content for the Access-Control-Allow-Methods header.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            item_type:
+              type: String
+          - name: 'allowHeaders'
+            type: Array
+            description: |
+              Specifies the content for the Access-Control-Allow-Headers header.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            item_type:
+              type: String
+          - name: 'exposeHeaders'
+            type: Array
+            description: |
+              Specifies the content for the Access-Control-Expose-Headers header.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            item_type:
+              type: String
+          - name: 'maxAge'
+            type: Integer
+            description: |
+              Specifies how long results of a preflight request can be cached in seconds.
+              This translates to the Access-Control-Max-Age header.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+          - name: 'allowCredentials'
+            type: Boolean
+            description: |
+              In response to a preflight request, setting this to true indicates that the actual request can include user credentials. This field translates to the Access-Control-Allow-Credentials header.
+              Default is false.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            default_value: false
+          - name: 'disabled'
+            type: Boolean
+            description: |
+              If true, the setting specifies the CORS policy is disabled. The default value of false, which indicates that the CORS policy is in effect.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            default_value: false
+      - name: 'faultInjectionPolicy'
+        type: NestedObject
+        description: |
+          The specification for fault injection introduced into traffic to test the resiliency of clients to backend service failure.
+          As part of fault injection, when clients send requests to a backend service, delays can be introduced by a load balancer on a percentage of requests before sending those requests to the backend service.
+          Similarly requests from clients can be aborted by the load balancer for a percentage of requests.
+          timeout and retryPolicy is ignored by clients that are configured with a faultInjectionPolicy if: 1. The traffic is generated by fault injection AND 2. The fault injection is not a delay fault injection.
+          Fault injection is not supported with the global external HTTP(S) load balancer (classic). To see which load balancers support fault injection, see Load balancing: [Routing and traffic management features](https://cloud.google.com/load-balancing/docs/features#routing-traffic-management).
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+        properties:
+          - name: 'delay'
+            type: NestedObject
+            description: |
+              The specification for how client requests are delayed as part of fault injection, before being sent to a backend service.
+            at_least_one_of:
+              - 'default_route_action.0.fault_injection_policy.0.delay'
+              - 'default_route_action.0.fault_injection_policy.0.abort'
+            properties:
+              - name: 'fixedDelay'
+                type: NestedObject
+                description: |
+                  Specifies the value of the fixed delay interval.
+                at_least_one_of:
+                  - 'default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay'
+                  - 'default_route_action.0.fault_injection_policy.0.delay.0.percentage'
+                properties:
+                  - name: 'seconds'
+                    type: String
+                    description: |
+                      Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                      Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                    at_least_one_of:
+                      - 'default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay.0.seconds'
+                      - 'default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay.0.nanos'
+                  - name: 'nanos'
+                    type: Integer
+                    description: |
+                      Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are
+                      represented with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                    at_least_one_of:
+                      - 'default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay.0.seconds'
+                      - 'default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay.0.nanos'
+                    validation:
+                      function: 'validation.IntBetween(0, 999999999)'
+              - name: 'percentage'
+                type: Double
+                description: |
+                  The percentage of traffic (connections/operations/requests) on which delay will be introduced as part of fault injection.
+                  The value must be between 0.0 and 100.0 inclusive.
+                at_least_one_of:
+                  - 'default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay'
+                  - 'default_route_action.0.fault_injection_policy.0.delay.0.percentage'
+                validation:
+                  function: 'validation.FloatBetween(0, 100)'
+          - name: 'abort'
+            type: NestedObject
+            description: |
+              The specification for how client requests are aborted as part of fault injection.
+            at_least_one_of:
+              - 'default_route_action.0.fault_injection_policy.0.delay'
+              - 'default_route_action.0.fault_injection_policy.0.abort'
+            properties:
+              - name: 'httpStatus'
+                type: Integer
+                description: |
+                  The HTTP status code used to abort the request.
+                  The value must be between 200 and 599 inclusive.
+                at_least_one_of:
+                  - 'default_route_action.0.fault_injection_policy.0.abort.0.http_status'
+                  - 'default_route_action.0.fault_injection_policy.0.abort.0.percentage'
+                validation:
+                  function: 'validation.IntBetween(200, 599)'
+              - name: 'percentage'
+                type: Double
+                description: |
+                  The percentage of traffic (connections/operations/requests) which will be aborted as part of fault injection.
+                  The value must be between 0.0 and 100.0 inclusive.
+                at_least_one_of:
+                  - 'default_route_action.0.fault_injection_policy.0.abort.0.http_status'
+                  - 'default_route_action.0.fault_injection_policy.0.abort.0.percentage'
+                validation:
+                  function: 'validation.FloatBetween(0, 100)'
+  - name: 'headerAction'
+    type: NestedObject
+    description: |
+      Specifies changes to request and response headers that need to take effect for the selected backendService.
+      headerAction specified here take effect before headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap.
+      headerAction is not supported for load balancers that have their loadBalancingScheme set to EXTERNAL.
+      Not supported when the URL map is bound to a target gRPC proxy that has validateForProxyless field set to true.
+    properties:
+      - name: 'requestHeadersToRemove'
+        type: Array
+        description: |
+          A list of header names for headers that need to be removed from the request before forwarding the request to the backendService.
+        item_type:
+          type: String
+      - name: 'requestHeadersToAdd'
+        type: Array
+        description: |
+          Headers to add to a matching request before forwarding the request to the backendService.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'headerName'
+              type: String
+              description: 'The name of the header.'
+            - name: 'headerValue'
+              type: String
+              description: 'The value of the header to add.'
+            - name: 'replace'
+              type: Boolean
+              description: |
+                If false, headerValue is appended to any values that already exist for the header. If true, headerValue is set for the header, discarding any values that were set for that header.
+                The default value is false.
+              default_value: false
+      - name: 'responseHeadersToRemove'
+        type: Array
+        description: |
+          A list of header names for headers that need to be removed from the response before sending the response back to the client.
+        item_type:
+          type: String
+      - name: 'responseHeadersToAdd'
+        type: Array
+        description: |
+          Headers to add the response before sending the response back to the client.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'headerName'
+              type: String
+              description: 'The name of the header.'
+            - name: 'headerValue'
+              type: String
+              description: 'The value of the header to add.'
+            - name: 'replace'
+              type: Boolean
+              description: |
+                If false, headerValue is appended to any values that already exist for the header. If true, headerValue is set for the header, discarding any values that were set for that header.
+                The default value is false.
+              default_value: false

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_ssl_certificate.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_ssl_certificate.yaml
@@ -1,0 +1,133 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'SslCertificate'
+kind: 'compute#sslCertificate'
+description: |
+  An SslCertificate resource, used for HTTPS load balancing. This resource
+  provides a mechanism to upload an SSL key and certificate to
+  the load balancer to serve secure connections from the user.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/load-balancing/docs/ssl-certificates'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates'
+docs:
+  optional_properties: |
+    * `name_prefix` - (Optional) Creates a unique name beginning with the
+     specified prefix. Conflicts with `name`. Max length is 54 characters.
+     Prefixes with lengths longer than 37 characters will use a shortened
+     UUID that will be more prone to collisions.
+     Resulting name for a `name_prefix` <= 37 characters:
+     `name_prefix` + YYYYmmddHHSSssss + 8 digit incremental counter
+     Resulting name for a `name_prefix` 38 - 54 characters:
+     `name_prefix` + YYmmdd + 3 digit incremental counter
+base_url: 'projects/{{project}}/global/sslCertificates'
+has_self_link: true
+immutable: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+custom_code:
+  extra_schema_entry: 'templates/terraform/extra_schema_entry/ssl_certificate.tmpl'
+examples:
+  - name: 'ssl_certificate_basic'
+    primary_resource_id: 'default'
+    ignore_read_extra:
+      - 'name_prefix'
+      # Uses id.UniqueId
+    skip_vcr: true
+  - name: 'ssl_certificate_basic_writeonly'
+    primary_resource_id: 'default'
+    ignore_read_extra:
+      - 'name_prefix'
+      # Uses id.UniqueId
+    skip_vcr: true
+  - name: 'ssl_certificate_random_provider'
+    primary_resource_id: 'default'
+    external_providers: ["random", "time"]
+      # Uses id.UniqueId
+    skip_vcr: true
+  - name: 'ssl_certificate_target_https_proxies'
+    primary_resource_id: 'default'
+    vars:
+      target_https_proxy_name: 'test-proxy'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'http-health-check'
+    ignore_read_extra:
+      - 'name_prefix'
+      # Uses id.UniqueId
+    skip_vcr: true
+parameters:
+properties:
+  - name: 'certificate'
+    type: String
+    description: |
+      The certificate in PEM format.
+      The certificate chain must be no greater than 5 certs long.
+      The chain must include at least one intermediate cert.
+    required: true
+    sensitive: true
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'description'
+    type: String
+    description: 'An optional description of this resource.'
+  - name: 'expireTime'
+    type: String
+    description: 'Expire time of the certificate in RFC3339 text format.'
+    output: true
+  - name: 'certificate_id'
+    type: Integer
+    description: 'The unique identifier for the resource.'
+    api_name: id
+    output: true
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+
+      These are in the same namespace as the managed SSL certificates.
+    default_from_api: true
+    custom_expand: 'templates/terraform/custom_expand/name_or_name_prefix.go.tmpl'
+    validation:
+      function: 'verify.ValidateGCEName'
+  - name: 'privateKey'
+    type: String
+    description: 'The write-only private key in PEM format.'
+    required: true
+    immutable: true
+    ignore_read: true
+    sensitive: true
+    write_only: true
+    diff_suppress_func: 'sha256DiffSuppress'
+    custom_flatten: 'templates/terraform/custom_flatten/sha256.tmpl'

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_ssl_policy.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_ssl_policy.yaml
@@ -1,0 +1,136 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'SslPolicy'
+kind: 'compute#sslPolicy'
+description: |
+  Represents a SSL policy. SSL policies give you the ability to control the
+  features of SSL that your SSL proxy or HTTPS load balancer negotiates.
+references:
+  guides:
+    'Using SSL Policies': 'https://cloud.google.com/compute/docs/load-balancing/ssl-policies'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/sslPolicies'
+docs:
+base_url: 'projects/{{project}}/global/sslPolicies'
+has_self_link: true
+update_verb: 'PATCH'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+custom_code:
+  constants: 'templates/terraform/constants/ssl_policy.tmpl'
+  update_encoder: 'templates/terraform/update_encoder/ssl_policy.tmpl'
+custom_diff:
+  - 'sslPolicyCustomizeDiff'
+examples:
+  - name: 'ssl_policy_basic'
+    primary_resource_id: 'prod-ssl-policy'
+    vars:
+      production_ssl_policy_name: 'production-ssl-policy'
+      nonprod_ssl_policy_name: 'nonprod-ssl-policy'
+      custom_ssl_policy_name: 'custom-ssl-policy'
+parameters:
+properties:
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'description'
+    type: String
+    description: 'An optional description of this resource.'
+    immutable: true
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    required: true
+    immutable: true
+    # TODO: profile, minTlsVersion, enabledFeatures, customFeatures, fingerprint, warnings, kind
+  - name: 'profile'
+    type: Enum
+    description: |
+      Profile specifies the set of SSL features that can be used by the
+      load balancer when negotiating SSL with clients. If using `CUSTOM`,
+      the set of SSL features to enable must be specified in the
+      `customFeatures` field.
+
+      See the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)
+      for information on what cipher suites each profile provides. If
+      `CUSTOM` is used, the `custom_features` attribute **must be set**.
+      If set to `FIPS_202205`, `minTlsVersion` must also be set to
+      `TLS_1_2`.
+    default_value: "COMPATIBLE"
+    enum_values:
+      - 'COMPATIBLE'
+      - 'MODERN'
+      - 'RESTRICTED'
+      - 'CUSTOM'
+      - 'FIPS_202205'
+  - name: 'minTlsVersion'
+    type: Enum
+    description: |
+      The minimum version of SSL protocol that can be used by the clients
+      to establish a connection with the load balancer. When set to`
+      TLS_1_3`, the profile field must be set to `RESTRICTED`.
+    default_value: "TLS_1_0"
+    enum_values:
+      - 'TLS_1_0'
+      - 'TLS_1_1'
+      - 'TLS_1_2'
+      - 'TLS_1_3'
+  - name: 'enabledFeatures'
+    type: Array
+    description: 'The list of features enabled in the SSL policy.'
+    is_set: true
+    output: true
+    item_type:
+      type: String
+  - name: 'customFeatures'
+    type: Array
+    description: |
+      Profile specifies the set of SSL features that can be used by the
+      load balancer when negotiating SSL with clients. This can be one of
+      `COMPATIBLE`, `MODERN`, `RESTRICTED`, or `CUSTOM`. If using `CUSTOM`,
+      the set of SSL features to enable must be specified in the
+      `customFeatures` field.
+
+      See the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)
+      for which ciphers are available to use. **Note**: this argument
+      *must* be present when using the `CUSTOM` profile. This argument
+      *must not* be present when using any other profile.
+    is_set: true
+    item_type:
+      type: String
+  - name: 'fingerprint'
+    type: String
+    description: |
+      Fingerprint of this resource. A hash of the contents stored in this
+      object. This field is used in optimistic locking.
+    output: true

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_target_http_proxy.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_target_http_proxy.yaml
@@ -1,0 +1,131 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'TargetHttpProxy'
+kind: 'compute#targetHttpProxy'
+description: |
+  Represents a TargetHttpProxy resource, which is used by one or more global
+  forwarding rule to route incoming HTTP requests to a URL map.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/compute/docs/load-balancing/http/target-proxies'
+  api: 'https://cloud.google.com/compute/docs/reference/v1/targetHttpProxies'
+docs:
+base_url: 'projects/{{project}}/global/targetHttpProxies'
+has_self_link: true
+immutable: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+custom_code:
+examples:
+  - name: 'target_http_proxy_basic'
+    primary_resource_id: 'default'
+    vars:
+      target_http_proxy_name: 'test-proxy'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'http-health-check'
+  - name: 'target_http_proxy_http_keep_alive_timeout'
+    primary_resource_id: 'default'
+    vars:
+      target_http_proxy_name: 'test-http-keep-alive-timeout-proxy'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'http-health-check'
+  - name: 'target_http_proxy_https_redirect'
+    primary_resource_id: 'default'
+    vars:
+      target_http_proxy_name: 'test-https-redirect-proxy'
+      url_map_name: 'url-map'
+  - name: 'target_http_proxy_fingerprint'
+    primary_resource_id: 'default'
+    vars:
+      target_http_proxy_name: 'test-fingerprint-proxy'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'http-health-check'
+parameters:
+properties:
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'description'
+    type: String
+    description: 'An optional description of this resource.'
+  - name: 'proxyId'
+    type: Integer
+    description: 'The unique identifier for the resource.'
+    api_name: id
+    output: true
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    required: true
+  - name: 'urlMap'
+    type: ResourceRef
+    description: |
+      A reference to the UrlMap resource that defines the mapping from URL
+      to the BackendService.
+    required: true
+    update_url: 'projects/{{project}}/targetHttpProxies/{{name}}/setUrlMap'
+    update_verb: 'POST'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'UrlMap'
+    imports: 'selfLink'
+  - name: 'proxyBind'
+    type: Boolean
+    description: |
+      This field only applies when the forwarding rule that references
+      this target proxy has a loadBalancingScheme set to INTERNAL_SELF_MANAGED.
+    default_from_api: true
+  - name: 'httpKeepAliveTimeoutSec'
+    type: Integer
+    description: |
+      Specifies how long to keep a connection open, after completing a response,
+      while there is no matching traffic (in seconds). If an HTTP keepalive is
+      not specified, a default value will be used. For Global
+      external HTTP(S) load balancer, the default value is 610 seconds, the
+      minimum allowed value is 5 seconds and the maximum allowed value is 1200
+      seconds. For cross-region internal HTTP(S) load balancer, the default
+      value is 600 seconds, the minimum allowed value is 5 seconds, and the
+      maximum allowed value is 600 seconds. For Global external HTTP(S) load
+      balancer (classic), this option is not available publicly.
+  - name: 'fingerprint'
+    type: Fingerprint
+    description: |
+      Fingerprint of this resource. A hash of the contents stored in this object. This field is used in optimistic locking.
+      This field will be ignored when inserting a TargetHttpProxy. An up-to-date fingerprint must be provided in order to
+      patch/update the TargetHttpProxy; otherwise, the request will fail with error 412 conditionNotMet.
+      To see the latest fingerprint, make a get() request to retrieve the TargetHttpProxy.
+      A base64-encoded string.
+    output: true

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_target_https_proxy.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_target_https_proxy.yaml
@@ -1,0 +1,258 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'TargetHttpsProxy'
+kind: 'compute#targetHttpsProxy'
+description: |
+  Represents a TargetHttpsProxy resource, which is used by one or more
+  global forwarding rule to route incoming HTTPS requests to a URL map.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/compute/docs/load-balancing/http/target-proxies'
+  api: 'https://cloud.google.com/compute/docs/reference/v1/targetHttpsProxies'
+docs:
+base_url: 'projects/{{project}}/global/targetHttpsProxies'
+has_self_link: true
+immutable: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+custom_code:
+  encoder: 'templates/terraform/encoders/compute_target_https_proxy.go.tmpl'
+  # update_encoder is usually the same as encoder by default. This resource is an uncommon case where the whole resource
+  # is marked to be immutable, but we have a field specific update that overrides it (e.g certifiacteManagerCertificates).
+  # This causes the encoder logic to not be applied during update.
+  update_encoder: 'templates/terraform/encoders/compute_target_https_proxy.go.tmpl'
+  decoder: 'templates/terraform/decoders/compute_target_https_proxy.go.tmpl'
+examples:
+  - name: 'target_https_proxy_basic'
+    primary_resource_id: 'default'
+    vars:
+      target_https_proxy_name: 'test-proxy'
+      ssl_certificate_name: 'my-certificate'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'http-health-check'
+  - name: 'target_https_proxy_http_keep_alive_timeout'
+    primary_resource_id: 'default'
+    vars:
+      target_https_proxy_name: 'test-http-keep-alive-timeout-proxy'
+      ssl_certificate_name: 'my-certificate'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'http-health-check'
+  - name: 'target_https_proxy_mtls'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      target_https_proxy_name: 'test-mtls-proxy'
+      ssl_certificate_name: 'my-certificate'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'http-health-check'
+      server_tls_policy_name: 'my-tls-policy'
+      trust_config_name: 'my-trust-config'
+  - name: 'target_https_proxy_certificate_manager_certificate'
+    primary_resource_id: 'default'
+    vars:
+      target_https_proxy_name: 'target-http-proxy'
+      certificate_manager_certificate_name: 'my-certificate'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+  - name: 'target_https_proxy_fingerprint'
+    primary_resource_id: 'default'
+    vars:
+      target_https_proxy_name: 'test-fingerprint-proxy'
+      ssl_certificate_name: 'my-certificate'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'http-health-check'
+parameters:
+properties:
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'description'
+    type: String
+    description: 'An optional description of this resource.'
+    immutable: true
+  - name: 'proxyId'
+    type: Integer
+    description: 'The unique identifier for the resource.'
+    api_name: id
+    output: true
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    required: true
+    immutable: true
+  - name: 'quicOverride'
+    type: Enum
+    description: |
+      Specifies the QUIC override policy for this resource. This determines
+      whether the load balancer will attempt to negotiate QUIC with clients
+      or not. Can specify one of NONE, ENABLE, or DISABLE. If NONE is
+      specified, Google manages whether QUIC is used.
+    update_url: 'projects/{{project}}/global/targetHttpsProxies/{{name}}/setQuicOverride'
+    update_verb: 'POST'
+    custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.tmpl'
+    default_value: "NONE"
+    enum_values:
+      - 'NONE'
+      - 'ENABLE'
+      - 'DISABLE'
+  - name: 'tlsEarlyData'
+    type: Enum
+    description: |
+      Specifies whether TLS 1.3 0-RTT Data (“Early Data”) should be accepted for this service.
+      Early Data allows a TLS resumption handshake to include the initial application payload
+      (a HTTP request) alongside the handshake, reducing the effective round trips to “zero”.
+      This applies to TLS 1.3 connections over TCP (HTTP/2) as well as over UDP (QUIC/h3).
+    default_from_api: true
+    enum_values:
+      - 'STRICT'
+      - 'PERMISSIVE'
+      - 'UNRESTRICTED'
+      - 'DISABLED'
+  - name: 'certificateManagerCertificates'
+    type: Array
+    description: |
+      URLs to certificate manager certificate resources that are used to authenticate connections between users and the load balancer.
+      Certificate manager certificates only apply when the load balancing scheme is set to INTERNAL_MANAGED.
+      For EXTERNAL and EXTERNAL_MANAGED, use certificate_map instead.
+      sslCertificates and certificateManagerCertificates fields can not be defined together.
+      Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificates/{resourceName}` or just the self_link `projects/{project}/locations/{location}/certificates/{resourceName}`
+    update_url: 'projects/{{project}}/targetHttpsProxies/{{name}}/setSslCertificates'
+    update_verb: 'POST'
+    conflicts:
+      - ssl_certificates
+    diff_suppress_func: 'tpgresource.CompareResourceNames'
+    custom_expand: 'templates/terraform/custom_expand/certificate_manager_certificate_construct_full_url.go.tmpl'
+    item_type:
+      type: String
+  - name: 'sslCertificates'
+    type: Array
+    description: |
+      URLs to SslCertificate resources that are used to authenticate connections between users and the load balancer.
+      Currently, you may specify up to 15 SSL certificates. sslCertificates do not apply when the load balancing scheme is set to INTERNAL_SELF_MANAGED.
+      sslCertificates and certificateManagerCertificates can not be defined together.
+    update_url: 'projects/{{project}}/targetHttpsProxies/{{name}}/setSslCertificates'
+    update_verb: 'POST'
+    conflicts:
+      - certificate_manager_certificates
+    custom_expand: 'templates/terraform/custom_expand/array_resourceref_with_validation.go.tmpl'
+    item_type:
+      name: 'sslCertificate'
+      type: ResourceRef
+      description: 'The SSL certificate URL used by this TargetHttpsProxy'
+      resource: 'SslCertificate'
+      imports: 'selfLink'
+  - name: 'certificateMap'
+    type: String
+    description: |
+      A reference to the CertificateMap resource uri that identifies a certificate map
+      associated with the given target proxy. This field is only supported for EXTERNAL and EXTERNAL_MANAGED load balancing schemes.
+      For INTERNAL_MANAGED, use certificate_manager_certificates instead.
+      Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificateMaps/{resourceName}`.
+    update_url: 'projects/{{project}}/global/targetHttpsProxies/{{name}}/setCertificateMap'
+    update_verb: 'POST'
+  - name: 'sslPolicy'
+    type: ResourceRef
+    description: |
+      A reference to the SslPolicy resource that will be associated with
+      the TargetHttpsProxy resource. If not set, the TargetHttpsProxy
+      resource will not have any SSL policy configured.
+    update_url: 'projects/{{project}}/global/targetHttpsProxies/{{name}}/setSslPolicy'
+    update_verb: 'POST'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'SslPolicy'
+    imports: 'selfLink'
+  - name: 'urlMap'
+    type: ResourceRef
+    description: |
+      A reference to the UrlMap resource that defines the mapping from URL
+      to the BackendService.
+    required: true
+    update_url: 'projects/{{project}}/targetHttpsProxies/{{name}}/setUrlMap'
+    update_verb: 'POST'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'UrlMap'
+    imports: 'selfLink'
+  - name: 'proxyBind'
+    type: Boolean
+    description: |
+      This field only applies when the forwarding rule that references
+      this target proxy has a loadBalancingScheme set to INTERNAL_SELF_MANAGED.
+    default_from_api: true
+  - name: 'httpKeepAliveTimeoutSec'
+    type: Integer
+    description: |
+      Specifies how long to keep a connection open, after completing a response,
+      while there is no matching traffic (in seconds). If an HTTP keepalive is
+      not specified, a default value will be used. For Global
+      external HTTP(S) load balancer, the default value is 610 seconds, the
+      minimum allowed value is 5 seconds and the maximum allowed value is 1200
+      seconds. For cross-region internal HTTP(S) load balancer, the default
+      value is 600 seconds, the minimum allowed value is 5 seconds, and the
+      maximum allowed value is 600 seconds. For Global external HTTP(S) load
+      balancer (classic), this option is not available publicly.
+  - name: 'serverTlsPolicy'
+    type: ResourceRef
+    description: |
+      A URL referring to a networksecurity.ServerTlsPolicy
+      resource that describes how the proxy should authenticate inbound
+      traffic. serverTlsPolicy only applies to a global TargetHttpsProxy
+      attached to globalForwardingRules with the loadBalancingScheme
+      set to INTERNAL_SELF_MANAGED or EXTERNAL or EXTERNAL_MANAGED.
+      For details which ServerTlsPolicy resources are accepted with
+      INTERNAL_SELF_MANAGED and which with EXTERNAL, EXTERNAL_MANAGED
+      loadBalancingScheme consult ServerTlsPolicy documentation.
+      If left blank, communications are not encrypted.
+
+      If you remove this field from your configuration at the same time as
+      deleting or recreating a referenced ServerTlsPolicy resource, you will
+      receive a resourceInUseByAnotherResource error. Use lifecycle.create_before_destroy
+      within the ServerTlsPolicy resource to avoid this.
+    update_url: 'projects/{{project}}/global/targetHttpsProxies/{{name}}'
+    update_verb: 'PATCH'
+    fingerprint_name: 'fingerprint'
+    resource: 'ServerTlsPolicy'
+    imports: 'selfLink'
+  - name: 'fingerprint'
+    type: Fingerprint
+    description: |
+      Fingerprint of this resource. A hash of the contents stored in this object. This field is used in optimistic locking.
+      This field will be ignored when inserting a TargetHttpsProxy. An up-to-date fingerprint must be provided in order to
+      patch the TargetHttpsProxy; otherwise, the request will fail with error 412 conditionNotMet.
+      To see the latest fingerprint, make a get() request to retrieve the TargetHttpsProxy.
+      A base64-encoded string.
+    output: true

--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_url_map.yaml
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/google_compute_url_map.yaml
@@ -1,0 +1,4598 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'UrlMap'
+kind: 'compute#urlMap'
+description: |
+  UrlMaps are used to route requests to a backend service based on rules
+  that you define for the host and path of an incoming URL.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/load-balancing/docs/url-map-concepts'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/urlMaps'
+docs:
+base_url: 'projects/{{project}}/global/urlMaps'
+has_self_link: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+collection_url_key: 'items'
+include_in_tgc_next: true
+tgc_tests:
+  - name: 'TestAccComputeUrlMap_cachePolicyMultiLevelUpdate'
+    skip: 'Index mismatch in path_matcher due to test framework limitation'
+custom_code:
+  tgc_decoder: 'templates/tgc_next/decoders/compute_url_map.go.tmpl'
+examples:
+  - name: 'url_map_bucket_and_service'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      login_backend_service_name: 'login'
+      http_health_check_name: 'health-check'
+      backend_bucket_name: 'static-asset-backend-bucket'
+      storage_bucket_name: 'static-asset-bucket'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      login_backend_service_name: '"login" + randomSuffix'
+  - name: 'url_map_traffic_director_route'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      home_backend_service_name: 'home'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      home_backend_service_name: '"home" + randomSuffix'
+  - name: 'url_map_traffic_director_route_partial'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      home_backend_service_name: 'home'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      home_backend_service_name: '"home" + randomSuffix'
+  - name: 'url_map_traffic_director_path'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      home_backend_service_name: 'home'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      home_backend_service_name: '"home" + randomSuffix'
+  - name: 'url_map_traffic_director_path_partial'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      home_backend_service_name: 'home'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      home_backend_service_name: '"home" + randomSuffix'
+  - name: 'url_map_header_based_routing'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      default_backend_service_name: 'default'
+      service_a_backend_service_name: 'service-a'
+      service_b_backend_service_name: 'service-b'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      default_backend_service_name: '"default" + randomSuffix'
+  - name: 'url_map_parameter_based_routing'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      default_backend_service_name: 'default'
+      service_a_backend_service_name: 'service-a'
+      service_b_backend_service_name: 'service-b'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      default_backend_service_name: '"default" + randomSuffix'
+  - name: 'url_map_default_mirror_percent'
+    primary_resource_id: 'urlmap'
+    min_version: 'beta'
+    vars:
+      url_map_name: 'urlmap'
+      home_backend_service_name: 'home'
+      mirror_backend_service_name: 'mirror'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      home_backend_service_name: '"home" + randomSuffix'
+      # for backward compatible
+      mirror_backend_service_name: '"mirror" + randomSuffix'
+  - name: 'url_map_path_matcher_default_mirror_percent'
+    primary_resource_id: 'urlmap'
+    min_version: 'beta'
+    vars:
+      url_map_name: 'urlmap'
+      home_backend_service_name: 'home'
+      mirror_backend_service_name: 'mirror'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      home_backend_service_name: '"home" + randomSuffix'
+      # for backward compatible
+      mirror_backend_service_name: '"mirror" + randomSuffix'
+  - name: 'url_map_cache_policy_basic'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      backend_service_name: 'home'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      backend_service_name: '"home" + randomSuffix'
+  - name: 'url_map_cache_policy_multi_level'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      backend_service_name: 'home'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      backend_service_name: '"home" + randomSuffix'
+  - name: 'url_map_path_rule_mirror_percent'
+    primary_resource_id: 'urlmap'
+    min_version: 'beta'
+    vars:
+      url_map_name: 'urlmap'
+      home_backend_service_name: 'home'
+      mirror_backend_service_name: 'mirror'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      home_backend_service_name: '"home" + randomSuffix'
+      # for backward compatible
+      mirror_backend_service_name: '"mirror" + randomSuffix'
+  - name: 'url_map_route_rule_mirror_percent'
+    primary_resource_id: 'urlmap'
+    min_version: 'beta'
+    vars:
+      url_map_name: 'urlmap'
+      home_backend_service_name: 'home'
+      mirror_backend_service_name: 'mirror'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      home_backend_service_name: '"home" + randomSuffix'
+      # for backward compatible
+      mirror_backend_service_name: '"mirror" + randomSuffix'
+  - name: 'url_map_test_headers'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      backend_service_name: 'backend'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      backend_service_name: '"backend" + randomSuffix'
+  - name: 'url_map_test_expected_output_url'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      backend_service_name: 'backend'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      backend_service_name: '"backend" + randomSuffix'
+  - name: 'url_map_test_redirect_response_code'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      backend_service_name: 'backend'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      backend_service_name: '"backend" + randomSuffix'
+  - name: 'external_http_lb_mig_backend'
+    primary_resource_id: 'default'
+    vars:
+      lb_backend_template: 'lb-backend-template'
+      lb_backend_example: 'lb-backend-example'
+      fw_allow_health_check: 'fw-allow-health-check'
+      lb_ipv4_1: 'lb-ipv4-1'
+      http_basic_check: 'http-basic-check'
+      web_backend_service: 'web-backend-service'
+      web_map_http: 'web-map-http'
+      http_lb_proxy: 'http-lb-proxy'
+      http_content_rule: 'http-content-rule'
+    ignore_read_extra:
+      - 'metadata'
+      - 'metadata_startup_script'
+ # Very similar to external_http_lb_mig_backend_custom_header
+    exclude_test: true
+    exclude_docs: true
+  - name: 'url_map_path_template_match'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      cart_backend_service_name: 'cart-service'
+      user_backend_service_name: 'user-service'
+      http_health_check_name: 'health-check'
+      backend_bucket_name: 'static-asset-backend-bucket'
+      storage_bucket_name: 'static-asset-bucket'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+  - name: 'url_map_custom_error_response_policy'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      backend_service_name: 'login'
+      http_health_check_name: 'health-check'
+      storage_bucket_name: 'static-asset-bucket'
+      error_backend_bucket_name: 'error-backend-bucket'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+      # for backward compatible
+      backend_service_name: '"login" + randomSuffix'
+  - name: 'url_map_http_filter_configs'
+    primary_resource_id: 'urlmap'
+    min_version: 'beta'
+    vars:
+      url_map_name: 'urlmap'
+      default_backend_service_name: 'default-backend'
+      service_a_backend_service_name: 'service-a-backend'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+  - name: 'url_map_http_filter_metadata'
+    primary_resource_id: 'urlmap'
+    min_version: 'beta'
+    vars:
+      url_map_name: 'urlmap'
+      default_backend_service_name: 'default-backend'
+      service_a_backend_service_name: 'service-a-backend'
+      service_b_backend_service_name: 'service-b-backend'
+      health_check_name: 'health-check'
+    test_vars_overrides:
+      # for backward compatible
+      url_map_name: '"urlmap" + randomSuffix'
+parameters:
+properties:
+  - name: 'creationTimestamp'
+    type: Time
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'defaultService'
+    type: ResourceRef
+    description: |-
+      The backend service or backend bucket to use when none of the given rules match.
+    exactly_one_of:
+      - 'default_service'
+      - 'default_url_redirect'
+      - 'default_route_action.0.weighted_backend_services'
+    custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+    resource: 'BackendService'
+    imports: 'selfLink'
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource. Provide this property when you create
+      the resource.
+  - name: 'map_id'
+    type: Integer
+    description: 'The unique identifier for the resource.'
+    api_name: id
+    output: true
+  - name: 'fingerprint'
+    type: Fingerprint
+    description: |
+      Fingerprint of this resource. A hash of the contents stored in this object. This
+      field is used in optimistic locking.
+    output: true
+  - name: 'headerAction'
+    type: NestedObject
+    description: |
+      Specifies changes to request and response headers that need to take effect for
+      the selected backendService. The headerAction specified here take effect after
+      headerAction specified under pathMatcher.
+    properties:
+      - name: 'requestHeadersToAdd'
+        type: Array
+        description: |
+          Headers to add to a matching request prior to forwarding the request to the
+          backendService.
+        at_least_one_of:
+          - 'header_action.0.request_headers_to_add'
+          - 'header_action.0.request_headers_to_remove'
+          - 'header_action.0.response_headers_to_add'
+          - 'header_action.0.response_headers_to_remove'
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'headerName'
+              type: String
+              description: |
+                The name of the header.
+              required: true
+            - name: 'headerValue'
+              type: String
+              description: |
+                The value of the header to add.
+              required: true
+            - name: 'replace'
+              type: Boolean
+              description: |
+                If false, headerValue is appended to any values that already exist for the
+                header. If true, headerValue is set for the header, discarding any values that
+                were set for that header.
+              required: true
+      - name: 'requestHeadersToRemove'
+        type: Array
+        description: |
+          A list of header names for headers that need to be removed from the request
+          prior to forwarding the request to the backendService.
+        at_least_one_of:
+          - 'header_action.0.request_headers_to_add'
+          - 'header_action.0.request_headers_to_remove'
+          - 'header_action.0.response_headers_to_add'
+          - 'header_action.0.response_headers_to_remove'
+        item_type:
+          type: String
+      - name: 'responseHeadersToAdd'
+        type: Array
+        description: |
+          Headers to add the response prior to sending the response back to the client.
+        at_least_one_of:
+          - 'header_action.0.request_headers_to_add'
+          - 'header_action.0.request_headers_to_remove'
+          - 'header_action.0.response_headers_to_add'
+          - 'header_action.0.response_headers_to_remove'
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'headerName'
+              type: String
+              description: |
+                The name of the header.
+              required: true
+            - name: 'headerValue'
+              type: String
+              description: |
+                The value of the header to add.
+              required: true
+            - name: 'replace'
+              type: Boolean
+              description: |
+                If false, headerValue is appended to any values that already exist for the
+                header. If true, headerValue is set for the header, discarding any values that
+                were set for that header.
+              required: true
+      - name: 'responseHeadersToRemove'
+        type: Array
+        description: |
+          A list of header names for headers that need to be removed from the response
+          prior to sending the response back to the client.
+        at_least_one_of:
+          - 'header_action.0.request_headers_to_add'
+          - 'header_action.0.request_headers_to_remove'
+          - 'header_action.0.response_headers_to_add'
+          - 'header_action.0.response_headers_to_remove'
+        item_type:
+          type: String
+  - name: 'host_rule'
+    type: Array
+    description: |
+      The list of HostRules to use against the URL.
+    api_name: hostRules
+    is_set: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'description'
+          type: String
+          description: |
+            An optional description of this resource. Provide this property when you create
+            the resource.
+        - name: 'hosts'
+          type: Array
+          description: |
+            The list of host patterns to match. They must be valid hostnames, except * will
+            match any string of ([a-z0-9-.]*). In that case, * must be the first character
+            and must be followed in the pattern by either - or ..
+          is_set: true
+          required: true
+          item_type:
+            type: String
+        - name: 'pathMatcher'
+          type: String
+          description: |
+            The name of the PathMatcher to use to match the path portion of the URL if the
+            hostRule matches the URL's host portion.
+          required: true
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is created. The
+      name must be 1-63 characters long, and comply with RFC1035. Specifically, the
+      name must be 1-63 characters long and match the regular expression
+      `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase
+      letter, and all following characters must be a dash, lowercase letter, or digit,
+      except the last character, which cannot be a dash.
+    required: true
+    immutable: true
+  - name: 'path_matcher'
+    type: Array
+    description: |
+      The list of named PathMatchers to use against the URL.
+    api_name: pathMatchers
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'defaultService'
+          type: ResourceRef
+          description: The backend service or backend bucket to use when none of the given paths match.
+          # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.
+          # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
+          # exactly_one_of:
+          #   - path_matchers.0.default_service
+          #   - path_matchers.0.default_url_redirect
+          #   - path_matchers.0.default_route_action.0.weighted_backend_services
+          custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+          resource: 'BackendService'
+          imports: 'selfLink'
+        - name: 'description'
+          type: String
+          description: |
+            An optional description of this resource. Provide this property when you create
+            the resource.
+        - name: 'defaultCustomErrorResponsePolicy'
+          type: NestedObject
+          description: |
+            defaultCustomErrorResponsePolicy specifies how the Load Balancer returns error responses when BackendService or BackendBucket responds with an error.
+
+            This policy takes effect at the PathMatcher level and applies only when no policy has been defined for the error code at lower levels like RouteRule and PathRule within this PathMatcher. If an error code does not have a policy defined in defaultCustomErrorResponsePolicy, then a policy defined for the error code in UrlMap.defaultCustomErrorResponsePolicy takes effect.
+
+            For example, consider a UrlMap with the following configuration:
+
+            UrlMap.defaultCustomErrorResponsePolicy is configured with policies for 5xx and 4xx errors
+            A RouteRule for /coming_soon/ is configured for the error code 404.
+            If the request is for www.myotherdomain.com and a 404 is encountered, the policy under UrlMap.defaultCustomErrorResponsePolicy takes effect. If a 404 response is encountered for the request www.example.com/current_events/, the pathMatcher's policy takes effect. If however, the request for www.example.com/coming_soon/ encounters a 404, the policy in RouteRule.customErrorResponsePolicy takes effect. If any of the requests in this example encounter a 500 error code, the policy at UrlMap.defaultCustomErrorResponsePolicy takes effect.
+
+            When used in conjunction with pathMatcher.defaultRouteAction.retryPolicy, retries take precedence. Only once all retries are exhausted, the defaultCustomErrorResponsePolicy is applied. While attempting a retry, if load balancer is successful in reaching the service, the defaultCustomErrorResponsePolicy is ignored and the response from the service is returned to the client.
+
+            defaultCustomErrorResponsePolicy is supported only for global external Application Load Balancers.
+          properties:
+            - name: 'errorResponseRule'
+              type: Array
+              description: |
+                Specifies rules for returning error responses.
+                In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority.
+                For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX).
+                If the backend service returns a 401, then the rule for 401 will be applied. However if the backend service returns a 403, the rule for 4xx takes effect.
+              api_name: errorResponseRules
+              is_missing_in_cai: true
+              item_type:
+                type: NestedObject
+                properties:
+                  - name: 'matchResponseCodes'
+                    type: Array
+                    description: |
+                      Valid values include:
+                      - A number between 400 and 599: For example 401 or 503, in which case the load balancer applies the policy if the error code exactly matches this value.
+                      - 5xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 500 to 599.
+                      - 4xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 400 to 499.
+                      Values must be unique within matchResponseCodes and across all errorResponseRules of CustomErrorResponsePolicy.
+                    item_type:
+                      type: String
+                  - name: 'path'
+                    type: String
+                    description: |
+                      The full path to a file within backendBucket . For example: /errors/defaultError.html
+                      path must start with a leading slash. path cannot have trailing slashes.
+                      If the file is not available in backendBucket or the load balancer cannot reach the BackendBucket, a simple Not Found Error is returned to the client.
+                      The value must be from 1 to 1024 characters
+                  - name: 'overrideResponseCode'
+                    type: Integer
+                    description: |
+                      The HTTP status code returned with the response containing the custom error content.
+                      If overrideResponseCode is not supplied, the same response code returned by the original backend bucket or backend service is returned to the client.
+            - name: 'errorService'
+              type: ResourceRef
+              description: |
+                The full or partial URL to the BackendBucket resource that contains the custom error content. Examples are:
+                https://www.googleapis.com/compute/v1/projects/project/global/backendBuckets/myBackendBucket
+                compute/v1/projects/project/global/backendBuckets/myBackendBucket
+                global/backendBuckets/myBackendBucket
+                If errorService is not specified at lower levels like pathMatcher, pathRule and routeRule, an errorService specified at a higher level in the UrlMap will be used. If UrlMap.defaultCustomErrorResponsePolicy contains one or more errorResponseRules[], it must specify errorService.
+                If load balancer cannot reach the backendBucket, a simple Not Found Error will be returned, with the original response code (or overrideResponseCode if configured).
+              resource: 'BackendBucket'
+              imports: 'selfLink'
+        - name: 'headerAction'
+          type: NestedObject
+          description: |
+            Specifies changes to request and response headers that need to take effect for
+            the selected backendService. HeaderAction specified here are applied after the
+            matching HttpRouteRule HeaderAction and before the HeaderAction in the UrlMap
+          properties:
+            - name: 'requestHeadersToAdd'
+              type: Array
+              description: |
+                Headers to add to a matching request prior to forwarding the request to the
+                backendService.
+              item_type:
+                type: NestedObject
+                properties:
+                  - name: 'headerName'
+                    type: String
+                    description: |
+                      The name of the header.
+                    required: true
+                  - name: 'headerValue'
+                    type: String
+                    description: |
+                      The value of the header to add.
+                    required: true
+                  - name: 'replace'
+                    type: Boolean
+                    description: |
+                      If false, headerValue is appended to any values that already exist for the
+                      header. If true, headerValue is set for the header, discarding any values that
+                      were set for that header.
+                    required: true
+            - name: 'requestHeadersToRemove'
+              type: Array
+              description: |
+                A list of header names for headers that need to be removed from the request
+                prior to forwarding the request to the backendService.
+              item_type:
+                type: String
+            - name: 'responseHeadersToAdd'
+              type: Array
+              description: |
+                Headers to add the response prior to sending the response back to the client.
+              item_type:
+                type: NestedObject
+                properties:
+                  - name: 'headerName'
+                    type: String
+                    description: |
+                      The name of the header.
+                    required: true
+                  - name: 'headerValue'
+                    type: String
+                    description: |
+                      The value of the header to add.
+                    required: true
+                  - name: 'replace'
+                    type: Boolean
+                    description: |
+                      If false, headerValue is appended to any values that already exist for the
+                      header. If true, headerValue is set for the header, discarding any values that
+                      were set for that header.
+                    required: true
+            - name: 'responseHeadersToRemove'
+              type: Array
+              description: |
+                A list of header names for headers that need to be removed from the response
+                prior to sending the response back to the client.
+              item_type:
+                type: String
+        - name: 'name'
+          type: String
+          description: |
+            The name to which this PathMatcher is referred by the HostRule.
+          required: true
+        - name: 'path_rule'
+          type: Array
+          description: |
+            The list of path rules. Use this list instead of routeRules when routing based
+            on simple path matching is all that's required. The order by which path rules
+            are specified does not matter. Matches are always done on the longest-path-first
+            basis. For example: a pathRule with a path /a/b/c/* will match before /a/b/*
+            irrespective of the order in which those paths appear in this list. Within a
+            given pathMatcher, only one of pathRules or routeRules must be set.
+          api_name: pathRules
+          item_type:
+            type: NestedObject
+            properties:
+              - name: 'service'
+                type: ResourceRef
+                description: The backend service or backend bucket to use if any of the given paths match.
+                custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+                resource: 'BackendService'
+                imports: 'selfLink'
+              - name: 'paths'
+                type: Array
+                description: |
+                  The list of path patterns to match. Each must start with / and the only place a
+                  \* is allowed is at the end following a /. The string fed to the path matcher
+                  does not include any text after the first ? or #, and those chars are not
+                  allowed here.
+                is_set: true
+                required: true
+                item_type:
+                  type: String
+              - name: 'customErrorResponsePolicy'
+                type: NestedObject
+                description: |
+                  customErrorResponsePolicy specifies how the Load Balancer returns error responses when BackendService or BackendBucket responds with an error.
+                  If a policy for an error code is not configured for the PathRule, a policy for the error code configured in pathMatcher.defaultCustomErrorResponsePolicy is applied. If one is not specified in pathMatcher.defaultCustomErrorResponsePolicy, the policy configured in UrlMap.defaultCustomErrorResponsePolicy takes effect.
+                  For example, consider a UrlMap with the following configuration:
+                  UrlMap.defaultCustomErrorResponsePolicy are configured with policies for 5xx and 4xx errors
+                  A PathRule for /coming_soon/ is configured for the error code 404.
+                  If the request is for www.myotherdomain.com and a 404 is encountered, the policy under UrlMap.defaultCustomErrorResponsePolicy takes effect. If a 404 response is encountered for the request www.example.com/current_events/, the pathMatcher's policy takes effect. If however, the request for www.example.com/coming_soon/ encounters a 404, the policy in PathRule.customErrorResponsePolicy takes effect. If any of the requests in this example encounter a 500 error code, the policy at UrlMap.defaultCustomErrorResponsePolicy takes effect.
+                  customErrorResponsePolicy is supported only for global external Application Load Balancers.
+                properties:
+                  - name: 'errorResponseRule'
+                    type: Array
+                    description: |
+                      Specifies rules for returning error responses.
+                      In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority.
+                      For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX).
+                      If the backend service returns a 401, then the rule for 401 will be applied. However if the backend service returns a 403, the rule for 4xx takes effect.
+                    api_name: errorResponseRules
+                    is_missing_in_cai: true
+                    item_type:
+                      type: NestedObject
+                      properties:
+                        - name: 'matchResponseCodes'
+                          type: Array
+                          description: |
+                            Valid values include:
+
+                            - A number between 400 and 599: For example 401 or 503, in which case the load balancer applies the policy if the error code exactly matches this value.
+                            - 5xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 500 to 599.
+                            - 4xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 400 to 499.
+
+                            Values must be unique within matchResponseCodes and across all errorResponseRules of CustomErrorResponsePolicy.
+                          item_type:
+                            type: String
+                        - name: 'path'
+                          type: String
+                          description: |
+                            The full path to a file within backendBucket . For example: /errors/defaultError.html
+                            path must start with a leading slash. path cannot have trailing slashes.
+                            If the file is not available in backendBucket or the load balancer cannot reach the BackendBucket, a simple Not Found Error is returned to the client.
+                            The value must be from 1 to 1024 characters
+                        - name: 'overrideResponseCode'
+                          type: Integer
+                          description: |
+                            The HTTP status code returned with the response containing the custom error content.
+                            If overrideResponseCode is not supplied, the same response code returned by the original backend bucket or backend service is returned to the client.
+                  - name: 'errorService'
+                    type: ResourceRef
+                    description: |
+                      The full or partial URL to the BackendBucket resource that contains the custom error content. Examples are:
+
+                      https://www.googleapis.com/compute/v1/projects/project/global/backendBuckets/myBackendBucket
+                      compute/v1/projects/project/global/backendBuckets/myBackendBucket
+                      global/backendBuckets/myBackendBucket
+
+                      If errorService is not specified at lower levels like pathMatcher, pathRule and routeRule, an errorService specified at a higher level in the UrlMap will be used. If UrlMap.defaultCustomErrorResponsePolicy contains one or more errorResponseRules[], it must specify errorService.
+                      If load balancer cannot reach the backendBucket, a simple Not Found Error will be returned, with the original response code (or overrideResponseCode if configured).
+                    resource: 'BackendBucket'
+                    imports: 'selfLink'
+              - name: 'routeAction'
+                type: NestedObject
+                description: |
+                  In response to a matching path, the load balancer performs advanced routing
+                  actions like URL rewrites, header transformations, etc. prior to forwarding the
+                  request to the selected backend. If routeAction specifies any
+                  weightedBackendServices, service must not be set. Conversely if service is set,
+                  routeAction cannot contain any  weightedBackendServices. Only one of routeAction
+                  or urlRedirect must be set.
+                properties:
+                  - name: 'corsPolicy'
+                    type: NestedObject
+                    description: |
+                      The specification for allowing client side cross-origin requests. Please see W3C
+                      Recommendation for Cross Origin Resource Sharing
+                    properties:
+                      - name: 'allowCredentials'
+                        type: Boolean
+                        description: |
+                          In response to a preflight request, setting this to true indicates that the
+                          actual request can include user credentials. This translates to the Access-
+                          Control-Allow-Credentials header. Defaults to false.
+                        default_value: false
+                      - name: 'allowHeaders'
+                        type: Array
+                        description: |
+                          Specifies the content for the Access-Control-Allow-Headers header.
+                        item_type:
+                          type: String
+                      - name: 'allowMethods'
+                        type: Array
+                        description: |
+                          Specifies the content for the Access-Control-Allow-Methods header.
+                        item_type:
+                          type: String
+                      - name: 'allowOriginRegexes'
+                        type: Array
+                        description: |
+                          Specifies the regular expression patterns that match allowed origins. For
+                          regular expression grammar please see en.cppreference.com/w/cpp/regex/ecmascript
+                          An origin is allowed if it matches either allow_origins or allow_origin_regex.
+                        item_type:
+                          type: String
+                      - name: 'allowOrigins'
+                        type: Array
+                        description: |
+                          Specifies the list of origins that will be allowed to do CORS requests. An
+                          origin is allowed if it matches either allow_origins or allow_origin_regex.
+                        item_type:
+                          type: String
+                      - name: 'disabled'
+                        type: Boolean
+                        description: |
+                          If true, specifies the CORS policy is disabled.
+                        required: true
+                      - name: 'exposeHeaders'
+                        type: Array
+                        description: |
+                          Specifies the content for the Access-Control-Expose-Headers header.
+                        item_type:
+                          type: String
+                      - name: 'maxAge'
+                        type: Integer
+                        description: |
+                          Specifies how long the results of a preflight request can be cached. This
+                          translates to the content for the Access-Control-Max-Age header.
+                  - name: 'faultInjectionPolicy'
+                    type: NestedObject
+                    description: |
+                      The specification for fault injection introduced into traffic to test the
+                      resiliency of clients to backend service failure. As part of fault injection,
+                      when clients send requests to a backend service, delays can be introduced by
+                      Loadbalancer on a percentage of requests before sending those request to the
+                      backend service. Similarly requests from clients can be aborted by the
+                      Loadbalancer for a percentage of requests. timeout and retry_policy will be
+                      ignored by clients that are configured with a fault_injection_policy.
+                    properties:
+                      - name: 'abort'
+                        type: NestedObject
+                        description: |
+                          The specification for how client requests are aborted as part of fault
+                          injection.
+                        properties:
+                          - name: 'httpStatus'
+                            type: Integer
+                            description: |
+                              The HTTP status code used to abort the request. The value must be between 200
+                              and 599 inclusive.
+                            required: true
+                          - name: 'percentage'
+                            type: Double
+                            description: |
+                              The percentage of traffic (connections/operations/requests) which will be
+                              aborted as part of fault injection. The value must be between 0.0 and 100.0
+                              inclusive.
+                            required: true
+                      - name: 'delay'
+                        type: NestedObject
+                        description: |
+                          The specification for how client requests are delayed as part of fault
+                          injection, before being sent to a backend service.
+                        properties:
+                          - name: 'fixedDelay'
+                            type: NestedObject
+                            description: |
+                              Specifies the value of the fixed delay interval.
+                            required: true
+                            properties:
+                              - name: 'nanos'
+                                type: Integer
+                                description: |
+                                  Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                  less than one second are represented with a 0 `seconds` field and a positive
+                                  `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                              - name: 'seconds'
+                                type: String
+                                description: |
+                                  Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                  inclusive.
+                                required: true
+                          - name: 'percentage'
+                            type: Double
+                            description: |
+                              The percentage of traffic (connections/operations/requests) on which delay will
+                              be introduced as part of fault injection. The value must be between 0.0 and
+                              100.0 inclusive.
+                            required: true
+                  - name: 'requestMirrorPolicy'
+                    type: NestedObject
+                    description: |
+                      Specifies the policy on how requests intended for the route's backends are
+                      shadowed to a separate mirrored backend service. Loadbalancer does not wait for
+                      responses from the shadow service. Prior to sending traffic to the shadow
+                      service, the host / authority header is suffixed with -shadow.
+                    properties:
+                      - name: 'backendService'
+                        type: ResourceRef
+                        description: |
+                          The BackendService resource being mirrored to.
+                        required: true
+                        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+                        resource: 'BackendService'
+                        imports: 'selfLink'
+                      - name: 'mirrorPercent'
+                        min_version: beta
+                        type: Double
+                        description: |
+                          The percentage of requests to be mirrored to backendService.
+                          The value must be between 0.0 and 100.0 inclusive.
+                        is_missing_in_cai: true
+                        validation:
+                          function: 'validation.FloatBetween(0, 100)'
+                  - name: 'retryPolicy'
+                    type: NestedObject
+                    description: |
+                      Specifies the retry policy associated with this route.
+                    properties:
+                      - name: 'numRetries'
+                        type: Integer
+                        description: |
+                          Specifies the allowed number retries. This number must be > 0.
+                      - name: 'perTryTimeout'
+                        type: NestedObject
+                        description: |
+                          Specifies a non-zero timeout per retry attempt.
+                        properties:
+                          - name: 'nanos'
+                            type: Integer
+                            include_empty_value_in_cai: true
+                            description: |
+                              Span of time that's a fraction of a second at nanosecond resolution. Durations
+                              less than one second are represented with a 0 `seconds` field and a positive
+                              `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                          - name: 'seconds'
+                            type: String
+                            description: |
+                              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                              inclusive.
+                            required: true
+                      - name: 'retryConditions'
+                        type: Array
+                        description: |
+                          Specifies one or more conditions when this retry rule applies. Valid values are:
+
+                          * 5xx: Loadbalancer will attempt a retry if the backend service responds with
+                          any 5xx response code, or if the backend service does not respond at all,
+                          for example: disconnects, reset, read timeout, connection failure, and refused
+                          streams.
+                          * gateway-error: Similar to 5xx, but only applies to response codes
+                          502, 503 or 504.
+                          * connect-failure: Loadbalancer will retry on failures
+                          connecting to backend services, for example due to connection timeouts.
+                          * retriable-4xx: Loadbalancer will retry for retriable 4xx response codes.
+                          Currently the only retriable error supported is 409.
+                          * refused-stream: Loadbalancer will retry if the backend service resets the stream with a
+                          REFUSED_STREAM error code. This reset type indicates that it is safe to retry.
+                          * cancelled: Loadbalancer will retry if the gRPC status code in the response
+                          header is set to cancelled
+                          * deadline-exceeded: Loadbalancer will retry if the
+                          gRPC status code in the response header is set to deadline-exceeded
+                          * resource-exhausted: Loadbalancer will retry if the gRPC status code in the response
+                          header is set to resource-exhausted
+                          * unavailable: Loadbalancer will retry if
+                          the gRPC status code in the response header is set to unavailable
+                        item_type:
+                          type: String
+                  - name: 'timeout'
+                    type: NestedObject
+                    description: |
+                      Specifies the timeout for the selected route. Timeout is computed from the time
+                      the request is has been fully processed (i.e. end-of-stream) up until the
+                      response has been completely processed. Timeout includes all retries. If not
+                      specified, the default value is 15 seconds.
+                    properties:
+                      - name: 'nanos'
+                        type: Integer
+                        description: |
+                          Span of time that's a fraction of a second at nanosecond resolution. Durations
+                          less than one second are represented with a 0 `seconds` field and a positive
+                          `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                      - name: 'seconds'
+                        type: String
+                        description: |
+                          Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                          inclusive.
+                        required: true
+                  - name: 'maxStreamDuration'
+                    type: NestedObject
+                    description: |
+                      Specifies the maximum duration (timeout) for streams on the selected route.
+                      Unlike the `Timeout` field where the timeout duration starts from the time the request
+                      has been fully processed (known as end-of-stream), the duration in this field
+                      is computed from the beginning of the stream until the response has been processed,
+                      including all retries. A stream that does not complete in this duration is closed.
+                    default_from_api: true
+                    properties:
+                      - name: 'nanos'
+                        type: Integer
+                        description: |
+                          Span of time that's a fraction of a second at nanosecond resolution. Durations
+                          less than one second are represented with a 0 `seconds` field and a positive
+                          `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                      - name: 'seconds'
+                        type: String
+                        description: |
+                          Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                          inclusive.
+                        required: true
+                  - name: 'urlRewrite'
+                    type: NestedObject
+                    description: |
+                      The spec to modify the URL of the request, prior to forwarding the request to
+                      the matched service
+                    properties:
+                      - name: 'hostRewrite'
+                        type: String
+                        description: |
+                          Prior to forwarding the request to the selected service, the request's host
+                          header is replaced with contents of hostRewrite. The value must be between 1 and
+                          255 characters.
+                      - name: 'pathPrefixRewrite'
+                        type: String
+                        description: |
+                          Prior to forwarding the request to the selected backend service, the matching
+                          portion of the request's path is replaced by pathPrefixRewrite. The value must
+                          be between 1 and 1024 characters.
+                  - name: 'weightedBackendServices'
+                    type: Array
+                    description: |
+                      A list of weighted backend services to send traffic to when a route match
+                      occurs. The weights determine the fraction of traffic that flows to their
+                      corresponding backend service. If all traffic needs to go to a single backend
+                      service, there must be one  weightedBackendService with weight set to a non 0
+                      number. Once a backendService is identified and before forwarding the request to
+                      the backend service, advanced routing actions like Url rewrites and header
+                      transformations are applied depending on additional settings specified in this
+                      HttpRouteAction.
+                    item_type:
+                      type: NestedObject
+                      properties:
+                        - name: 'backendService'
+                          type: ResourceRef
+                          description: |
+                            The default BackendService resource. Before
+                            forwarding the request to backendService, the loadbalancer applies any relevant
+                            headerActions specified as part of this backendServiceWeight.
+                          required: true
+                          custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+                          resource: 'BackendService'
+                          imports: 'selfLink'
+                        - name: 'headerAction'
+                          type: NestedObject
+                          description: |
+                            Specifies changes to request and response headers that need to take effect for
+                            the selected backendService. headerAction specified here take effect before
+                            headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap.
+                          properties:
+                            - name: 'requestHeadersToAdd'
+                              type: Array
+                              description: |
+                                Headers to add to a matching request prior to forwarding the request to the
+                                backendService.
+                              item_type:
+                                type: NestedObject
+                                properties:
+                                  - name: 'headerName'
+                                    type: String
+                                    description: |
+                                      The name of the header.
+                                    required: true
+                                  - name: 'headerValue'
+                                    type: String
+                                    description: |
+                                      The value of the header to add.
+                                    required: true
+                                  - name: 'replace'
+                                    type: Boolean
+                                    description: |
+                                      If false, headerValue is appended to any values that already exist for the
+                                      header. If true, headerValue is set for the header, discarding any values that
+                                      were set for that header.
+                                    required: true
+                            - name: 'requestHeadersToRemove'
+                              type: Array
+                              description: |
+                                A list of header names for headers that need to be removed from the request
+                                prior to forwarding the request to the backendService.
+                              item_type:
+                                type: String
+                            - name: 'responseHeadersToAdd'
+                              type: Array
+                              description: |
+                                Headers to add the response prior to sending the response back to the client.
+                              item_type:
+                                type: NestedObject
+                                properties:
+                                  - name: 'headerName'
+                                    type: String
+                                    description: |
+                                      The name of the header.
+                                    required: true
+                                  - name: 'headerValue'
+                                    type: String
+                                    description: |
+                                      The value of the header to add.
+                                    required: true
+                                  - name: 'replace'
+                                    type: Boolean
+                                    description: |
+                                      If false, headerValue is appended to any values that already exist for the
+                                      header. If true, headerValue is set for the header, discarding any values that
+                                      were set for that header.
+                                    required: true
+                            - name: 'responseHeadersToRemove'
+                              type: Array
+                              description: |
+                                A list of header names for headers that need to be removed from the response
+                                prior to sending the response back to the client.
+                              item_type:
+                                type: String
+                        - name: 'weight'
+                          type: Integer
+                          description: |
+                            Specifies the fraction of traffic sent to backendService, computed as weight /
+                            (sum of all weightedBackendService weights in routeAction) . The selection of a
+                            backend service is determined only for new traffic. Once a user's request has
+                            been directed to a backendService, subsequent requests will be sent to the same
+                            backendService as determined by the BackendService's session affinity policy.
+                            The value must be between 0 and 1000
+                          required: true
+                  - name: 'cachePolicy'
+                    type: NestedObject
+                    description: |
+                      Specifies the cache policy configuration for matched traffic. Available
+                      only for Global EXTERNAL_MANAGED load balancer schemes. At least one
+                      property must be specified. This policy cannot be specified if any target
+                      backend has Identity-Aware Proxy enabled.
+                    properties:
+                      - name: 'cacheMode'
+                        type: Enum
+                        is_missing_in_cai: true
+                        description: |
+                          Specifies the cache setting for all responses from this route. If not
+                          specified, Cloud CDN uses CACHE_ALL_STATIC mode.
+                        enum_values:
+                          - 'USE_ORIGIN_HEADERS'
+                          - 'FORCE_CACHE_ALL'
+                          - 'CACHE_ALL_STATIC'
+                      - name: 'defaultTtl'
+                        type: NestedObject
+                        is_missing_in_cai: true
+                        description: |
+                          Specifies the default TTL for cached content for responses that do not have
+                          an existing valid TTL (max-age or s-maxage). Setting a TTL of "0" means
+                          "always revalidate". The value of defaultTtl cannot be set to a value
+                          greater than that of maxTtl. When the cacheMode is set to
+                          FORCE_CACHE_ALL, the defaultTtl will overwrite the TTL set in all
+                          responses. The maximum allowed value is 31,622,400s (1 year). Infrequently
+                          accessed objects may be evicted from the cache before the defined TTL. If
+                          not specified, Cloud CDN uses 3600s (1 hour) for CACHE_ALL_STATIC and
+                          FORCE_CACHE_ALL modes. Cannot be specified when cacheMode is
+                          USE_ORIGIN_HEADERS.
+                        properties:
+                          - name: 'seconds'
+                            type: String
+                            required: true
+                            description: |
+                              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                          - name: 'nanos'
+                            type: Integer
+                            ignore_read: true
+                            description: |
+                              Span of time that's a fraction of a second at nanosecond resolution.
+                            validation:
+                              function: 'validation.IntBetween(0, 0)'
+                      - name: 'maxTtl'
+                        type: NestedObject
+                        is_missing_in_cai: true
+                        description: |
+                          Specifies the maximum allowed TTL for cached content. Cache directives that
+                          attempt to set a max-age or s-maxage higher than this, or an Expires header
+                          more than maxTtl seconds in the future will be capped at the value of
+                          maxTtl, as if it were the value of an s-maxage Cache-Control directive.
+                          Headers sent to the client will not be modified. Setting a TTL of "0" means
+                          "always revalidate". The maximum allowed value is 31,622,400s (1 year).
+                          Infrequently accessed objects may be evicted from the cache before the
+                          defined TTL. If not specified, Cloud CDN uses 86400s (1 day) for
+                          CACHE_ALL_STATIC mode. Can be specified only for CACHE_ALL_STATIC cache
+                          mode.
+                        properties:
+                          - name: 'seconds'
+                            type: String
+                            required: true
+                            description: |
+                              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                          - name: 'nanos'
+                            type: Integer
+                            ignore_read: true
+                            description: |
+                              Span of time that's a fraction of a second at nanosecond resolution.
+                            validation:
+                              function: 'validation.IntBetween(0, 0)'
+                      - name: 'clientTtl'
+                        type: NestedObject
+                        is_missing_in_cai: true
+                        description: |
+                          Specifies a separate client (e.g. browser client) maximum TTL for cached
+                          content. This is used to clamp the max-age (or Expires) value sent to the
+                          client. With FORCE_CACHE_ALL, the lesser of clientTtl and defaultTtl
+                          is used for the response max-age directive, along with a "public"
+                          directive. For cacheable content in CACHE_ALL_STATIC mode, clientTtl
+                          clamps the max-age from the origin (if specified), or else sets the
+                          response max-age directive to the lesser of the clientTtl and defaultTtl,
+                          and also ensures a "public" cache-control directive is present. The maximum
+                          allowed value is 31,622,400s (1 year). If not specified, Cloud CDN uses
+                          3600s (1 hour) for CACHE_ALL_STATIC mode. Cannot exceed maxTtl.
+                          Cannot be specified when cacheMode is USE_ORIGIN_HEADERS.
+                        properties:
+                          - name: 'seconds'
+                            type: String
+                            required: true
+                            description: |
+                              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                          - name: 'nanos'
+                            type: Integer
+                            ignore_read: true
+                            description: |
+                              Span of time that's a fraction of a second at nanosecond resolution.
+                            validation:
+                              function: 'validation.IntBetween(0, 0)'
+                      - name: 'requestCoalescing'
+                        type: Boolean
+                        is_missing_in_cai: true
+                        send_empty_value: true
+                        description: |
+                          If true then Cloud CDN will combine multiple concurrent cache fill
+                          requests into a small number of requests to the origin. If not specified,
+                          Cloud CDN applies request coalescing by default.
+                      - name: 'negativeCaching'
+                        type: Boolean
+                        is_missing_in_cai: true
+                        send_empty_value: true
+                        description: |
+                          Negative caching allows per-status code TTLs to be set, in order to apply
+                          fine-grained caching for common errors or redirects. This can reduce the
+                          load on your origin and improve end-user experience by reducing response
+                          latency. When the cacheMode is set to CACHE_ALL_STATIC or
+                          USE_ORIGIN_HEADERS, negative caching applies to responses with the
+                          specified response code that lack any Cache-Control, Expires, or
+                          Pragma: no-cache directives. When the cacheMode is set to
+                          FORCE_CACHE_ALL, negative caching applies to all responses with the
+                          specified response code, and overrides any caching headers. By default,
+                          Cloud CDN applies the following TTLs to these HTTP status codes:
+                          * 300 (Multiple Choice), 301, 308 (Permanent Redirects): 10m
+                          * 404 (Not Found), 410 (Gone), 451 (Unavailable For Legal Reasons): 120s
+                          * 405 (Method Not Found), 501 (Not Implemented): 60s
+                          These defaults can be overridden in negativeCachingPolicy. If not
+                          specified, Cloud CDN applies negative caching by default.
+                      - name: 'negativeCachingPolicy'
+                        type: Array
+                        is_missing_in_cai: true
+                        send_empty_value: true
+                        description: |
+                          Sets a cache TTL for the specified HTTP status code. negativeCaching
+                          must be enabled to configure negativeCachingPolicy. Omitting the policy
+                          and leaving negativeCaching enabled will use Cloud CDN's default cache
+                          TTLs. Note that when specifying an explicit negativeCachingPolicy, you
+                          should take care to specify a cache TTL for all response codes that you
+                          wish to cache. Cloud CDN will not apply any default negative caching when
+                          a policy exists.
+                        item_type:
+                          type: NestedObject
+                          properties:
+                            - name: 'code'
+                              type: Integer
+                              description: |
+                                The HTTP status code to define a TTL against. Only HTTP status codes
+                                300, 301, 302, 307, 308, 404, 405, 410, 421, 451 and 501 can be
+                                specified as values, and you cannot specify a status code more than
+                                once.
+                            - name: 'ttl'
+                              type: NestedObject
+                              description: |
+                                The TTL (in seconds) for which to cache responses with the
+                                corresponding status code. The maximum allowed value is 1800s (30
+                                minutes). Infrequently accessed objects may be evicted from the cache
+                                before the defined TTL.
+                              properties:
+                                - name: 'seconds'
+                                  type: String
+                                  required: true
+                                  description: |
+                                    Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                                - name: 'nanos'
+                                  type: Integer
+                                  ignore_read: true
+                                  description: |
+                                    Span of time that's a fraction of a second at nanosecond resolution.
+                                  validation:
+                                    function: 'validation.IntBetween(0, 0)'
+                      - name: 'cacheBypassRequestHeaderNames'
+                        type: Array
+                        is_missing_in_cai: true
+                        description: |
+                          Bypass the cache when the specified request headers are matched by name,
+                          e.g. Pragma or Authorization headers. Values are case-insensitive. Up to 5
+                          header names can be specified. The cache is bypassed for all cacheMode
+                          values.
+                        item_type:
+                          type: String
+                      - name: 'serveWhileStale'
+                        type: NestedObject
+                        is_missing_in_cai: true
+                        description: |
+                          Serve existing content from the cache (if available) when revalidating
+                          content with the origin, or when an error is encountered when refreshing
+                          the cache. This setting defines the default "max-stale" duration for any
+                          cached responses that do not specify a max-stale directive. Stale
+                          responses that exceed the TTL configured here will not be served. The
+                          default limit (max-stale) is 86400s (1 day), which will allow stale
+                          content to be served up to this limit beyond the max-age (or s-maxage) of
+                          a cached response. The maximum allowed value is 604800 (1 week). Set this
+                          to zero (0) to disable serve-while-stale.
+                        properties:
+                          - name: 'seconds'
+                            type: String
+                            required: true
+                            description: |
+                              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                          - name: 'nanos'
+                            type: Integer
+                            ignore_read: true
+                            description: |
+                              Span of time that's a fraction of a second at nanosecond resolution.
+                            validation:
+                              function: 'validation.IntBetween(0, 0)'
+                      - name: 'cacheKeyPolicy'
+                        type: NestedObject
+                        description: |
+                          The cache key configuration. If not specified, the default behavior depends
+                          on the backend type: for Backend Services, the complete request URI is
+                          used; for Backend Buckets, the request URI is used without the protocol or
+                          host, and only query parameters known to Cloud Storage are included.
+                        properties:
+                          - name: 'includeProtocol'
+                            type: Boolean
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              If true, http and https requests will be cached separately. Note: This
+                              setting is only applicable to routes that use a Backend Service. It
+                              does not affect requests served by a Backend Bucket, as the protocol is
+                              never included in a Backend Bucket's cache key. Attempting to set on a
+                              route that points exclusively to Backend Buckets will result in a
+                              configuration error.
+                          - name: 'includeHost'
+                            type: Boolean
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              If true, requests to different hosts will be cached separately. Note:
+                              This setting is only applicable to routes that use a Backend Service.
+                              It does not affect requests served by a Backend Bucket, as the host is
+                              never included in a Backend Bucket's cache key. Attempting to set it on
+                              a route that points exclusively to Backend Buckets will result in a
+                              configuration error.
+                          - name: 'includeQueryString'
+                            type: Boolean
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              If true, include query string parameters in the cache key according to
+                              includedQueryParameters and excludedQueryParameters. If neither is
+                              set, the entire query string will be included. If false, the query
+                              string will be excluded from the cache key entirely. Note: This field
+                              applies to routes that use backend services. Attempting to set it on a
+                              route that points exclusively to Backend Buckets will result in a
+                              configuration error. For routes that point to a Backend Bucket, use
+                              includedQueryParameters to define which parameters should be part of
+                              the cache key.
+                          - name: 'includedQueryParameters'
+                            type: Array
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              Names of query string parameters to include in cache keys. All other
+                              parameters will be excluded. Either specify includedQueryParameters
+                              or excludedQueryParameters, not both. '&' and '=' will be percent
+                              encoded and not treated as delimiters.
+                            item_type:
+                              type: String
+                          - name: 'excludedQueryParameters'
+                            type: Array
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              Names of query string parameters to exclude in cache keys. All other
+                              parameters will be included. Either specify excludedQueryParameters
+                              or includedQueryParameters, not both. '&' and '=' will be percent
+                              encoded and not treated as delimiters. Note: This field applies to
+                              routes that use backend services. Attempting to set it on a route that
+                              points exclusively to Backend Buckets will result in a configuration
+                              error. For routes that point to a Backend Bucket, use
+                              includedQueryParameters to define which parameters should be part of
+                              the cache key.
+                            item_type:
+                              type: String
+                          - name: 'includedHeaderNames'
+                            type: Array
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              Allows HTTP request headers (by name) to be used in the cache key.
+                            item_type:
+                              type: String
+                          - name: 'includedCookieNames'
+                            type: Array
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              Allows HTTP cookies (by name) to be used in the cache key. The
+                              name=value pair will be used in the cache key Cloud CDN generates.
+                              Note: This setting is only applicable to routes that use a Backend
+                              Service. It does not affect requests served by a Backend Bucket.
+                              Attempting to set it on a route that points exclusively to Backend
+                              Buckets will result in a configuration error. Up to 5 cookie names can
+                              be specified.
+                            item_type:
+                              type: String
+              - name: 'urlRedirect'
+                type: NestedObject
+                description: |
+                  When a path pattern is matched, the request is redirected to a URL specified
+                  by urlRedirect. If urlRedirect is specified, service or routeAction must not
+                  be set.
+                properties:
+                  - name: 'hostRedirect'
+                    type: String
+                    description: |
+                      The host that will be used in the redirect response instead of the one
+                      that was supplied in the request. The value must be between 1 and 255
+                      characters.
+                  - name: 'httpsRedirect'
+                    type: Boolean
+                    description: |
+                      If set to true, the URL scheme in the redirected request is set to https.
+                      If set to false, the URL scheme of the redirected request will remain the
+                      same as that of the request. This must only be set for UrlMaps used in
+                      TargetHttpProxys. Setting this true for TargetHttpsProxy is not
+                      permitted. The default is set to false.
+                    default_value: false
+                  - name: 'pathRedirect'
+                    type: String
+                    description: |
+                      The path that will be used in the redirect response instead of the one
+                      that was supplied in the request. pathRedirect cannot be supplied
+                      together with prefixRedirect. Supply one alone or neither. If neither is
+                      supplied, the path of the original request will be used for the redirect.
+                      The value must be between 1 and 1024 characters.
+                  - name: 'prefixRedirect'
+                    type: String
+                    description: |
+                      The prefix that replaces the prefixMatch specified in the
+                      HttpRouteRuleMatch, retaining the remaining portion of the URL before
+                      redirecting the request. prefixRedirect cannot be supplied together with
+                      pathRedirect. Supply one alone or neither. If neither is supplied, the
+                      path of the original request will be used for the redirect. The value
+                      must be between 1 and 1024 characters.
+                  - name: 'redirectResponseCode'
+                    type: Enum
+                    description: |
+                      The HTTP Status code to use for this RedirectAction. Supported values are:
+
+                      * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+
+                      * FOUND, which corresponds to 302.
+
+                      * SEE_OTHER which corresponds to 303.
+
+                      * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+                      will be retained.
+
+                      * PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                      the request method will be retained.
+                    enum_values:
+                      - 'FOUND'
+                      - 'MOVED_PERMANENTLY_DEFAULT'
+                      - 'PERMANENT_REDIRECT'
+                      - 'SEE_OTHER'
+                      - 'TEMPORARY_REDIRECT'
+                    exclude_docs_values: true
+                  - name: 'stripQuery'
+                    type: Boolean
+                    description: |
+                      If set to true, any accompanying query portion of the original URL is
+                      removed prior to redirecting the request. If set to false, the query
+                      portion of the original URL is retained.
+                       This field is required to ensure an empty block is not set. The normal default value is false.
+                    required: true
+        - name: 'routeRules'
+          type: Array
+          description: |
+            The list of ordered HTTP route rules. Use this list instead of pathRules when
+            advanced route matching and routing actions are desired. The order of specifying
+            routeRules matters: the first rule that matches will cause its specified routing
+            action to take effect. Within a given pathMatcher, only one of pathRules or
+            routeRules must be set. routeRules are not supported in UrlMaps intended for
+            External load balancers.
+          item_type:
+            type: NestedObject
+            properties:
+              - name: 'priority'
+                type: Integer
+                description: |
+                  For routeRules within a given pathMatcher, priority determines the order
+                  in which load balancer will interpret routeRules. RouteRules are evaluated
+                  in order of priority, from the lowest to highest number. The priority of
+                  a rule decreases as its number increases (1, 2, 3, N+1). The first rule
+                  that matches the request is applied.
+
+                  You cannot configure two or more routeRules with the same priority.
+                  Priority for each rule must be set to a number between 0 and
+                  2147483647 inclusive.
+
+                  Priority numbers can have gaps, which enable you to add or remove rules
+                  in the future without affecting the rest of the rules. For example,
+                  1, 2, 3, 4, 5, 9, 12, 16 is a valid series of priority numbers to which
+                  you could add rules numbered from 6 to 8, 10 to 11, and 13 to 15 in the
+                  future without any impact on existing rules.
+                required: true
+              - name: 'service'
+                type: ResourceRef
+                description: |
+                  The backend service resource to which traffic is
+                  directed if this rule is matched. If routeAction is additionally specified,
+                  advanced routing actions like URL Rewrites, etc. take effect prior to sending
+                  the request to the backend. However, if service is specified, routeAction cannot
+                  contain any weightedBackendService s. Conversely, if routeAction specifies any
+                  weightedBackendServices, service must not be specified. Only one of urlRedirect,
+                  service or routeAction.weightedBackendService must be set.
+                custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+                resource: 'BackendService'
+                imports: 'selfLink'
+              - name: 'headerAction'
+                type: NestedObject
+                description: |
+                  Specifies changes to request and response headers that need to take effect for
+                  the selected backendService. The headerAction specified here are applied before
+                  the matching pathMatchers[].headerAction and after pathMatchers[].routeRules[].r
+                  outeAction.weightedBackendService.backendServiceWeightAction[].headerAction
+                properties:
+                  - name: 'requestHeadersToAdd'
+                    type: Array
+                    description: |
+                      Headers to add to a matching request prior to forwarding the request to the
+                      backendService.
+                    item_type:
+                      type: NestedObject
+                      properties:
+                        - name: 'headerName'
+                          type: String
+                          description: |
+                            The name of the header.
+                          required: true
+                        - name: 'headerValue'
+                          type: String
+                          description: |
+                            The value of the header to add.
+                          required: true
+                        - name: 'replace'
+                          type: Boolean
+                          description: |
+                            If false, headerValue is appended to any values that already exist for the
+                            header. If true, headerValue is set for the header, discarding any values that
+                            were set for that header.
+                          required: true
+                  - name: 'requestHeadersToRemove'
+                    type: Array
+                    description: |
+                      A list of header names for headers that need to be removed from the request
+                      prior to forwarding the request to the backendService.
+                    item_type:
+                      type: String
+                  - name: 'responseHeadersToAdd'
+                    type: Array
+                    description: |
+                      Headers to add the response prior to sending the response back to the client.
+                    item_type:
+                      type: NestedObject
+                      properties:
+                        - name: 'headerName'
+                          type: String
+                          description: |
+                            The name of the header.
+                          required: true
+                        - name: 'headerValue'
+                          type: String
+                          description: |
+                            The value of the header to add.
+                          required: true
+                        - name: 'replace'
+                          type: Boolean
+                          description: |
+                            If false, headerValue is appended to any values that already exist for the
+                            header. If true, headerValue is set for the header, discarding any values that
+                            were set for that header.
+                          required: true
+                  - name: 'responseHeadersToRemove'
+                    type: Array
+                    description: |
+                      A list of header names for headers that need to be removed from the response
+                      prior to sending the response back to the client.
+                    item_type:
+                      type: String
+              - name: 'matchRules'
+                type: Array
+                description: |
+                  The rules for determining a match.
+                item_type:
+                  type: NestedObject
+                  properties:
+                    - name: 'fullPathMatch'
+                      type: String
+                      description: |
+                        For satisfying the matchRule condition, the path of the request must exactly
+                        match the value specified in fullPathMatch after removing any query parameters
+                        and anchor that may be part of the original URL. FullPathMatch must be between 1
+                        and 1024 characters. Only one of prefixMatch, fullPathMatch or regexMatch must
+                        be specified.
+                    - name: 'headerMatches'
+                      type: Array
+                      description: |
+                        Specifies a list of header match criteria, all of which must match corresponding
+                        headers in the request.
+                      item_type:
+                        type: NestedObject
+                        properties:
+                          - name: 'exactMatch'
+                            type: String
+                            description: |
+                              The value should exactly match contents of exactMatch. Only one of exactMatch,
+                              prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch must be set.
+                          - name: 'headerName'
+                            type: String
+                            description: |
+                              The name of the HTTP header to match. For matching against the HTTP request's
+                              authority, use a headerMatch with the header name ":authority". For matching a
+                              request's method, use the headerName ":method".
+                            required: true
+                          - name: 'invertMatch'
+                            type: Boolean
+                            description: |
+                              If set to false, the headerMatch is considered a match if the match criteria
+                              above are met. If set to true, the headerMatch is considered a match if the
+                              match criteria above are NOT met. Defaults to false.
+                            default_value: false
+                          - name: 'prefixMatch'
+                            type: String
+                            description: |
+                              The value of the header must start with the contents of prefixMatch. Only one of
+                              exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch
+                              must be set.
+                          - name: 'presentMatch'
+                            type: Boolean
+                            description: |
+                              A header with the contents of headerName must exist. The match takes place
+                              whether or not the request's header has a value or not. Only one of exactMatch,
+                              prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch must be set.
+                          - name: 'rangeMatch'
+                            type: NestedObject
+                            description: |
+                              The header value must be an integer and its value must be in the range specified
+                              in rangeMatch. If the header does not contain an integer, number or is empty,
+                              the match fails. For example for a range [-5, 0]   - -3 will match.  - 0 will
+                              not match.  - 0.25 will not match.  - -3someString will not match.   Only one of
+                              exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch
+                              must be set.
+                            properties:
+                              - name: 'rangeEnd'
+                                type: Integer
+                                description: |
+                                  The end of the range (exclusive).
+                                required: true
+                              - name: 'rangeStart'
+                                type: Integer
+                                description: |
+                                  The start of the range (inclusive).
+                                required: true
+                          - name: 'regexMatch'
+                            type: String
+                            description: |
+                              The value of the header must match the regular expression specified in
+                              regexMatch. For regular expression grammar, please see:
+                              en.cppreference.com/w/cpp/regex/ecmascript  For matching against a port
+                              specified in the HTTP request, use a headerMatch with headerName set to PORT and
+                              a regular expression that satisfies the RFC2616 Host header's port specifier.
+                              Only one of exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or
+                              rangeMatch must be set.
+                          - name: 'suffixMatch'
+                            type: String
+                            description: |
+                              The value of the header must end with the contents of suffixMatch. Only one of
+                              exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch
+                              must be set.
+                    - name: 'ignoreCase'
+                      type: Boolean
+                      description: |
+                        Specifies that prefixMatch and fullPathMatch matches are case sensitive.
+                        Defaults to false.
+                      default_value: false
+                    - name: 'metadataFilters'
+                      type: Array
+                      description: |
+                        Opaque filter criteria used by Loadbalancer to restrict routing configuration to
+                        a limited set xDS compliant clients. In their xDS requests to Loadbalancer, xDS
+                        clients present node metadata. If a match takes place, the relevant routing
+                        configuration is made available to those proxies. For each metadataFilter in
+                        this list, if its filterMatchCriteria is set to MATCH_ANY, at least one of the
+                        filterLabels must match the corresponding label provided in the metadata. If its
+                        filterMatchCriteria is set to MATCH_ALL, then all of its filterLabels must match
+                        with corresponding labels in the provided metadata. metadataFilters specified
+                        here can be overrides those specified in ForwardingRule that refers to this
+                        UrlMap. metadataFilters only applies to Loadbalancers that have their
+                        loadBalancingScheme set to INTERNAL_SELF_MANAGED.
+                      item_type:
+                        type: NestedObject
+                        properties:
+                          - name: 'filterLabels'
+                            type: Array
+                            description: |
+                              The list of label value pairs that must match labels in the provided metadata
+                              based on filterMatchCriteria  This list must not be empty and can have at the
+                              most 64 entries.
+                            required: true
+                            item_type:
+                              type: NestedObject
+                              properties:
+                                - name: 'name'
+                                  type: String
+                                  description: |
+                                    Name of metadata label. The name can have a maximum length of 1024 characters
+                                    and must be at least 1 character long.
+                                  required: true
+                                - name: 'value'
+                                  type: String
+                                  description: |
+                                    The value of the label must match the specified value. value can have a maximum
+                                    length of 1024 characters.
+                                  required: true
+                            min_size: 1
+                            max_size: 64
+                          - name: 'filterMatchCriteria'
+                            type: Enum
+                            description: |
+                              Specifies how individual filterLabel matches within the list of filterLabels
+                              contribute towards the overall metadataFilter match. Supported values are:
+                                - MATCH_ANY: At least one of the filterLabels must have a matching label in the
+                              provided metadata.
+                                - MATCH_ALL: All filterLabels must have matching labels in
+                              the provided metadata.
+                            required: true
+                            enum_values:
+                              - 'MATCH_ALL'
+                              - 'MATCH_ANY'
+                    - name: 'prefixMatch'
+                      type: String
+                      description: |
+                        For satisfying the matchRule condition, the request's path must begin with the
+                        specified prefixMatch. prefixMatch must begin with a /. The value must be
+                        between 1 and 1024 characters. Only one of prefixMatch, fullPathMatch or
+                        regexMatch must be specified.
+                    - name: 'queryParameterMatches'
+                      type: Array
+                      description: |
+                        Specifies a list of query parameter match criteria, all of which must match
+                        corresponding query parameters in the request.
+                      item_type:
+                        type: NestedObject
+                        properties:
+                          - name: 'exactMatch'
+                            type: String
+                            description: |
+                              The queryParameterMatch matches if the value of the parameter exactly matches
+                              the contents of exactMatch. Only one of presentMatch, exactMatch and regexMatch
+                              must be set.
+                          - name: 'name'
+                            type: String
+                            description: |
+                              The name of the query parameter to match. The query parameter must exist in the
+                              request, in the absence of which the request match fails.
+                            required: true
+                          - name: 'presentMatch'
+                            type: Boolean
+                            description: |
+                              Specifies that the queryParameterMatch matches if the request contains the query
+                              parameter, irrespective of whether the parameter has a value or not. Only one of
+                              presentMatch, exactMatch and regexMatch must be set.
+                          - name: 'regexMatch'
+                            type: String
+                            description: |
+                              The queryParameterMatch matches if the value of the parameter matches the
+                              regular expression specified by regexMatch. For the regular expression grammar,
+                              please see en.cppreference.com/w/cpp/regex/ecmascript  Only one of presentMatch,
+                              exactMatch and regexMatch must be set.
+                    - name: 'regexMatch'
+                      type: String
+                      description: |
+                        For satisfying the matchRule condition, the path of the request must satisfy the
+                        regular expression specified in regexMatch after removing any query parameters
+                        and anchor supplied with the original URL. For regular expression grammar please
+                        see en.cppreference.com/w/cpp/regex/ecmascript  Only one of prefixMatch,
+                        fullPathMatch or regexMatch must be specified.
+                    - name: 'pathTemplateMatch'
+                      type: String
+                      description: |
+                        For satisfying the matchRule condition, the path of the request
+                        must match the wildcard pattern specified in pathTemplateMatch
+                        after removing any query parameters and anchor that may be part
+                        of the original URL.
+
+                        pathTemplateMatch must be between 1 and 255 characters
+                        (inclusive).  The pattern specified by pathTemplateMatch may
+                        have at most 5 wildcard operators and at most 5 variable
+                        captures in total.
+              - name: 'routeAction'
+                type: NestedObject
+                description: |
+                  In response to a matching matchRule, the load balancer performs advanced routing
+                  actions like URL rewrites, header transformations, etc. prior to forwarding the
+                  request to the selected backend. If  routeAction specifies any
+                  weightedBackendServices, service must not be set. Conversely if service is set,
+                  routeAction cannot contain any  weightedBackendServices. Only one of routeAction
+                  or urlRedirect must be set.
+                properties:
+                  - name: 'corsPolicy'
+                    type: NestedObject
+                    description: |
+                      The specification for allowing client side cross-origin requests. Please see W3C
+                      Recommendation for Cross Origin Resource Sharing
+                    properties:
+                      - name: 'allowCredentials'
+                        type: Boolean
+                        description: |
+                          In response to a preflight request, setting this to true indicates that the
+                          actual request can include user credentials. This translates to the Access-
+                          Control-Allow-Credentials header. Defaults to false.
+                        default_value: false
+                      - name: 'allowHeaders'
+                        type: Array
+                        description: |
+                          Specifies the content for the Access-Control-Allow-Headers header.
+                        item_type:
+                          type: String
+                      - name: 'allowMethods'
+                        type: Array
+                        description: |
+                          Specifies the content for the Access-Control-Allow-Methods header.
+                        item_type:
+                          type: String
+                      - name: 'allowOriginRegexes'
+                        type: Array
+                        description: |
+                          Specifies the regular expression patterns that match allowed origins. For
+                          regular expression grammar please see en.cppreference.com/w/cpp/regex/ecmascript
+                          An origin is allowed if it matches either allow_origins or allow_origin_regex.
+                        item_type:
+                          type: String
+                      - name: 'allowOrigins'
+                        type: Array
+                        description: |
+                          Specifies the list of origins that will be allowed to do CORS requests. An
+                          origin is allowed if it matches either allow_origins or allow_origin_regex.
+                        item_type:
+                          type: String
+                      - name: 'disabled'
+                        type: Boolean
+                        description: |
+                          If true, specifies the CORS policy is disabled.
+                          which indicates that the CORS policy is in effect. Defaults to false.
+                        default_value: false
+                      - name: 'exposeHeaders'
+                        type: Array
+                        description: |
+                          Specifies the content for the Access-Control-Expose-Headers header.
+                        item_type:
+                          type: String
+                      - name: 'maxAge'
+                        type: Integer
+                        description: |
+                          Specifies how long the results of a preflight request can be cached. This
+                          translates to the content for the Access-Control-Max-Age header.
+                  - name: 'faultInjectionPolicy'
+                    type: NestedObject
+                    description: |
+                      The specification for fault injection introduced into traffic to test the
+                      resiliency of clients to backend service failure. As part of fault injection,
+                      when clients send requests to a backend service, delays can be introduced by
+                      Loadbalancer on a percentage of requests before sending those request to the
+                      backend service. Similarly requests from clients can be aborted by the
+                      Loadbalancer for a percentage of requests. timeout and retry_policy will be
+                      ignored by clients that are configured with a fault_injection_policy.
+                    properties:
+                      - name: 'abort'
+                        type: NestedObject
+                        description: |
+                          The specification for how client requests are aborted as part of fault
+                          injection.
+                        properties:
+                          - name: 'httpStatus'
+                            type: Integer
+                            description: |
+                              The HTTP status code used to abort the request. The value must be between 200
+                              and 599 inclusive.
+                          - name: 'percentage'
+                            type: Double
+                            description: |
+                              The percentage of traffic (connections/operations/requests) which will be
+                              aborted as part of fault injection. The value must be between 0.0 and 100.0
+                              inclusive.
+                      - name: 'delay'
+                        type: NestedObject
+                        description: |
+                          The specification for how client requests are delayed as part of fault
+                          injection, before being sent to a backend service.
+                        properties:
+                          - name: 'fixedDelay'
+                            type: NestedObject
+                            description: |
+                              Specifies the value of the fixed delay interval.
+                            properties:
+                              - name: 'nanos'
+                                type: Integer
+                                description: |
+                                  Span of time that's a fraction of a second at nanosecond resolution. Durations
+                                  less than one second are represented with a 0 `seconds` field and a positive
+                                  `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                              - name: 'seconds'
+                                type: String
+                                description: |
+                                  Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                                  inclusive.
+                                required: true
+                          - name: 'percentage'
+                            type: Double
+                            description: |
+                              The percentage of traffic (connections/operations/requests) on which delay will
+                              be introduced as part of fault injection. The value must be between 0.0 and
+                              100.0 inclusive.
+                  - name: 'requestMirrorPolicy'
+                    type: NestedObject
+                    description: |
+                      Specifies the policy on how requests intended for the route's backends are
+                      shadowed to a separate mirrored backend service. Loadbalancer does not wait for
+                      responses from the shadow service. Prior to sending traffic to the shadow
+                      service, the host / authority header is suffixed with -shadow.
+                    properties:
+                      - name: 'backendService'
+                        type: ResourceRef
+                        description: |
+                          The BackendService resource being mirrored to.
+                        required: true
+                        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+                        resource: 'BackendService'
+                        imports: 'selfLink'
+                      - name: 'mirrorPercent'
+                        min_version: beta
+                        type: Double
+                        description: |
+                          The percentage of requests to be mirrored to backendService.
+                          The value must be between 0.0 and 100.0 inclusive.
+                        validation:
+                          function: 'validation.FloatBetween(0, 100)'
+                  - name: 'retryPolicy'
+                    type: NestedObject
+                    description: |
+                      Specifies the retry policy associated with this route.
+                    properties:
+                      - name: 'numRetries'
+                        type: Integer
+                        description: |
+                          Specifies the allowed number retries. This number must be > 0.
+                        required: true
+                      - name: 'perTryTimeout'
+                        type: NestedObject
+                        description: |
+                          Specifies a non-zero timeout per retry attempt.
+                          If not specified, will use the timeout set in HttpRouteAction. If timeout in HttpRouteAction
+                          is not set, will use the largest timeout among all backend services associated with the route.
+                        properties:
+                          - name: 'nanos'
+                            type: Integer
+                            description: |
+                              Span of time that's a fraction of a second at nanosecond resolution. Durations
+                              less than one second are represented with a 0 `seconds` field and a positive
+                              `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                          - name: 'seconds'
+                            type: String
+                            description: |
+                              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                              inclusive.
+                            required: true
+                      - name: 'retryConditions'
+                        type: Array
+                        description: |
+                          Specfies one or more conditions when this retry rule applies. Valid values are:
+
+                          * 5xx: Loadbalancer will attempt a retry if the backend service responds with
+                            any 5xx response code, or if the backend service does not respond at all,
+                            for example: disconnects, reset, read timeout, connection failure, and refused
+                            streams.
+                          * gateway-error: Similar to 5xx, but only applies to response codes
+                            502, 503 or 504.
+                          * connect-failure: Loadbalancer will retry on failures
+                            connecting to backend services, for example due to connection timeouts.
+                          * retriable-4xx: Loadbalancer will retry for retriable 4xx response codes.
+                            Currently the only retriable error supported is 409.
+                          * refused-stream: Loadbalancer will retry if the backend service resets the stream with a
+                            REFUSED_STREAM error code. This reset type indicates that it is safe to retry.
+                          * cancelled: Loadbalancer will retry if the gRPC status code in the response
+                            header is set to cancelled
+                          * deadline-exceeded: Loadbalancer will retry if the
+                            gRPC status code in the response header is set to deadline-exceeded
+                          * resource-exhausted: Loadbalancer will retry if the gRPC status code in the response
+                            header is set to resource-exhausted
+                          * unavailable: Loadbalancer will retry if the gRPC status code in
+                            the response header is set to unavailable
+                        item_type:
+                          type: String
+                  - name: 'timeout'
+                    type: NestedObject
+                    description: |
+                      Specifies the timeout for the selected route. Timeout is computed from the time
+                      the request is has been fully processed (i.e. end-of-stream) up until the
+                      response has been completely processed. Timeout includes all retries. If not
+                      specified, the default value is 15 seconds.
+                    properties:
+                      - name: 'nanos'
+                        type: Integer
+                        description: |
+                          Span of time that's a fraction of a second at nanosecond resolution. Durations
+                          less than one second are represented with a 0 `seconds` field and a positive
+                          `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                      - name: 'seconds'
+                        type: String
+                        description: |
+                          Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                          inclusive.
+                        required: true
+                  - name: 'maxStreamDuration'
+                    type: NestedObject
+                    description: |
+                      Specifies the maximum duration (timeout) for streams on the selected route.
+                      Unlike the `Timeout` field where the timeout duration starts from the time the request
+                      has been fully processed (known as end-of-stream), the duration in this field
+                      is computed from the beginning of the stream until the response has been processed,
+                      including all retries. A stream that does not complete in this duration is closed.
+                    default_from_api: true
+                    properties:
+                      - name: 'nanos'
+                        type: Integer
+                        description: |
+                          Span of time that's a fraction of a second at nanosecond resolution. Durations
+                          less than one second are represented with a 0 `seconds` field and a positive
+                          `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                      - name: 'seconds'
+                        type: String
+                        description: |
+                          Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                          inclusive.
+                        required: true
+                  - name: 'urlRewrite'
+                    type: NestedObject
+                    description: |
+                      The spec to modify the URL of the request, prior to forwarding the request to
+                      the matched service
+                    properties:
+                      - name: 'hostRewrite'
+                        type: String
+                        description: |
+                          Prior to forwarding the request to the selected service, the request's host
+                          header is replaced with contents of hostRewrite. The value must be between 1 and
+                          255 characters.
+                      - name: 'pathPrefixRewrite'
+                        type: String
+                        description: |
+                          Prior to forwarding the request to the selected backend service, the matching
+                          portion of the request's path is replaced by pathPrefixRewrite. The value must
+                          be between 1 and 1024 characters.
+                      - name: 'pathTemplateRewrite'
+                        type: String
+                        description: |
+                          Prior to forwarding the request to the selected origin, if the
+                          request matched a pathTemplateMatch, the matching portion of the
+                          request's path is replaced re-written using the pattern specified
+                          by pathTemplateRewrite.
+
+                          pathTemplateRewrite must be between 1 and 255 characters
+                          (inclusive), must start with a '/', and must only use variables
+                          captured by the route's pathTemplate matchers.
+
+                          pathTemplateRewrite may only be used when all of a route's
+                          MatchRules specify pathTemplate.
+
+                          Only one of pathPrefixRewrite and pathTemplateRewrite may be
+                          specified.
+                  - name: 'weightedBackendServices'
+                    type: Array
+                    description: |
+                      A list of weighted backend services to send traffic to when a route match
+                      occurs. The weights determine the fraction of traffic that flows to their
+                      corresponding backend service. If all traffic needs to go to a single backend
+                      service, there must be one  weightedBackendService with weight set to a non 0
+                      number. Once a backendService is identified and before forwarding the request to
+                      the backend service, advanced routing actions like Url rewrites and header
+                      transformations are applied depending on additional settings specified in this
+                      HttpRouteAction.
+                    item_type:
+                      type: NestedObject
+                      properties:
+                        - name: 'backendService'
+                          type: ResourceRef
+                          description: |
+                            The default BackendService resource. Before
+                            forwarding the request to backendService, the loadbalancer applies any relevant
+                            headerActions specified as part of this backendServiceWeight.
+                          required: true
+                          custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+                          resource: 'BackendService'
+                          imports: 'selfLink'
+                        - name: 'headerAction'
+                          type: NestedObject
+                          description: |
+                            Specifies changes to request and response headers that need to take effect for
+                            the selected backendService. headerAction specified here take effect before
+                            headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap.
+                          properties:
+                            - name: 'requestHeadersToAdd'
+                              type: Array
+                              description: |
+                                Headers to add to a matching request prior to forwarding the request to the
+                                backendService.
+                              item_type:
+                                type: NestedObject
+                                properties:
+                                  - name: 'headerName'
+                                    type: String
+                                    description: |
+                                      The name of the header.
+                                    required: true
+                                  - name: 'headerValue'
+                                    type: String
+                                    description: |
+                                      The value of the header to add.
+                                    required: true
+                                  - name: 'replace'
+                                    type: Boolean
+                                    description: |
+                                      If false, headerValue is appended to any values that already exist for the
+                                      header. If true, headerValue is set for the header, discarding any values that
+                                      were set for that header.
+                                    required: true
+                            - name: 'requestHeadersToRemove'
+                              type: Array
+                              description: |
+                                A list of header names for headers that need to be removed from the request
+                                prior to forwarding the request to the backendService.
+                              item_type:
+                                type: String
+                            - name: 'responseHeadersToAdd'
+                              type: Array
+                              description: |
+                                Headers to add the response prior to sending the response back to the client.
+                              item_type:
+                                type: NestedObject
+                                properties:
+                                  - name: 'headerName'
+                                    type: String
+                                    description: |
+                                      The name of the header.
+                                    required: true
+                                  - name: 'headerValue'
+                                    type: String
+                                    description: |
+                                      The value of the header to add.
+                                    required: true
+                                  - name: 'replace'
+                                    type: Boolean
+                                    description: |
+                                      If false, headerValue is appended to any values that already exist for the
+                                      header. If true, headerValue is set for the header, discarding any values that
+                                      were set for that header.
+                                    required: true
+                            - name: 'responseHeadersToRemove'
+                              type: Array
+                              description: |
+                                A list of header names for headers that need to be removed from the response
+                                prior to sending the response back to the client.
+                              item_type:
+                                type: String
+                        - name: 'weight'
+                          type: Integer
+                          description: |
+                            Specifies the fraction of traffic sent to backendService, computed as weight /
+                            (sum of all weightedBackendService weights in routeAction) . The selection of a
+                            backend service is determined only for new traffic. Once a user's request has
+                            been directed to a backendService, subsequent requests will be sent to the same
+                            backendService as determined by the BackendService's session affinity policy.
+                            The value must be between 0 and 1000
+                          required: true
+                  - name: 'cachePolicy'
+                    type: NestedObject
+                    description: |
+                      Specifies the cache policy configuration for matched traffic. Available
+                      only for Global EXTERNAL_MANAGED load balancer schemes. At least one
+                      property must be specified. This policy cannot be specified if any target
+                      backend has Identity-Aware Proxy enabled.
+                    properties:
+                      - name: 'cacheMode'
+                        type: Enum
+                        is_missing_in_cai: true
+                        description: |
+                          Specifies the cache setting for all responses from this route. If not
+                          specified, Cloud CDN uses CACHE_ALL_STATIC mode.
+                        enum_values:
+                          - 'USE_ORIGIN_HEADERS'
+                          - 'FORCE_CACHE_ALL'
+                          - 'CACHE_ALL_STATIC'
+                      - name: 'defaultTtl'
+                        type: NestedObject
+                        is_missing_in_cai: true
+                        description: |
+                          Specifies the default TTL for cached content for responses that do not have
+                          an existing valid TTL (max-age or s-maxage). Setting a TTL of "0" means
+                          "always revalidate". The value of defaultTtl cannot be set to a value
+                          greater than that of maxTtl. When the cacheMode is set to
+                          FORCE_CACHE_ALL, the defaultTtl will overwrite the TTL set in all
+                          responses. The maximum allowed value is 31,622,400s (1 year). Infrequently
+                          accessed objects may be evicted from the cache before the defined TTL. If
+                          not specified, Cloud CDN uses 3600s (1 hour) for CACHE_ALL_STATIC and
+                          FORCE_CACHE_ALL modes. Cannot be specified when cacheMode is
+                          USE_ORIGIN_HEADERS.
+                        properties:
+                          - name: 'seconds'
+                            type: String
+                            required: true
+                            description: |
+                              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                          - name: 'nanos'
+                            type: Integer
+                            ignore_read: true
+                            description: |
+                              Span of time that's a fraction of a second at nanosecond resolution.
+                            validation:
+                              function: 'validation.IntBetween(0, 0)'
+                      - name: 'maxTtl'
+                        type: NestedObject
+                        is_missing_in_cai: true
+                        description: |
+                          Specifies the maximum allowed TTL for cached content. Cache directives that
+                          attempt to set a max-age or s-maxage higher than this, or an Expires header
+                          more than maxTtl seconds in the future will be capped at the value of
+                          maxTtl, as if it were the value of an s-maxage Cache-Control directive.
+                          Headers sent to the client will not be modified. Setting a TTL of "0" means
+                          "always revalidate". The maximum allowed value is 31,622,400s (1 year).
+                          Infrequently accessed objects may be evicted from the cache before the
+                          defined TTL. If not specified, Cloud CDN uses 86400s (1 day) for
+                          CACHE_ALL_STATIC mode. Can be specified only for CACHE_ALL_STATIC cache
+                          mode.
+                        properties:
+                          - name: 'seconds'
+                            type: String
+                            required: true
+                            description: |
+                              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                          - name: 'nanos'
+                            type: Integer
+                            ignore_read: true
+                            description: |
+                              Span of time that's a fraction of a second at nanosecond resolution.
+                            validation:
+                              function: 'validation.IntBetween(0, 0)'
+                      - name: 'clientTtl'
+                        type: NestedObject
+                        is_missing_in_cai: true
+                        description: |
+                          Specifies a separate client (e.g. browser client) maximum TTL for cached
+                          content. This is used to clamp the max-age (or Expires) value sent to the
+                          client. With FORCE_CACHE_ALL, the lesser of clientTtl and defaultTtl
+                          is used for the response max-age directive, along with a "public"
+                          directive. For cacheable content in CACHE_ALL_STATIC mode, clientTtl
+                          clamps the max-age from the origin (if specified), or else sets the
+                          response max-age directive to the lesser of the clientTtl and defaultTtl,
+                          and also ensures a "public" cache-control directive is present. The maximum
+                          allowed value is 31,622,400s (1 year). If not specified, Cloud CDN uses
+                          3600s (1 hour) for CACHE_ALL_STATIC mode. Cannot exceed maxTtl.
+                          Cannot be specified when cacheMode is USE_ORIGIN_HEADERS.
+                        properties:
+                          - name: 'seconds'
+                            type: String
+                            required: true
+                            description: |
+                              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                          - name: 'nanos'
+                            type: Integer
+                            ignore_read: true
+                            description: |
+                              Span of time that's a fraction of a second at nanosecond resolution.
+                            validation:
+                              function: 'validation.IntBetween(0, 0)'
+                      - name: 'requestCoalescing'
+                        type: Boolean
+                        is_missing_in_cai: true
+                        send_empty_value: true
+                        description: |
+                          If true then Cloud CDN will combine multiple concurrent cache fill
+                          requests into a small number of requests to the origin. If not specified,
+                          Cloud CDN applies request coalescing by default.
+                      - name: 'negativeCaching'
+                        type: Boolean
+                        is_missing_in_cai: true
+                        send_empty_value: true
+                        description: |
+                          Negative caching allows per-status code TTLs to be set, in order to apply
+                          fine-grained caching for common errors or redirects. This can reduce the
+                          load on your origin and improve end-user experience by reducing response
+                          latency. When the cacheMode is set to CACHE_ALL_STATIC or
+                          USE_ORIGIN_HEADERS, negative caching applies to responses with the
+                          specified response code that lack any Cache-Control, Expires, or
+                          Pragma: no-cache directives. When the cacheMode is set to
+                          FORCE_CACHE_ALL, negative caching applies to all responses with the
+                          specified response code, and overrides any caching headers. By default,
+                          Cloud CDN applies the following TTLs to these HTTP status codes:
+                          * 300 (Multiple Choice), 301, 308 (Permanent Redirects): 10m
+                          * 404 (Not Found), 410 (Gone), 451 (Unavailable For Legal Reasons): 120s
+                          * 405 (Method Not Found), 501 (Not Implemented): 60s
+                          These defaults can be overridden in negativeCachingPolicy. If not
+                          specified, Cloud CDN applies negative caching by default.
+                      - name: 'negativeCachingPolicy'
+                        type: Array
+                        is_missing_in_cai: true
+                        send_empty_value: true
+                        description: |
+                          Sets a cache TTL for the specified HTTP status code. negativeCaching
+                          must be enabled to configure negativeCachingPolicy. Omitting the policy
+                          and leaving negativeCaching enabled will use Cloud CDN's default cache
+                          TTLs. Note that when specifying an explicit negativeCachingPolicy, you
+                          should take care to specify a cache TTL for all response codes that you
+                          wish to cache. Cloud CDN will not apply any default negative caching when
+                          a policy exists.
+                        item_type:
+                          type: NestedObject
+                          properties:
+                            - name: 'code'
+                              type: Integer
+                              description: |
+                                The HTTP status code to define a TTL against. Only HTTP status codes
+                                300, 301, 302, 307, 308, 404, 405, 410, 421, 451 and 501 can be
+                                specified as values, and you cannot specify a status code more than
+                                once.
+                            - name: 'ttl'
+                              type: NestedObject
+                              description: |
+                                The TTL (in seconds) for which to cache responses with the
+                                corresponding status code. The maximum allowed value is 1800s (30
+                                minutes). Infrequently accessed objects may be evicted from the cache
+                                before the defined TTL.
+                              properties:
+                                - name: 'seconds'
+                                  type: String
+                                  required: true
+                                  description: |
+                                    Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                                - name: 'nanos'
+                                  type: Integer
+                                  ignore_read: true
+                                  description: |
+                                    Span of time that's a fraction of a second at nanosecond resolution.
+                                  validation:
+                                    function: 'validation.IntBetween(0, 0)'
+                      - name: 'cacheBypassRequestHeaderNames'
+                        type: Array
+                        is_missing_in_cai: true
+                        description: |
+                          Bypass the cache when the specified request headers are matched by name,
+                          e.g. Pragma or Authorization headers. Values are case-insensitive. Up to 5
+                          header names can be specified. The cache is bypassed for all cacheMode
+                          values.
+                        item_type:
+                          type: String
+                      - name: 'serveWhileStale'
+                        type: NestedObject
+                        is_missing_in_cai: true
+                        description: |
+                          Serve existing content from the cache (if available) when revalidating
+                          content with the origin, or when an error is encountered when refreshing
+                          the cache. This setting defines the default "max-stale" duration for any
+                          cached responses that do not specify a max-stale directive. Stale
+                          responses that exceed the TTL configured here will not be served. The
+                          default limit (max-stale) is 86400s (1 day), which will allow stale
+                          content to be served up to this limit beyond the max-age (or s-maxage) of
+                          a cached response. The maximum allowed value is 604800 (1 week). Set this
+                          to zero (0) to disable serve-while-stale.
+                        properties:
+                          - name: 'seconds'
+                            type: String
+                            required: true
+                            description: |
+                              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                          - name: 'nanos'
+                            type: Integer
+                            ignore_read: true
+                            description: |
+                              Span of time that's a fraction of a second at nanosecond resolution.
+                            validation:
+                              function: 'validation.IntBetween(0, 0)'
+                      - name: 'cacheKeyPolicy'
+                        type: NestedObject
+                        description: |
+                          The cache key configuration. If not specified, the default behavior depends
+                          on the backend type: for Backend Services, the complete request URI is
+                          used; for Backend Buckets, the request URI is used without the protocol or
+                          host, and only query parameters known to Cloud Storage are included.
+                        properties:
+                          - name: 'includeProtocol'
+                            type: Boolean
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              If true, http and https requests will be cached separately. Note: This
+                              setting is only applicable to routes that use a Backend Service. It
+                              does not affect requests served by a Backend Bucket, as the protocol is
+                              never included in a Backend Bucket's cache key. Attempting to set on a
+                              route that points exclusively to Backend Buckets will result in a
+                              configuration error.
+                          - name: 'includeHost'
+                            type: Boolean
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              If true, requests to different hosts will be cached separately. Note:
+                              This setting is only applicable to routes that use a Backend Service.
+                              It does not affect requests served by a Backend Bucket, as the host is
+                              never included in a Backend Bucket's cache key. Attempting to set it on
+                              a route that points exclusively to Backend Buckets will result in a
+                              configuration error.
+                          - name: 'includeQueryString'
+                            type: Boolean
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              If true, include query string parameters in the cache key according to
+                              includedQueryParameters and excludedQueryParameters. If neither is
+                              set, the entire query string will be included. If false, the query
+                              string will be excluded from the cache key entirely. Note: This field
+                              applies to routes that use backend services. Attempting to set it on a
+                              route that points exclusively to Backend Buckets will result in a
+                              configuration error. For routes that point to a Backend Bucket, use
+                              includedQueryParameters to define which parameters should be part of
+                              the cache key.
+                          - name: 'includedQueryParameters'
+                            type: Array
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              Names of query string parameters to include in cache keys. All other
+                              parameters will be excluded. Either specify includedQueryParameters
+                              or excludedQueryParameters, not both. '&' and '=' will be percent
+                              encoded and not treated as delimiters.
+                            item_type:
+                              type: String
+                          - name: 'excludedQueryParameters'
+                            type: Array
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              Names of query string parameters to exclude in cache keys. All other
+                              parameters will be included. Either specify excludedQueryParameters
+                              or includedQueryParameters, not both. '&' and '=' will be percent
+                              encoded and not treated as delimiters. Note: This field applies to
+                              routes that use backend services. Attempting to set it on a route that
+                              points exclusively to Backend Buckets will result in a configuration
+                              error. For routes that point to a Backend Bucket, use
+                              includedQueryParameters to define which parameters should be part of
+                              the cache key.
+                            item_type:
+                              type: String
+                          - name: 'includedHeaderNames'
+                            type: Array
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              Allows HTTP request headers (by name) to be used in the cache key.
+                            item_type:
+                              type: String
+                          - name: 'includedCookieNames'
+                            type: Array
+                            send_empty_value: true
+                            is_missing_in_cai: true
+                            description: |
+                              Allows HTTP cookies (by name) to be used in the cache key. The
+                              name=value pair will be used in the cache key Cloud CDN generates.
+                              Note: This setting is only applicable to routes that use a Backend
+                              Service. It does not affect requests served by a Backend Bucket.
+                              Attempting to set it on a route that points exclusively to Backend
+                              Buckets will result in a configuration error. Up to 5 cookie names can
+                              be specified.
+                            item_type:
+                              type: String
+              - name: 'urlRedirect'
+                type: NestedObject
+                description: |
+                  When this rule is matched, the request is redirected to a URL specified by
+                  urlRedirect. If urlRedirect is specified, service or routeAction must not be
+                  set.
+                properties:
+                  - name: 'hostRedirect'
+                    type: String
+                    description: |
+                      The host that will be used in the redirect response instead of the one that was
+                      supplied in the request. The value must be between 1 and 255 characters.
+                  - name: 'httpsRedirect'
+                    type: Boolean
+                    description: |
+                      If set to true, the URL scheme in the redirected request is set to https. If set
+                      to false, the URL scheme of the redirected request will remain the same as that
+                      of the request. This must only be set for UrlMaps used in TargetHttpProxys.
+                      Setting this true for TargetHttpsProxy is not permitted. Defaults to false.
+                    default_value: false
+                  - name: 'pathRedirect'
+                    type: String
+                    description: |
+                      The path that will be used in the redirect response instead of the one that was
+                      supplied in the request. Only one of pathRedirect or prefixRedirect must be
+                      specified. The value must be between 1 and 1024 characters.
+                  - name: 'prefixRedirect'
+                    type: String
+                    description: |
+                      The prefix that replaces the prefixMatch specified in the HttpRouteRuleMatch,
+                      retaining the remaining portion of the URL before redirecting the request.
+                  - name: 'redirectResponseCode'
+                    type: Enum
+                    description: |
+                      The HTTP Status code to use for this RedirectAction. Supported values are:
+
+                      * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+
+                      * FOUND, which corresponds to 302.
+
+                      * SEE_OTHER which corresponds to 303.
+
+                      * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method will be retained.
+
+                      * PERMANENT_REDIRECT, which corresponds to 308. In this case, the request method will be retained.
+                    enum_values:
+                      - 'FOUND'
+                      - 'MOVED_PERMANENTLY_DEFAULT'
+                      - 'PERMANENT_REDIRECT'
+                      - 'SEE_OTHER'
+                      - 'TEMPORARY_REDIRECT'
+                    exclude_docs_values: true
+                  - name: 'stripQuery'
+                    type: Boolean
+                    description: |
+                      If set to true, any accompanying query portion of the original URL is removed
+                      prior to redirecting the request. If set to false, the query portion of the
+                      original URL is retained. Defaults to false.
+                    default_value: false
+              - name: 'customErrorResponsePolicy'
+                type: NestedObject
+                description: |
+                  customErrorResponsePolicy specifies how the Load Balancer returns error responses when BackendService or BackendBucket responds with an error.
+                properties:
+                  - name: 'errorResponseRule'
+                    type: Array
+                    description: |
+                      Specifies rules for returning error responses.
+                      In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority.
+                      For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX).
+                      If the backend service returns a 401, then the rule for 401 will be applied. However if the backend service returns a 403, the rule for 4xx takes effect.
+                    api_name: errorResponseRules
+                    item_type:
+                      type: NestedObject
+                      properties:
+                        - name: 'matchResponseCodes'
+                          type: Array
+                          description: |
+                            Valid values include:
+
+                            - A number between 400 and 599: For example 401 or 503, in which case the load balancer applies the policy if the error code exactly matches this value.
+                            - 5xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 500 to 599.
+                            - 4xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 400 to 499.
+
+                            Values must be unique within matchResponseCodes and across all errorResponseRules of CustomErrorResponsePolicy.
+                          item_type:
+                            type: String
+                        - name: 'path'
+                          type: String
+                          description: |
+                            The full path to a file within backendBucket . For example: /errors/defaultError.html
+                            path must start with a leading slash. path cannot have trailing slashes.
+                            If the file is not available in backendBucket or the load balancer cannot reach the BackendBucket, a simple Not Found Error is returned to the client.
+                            The value must be from 1 to 1024 characters
+                        - name: 'overrideResponseCode'
+                          type: Integer
+                          description: |
+                            The HTTP status code returned with the response containing the custom error content.
+                            If overrideResponseCode is not supplied, the same response code returned by the original backend bucket or backend service is returned to the client.
+                  - name: 'errorService'
+                    type: ResourceRef
+                    description: |
+                      The full or partial URL to the BackendBucket resource that contains the custom error content. Examples are:
+
+                      https://www.googleapis.com/compute/v1/projects/project/global/backendBuckets/myBackendBucket
+                      compute/v1/projects/project/global/backendBuckets/myBackendBucket
+                      global/backendBuckets/myBackendBucket
+
+                      If errorService is not specified at lower levels like pathMatcher, pathRule and routeRule, an errorService specified at a higher level in the UrlMap will be used. If UrlMap.defaultCustomErrorResponsePolicy contains one or more errorResponseRules[], it must specify errorService.
+                      If load balancer cannot reach the backendBucket, a simple Not Found Error will be returned, with the original response code (or overrideResponseCode if configured).
+                    resource: 'BackendBucket'
+                    imports: 'selfLink'
+              - name: 'httpFilterConfigs'
+                type: Array
+                min_version: 'beta'
+                is_missing_in_cai: true
+                description: |
+                  Outbound route specific configuration for networkservices.HttpFilter resources enabled by Traffic Director.
+                  httpFilterConfigs only applies for load balancers with loadBalancingScheme set to INTERNAL_SELF_MANAGED.
+                  See ForwardingRule for more details.
+
+                  Not supported when the URL map is bound to a target gRPC proxy that has validateForProxyless field set to true.
+                item_type:
+                  type: NestedObject
+                  properties:
+                    - name: 'filterName'
+                      type: String
+                      description: |
+                        Name of the networkservices.HttpFilter resource this configuration belongs to.
+                        This name must be known to the xDS client. Example: envoy.wasm
+                    - name: 'configTypeUrl'
+                      type: String
+                      description: |
+                        The fully qualified versioned proto3 type url of the protobuf that the filter expects for its contextual settings,
+                        for example: type.googleapis.com/google.protobuf.Struct
+                    - name: 'config'
+                      type: String
+                      description: |
+                        The configuration needed to enable the networkservices.HttpFilter resource.
+                        The configuration must be YAML formatted and only contain fields defined in the protobuf identified in configTypeUrl
+              - name: 'httpFilterMetadata'
+                type: Array
+                min_version: 'beta'
+                is_missing_in_cai: true
+                description: |
+                  Outbound route specific metadata supplied to networkservices.HttpFilter resources enabled by Traffic Director.
+                  httpFilterMetadata only applies for load balancers with loadBalancingScheme set to INTERNAL_SELF_MANAGED.
+                  See ForwardingRule for more details.
+
+                  Not supported when the URL map is bound to a target gRPC proxy that has validateForProxyless field set to true.
+                item_type:
+                  type: NestedObject
+                  properties:
+                    - name: 'filterName'
+                      type: String
+                      description: |
+                        Name of the networkservices.HttpFilter resource this configuration belongs to.
+                        This name must be known to the xDS client. Example: envoy.wasm
+                    - name: 'configTypeUrl'
+                      type: String
+                      description: |
+                        The fully qualified versioned proto3 type url of the protobuf that the filter expects for its contextual settings,
+                        for example: type.googleapis.com/google.protobuf.Struct
+                    - name: 'config'
+                      type: String
+                      description: |
+                        The configuration needed to enable the networkservices.HttpFilter resource.
+                        The configuration must be YAML formatted and only contain fields defined in the protobuf identified in configTypeUrl
+        - name: 'defaultUrlRedirect'
+          type: NestedObject
+          # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.
+          # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
+          # exactly_one_of:
+          #   - path_matchers.0.default_service
+          #   - path_matchers.0.default_url_redirect
+          #   - path_matchers.0.default_route_action.0.weighted_backend_services
+          description: |
+            When none of the specified hostRules match, the request is redirected to a URL specified
+            by defaultUrlRedirect. If defaultUrlRedirect is specified, defaultService or
+            defaultRouteAction must not be set.
+          properties:
+            - name: 'hostRedirect'
+              type: String
+              description: |
+                The host that will be used in the redirect response instead of the one that was
+                supplied in the request. The value must be between 1 and 255 characters.
+            - name: 'httpsRedirect'
+              type: Boolean
+              description: |
+                If set to true, the URL scheme in the redirected request is set to https. If set to
+                false, the URL scheme of the redirected request will remain the same as that of the
+                request. This must only be set for UrlMaps used in TargetHttpProxys. Setting this
+                true for TargetHttpsProxy is not permitted. The default is set to false.
+              default_value: false
+            - name: 'pathRedirect'
+              type: String
+              description: |
+                The path that will be used in the redirect response instead of the one that was
+                supplied in the request. pathRedirect cannot be supplied together with
+                prefixRedirect. Supply one alone or neither. If neither is supplied, the path of the
+                original request will be used for the redirect. The value must be between 1 and 1024
+                characters.
+            - name: 'prefixRedirect'
+              type: String
+              description: |
+                The prefix that replaces the prefixMatch specified in the HttpRouteRuleMatch,
+                retaining the remaining portion of the URL before redirecting the request.
+                prefixRedirect cannot be supplied together with pathRedirect. Supply one alone or
+                neither. If neither is supplied, the path of the original request will be used for
+                the redirect. The value must be between 1 and 1024 characters.
+            - name: 'redirectResponseCode'
+              type: Enum
+              description: |
+                The HTTP Status code to use for this RedirectAction. Supported values are:
+
+                * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+
+                * FOUND, which corresponds to 302.
+
+                * SEE_OTHER which corresponds to 303.
+
+                * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+                will be retained.
+
+                * PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                the request method will be retained.
+              enum_values:
+                - 'FOUND'
+                - 'MOVED_PERMANENTLY_DEFAULT'
+                - 'PERMANENT_REDIRECT'
+                - 'SEE_OTHER'
+                - 'TEMPORARY_REDIRECT'
+              exclude_docs_values: true
+            - name: 'stripQuery'
+              type: Boolean
+              description: |
+                If set to true, any accompanying query portion of the original URL is removed prior
+                to redirecting the request. If set to false, the query portion of the original URL is
+                retained.
+                 This field is required to ensure an empty block is not set. The normal default value is false.
+              required: true
+        - name: 'defaultRouteAction'
+          type: NestedObject
+          # TODO: (mbang) conflicts also won't work for array path matchers yet, uncomment here once supported.
+          # conflicts:
+          #   - path_matcher.path_matcher.default_url_redirect
+          description: |
+            defaultRouteAction takes effect when none of the pathRules or routeRules match. The load balancer performs
+            advanced routing actions like URL rewrites, header transformations, etc. prior to forwarding the request
+            to the selected backend. If defaultRouteAction specifies any weightedBackendServices, defaultService must not be set.
+            Conversely if defaultService is set, defaultRouteAction cannot contain any weightedBackendServices.
+
+            Only one of defaultRouteAction or defaultUrlRedirect must be set.
+          properties:
+            - name: 'weightedBackendServices'
+              type: Array
+              # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.
+              # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
+              # exactly_one_of:
+              #   - path_matchers.0.default_service
+              #   - path_matchers.0.default_url_redirect
+              #   - path_matchers.0.default_route_action.0.weighted_backend_services
+              description: |
+                A list of weighted backend services to send traffic to when a route match occurs.
+                The weights determine the fraction of traffic that flows to their corresponding backend service.
+                If all traffic needs to go to a single backend service, there must be one weightedBackendService
+                with weight set to a non 0 number.
+
+                Once a backendService is identified and before forwarding the request to the backend service,
+                advanced routing actions like Url rewrites and header transformations are applied depending on
+                additional settings specified in this HttpRouteAction.
+              item_type:
+                type: NestedObject
+                properties:
+                  - name: 'backendService'
+                    type: ResourceRef
+                    description: |
+                      The full or partial URL to the default BackendService resource. Before forwarding the
+                      request to backendService, the loadbalancer applies any relevant headerActions
+                      specified as part of this backendServiceWeight.
+                    custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+                    resource: 'BackendService'
+                    imports: 'selfLink'
+                  - name: 'weight'
+                    type: Integer
+                    description: |
+                      Specifies the fraction of traffic sent to backendService, computed as
+                      weight / (sum of all weightedBackendService weights in routeAction) .
+
+                      The selection of a backend service is determined only for new traffic. Once a user's request
+                      has been directed to a backendService, subsequent requests will be sent to the same backendService
+                      as determined by the BackendService's session affinity policy.
+
+                      The value must be between 0 and 1000
+                    validation:
+                      function: 'validation.IntBetween(0, 1000)'
+                  - name: 'headerAction'
+                    type: NestedObject
+                    description: |
+                      Specifies changes to request and response headers that need to take effect for
+                      the selected backendService.
+
+                      headerAction specified here take effect before headerAction in the enclosing
+                      HttpRouteRule, PathMatcher and UrlMap.
+                    properties:
+                      - name: 'requestHeadersToRemove'
+                        type: Array
+                        description: |
+                          A list of header names for headers that need to be removed from the request prior to
+                          forwarding the request to the backendService.
+                        item_type:
+                          type: String
+                      - name: 'requestHeadersToAdd'
+                        type: Array
+                        description: |
+                          Headers to add to a matching request prior to forwarding the request to the backendService.
+                        item_type:
+                          type: NestedObject
+                          properties:
+                            - name: 'headerName'
+                              type: String
+                              description: |
+                                The name of the header to add.
+                            - name: 'headerValue'
+                              type: String
+                              description: |
+                                The value of the header to add.
+                            - name: 'replace'
+                              type: Boolean
+                              description: |
+                                If false, headerValue is appended to any values that already exist for the header.
+                                If true, headerValue is set for the header, discarding any values that were set for that header.
+                              default_value: false
+                      - name: 'responseHeadersToRemove'
+                        type: Array
+                        description: |
+                          A list of header names for headers that need to be removed from the response prior to sending the
+                          response back to the client.
+                        item_type:
+                          type: String
+                      - name: 'responseHeadersToAdd'
+                        type: Array
+                        description: |
+                          Headers to add the response prior to sending the response back to the client.
+                        item_type:
+                          type: NestedObject
+                          properties:
+                            - name: 'headerName'
+                              type: String
+                              description: |
+                                The name of the header to add.
+                            - name: 'headerValue'
+                              type: String
+                              description: |
+                                The value of the header to add.
+                            - name: 'replace'
+                              type: Boolean
+                              description: |
+                                If false, headerValue is appended to any values that already exist for the header.
+                                If true, headerValue is set for the header, discarding any values that were set for that header.
+                              default_value: false
+            - name: 'urlRewrite'
+              type: NestedObject
+              description: |
+                The spec to modify the URL of the request, prior to forwarding the request to the matched service.
+              properties:
+                - name: 'pathPrefixRewrite'
+                  type: String
+                  description: |
+                    Prior to forwarding the request to the selected backend service, the matching portion of the
+                    request's path is replaced by pathPrefixRewrite.
+
+                    The value must be between 1 and 1024 characters.
+                - name: 'hostRewrite'
+                  type: String
+                  description: |
+                    Prior to forwarding the request to the selected service, the request's host header is replaced
+                    with contents of hostRewrite.
+
+                    The value must be between 1 and 255 characters.
+            - name: 'timeout'
+              type: NestedObject
+              description: |
+                Specifies the timeout for the selected route. Timeout is computed from the time the request has been
+                fully processed (i.e. end-of-stream) up until the response has been completely processed. Timeout includes all retries.
+
+                If not specified, will use the largest timeout among all backend services associated with the route.
+              default_from_api: true
+              properties:
+                - name: 'seconds'
+                  type: String
+                  description: |
+                    Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                    Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                - name: 'nanos'
+                  type: Integer
+                  description: |
+                    Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented
+                    with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+            - name: 'maxStreamDuration'
+              type: NestedObject
+              description: |
+                Specifies the maximum duration (timeout) for streams on the selected route.
+                Unlike the `Timeout` field where the timeout duration starts from the time the request
+                has been fully processed (known as end-of-stream), the duration in this field
+                is computed from the beginning of the stream until the response has been processed,
+                including all retries. A stream that does not complete in this duration is closed.
+              default_from_api: true
+              properties:
+                - name: 'nanos'
+                  type: Integer
+                  description: |
+                    Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented
+                    with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                - name: 'seconds'
+                  type: String
+                  description: |
+                    Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                    Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                  required: true
+            - name: 'retryPolicy'
+              type: NestedObject
+              description: |
+                Specifies the retry policy associated with this route.
+              properties:
+                - name: 'retryConditions'
+                  type: Array
+                  description: |
+                    Specfies one or more conditions when this retry rule applies. Valid values are:
+
+                    * 5xx: Loadbalancer will attempt a retry if the backend service responds with any 5xx response code,
+                      or if the backend service does not respond at all, example: disconnects, reset, read timeout,
+                    * connection failure, and refused streams.
+                    * gateway-error: Similar to 5xx, but only applies to response codes 502, 503 or 504.
+                    * connect-failure: Loadbalancer will retry on failures connecting to backend services,
+                      for example due to connection timeouts.
+                    * retriable-4xx: Loadbalancer will retry for retriable 4xx response codes.
+                      Currently the only retriable error supported is 409.
+                    * refused-stream:Loadbalancer will retry if the backend service resets the stream with a REFUSED_STREAM error code.
+                      This reset type indicates that it is safe to retry.
+                    * cancelled: Loadbalancer will retry if the gRPC status code in the response header is set to cancelled
+                    * deadline-exceeded: Loadbalancer will retry if the gRPC status code in the response header is set to deadline-exceeded
+                    * resource-exhausted: Loadbalancer will retry if the gRPC status code in the response header is set to resource-exhausted
+                    * unavailable: Loadbalancer will retry if the gRPC status code in the response header is set to unavailable
+                  item_type:
+                    type: String
+                - name: 'numRetries'
+                  type: Integer
+                  description: |
+                    Specifies the allowed number retries. This number must be > 0. If not specified, defaults to 1.
+                  validation:
+                    function: 'validation.IntAtLeast(1)'
+                  default_value: 1
+                - name: 'perTryTimeout'
+                  type: NestedObject
+                  description: |
+                    Specifies a non-zero timeout per retry attempt.
+
+                    If not specified, will use the timeout set in HttpRouteAction. If timeout in HttpRouteAction is not set,
+                    will use the largest timeout among all backend services associated with the route.
+                  properties:
+                    - name: 'seconds'
+                      type: String
+                      description: |
+                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                        Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                    - name: 'nanos'
+                      type: Integer
+                      description: |
+                        Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are
+                        represented with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+            - name: 'requestMirrorPolicy'
+              type: NestedObject
+              description: |
+                Specifies the policy on how requests intended for the route's backends are shadowed to a separate mirrored backend service.
+                Loadbalancer does not wait for responses from the shadow service. Prior to sending traffic to the shadow service,
+                the host / authority header is suffixed with -shadow.
+              properties:
+                - name: 'backendService'
+                  type: ResourceRef
+                  description: |
+                    The full or partial URL to the BackendService resource being mirrored to.
+                  required: true
+                  custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+                  resource: 'BackendService'
+                  imports: 'selfLink'
+                - name: 'mirrorPercent'
+                  min_version: beta
+                  type: Double
+                  is_missing_in_cai: true
+                  description: |
+                    The percentage of requests to be mirrored to backendService.
+                    The value must be between 0.0 and 100.0 inclusive.
+                  validation:
+                    function: 'validation.FloatBetween(0, 100)'
+            - name: 'corsPolicy'
+              type: NestedObject
+              description: |
+                The specification for allowing client side cross-origin requests. Please see
+                [W3C Recommendation for Cross Origin Resource Sharing](https://www.w3.org/TR/cors/)
+              properties:
+                - name: 'allowOrigins'
+                  type: Array
+                  description: |
+                    Specifies the list of origins that will be allowed to do CORS requests.
+                    An origin is allowed if it matches either an item in allowOrigins or an item in allowOriginRegexes.
+                  item_type:
+                    type: String
+                - name: 'allowOriginRegexes'
+                  type: Array
+                  description: |
+                    Specifies the regular expression patterns that match allowed origins. For regular expression grammar
+                    please see en.cppreference.com/w/cpp/regex/ecmascript
+                    An origin is allowed if it matches either an item in allowOrigins or an item in allowOriginRegexes.
+                  item_type:
+                    type: String
+                - name: 'allowMethods'
+                  type: Array
+                  description: |
+                    Specifies the content for the Access-Control-Allow-Methods header.
+                  item_type:
+                    type: String
+                - name: 'allowHeaders'
+                  type: Array
+                  description: |
+                    Specifies the content for the Access-Control-Allow-Headers header.
+                  item_type:
+                    type: String
+                - name: 'exposeHeaders'
+                  type: Array
+                  description: |
+                    Specifies the content for the Access-Control-Expose-Headers header.
+                  item_type:
+                    type: String
+                - name: 'maxAge'
+                  type: Integer
+                  description: |
+                    Specifies how long results of a preflight request can be cached in seconds.
+                    This translates to the Access-Control-Max-Age header.
+                - name: 'allowCredentials'
+                  type: Boolean
+                  description: |
+                    In response to a preflight request, setting this to true indicates that the actual request can include user credentials.
+                    This translates to the Access-Control-Allow-Credentials header.
+                  default_value: false
+                - name: 'disabled'
+                  type: Boolean
+                  description: |
+                    If true, specifies the CORS policy is disabled. The default value is false, which indicates that the CORS policy is in effect.
+                  default_value: false
+            - name: 'faultInjectionPolicy'
+              type: NestedObject
+              description: |
+                The specification for fault injection introduced into traffic to test the resiliency of clients to backend service failure.
+                As part of fault injection, when clients send requests to a backend service, delays can be introduced by Loadbalancer on a
+                percentage of requests before sending those request to the backend service. Similarly requests from clients can be aborted
+                by the Loadbalancer for a percentage of requests.
+
+                timeout and retryPolicy will be ignored by clients that are configured with a faultInjectionPolicy.
+              properties:
+                - name: 'delay'
+                  type: NestedObject
+                  description: |
+                    The specification for how client requests are delayed as part of fault injection, before being sent to a backend service.
+                  properties:
+                    - name: 'fixedDelay'
+                      type: NestedObject
+                      description: |
+                        Specifies the value of the fixed delay interval.
+                      properties:
+                        - name: 'seconds'
+                          type: String
+                          description: |
+                            Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                            Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                        - name: 'nanos'
+                          type: Integer
+                          description: |
+                            Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are
+                            represented with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                    - name: 'percentage'
+                      type: Double
+                      description: |
+                        The percentage of traffic (connections/operations/requests) on which delay will be introduced as part of fault injection.
+                        The value must be between 0.0 and 100.0 inclusive.
+                      validation:
+                        function: 'validation.FloatBetween(0, 100)'
+                - name: 'abort'
+                  type: NestedObject
+                  description: |
+                    The specification for how client requests are aborted as part of fault injection.
+                  properties:
+                    - name: 'httpStatus'
+                      type: Integer
+                      description: |
+                        The HTTP status code used to abort the request.
+                        The value must be between 200 and 599 inclusive.
+                      validation:
+                        function: 'validation.IntBetween(200, 599)'
+                    - name: 'percentage'
+                      type: Double
+                      description: |
+                        The percentage of traffic (connections/operations/requests) which will be aborted as part of fault injection.
+                        The value must be between 0.0 and 100.0 inclusive.
+                      validation:
+                        function: 'validation.FloatBetween(0, 100)'
+            - name: 'cachePolicy'
+              type: NestedObject
+              description: |
+                Specifies the cache policy configuration for matched traffic. Available
+                only for Global EXTERNAL_MANAGED load balancer schemes. At least one
+                property must be specified. This policy cannot be specified if any target
+                backend has Identity-Aware Proxy enabled.
+              properties:
+                - name: 'cacheMode'
+                  type: Enum
+                  is_missing_in_cai: true
+                  description: |
+                    Specifies the cache setting for all responses from this route. If not
+                    specified, Cloud CDN uses CACHE_ALL_STATIC mode.
+                  enum_values:
+                    - 'USE_ORIGIN_HEADERS'
+                    - 'FORCE_CACHE_ALL'
+                    - 'CACHE_ALL_STATIC'
+                - name: 'defaultTtl'
+                  type: NestedObject
+                  is_missing_in_cai: true
+                  description: |
+                    Specifies the default TTL for cached content for responses that do not have
+                    an existing valid TTL (max-age or s-maxage). Setting a TTL of "0" means
+                    "always revalidate". The value of defaultTtl cannot be set to a value
+                    greater than that of maxTtl. When the cacheMode is set to
+                    FORCE_CACHE_ALL, the defaultTtl will overwrite the TTL set in all
+                    responses. The maximum allowed value is 31,622,400s (1 year). Infrequently
+                    accessed objects may be evicted from the cache before the defined TTL. If
+                    not specified, Cloud CDN uses 3600s (1 hour) for CACHE_ALL_STATIC and
+                    FORCE_CACHE_ALL modes. Cannot be specified when cacheMode is
+                    USE_ORIGIN_HEADERS.
+                  properties:
+                    - name: 'seconds'
+                      type: String
+                      required: true
+                      description: |
+                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                    - name: 'nanos'
+                      type: Integer
+                      ignore_read: true
+                      description: |
+                        Span of time that's a fraction of a second at nanosecond resolution.
+                      validation:
+                        function: 'validation.IntBetween(0, 0)'
+                - name: 'maxTtl'
+                  type: NestedObject
+                  is_missing_in_cai: true
+                  description: |
+                    Specifies the maximum allowed TTL for cached content. Cache directives that
+                    attempt to set a max-age or s-maxage higher than this, or an Expires header
+                    more than maxTtl seconds in the future will be capped at the value of
+                    maxTtl, as if it were the value of an s-maxage Cache-Control directive.
+                    Headers sent to the client will not be modified. Setting a TTL of "0" means
+                    "always revalidate". The maximum allowed value is 31,622,400s (1 year).
+                    Infrequently accessed objects may be evicted from the cache before the
+                    defined TTL. If not specified, Cloud CDN uses 86400s (1 day) for
+                    CACHE_ALL_STATIC mode. Can be specified only for CACHE_ALL_STATIC cache
+                    mode.
+                  properties:
+                    - name: 'seconds'
+                      type: String
+                      required: true
+                      description: |
+                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                    - name: 'nanos'
+                      type: Integer
+                      ignore_read: true
+                      description: |
+                        Span of time that's a fraction of a second at nanosecond resolution.
+                      validation:
+                        function: 'validation.IntBetween(0, 0)'
+                - name: 'clientTtl'
+                  type: NestedObject
+                  is_missing_in_cai: true
+                  description: |
+                    Specifies a separate client (e.g. browser client) maximum TTL for cached
+                    content. This is used to clamp the max-age (or Expires) value sent to the
+                    client. With FORCE_CACHE_ALL, the lesser of clientTtl and defaultTtl
+                    is used for the response max-age directive, along with a "public"
+                    directive. For cacheable content in CACHE_ALL_STATIC mode, clientTtl
+                    clamps the max-age from the origin (if specified), or else sets the
+                    response max-age directive to the lesser of the clientTtl and defaultTtl,
+                    and also ensures a "public" cache-control directive is present. The maximum
+                    allowed value is 31,622,400s (1 year). If not specified, Cloud CDN uses
+                    3600s (1 hour) for CACHE_ALL_STATIC mode. Cannot exceed maxTtl.
+                    Cannot be specified when cacheMode is USE_ORIGIN_HEADERS.
+                  properties:
+                    - name: 'seconds'
+                      type: String
+                      required: true
+                      description: |
+                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                    - name: 'nanos'
+                      type: Integer
+                      ignore_read: true
+                      description: |
+                        Span of time that's a fraction of a second at nanosecond resolution.
+                      validation:
+                        function: 'validation.IntBetween(0, 0)'
+                - name: 'requestCoalescing'
+                  type: Boolean
+                  is_missing_in_cai: true
+                  send_empty_value: true
+                  description: |
+                    If true then Cloud CDN will combine multiple concurrent cache fill
+                    requests into a small number of requests to the origin. If not specified,
+                    Cloud CDN applies request coalescing by default.
+                - name: 'negativeCaching'
+                  type: Boolean
+                  is_missing_in_cai: true
+                  send_empty_value: true
+                  description: |
+                    Negative caching allows per-status code TTLs to be set, in order to apply
+                    fine-grained caching for common errors or redirects. This can reduce the
+                    load on your origin and improve end-user experience by reducing response
+                    latency. When the cacheMode is set to CACHE_ALL_STATIC or
+                    USE_ORIGIN_HEADERS, negative caching applies to responses with the
+                    specified response code that lack any Cache-Control, Expires, or
+                    Pragma: no-cache directives. When the cacheMode is set to
+                    FORCE_CACHE_ALL, negative caching applies to all responses with the
+                    specified response code, and overrides any caching headers. By default,
+                    Cloud CDN applies the following TTLs to these HTTP status codes:
+                    * 300 (Multiple Choice), 301, 308 (Permanent Redirects): 10m
+                    * 404 (Not Found), 410 (Gone), 451 (Unavailable For Legal Reasons): 120s
+                    * 405 (Method Not Found), 501 (Not Implemented): 60s
+                    These defaults can be overridden in negativeCachingPolicy. If not
+                    specified, Cloud CDN applies negative caching by default.
+                - name: 'negativeCachingPolicy'
+                  type: Array
+                  is_missing_in_cai: true
+                  send_empty_value: true
+                  description: |
+                    Sets a cache TTL for the specified HTTP status code. negativeCaching
+                    must be enabled to configure negativeCachingPolicy. Omitting the policy
+                    and leaving negativeCaching enabled will use Cloud CDN's default cache
+                    TTLs. Note that when specifying an explicit negativeCachingPolicy, you
+                    should take care to specify a cache TTL for all response codes that you
+                    wish to cache. Cloud CDN will not apply any default negative caching when
+                    a policy exists.
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: 'code'
+                        type: Integer
+                        description: |
+                          The HTTP status code to define a TTL against. Only HTTP status codes
+                          300, 301, 302, 307, 308, 404, 405, 410, 421, 451 and 501 can be
+                          specified as values, and you cannot specify a status code more than
+                          once.
+                      - name: 'ttl'
+                        type: NestedObject
+                        description: |
+                          The TTL (in seconds) for which to cache responses with the
+                          corresponding status code. The maximum allowed value is 1800s (30
+                          minutes). Infrequently accessed objects may be evicted from the cache
+                          before the defined TTL.
+                        properties:
+                          - name: 'seconds'
+                            type: String
+                            required: true
+                            description: |
+                              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                          - name: 'nanos'
+                            type: Integer
+                            ignore_read: true
+                            description: |
+                              Span of time that's a fraction of a second at nanosecond resolution.
+                            validation:
+                              function: 'validation.IntBetween(0, 0)'
+                - name: 'cacheBypassRequestHeaderNames'
+                  type: Array
+                  is_missing_in_cai: true
+                  description: |
+                    Bypass the cache when the specified request headers are matched by name,
+                    e.g. Pragma or Authorization headers. Values are case-insensitive. Up to 5
+                    header names can be specified. The cache is bypassed for all cacheMode
+                    values.
+                  item_type:
+                    type: String
+                - name: 'serveWhileStale'
+                  type: NestedObject
+                  is_missing_in_cai: true
+                  description: |
+                    Serve existing content from the cache (if available) when revalidating
+                    content with the origin, or when an error is encountered when refreshing
+                    the cache. This setting defines the default "max-stale" duration for any
+                    cached responses that do not specify a max-stale directive. Stale
+                    responses that exceed the TTL configured here will not be served. The
+                    default limit (max-stale) is 86400s (1 day), which will allow stale
+                    content to be served up to this limit beyond the max-age (or s-maxage) of
+                    a cached response. The maximum allowed value is 604800 (1 week). Set this
+                    to zero (0) to disable serve-while-stale.
+                  properties:
+                    - name: 'seconds'
+                      type: String
+                      required: true
+                      description: |
+                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                    - name: 'nanos'
+                      type: Integer
+                      ignore_read: true
+                      description: |
+                        Span of time that's a fraction of a second at nanosecond resolution.
+                      validation:
+                        function: 'validation.IntBetween(0, 0)'
+                - name: 'cacheKeyPolicy'
+                  type: NestedObject
+                  description: |
+                    The cache key configuration. If not specified, the default behavior depends
+                    on the backend type: for Backend Services, the complete request URI is
+                    used; for Backend Buckets, the request URI is used without the protocol or
+                    host, and only query parameters known to Cloud Storage are included.
+                  properties:
+                    - name: 'includeProtocol'
+                      type: Boolean
+                      send_empty_value: true
+                      is_missing_in_cai: true
+                      description: |
+                        If true, http and https requests will be cached separately. Note: This
+                        setting is only applicable to routes that use a Backend Service. It
+                        does not affect requests served by a Backend Bucket, as the protocol is
+                        never included in a Backend Bucket's cache key. Attempting to set on a
+                        route that points exclusively to Backend Buckets will result in a
+                        configuration error.
+                    - name: 'includeHost'
+                      type: Boolean
+                      send_empty_value: true
+                      is_missing_in_cai: true
+                      description: |
+                        If true, requests to different hosts will be cached separately. Note:
+                        This setting is only applicable to routes that use a Backend Service.
+                        It does not affect requests served by a Backend Bucket, as the host is
+                        never included in a Backend Bucket's cache key. Attempting to set it on
+                        a route that points exclusively to Backend Buckets will result in a
+                        configuration error.
+                    - name: 'includeQueryString'
+                      type: Boolean
+                      send_empty_value: true
+                      is_missing_in_cai: true
+                      description: |
+                        If true, include query string parameters in the cache key according to
+                        includedQueryParameters and excludedQueryParameters. If neither is
+                        set, the entire query string will be included. If false, the query
+                        string will be excluded from the cache key entirely. Note: This field
+                        applies to routes that use backend services. Attempting to set it on a
+                        route that points exclusively to Backend Buckets will result in a
+                        configuration error. For routes that point to a Backend Bucket, use
+                        includedQueryParameters to define which parameters should be part of
+                        the cache key.
+                    - name: 'includedQueryParameters'
+                      type: Array
+                      send_empty_value: true
+                      is_missing_in_cai: true
+                      description: |
+                        Names of query string parameters to include in cache keys. All other
+                        parameters will be excluded. Either specify includedQueryParameters
+                        or excludedQueryParameters, not both. '&' and '=' will be percent
+                        encoded and not treated as delimiters.
+                      item_type:
+                        type: String
+                    - name: 'excludedQueryParameters'
+                      type: Array
+                      send_empty_value: true
+                      is_missing_in_cai: true
+                      description: |
+                        Names of query string parameters to exclude in cache keys. All other
+                        parameters will be included. Either specify excludedQueryParameters
+                        or includedQueryParameters, not both. '&' and '=' will be percent
+                        encoded and not treated as delimiters. Note: This field applies to
+                        routes that use backend services. Attempting to set it on a route that
+                        points exclusively to Backend Buckets will result in a configuration
+                        error. For routes that point to a Backend Bucket, use
+                        includedQueryParameters to define which parameters should be part of
+                        the cache key.
+                      item_type:
+                        type: String
+                    - name: 'includedHeaderNames'
+                      type: Array
+                      send_empty_value: true
+                      is_missing_in_cai: true
+                      description: |
+                        Allows HTTP request headers (by name) to be used in the cache key.
+                      item_type:
+                        type: String
+                    - name: 'includedCookieNames'
+                      type: Array
+                      send_empty_value: true
+                      is_missing_in_cai: true
+                      description: |
+                        Allows HTTP cookies (by name) to be used in the cache key. The
+                        name=value pair will be used in the cache key Cloud CDN generates.
+                        Note: This setting is only applicable to routes that use a Backend
+                        Service. It does not affect requests served by a Backend Bucket.
+                        Attempting to set it on a route that points exclusively to Backend
+                        Buckets will result in a configuration error. Up to 5 cookie names can
+                        be specified.
+                      item_type:
+                        type: String
+  - name: 'defaultCustomErrorResponsePolicy'
+    type: NestedObject
+    description: |
+      defaultCustomErrorResponsePolicy specifies how the Load Balancer returns error responses when BackendService or BackendBucket responds with an error.
+
+      This policy takes effect at the PathMatcher level and applies only when no policy has been defined for the error code at lower levels like RouteRule and PathRule within this PathMatcher. If an error code does not have a policy defined in defaultCustomErrorResponsePolicy, then a policy defined for the error code in UrlMap.defaultCustomErrorResponsePolicy takes effect.
+
+      For example, consider a UrlMap with the following configuration:
+
+      UrlMap.defaultCustomErrorResponsePolicy is configured with policies for 5xx and 4xx errors
+      A RouteRule for /coming_soon/ is configured for the error code 404.
+      If the request is for www.myotherdomain.com and a 404 is encountered, the policy under UrlMap.defaultCustomErrorResponsePolicy takes effect. If a 404 response is encountered for the request www.example.com/current_events/, the pathMatcher's policy takes effect. If however, the request for www.example.com/coming_soon/ encounters a 404, the policy in RouteRule.customErrorResponsePolicy takes effect. If any of the requests in this example encounter a 500 error code, the policy at UrlMap.defaultCustomErrorResponsePolicy takes effect.
+
+      When used in conjunction with pathMatcher.defaultRouteAction.retryPolicy, retries take precedence. Only once all retries are exhausted, the defaultCustomErrorResponsePolicy is applied. While attempting a retry, if load balancer is successful in reaching the service, the defaultCustomErrorResponsePolicy is ignored and the response from the service is returned to the client.
+
+      defaultCustomErrorResponsePolicy is supported only for global external Application Load Balancers.
+    properties:
+      - name: 'errorResponseRule'
+        type: Array
+        description: |
+          Specifies rules for returning error responses.
+          In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority.
+          For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX).
+          If the backend service returns a 401, then the rule for 401 will be applied. However if the backend service returns a 403, the rule for 4xx takes effect.
+        api_name: errorResponseRules
+        is_missing_in_cai: true
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'matchResponseCodes'
+              type: Array
+              description: |
+                Valid values include:
+                - A number between 400 and 599: For example 401 or 503, in which case the load balancer applies the policy if the error code exactly matches this value.
+                - 5xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 500 to 599.
+                - 4xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 400 to 499.
+                Values must be unique within matchResponseCodes and across all errorResponseRules of CustomErrorResponsePolicy.
+              item_type:
+                type: String
+            - name: 'path'
+              type: String
+              description: |
+                The full path to a file within backendBucket. For example: /errors/defaultError.html
+                path must start with a leading slash. path cannot have trailing slashes.
+                If the file is not available in backendBucket or the load balancer cannot reach the BackendBucket, a simple Not Found Error is returned to the client.
+                The value must be from 1 to 1024 characters.
+            - name: 'overrideResponseCode'
+              type: Integer
+              description: |
+                The HTTP status code returned with the response containing the custom error content.
+                If overrideResponseCode is not supplied, the same response code returned by the original backend bucket or backend service is returned to the client.
+      - name: 'errorService'
+        type: ResourceRef
+        description: |
+          The full or partial URL to the BackendBucket resource that contains the custom error content. Examples are:
+
+          https://www.googleapis.com/compute/v1/projects/project/global/backendBuckets/myBackendBucket
+          compute/v1/projects/project/global/backendBuckets/myBackendBucket
+          global/backendBuckets/myBackendBucket
+
+          If errorService is not specified at lower levels like pathMatcher, pathRule and routeRule, an errorService specified at a higher level in the UrlMap will be used. If UrlMap.defaultCustomErrorResponsePolicy contains one or more errorResponseRules[], it must specify errorService.
+          If load balancer cannot reach the backendBucket, a simple Not Found Error will be returned, with the original response code (or overrideResponseCode if configured).
+        resource: 'BackendBucket'
+        imports: 'selfLink'
+  - name: 'test'
+    type: Array
+    description: |
+      The list of expected URL mapping tests. Request to update this UrlMap will
+      succeed only if all of the test cases pass. You can specify a maximum of 100
+      tests per UrlMap.
+    api_name: tests
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'description'
+          type: String
+          description: |
+            Description of this test case.
+        - name: 'host'
+          type: String
+          description: |
+            Host portion of the URL.
+          required: true
+        - name: 'path'
+          type: String
+          description: |
+            Path portion of the URL.
+          required: true
+        - name: 'headers'
+          type: Array
+          description: |
+            HTTP headers for this request.
+          item_type:
+            type: NestedObject
+            properties:
+              - name: 'name'
+                type: String
+                description: |
+                  Header name.
+                required: true
+              - name: 'value'
+                type: String
+                description: |
+                  Header value.
+                required: true
+        - name: 'service'
+          type: ResourceRef
+          description: The backend service or backend bucket link that should be matched by this test.
+          custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+          resource: 'BackendService'
+          imports: 'selfLink'
+        - name: 'expectedOutputUrl'
+          type: String
+          description: |
+            The expected output URL evaluated by the load balancer containing the scheme, host, path and query parameters.
+
+            For rules that forward requests to backends, the test passes only when expectedOutputUrl matches the request forwarded by the load balancer to backends. For rules with urlRewrite, the test verifies that the forwarded request matches hostRewrite and pathPrefixRewrite in the urlRewrite action. When service is specified, expectedOutputUrl`s scheme is ignored.
+
+            For rules with urlRedirect, the test passes only if expectedOutputUrl matches the URL in the load balancer's redirect response. If urlRedirect specifies httpsRedirect, the test passes only if the scheme in expectedOutputUrl is also set to HTTPS. If urlRedirect specifies stripQuery, the test passes only if expectedOutputUrl does not contain any query parameters.
+
+            expectedOutputUrl is optional when service is specified.
+        - name: 'expectedRedirectResponseCode'
+          type: Integer
+          description: |
+            For rules with urlRedirect, the test passes only if expectedRedirectResponseCode matches the HTTP status code in load balancer's redirect response.
+
+            expectedRedirectResponseCode cannot be set when service is set.
+  - name: 'defaultUrlRedirect'
+    type: NestedObject
+    description: |
+      When none of the specified hostRules match, the request is redirected to a URL specified
+      by defaultUrlRedirect. If defaultUrlRedirect is specified, defaultService or
+      defaultRouteAction must not be set.
+    conflicts:
+      - default_route_action
+    exactly_one_of:
+      - 'default_service'
+      - 'default_url_redirect'
+      - 'default_route_action.0.weighted_backend_services'
+    properties:
+      - name: 'hostRedirect'
+        type: String
+        description: |
+          The host that will be used in the redirect response instead of the one that was
+          supplied in the request. The value must be between 1 and 255 characters.
+      - name: 'httpsRedirect'
+        type: Boolean
+        description: |
+          If set to true, the URL scheme in the redirected request is set to https. If set to
+          false, the URL scheme of the redirected request will remain the same as that of the
+          request. This must only be set for UrlMaps used in TargetHttpProxys. Setting this
+          true for TargetHttpsProxy is not permitted. The default is set to false.
+        default_value: false
+      - name: 'pathRedirect'
+        type: String
+        description: |
+          The path that will be used in the redirect response instead of the one that was
+          supplied in the request. pathRedirect cannot be supplied together with
+          prefixRedirect. Supply one alone or neither. If neither is supplied, the path of the
+          original request will be used for the redirect. The value must be between 1 and 1024
+          characters.
+      - name: 'prefixRedirect'
+        type: String
+        description: |
+          The prefix that replaces the prefixMatch specified in the HttpRouteRuleMatch,
+          retaining the remaining portion of the URL before redirecting the request.
+          prefixRedirect cannot be supplied together with pathRedirect. Supply one alone or
+          neither. If neither is supplied, the path of the original request will be used for
+          the redirect. The value must be between 1 and 1024 characters.
+      - name: 'redirectResponseCode'
+        type: Enum
+        description: |
+          The HTTP Status code to use for this RedirectAction. Supported values are:
+
+          * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+
+          * FOUND, which corresponds to 302.
+
+          * SEE_OTHER which corresponds to 303.
+
+          * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+          will be retained.
+
+          * PERMANENT_REDIRECT, which corresponds to 308. In this case,
+          the request method will be retained.
+        enum_values:
+          - 'FOUND'
+          - 'MOVED_PERMANENTLY_DEFAULT'
+          - 'PERMANENT_REDIRECT'
+          - 'SEE_OTHER'
+          - 'TEMPORARY_REDIRECT'
+        exclude_docs_values: true
+      - name: 'stripQuery'
+        type: Boolean
+        description: |
+          If set to true, any accompanying query portion of the original URL is removed prior
+          to redirecting the request. If set to false, the query portion of the original URL is
+          retained. The default is set to false.
+           This field is required to ensure an empty block is not set. The normal default value is false.
+        required: true
+  - name: 'defaultRouteAction'
+    type: NestedObject
+    description: |
+      defaultRouteAction takes effect when none of the hostRules match. The load balancer performs advanced routing actions
+      like URL rewrites, header transformations, etc. prior to forwarding the request to the selected backend.
+      If defaultRouteAction specifies any weightedBackendServices, defaultService must not be set. Conversely if defaultService
+      is set, defaultRouteAction cannot contain any weightedBackendServices.
+
+      Only one of defaultRouteAction or defaultUrlRedirect must be set.
+    conflicts:
+      - default_url_redirect
+    properties:
+      - name: 'weightedBackendServices'
+        type: Array
+        description: |
+          A list of weighted backend services to send traffic to when a route match occurs.
+          The weights determine the fraction of traffic that flows to their corresponding backend service.
+          If all traffic needs to go to a single backend service, there must be one weightedBackendService
+          with weight set to a non 0 number.
+
+          Once a backendService is identified and before forwarding the request to the backend service,
+          advanced routing actions like Url rewrites and header transformations are applied depending on
+          additional settings specified in this HttpRouteAction.
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+          - 'default_route_action.0.cache_policy'
+        exactly_one_of:
+          - 'default_service'
+          - 'default_url_redirect'
+          - 'default_route_action.0.weighted_backend_services'
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'backendService'
+              type: ResourceRef
+              description: |
+                The full or partial URL to the default BackendService resource. Before forwarding the
+                request to backendService, the loadbalancer applies any relevant headerActions
+                specified as part of this backendServiceWeight.
+              custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+              resource: 'BackendService'
+              imports: 'selfLink'
+            - name: 'weight'
+              type: Integer
+              description: |
+                Specifies the fraction of traffic sent to backendService, computed as
+                weight / (sum of all weightedBackendService weights in routeAction) .
+
+                The selection of a backend service is determined only for new traffic. Once a user's request
+                has been directed to a backendService, subsequent requests will be sent to the same backendService
+                as determined by the BackendService's session affinity policy.
+
+                The value must be between 0 and 1000
+              validation:
+                function: 'validation.IntBetween(0, 1000)'
+            - name: 'headerAction'
+              type: NestedObject
+              description: |
+                Specifies changes to request and response headers that need to take effect for
+                the selected backendService.
+
+                headerAction specified here take effect before headerAction in the enclosing
+                HttpRouteRule, PathMatcher and UrlMap.
+              properties:
+                - name: 'requestHeadersToRemove'
+                  type: Array
+                  description: |
+                    A list of header names for headers that need to be removed from the request prior to
+                    forwarding the request to the backendService.
+                  item_type:
+                    type: String
+                - name: 'requestHeadersToAdd'
+                  type: Array
+                  description: |
+                    Headers to add to a matching request prior to forwarding the request to the backendService.
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: 'headerName'
+                        type: String
+                        description: |
+                          The name of the header to add.
+                      - name: 'headerValue'
+                        type: String
+                        description: |
+                          The value of the header to add.
+                      - name: 'replace'
+                        type: Boolean
+                        description: |
+                          If false, headerValue is appended to any values that already exist for the header.
+                          If true, headerValue is set for the header, discarding any values that were set for that header.
+                        default_value: false
+                - name: 'responseHeadersToRemove'
+                  type: Array
+                  description: |
+                    A list of header names for headers that need to be removed from the response prior to sending the
+                    response back to the client.
+                  item_type:
+                    type: String
+                - name: 'responseHeadersToAdd'
+                  type: Array
+                  description: |
+                    Headers to add the response prior to sending the response back to the client.
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: 'headerName'
+                        type: String
+                        description: |
+                          The name of the header to add.
+                      - name: 'headerValue'
+                        type: String
+                        description: |
+                          The value of the header to add.
+                      - name: 'replace'
+                        type: Boolean
+                        description: |
+                          If false, headerValue is appended to any values that already exist for the header.
+                          If true, headerValue is set for the header, discarding any values that were set for that header.
+                        default_value: false
+      - name: 'urlRewrite'
+        type: NestedObject
+        description: |
+          The spec to modify the URL of the request, prior to forwarding the request to the matched service.
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+          - 'default_route_action.0.cache_policy'
+        properties:
+          - name: 'pathPrefixRewrite'
+            type: String
+            description: |
+              Prior to forwarding the request to the selected backend service, the matching portion of the
+              request's path is replaced by pathPrefixRewrite.
+
+              The value must be between 1 and 1024 characters.
+            at_least_one_of:
+              - 'default_route_action.0.url_rewrite.0.path_prefix_rewrite'
+              - 'default_route_action.0.url_rewrite.0.host_rewrite'
+          - name: 'hostRewrite'
+            type: String
+            description: |
+              Prior to forwarding the request to the selected service, the request's host header is replaced
+              with contents of hostRewrite.
+
+              The value must be between 1 and 255 characters.
+            at_least_one_of:
+              - 'default_route_action.0.url_rewrite.0.path_prefix_rewrite'
+              - 'default_route_action.0.url_rewrite.0.host_rewrite'
+      - name: 'timeout'
+        type: NestedObject
+        description: |
+          Specifies the timeout for the selected route. Timeout is computed from the time the request has been
+          fully processed (i.e. end-of-stream) up until the response has been completely processed. Timeout includes all retries.
+
+          If not specified, will use the largest timeout among all backend services associated with the route.
+        default_from_api: true
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+          - 'default_route_action.0.cache_policy'
+        properties:
+          - name: 'seconds'
+            type: String
+            description: |
+              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+              Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+            at_least_one_of:
+              - 'default_route_action.0.timeout.0.seconds'
+              - 'default_route_action.0.timeout.0.nanos'
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented
+              with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+            at_least_one_of:
+              - 'default_route_action.0.timeout.0.seconds'
+              - 'default_route_action.0.timeout.0.nanos'
+      - name: 'maxStreamDuration'
+        type: NestedObject
+        description: |
+          Specifies the maximum duration (timeout) for streams on the selected route.
+          Unlike the `Timeout` field where the timeout duration starts from the time the request
+          has been fully processed (known as end-of-stream), the duration in this field
+          is computed from the beginning of the stream until the response has been processed,
+          including all retries. A stream that does not complete in this duration is closed.
+        default_from_api: true
+        properties:
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented
+              with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+          - name: 'seconds'
+            type: String
+            description: |
+              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+              Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+            required: true
+      - name: 'retryPolicy'
+        type: NestedObject
+        description: |
+          Specifies the retry policy associated with this route.
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+          - 'default_route_action.0.cache_policy'
+        properties:
+          - name: 'retryConditions'
+            type: Array
+            description: |
+              Specfies one or more conditions when this retry rule applies. Valid values are:
+
+              * 5xx: Loadbalancer will attempt a retry if the backend service responds with any 5xx response code,
+                or if the backend service does not respond at all, example: disconnects, reset, read timeout,
+              * connection failure, and refused streams.
+              * gateway-error: Similar to 5xx, but only applies to response codes 502, 503 or 504.
+              * connect-failure: Loadbalancer will retry on failures connecting to backend services,
+                for example due to connection timeouts.
+              * retriable-4xx: Loadbalancer will retry for retriable 4xx response codes.
+                Currently the only retriable error supported is 409.
+              * refused-stream:Loadbalancer will retry if the backend service resets the stream with a REFUSED_STREAM error code.
+                This reset type indicates that it is safe to retry.
+              * cancelled: Loadbalancer will retry if the gRPC status code in the response header is set to cancelled
+              * deadline-exceeded: Loadbalancer will retry if the gRPC status code in the response header is set to deadline-exceeded
+              * resource-exhausted: Loadbalancer will retry if the gRPC status code in the response header is set to resource-exhausted
+              * unavailable: Loadbalancer will retry if the gRPC status code in the response header is set to unavailable
+            at_least_one_of:
+              - 'default_route_action.0.retry_policy.0.retry_conditions'
+              - 'default_route_action.0.retry_policy.0.num_retries'
+              - 'default_route_action.0.retry_policy.0.per_try_timeout'
+            item_type:
+              type: String
+          - name: 'numRetries'
+            type: Integer
+            description: |
+              Specifies the allowed number retries. This number must be > 0. If not specified, defaults to 1.
+            at_least_one_of:
+              - 'default_route_action.0.retry_policy.0.retry_conditions'
+              - 'default_route_action.0.retry_policy.0.num_retries'
+              - 'default_route_action.0.retry_policy.0.per_try_timeout'
+            validation:
+              function: 'validation.IntAtLeast(1)'
+            default_value: 1
+          - name: 'perTryTimeout'
+            type: NestedObject
+            description: |
+              Specifies a non-zero timeout per retry attempt.
+
+              If not specified, will use the timeout set in HttpRouteAction. If timeout in HttpRouteAction is not set,
+              will use the largest timeout among all backend services associated with the route.
+            at_least_one_of:
+              - 'default_route_action.0.retry_policy.0.retry_conditions'
+              - 'default_route_action.0.retry_policy.0.num_retries'
+              - 'default_route_action.0.retry_policy.0.per_try_timeout'
+            properties:
+              - name: 'seconds'
+                type: String
+                description: |
+                  Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                  Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                at_least_one_of:
+                  - 'default_route_action.0.retry_policy.0.per_try_timeout.0.seconds'
+                  - 'default_route_action.0.retry_policy.0.per_try_timeout.0.nanos'
+              - name: 'nanos'
+                type: Integer
+                description: |
+                  Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are
+                  represented with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                at_least_one_of:
+                  - 'default_route_action.0.retry_policy.0.per_try_timeout.0.seconds'
+                  - 'default_route_action.0.retry_policy.0.per_try_timeout.0.nanos'
+      - name: 'requestMirrorPolicy'
+        type: NestedObject
+        description: |
+          Specifies the policy on how requests intended for the route's backends are shadowed to a separate mirrored backend service.
+          Loadbalancer does not wait for responses from the shadow service. Prior to sending traffic to the shadow service,
+          the host / authority header is suffixed with -shadow.
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+          - 'default_route_action.0.cache_policy'
+        properties:
+          - name: 'backendService'
+            type: ResourceRef
+            description: |
+              The full or partial URL to the BackendService resource being mirrored to.
+            required: true
+            custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
+            resource: 'BackendService'
+            imports: 'selfLink'
+          - name: 'mirrorPercent'
+            min_version: beta
+            is_missing_in_cai: true
+            type: Double
+            description: |
+              The percentage of requests to be mirrored to backendService.
+              The value must be between 0.0 and 100.0 inclusive.
+            validation:
+              function: 'validation.FloatBetween(0, 100)'
+      - name: 'corsPolicy'
+        type: NestedObject
+        description: |
+          The specification for allowing client side cross-origin requests. Please see
+          [W3C Recommendation for Cross Origin Resource Sharing](https://www.w3.org/TR/cors/)
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+          - 'default_route_action.0.cache_policy'
+        properties:
+          - name: 'allowOrigins'
+            type: Array
+            description: |
+              Specifies the list of origins that will be allowed to do CORS requests.
+              An origin is allowed if it matches either an item in allowOrigins or an item in allowOriginRegexes.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            item_type:
+              type: String
+          - name: 'allowOriginRegexes'
+            type: Array
+            description: |
+              Specifies the regular expression patterns that match allowed origins. For regular expression grammar
+              please see en.cppreference.com/w/cpp/regex/ecmascript
+              An origin is allowed if it matches either an item in allowOrigins or an item in allowOriginRegexes.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            item_type:
+              type: String
+          - name: 'allowMethods'
+            type: Array
+            description: |
+              Specifies the content for the Access-Control-Allow-Methods header.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            item_type:
+              type: String
+          - name: 'allowHeaders'
+            type: Array
+            description: |
+              Specifies the content for the Access-Control-Allow-Headers header.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            item_type:
+              type: String
+          - name: 'exposeHeaders'
+            type: Array
+            description: |
+              Specifies the content for the Access-Control-Expose-Headers header.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            item_type:
+              type: String
+          - name: 'maxAge'
+            type: Integer
+            description: |
+              Specifies how long results of a preflight request can be cached in seconds.
+              This translates to the Access-Control-Max-Age header.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+          - name: 'allowCredentials'
+            type: Boolean
+            description: |
+              In response to a preflight request, setting this to true indicates that the actual request can include user credentials.
+              This translates to the Access-Control-Allow-Credentials header.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            default_value: false
+          - name: 'disabled'
+            type: Boolean
+            description: |
+              If true, specifies the CORS policy is disabled. The default value is false, which indicates that the CORS policy is in effect.
+            at_least_one_of:
+              - 'default_route_action.0.cors_policy.0.allow_origins'
+              - 'default_route_action.0.cors_policy.0.allow_origin_regexes'
+              - 'default_route_action.0.cors_policy.0.allow_methods'
+              - 'default_route_action.0.cors_policy.0.allow_headers'
+              - 'default_route_action.0.cors_policy.0.expose_headers'
+              - 'default_route_action.0.cors_policy.0.max_age'
+              - 'default_route_action.0.cors_policy.0.allow_credentials'
+              - 'default_route_action.0.cors_policy.0.disabled'
+            default_value: false
+      - name: 'faultInjectionPolicy'
+        type: NestedObject
+        description: |
+          The specification for fault injection introduced into traffic to test the resiliency of clients to backend service failure.
+          As part of fault injection, when clients send requests to a backend service, delays can be introduced by Loadbalancer on a
+          percentage of requests before sending those request to the backend service. Similarly requests from clients can be aborted
+          by the Loadbalancer for a percentage of requests.
+
+          timeout and retryPolicy will be ignored by clients that are configured with a faultInjectionPolicy.
+        at_least_one_of:
+          - 'default_route_action.0.weighted_backend_services'
+          - 'default_route_action.0.url_rewrite'
+          - 'default_route_action.0.timeout'
+          - 'default_route_action.0.retry_policy'
+          - 'default_route_action.0.request_mirror_policy'
+          - 'default_route_action.0.cors_policy'
+          - 'default_route_action.0.fault_injection_policy'
+          - 'default_route_action.0.cache_policy'
+        properties:
+          - name: 'delay'
+            type: NestedObject
+            description: |
+              The specification for how client requests are delayed as part of fault injection, before being sent to a backend service.
+            at_least_one_of:
+              - 'default_route_action.0.fault_injection_policy.0.delay'
+              - 'default_route_action.0.fault_injection_policy.0.abort'
+            properties:
+              - name: 'fixedDelay'
+                type: NestedObject
+                description: |
+                  Specifies the value of the fixed delay interval.
+                at_least_one_of:
+                  - 'default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay'
+                  - 'default_route_action.0.fault_injection_policy.0.delay.0.percentage'
+                properties:
+                  - name: 'seconds'
+                    type: String
+                    description: |
+                      Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                      Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                    at_least_one_of:
+                      - 'default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay.0.seconds'
+                      - 'default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay.0.nanos'
+                  - name: 'nanos'
+                    type: Integer
+                    description: |
+                      Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are
+                      represented with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                    at_least_one_of:
+                      - 'default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay.0.seconds'
+                      - 'default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay.0.nanos'
+              - name: 'percentage'
+                type: Double
+                description: |
+                  The percentage of traffic (connections/operations/requests) on which delay will be introduced as part of fault injection.
+                  The value must be between 0.0 and 100.0 inclusive.
+                at_least_one_of:
+                  - 'default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay'
+                  - 'default_route_action.0.fault_injection_policy.0.delay.0.percentage'
+                validation:
+                  function: 'validation.FloatBetween(0, 100)'
+          - name: 'abort'
+            type: NestedObject
+            description: |
+              The specification for how client requests are aborted as part of fault injection.
+            at_least_one_of:
+              - 'default_route_action.0.fault_injection_policy.0.delay'
+              - 'default_route_action.0.fault_injection_policy.0.abort'
+            properties:
+              - name: 'httpStatus'
+                type: Integer
+                description: |
+                  The HTTP status code used to abort the request.
+                  The value must be between 200 and 599 inclusive.
+                at_least_one_of:
+                  - 'default_route_action.0.fault_injection_policy.0.abort.0.http_status'
+                  - 'default_route_action.0.fault_injection_policy.0.abort.0.percentage'
+                validation:
+                  function: 'validation.IntBetween(200, 599)'
+              - name: 'percentage'
+                type: Double
+                description: |
+                  The percentage of traffic (connections/operations/requests) which will be aborted as part of fault injection.
+                  The value must be between 0.0 and 100.0 inclusive.
+                at_least_one_of:
+                  - 'default_route_action.0.fault_injection_policy.0.abort.0.http_status'
+                  - 'default_route_action.0.fault_injection_policy.0.abort.0.percentage'
+                validation:
+                  function: 'validation.FloatBetween(0, 100)'
+      - name: 'cachePolicy'
+        type: NestedObject
+        description: |
+          Specifies the cache policy configuration for matched traffic. Available
+          only for Global EXTERNAL_MANAGED load balancer schemes. At least one
+          property must be specified. This policy cannot be specified if any target
+          backend has Identity-Aware Proxy enabled.
+        properties:
+          - name: 'cacheMode'
+            type: Enum
+            is_missing_in_cai: true
+            description: |
+              Specifies the cache setting for all responses from this route. If not
+              specified, Cloud CDN uses CACHE_ALL_STATIC mode.
+            enum_values:
+              - 'USE_ORIGIN_HEADERS'
+              - 'FORCE_CACHE_ALL'
+              - 'CACHE_ALL_STATIC'
+            at_least_one_of:
+              - 'default_route_action.0.cache_policy.0.cache_mode'
+              - 'default_route_action.0.cache_policy.0.default_ttl'
+              - 'default_route_action.0.cache_policy.0.max_ttl'
+              - 'default_route_action.0.cache_policy.0.client_ttl'
+              - 'default_route_action.0.cache_policy.0.request_coalescing'
+              - 'default_route_action.0.cache_policy.0.negative_caching'
+              - 'default_route_action.0.cache_policy.0.negative_caching_policy'
+              - 'default_route_action.0.cache_policy.0.cache_bypass_request_header_names'
+              - 'default_route_action.0.cache_policy.0.cache_key_policy'
+              - 'default_route_action.0.cache_policy.0.serve_while_stale'
+          - name: 'defaultTtl'
+            type: NestedObject
+            is_missing_in_cai: true
+            description: |
+              Specifies the default TTL for cached content for responses that do not have
+              an existing valid TTL (max-age or s-maxage). Setting a TTL of "0" means
+              "always revalidate". The value of defaultTtl cannot be set to a value
+              greater than that of maxTtl. When the cacheMode is set to
+              FORCE_CACHE_ALL, the defaultTtl will overwrite the TTL set in all
+              responses. The maximum allowed value is 31,622,400s (1 year). Infrequently
+              accessed objects may be evicted from the cache before the defined TTL. If
+              not specified, Cloud CDN uses 3600s (1 hour) for CACHE_ALL_STATIC and
+              FORCE_CACHE_ALL modes. Cannot be specified when cacheMode is
+              USE_ORIGIN_HEADERS.
+            at_least_one_of:
+              - 'default_route_action.0.cache_policy.0.cache_mode'
+              - 'default_route_action.0.cache_policy.0.default_ttl'
+              - 'default_route_action.0.cache_policy.0.max_ttl'
+              - 'default_route_action.0.cache_policy.0.client_ttl'
+              - 'default_route_action.0.cache_policy.0.request_coalescing'
+              - 'default_route_action.0.cache_policy.0.negative_caching'
+              - 'default_route_action.0.cache_policy.0.negative_caching_policy'
+              - 'default_route_action.0.cache_policy.0.cache_bypass_request_header_names'
+              - 'default_route_action.0.cache_policy.0.cache_key_policy'
+              - 'default_route_action.0.cache_policy.0.serve_while_stale'
+            properties:
+              - name: 'seconds'
+                type: String
+                required: true
+                description: |
+                  Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+              - name: 'nanos'
+                type: Integer
+                ignore_read: true
+                description: |
+                  Span of time that's a fraction of a second at nanosecond resolution.
+                validation:
+                  function: 'validation.IntBetween(0, 0)'
+          - name: 'maxTtl'
+            type: NestedObject
+            is_missing_in_cai: true
+            description: |
+              Specifies the maximum allowed TTL for cached content. Cache directives that
+              attempt to set a max-age or s-maxage higher than this, or an Expires header
+              more than maxTtl seconds in the future will be capped at the value of
+              maxTtl, as if it were the value of an s-maxage Cache-Control directive.
+              Headers sent to the client will not be modified. Setting a TTL of "0" means
+              "always revalidate". The maximum allowed value is 31,622,400s (1 year).
+              Infrequently accessed objects may be evicted from the cache before the
+              defined TTL. If not specified, Cloud CDN uses 86400s (1 day) for
+              CACHE_ALL_STATIC mode. Can be specified only for CACHE_ALL_STATIC cache
+              mode.
+            at_least_one_of:
+              - 'default_route_action.0.cache_policy.0.cache_mode'
+              - 'default_route_action.0.cache_policy.0.default_ttl'
+              - 'default_route_action.0.cache_policy.0.max_ttl'
+              - 'default_route_action.0.cache_policy.0.client_ttl'
+              - 'default_route_action.0.cache_policy.0.request_coalescing'
+              - 'default_route_action.0.cache_policy.0.negative_caching'
+              - 'default_route_action.0.cache_policy.0.negative_caching_policy'
+              - 'default_route_action.0.cache_policy.0.cache_bypass_request_header_names'
+              - 'default_route_action.0.cache_policy.0.cache_key_policy'
+              - 'default_route_action.0.cache_policy.0.serve_while_stale'
+            properties:
+              - name: 'seconds'
+                type: String
+                required: true
+                description: |
+                  Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+              - name: 'nanos'
+                type: Integer
+                ignore_read: true
+                description: |
+                  Span of time that's a fraction of a second at nanosecond resolution.
+                validation:
+                  function: 'validation.IntBetween(0, 0)'
+          - name: 'clientTtl'
+            type: NestedObject
+            is_missing_in_cai: true
+            description: |
+              Specifies a separate client (e.g. browser client) maximum TTL for cached
+              content. This is used to clamp the max-age (or Expires) value sent to the
+              client. With FORCE_CACHE_ALL, the lesser of clientTtl and defaultTtl
+              is used for the response max-age directive, along with a "public"
+              directive. For cacheable content in CACHE_ALL_STATIC mode, clientTtl
+              clamps the max-age from the origin (if specified), or else sets the
+              response max-age directive to the lesser of the clientTtl and defaultTtl,
+              and also ensures a "public" cache-control directive is present. The maximum
+              allowed value is 31,622,400s (1 year). If not specified, Cloud CDN uses
+              3600s (1 hour) for CACHE_ALL_STATIC mode. Cannot exceed maxTtl.
+              Cannot be specified when cacheMode is USE_ORIGIN_HEADERS.
+            at_least_one_of:
+              - 'default_route_action.0.cache_policy.0.cache_mode'
+              - 'default_route_action.0.cache_policy.0.default_ttl'
+              - 'default_route_action.0.cache_policy.0.max_ttl'
+              - 'default_route_action.0.cache_policy.0.client_ttl'
+              - 'default_route_action.0.cache_policy.0.request_coalescing'
+              - 'default_route_action.0.cache_policy.0.negative_caching'
+              - 'default_route_action.0.cache_policy.0.negative_caching_policy'
+              - 'default_route_action.0.cache_policy.0.cache_bypass_request_header_names'
+              - 'default_route_action.0.cache_policy.0.cache_key_policy'
+              - 'default_route_action.0.cache_policy.0.serve_while_stale'
+            properties:
+              - name: 'seconds'
+                type: String
+                required: true
+                description: |
+                  Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+              - name: 'nanos'
+                type: Integer
+                ignore_read: true
+                description: |
+                  Span of time that's a fraction of a second at nanosecond resolution.
+                validation:
+                  function: 'validation.IntBetween(0, 0)'
+          - name: 'requestCoalescing'
+            type: Boolean
+            send_empty_value: true
+            is_missing_in_cai: true
+            at_least_one_of:
+              - 'default_route_action.0.cache_policy.0.cache_mode'
+              - 'default_route_action.0.cache_policy.0.default_ttl'
+              - 'default_route_action.0.cache_policy.0.max_ttl'
+              - 'default_route_action.0.cache_policy.0.client_ttl'
+              - 'default_route_action.0.cache_policy.0.request_coalescing'
+              - 'default_route_action.0.cache_policy.0.negative_caching'
+              - 'default_route_action.0.cache_policy.0.negative_caching_policy'
+              - 'default_route_action.0.cache_policy.0.cache_bypass_request_header_names'
+              - 'default_route_action.0.cache_policy.0.cache_key_policy'
+              - 'default_route_action.0.cache_policy.0.serve_while_stale'
+            description: |
+              If true then Cloud CDN will combine multiple concurrent cache fill
+              requests into a small number of requests to the origin. If not specified,
+              Cloud CDN applies request coalescing by default.
+          - name: 'negativeCaching'
+            type: Boolean
+            send_empty_value: true
+            is_missing_in_cai: true
+            at_least_one_of:
+              - 'default_route_action.0.cache_policy.0.cache_mode'
+              - 'default_route_action.0.cache_policy.0.default_ttl'
+              - 'default_route_action.0.cache_policy.0.max_ttl'
+              - 'default_route_action.0.cache_policy.0.client_ttl'
+              - 'default_route_action.0.cache_policy.0.request_coalescing'
+              - 'default_route_action.0.cache_policy.0.negative_caching'
+              - 'default_route_action.0.cache_policy.0.negative_caching_policy'
+              - 'default_route_action.0.cache_policy.0.cache_bypass_request_header_names'
+              - 'default_route_action.0.cache_policy.0.cache_key_policy'
+              - 'default_route_action.0.cache_policy.0.serve_while_stale'
+            description: |
+              Negative caching allows per-status code TTLs to be set, in order to apply
+              fine-grained caching for common errors or redirects. This can reduce the
+              load on your origin and improve end-user experience by reducing response
+              latency. When the cacheMode is set to CACHE_ALL_STATIC or
+              USE_ORIGIN_HEADERS, negative caching applies to responses with the
+              specified response code that lack any Cache-Control, Expires, or
+              Pragma: no-cache directives. When the cacheMode is set to
+              FORCE_CACHE_ALL, negative caching applies to all responses with the
+              specified response code, and overrides any caching headers. By default,
+              Cloud CDN applies the following TTLs to these HTTP status codes:
+              * 300 (Multiple Choice), 301, 308 (Permanent Redirects): 10m
+              * 404 (Not Found), 410 (Gone), 451 (Unavailable For Legal Reasons): 120s
+              * 405 (Method Not Found), 501 (Not Implemented): 60s
+              These defaults can be overridden in negativeCachingPolicy. If not
+              specified, Cloud CDN applies negative caching by default.
+          - name: 'negativeCachingPolicy'
+            type: Array
+            send_empty_value: true
+            is_missing_in_cai: true
+            at_least_one_of:
+              - 'default_route_action.0.cache_policy.0.cache_mode'
+              - 'default_route_action.0.cache_policy.0.default_ttl'
+              - 'default_route_action.0.cache_policy.0.max_ttl'
+              - 'default_route_action.0.cache_policy.0.client_ttl'
+              - 'default_route_action.0.cache_policy.0.request_coalescing'
+              - 'default_route_action.0.cache_policy.0.negative_caching'
+              - 'default_route_action.0.cache_policy.0.negative_caching_policy'
+              - 'default_route_action.0.cache_policy.0.cache_bypass_request_header_names'
+              - 'default_route_action.0.cache_policy.0.cache_key_policy'
+              - 'default_route_action.0.cache_policy.0.serve_while_stale'
+            description: |
+              Sets a cache TTL for the specified HTTP status code. negativeCaching
+              must be enabled to configure negativeCachingPolicy. Omitting the policy
+              and leaving negativeCaching enabled will use Cloud CDN's default cache
+              TTLs. Note that when specifying an explicit negativeCachingPolicy, you
+              should take care to specify a cache TTL for all response codes that you
+              wish to cache. Cloud CDN will not apply any default negative caching when
+              a policy exists.
+            item_type:
+              type: NestedObject
+              properties:
+                - name: 'code'
+                  type: Integer
+                  description: |
+                    The HTTP status code to define a TTL against. Only HTTP status codes
+                    300, 301, 302, 307, 308, 404, 405, 410, 421, 451 and 501 can be
+                    specified as values, and you cannot specify a status code more than
+                    once.
+                - name: 'ttl'
+                  type: NestedObject
+                  description: |
+                    The TTL (in seconds) for which to cache responses with the
+                    corresponding status code. The maximum allowed value is 1800s (30
+                    minutes). Infrequently accessed objects may be evicted from the cache
+                    before the defined TTL.
+                  properties:
+                    - name: 'seconds'
+                      type: String
+                      required: true
+                      description: |
+                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                    - name: 'nanos'
+                      type: Integer
+                      ignore_read: true
+                      description: |
+                        Span of time that's a fraction of a second at nanosecond resolution.
+                      validation:
+                        function: 'validation.IntBetween(0, 0)'
+          - name: 'cacheBypassRequestHeaderNames'
+            type: Array
+            is_missing_in_cai: true
+            at_least_one_of:
+              - 'default_route_action.0.cache_policy.0.cache_mode'
+              - 'default_route_action.0.cache_policy.0.default_ttl'
+              - 'default_route_action.0.cache_policy.0.max_ttl'
+              - 'default_route_action.0.cache_policy.0.client_ttl'
+              - 'default_route_action.0.cache_policy.0.request_coalescing'
+              - 'default_route_action.0.cache_policy.0.negative_caching'
+              - 'default_route_action.0.cache_policy.0.negative_caching_policy'
+              - 'default_route_action.0.cache_policy.0.cache_bypass_request_header_names'
+              - 'default_route_action.0.cache_policy.0.cache_key_policy'
+              - 'default_route_action.0.cache_policy.0.serve_while_stale'
+            description: |
+              Bypass the cache when the specified request headers are matched by name,
+              e.g. Pragma or Authorization headers. Values are case-insensitive. Up to 5
+              header names can be specified. The cache is bypassed for all cacheMode
+              values.
+            item_type:
+              type: String
+          - name: 'serveWhileStale'
+            type: NestedObject
+            is_missing_in_cai: true
+            at_least_one_of:
+              - 'default_route_action.0.cache_policy.0.cache_mode'
+              - 'default_route_action.0.cache_policy.0.default_ttl'
+              - 'default_route_action.0.cache_policy.0.max_ttl'
+              - 'default_route_action.0.cache_policy.0.client_ttl'
+              - 'default_route_action.0.cache_policy.0.request_coalescing'
+              - 'default_route_action.0.cache_policy.0.negative_caching'
+              - 'default_route_action.0.cache_policy.0.negative_caching_policy'
+              - 'default_route_action.0.cache_policy.0.cache_bypass_request_header_names'
+              - 'default_route_action.0.cache_policy.0.cache_key_policy'
+              - 'default_route_action.0.cache_policy.0.serve_while_stale'
+            description: |
+              Serve existing content from the cache (if available) when revalidating
+              content with the origin, or when an error is encountered when refreshing
+              the cache. This setting defines the default "max-stale" duration for any
+              cached responses that do not specify a max-stale directive. Stale
+              responses that exceed the TTL configured here will not be served. The
+              default limit (max-stale) is 86400s (1 day), which will allow stale
+              content to be served up to this limit beyond the max-age (or s-maxage) of
+              a cached response. The maximum allowed value is 604800 (1 week). Set this
+              to zero (0) to disable serve-while-stale.
+            properties:
+              - name: 'seconds'
+                type: String
+                required: true
+                description: |
+                  Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+              - name: 'nanos'
+                type: Integer
+                ignore_read: true
+                description: |
+                  Span of time that's a fraction of a second at nanosecond resolution.
+                validation:
+                  function: 'validation.IntBetween(0, 0)'
+          - name: 'cacheKeyPolicy'
+            type: NestedObject
+            at_least_one_of:
+              - 'default_route_action.0.cache_policy.0.cache_mode'
+              - 'default_route_action.0.cache_policy.0.default_ttl'
+              - 'default_route_action.0.cache_policy.0.max_ttl'
+              - 'default_route_action.0.cache_policy.0.client_ttl'
+              - 'default_route_action.0.cache_policy.0.request_coalescing'
+              - 'default_route_action.0.cache_policy.0.negative_caching'
+              - 'default_route_action.0.cache_policy.0.negative_caching_policy'
+              - 'default_route_action.0.cache_policy.0.cache_bypass_request_header_names'
+              - 'default_route_action.0.cache_policy.0.cache_key_policy'
+              - 'default_route_action.0.cache_policy.0.serve_while_stale'
+            description: |
+              The cache key configuration. If not specified, the default behavior depends
+              on the backend type: for Backend Services, the complete request URI is
+              used; for Backend Buckets, the request URI is used without the protocol or
+              host, and only query parameters known to Cloud Storage are included.
+            properties:
+              - name: 'includeProtocol'
+                type: Boolean
+                send_empty_value: true
+                is_missing_in_cai: true
+                description: |
+                  If true, http and https requests will be cached separately. Note: This
+                  setting is only applicable to routes that use a Backend Service. It
+                  does not affect requests served by a Backend Bucket, as the protocol is
+                  never included in a Backend Bucket's cache key. Attempting to set on a
+                  route that points exclusively to Backend Buckets will result in a
+                  configuration error.
+                at_least_one_of:
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_protocol'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_host'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_query_string'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.excluded_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_header_names'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_cookie_names'
+              - name: 'includeHost'
+                type: Boolean
+                send_empty_value: true
+                is_missing_in_cai: true
+                description: |
+                  If true, requests to different hosts will be cached separately. Note:
+                  This setting is only applicable to routes that use a Backend Service.
+                  It does not affect requests served by a Backend Bucket, as the host is
+                  never included in a Backend Bucket's cache key. Attempting to set it on
+                  a route that points exclusively to Backend Buckets will result in a
+                  configuration error.
+                at_least_one_of:
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_protocol'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_host'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_query_string'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.excluded_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_header_names'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_cookie_names'
+              - name: 'includeQueryString'
+                type: Boolean
+                send_empty_value: true
+                is_missing_in_cai: true
+                description: |
+                  If true, include query string parameters in the cache key according to
+                  includedQueryParameters and excludedQueryParameters. If neither is
+                  set, the entire query string will be included. If false, the query
+                  string will be excluded from the cache key entirely. Note: This field
+                  applies to routes that use backend services. Attempting to set it on a
+                  route that points exclusively to Backend Buckets will result in a
+                  configuration error. For routes that point to a Backend Bucket, use
+                  includedQueryParameters to define which parameters should be part of
+                  the cache key.
+                at_least_one_of:
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_protocol'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_host'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_query_string'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.excluded_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_header_names'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_cookie_names'
+              - name: 'includedQueryParameters'
+                type: Array
+                send_empty_value: true
+                is_missing_in_cai: true
+                description: |
+                  Names of query string parameters to include in cache keys. All other
+                  parameters will be excluded. Either specify includedQueryParameters
+                  or excludedQueryParameters, not both. '&' and '=' will be percent
+                  encoded and not treated as delimiters.
+                conflicts:
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.excluded_query_parameters'
+                at_least_one_of:
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_protocol'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_host'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_query_string'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.excluded_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_header_names'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_cookie_names'
+                item_type:
+                  type: String
+              - name: 'excludedQueryParameters'
+                type: Array
+                send_empty_value: true
+                is_missing_in_cai: true
+                description: |
+                  Names of query string parameters to exclude in cache keys. All other
+                  parameters will be included. Either specify excludedQueryParameters
+                  or includedQueryParameters, not both. '&' and '=' will be percent
+                  encoded and not treated as delimiters. Note: This field applies to
+                  routes that use backend services. Attempting to set it on a route that
+                  points exclusively to Backend Buckets will result in a configuration
+                  error. For routes that point to a Backend Bucket, use
+                  includedQueryParameters to define which parameters should be part of
+                  the cache key.
+                conflicts:
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_query_parameters'
+                at_least_one_of:
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_protocol'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_host'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_query_string'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.excluded_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_header_names'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_cookie_names'
+                item_type:
+                  type: String
+              - name: 'includedHeaderNames'
+                type: Array
+                send_empty_value: true
+                is_missing_in_cai: true
+                description: |
+                  Allows HTTP request headers (by name) to be used in the cache key.
+                at_least_one_of:
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_protocol'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_host'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_query_string'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.excluded_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_header_names'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_cookie_names'
+                item_type:
+                  type: String
+              - name: 'includedCookieNames'
+                type: Array
+                send_empty_value: true
+                is_missing_in_cai: true
+                description: |
+                  Allows HTTP cookies (by name) to be used in the cache key. The
+                  name=value pair will be used in the cache key Cloud CDN generates.
+                  Note: This setting is only applicable to routes that use a Backend
+                  Service. It does not affect requests served by a Backend Bucket.
+                  Attempting to set it on a route that points exclusively to Backend
+                  Buckets will result in a configuration error. Up to 5 cookie names can
+                  be specified.
+                at_least_one_of:
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_protocol'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_host'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.include_query_string'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.excluded_query_parameters'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_header_names'
+                  - 'default_route_action.0.cache_policy.0.cache_key_policy.0.included_cookie_names'
+                item_type:
+                  type: String

--- a/tool/mm_yaml_sources.yaml
+++ b/tool/mm_yaml_sources.yaml
@@ -101,3 +101,58 @@ files:
     upstream: null  # MM templates IAM bindings; schema-only curation
   google_dns_managed_zone_iam_member:
     upstream: null  # MM templates IAM bindings; schema-only curation
+
+  # Wave 6 — Compute LB stack (Plan 5.G).
+  # MM URLs are best-effort guesses; Batch 0 probes each and rewrites to
+  # `upstream: null` for any that return 404 (handwritten in
+  # terraform-provider-google, not generated from Magic Modules).
+  google_compute_autoscaler:
+    upstream: mmv1/products/compute/Autoscaler.yaml
+  google_compute_backend_bucket:
+    upstream: mmv1/products/compute/BackendBucket.yaml
+  google_compute_backend_service:
+    upstream: mmv1/products/compute/BackendService.yaml
+  google_compute_forwarding_rule:
+    upstream: mmv1/products/compute/ForwardingRule.yaml
+  google_compute_global_forwarding_rule:
+    upstream: mmv1/products/compute/GlobalForwardingRule.yaml
+  google_compute_global_network_endpoint_group:
+    upstream: mmv1/products/compute/GlobalNetworkEndpointGroup.yaml
+  google_compute_health_check:
+    upstream: mmv1/products/compute/HealthCheck.yaml
+  google_compute_instance_group_manager:
+    upstream: mmv1/products/compute/InstanceGroupManager.yaml
+  google_compute_instance_template:
+    upstream: mmv1/products/compute/InstanceTemplate.yaml
+  google_compute_managed_ssl_certificate:
+    upstream: mmv1/products/compute/ManagedSslCertificate.yaml
+  google_compute_network_endpoint_group:
+    upstream: mmv1/products/compute/NetworkEndpointGroup.yaml
+  google_compute_region_autoscaler:
+    upstream: mmv1/products/compute/RegionAutoscaler.yaml
+  google_compute_region_backend_service:
+    upstream: mmv1/products/compute/RegionBackendService.yaml
+  google_compute_region_health_check:
+    upstream: mmv1/products/compute/RegionHealthCheck.yaml
+  google_compute_region_instance_group_manager:
+    upstream: mmv1/products/compute/RegionInstanceGroupManager.yaml
+  google_compute_region_network_endpoint_group:
+    upstream: mmv1/products/compute/RegionNetworkEndpointGroup.yaml
+  google_compute_region_target_http_proxy:
+    upstream: mmv1/products/compute/RegionTargetHttpProxy.yaml
+  google_compute_region_target_https_proxy:
+    upstream: mmv1/products/compute/RegionTargetHttpsProxy.yaml
+  google_compute_region_url_map:
+    upstream: mmv1/products/compute/RegionUrlMap.yaml
+  google_compute_security_policy:
+    upstream: null  # handwritten in terraform-provider-google (probe returned 404)
+  google_compute_ssl_certificate:
+    upstream: mmv1/products/compute/SslCertificate.yaml
+  google_compute_ssl_policy:
+    upstream: mmv1/products/compute/SslPolicy.yaml
+  google_compute_target_http_proxy:
+    upstream: mmv1/products/compute/TargetHttpProxy.yaml
+  google_compute_target_https_proxy:
+    upstream: mmv1/products/compute/TargetHttpsProxy.yaml
+  google_compute_url_map:
+    upstream: mmv1/products/compute/UrlMap.yaml


### PR DESCRIPTION
## Summary

Seeds `tool/mm_yaml_sources.yaml` with 25 entries covering the Wave 6 Compute LB stack. MM probe ran during this PR's prep; 24/25 resources are present in Magic Modules, 1 is handwritten in terraform-provider-google and marked `upstream: null`.

This is the **Batch 0 prep PR** for Plan 5.G — Wave 6. Batches 1-4 follow on the same branch after this merges.

## MM probe results

- **Present (24)**: autoscaler, backend_bucket, backend_service, forwarding_rule, global_forwarding_rule, global_network_endpoint_group, health_check, instance_group_manager, instance_template, managed_ssl_certificate, network_endpoint_group, region_autoscaler, region_backend_service, region_health_check, region_instance_group_manager, region_network_endpoint_group, region_target_http_proxy, region_target_https_proxy, region_url_map, ssl_certificate, ssl_policy, target_http_proxy, target_https_proxy, url_map
- **MM-absent (1)**: `google_compute_security_policy` → `upstream: null` (handwritten)

The Plan 5.G design hypothesis ("LB legacy resources are historically more handwritten, expect higher null-upstream ratio than Wave 5's 23%") turned out backwards — LB coverage in Magic Modules is **96%** (24/25), significantly better than Wave 5's IAM/Cloud SQL coverage (77%).

## Resource coverage

- L7 Global Application LB core (8)
- L7 Regional/Internal Application LB core (5)
- Health checks (2)
- MIG / Autoscaler (5)
- NEG (3)
- Cloud Armor + SSL Policy (2)

Total: 25.

## Test plan

- [x] `dart run tool/sync_mm_yaml.dart` returns `failed: []` after the `security_policy` null
- [x] Baseline universal_invariants_test green (4 gates / + Gate 2 + Gate 6 in other suites)
- [x] Per-service barrel invariant green (24 barrels + 1 discovery)
- [x] No changes to package code; manifest + MM YAML mirrors only