### PR TITLE
Wave 7 Batch 3 — Monitoring channels + uptime + SLO (5 resources, Plan 5.H)

### DIFF
--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_monitoring_dashboard.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_monitoring_dashboard.yaml
@@ -1,0 +1,97 @@
+outputDir: monitoring
+
+classDocComment: |-
+  /// Factory wrapper for `google_monitoring_dashboard` (provider
+  /// `hashicorp/google ~> 7.0`).
+  ///
+  /// Manages a Cloud Monitoring dashboard. Dashboards in this version are
+  /// modeled **deliberately minimally**: the entire dashboard layout — rows,
+  /// columns, mosaics, widgets, charts, thresholds, etc. — is passed as a
+  /// **single JSON string** via [dashboardJson]. There is no typed Dart
+  /// widget model in v0.0.x; the Cloud Console UI is the source of truth
+  /// for the dashboard schema, which is large, fluid, and well-supported
+  /// by the in-product editor.
+  ///
+  /// Required identity:
+  /// - [localName]: Terraform local name (the address segment after
+  ///   `google_monitoring_dashboard.`).
+  /// - `dashboardJson`: full dashboard JSON payload as a Dart `String`. Must
+  ///   conform to
+  ///   <https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards>.
+  ///
+  /// ## Authoring workflow
+  ///
+  /// 1. Build the dashboard interactively in the Cloud Console
+  ///    (Monitoring -> Dashboards -> Create dashboard).
+  /// 2. Once it looks right, open `Settings -> JSON` and copy the full JSON
+  ///    body. (Equivalently, run
+  ///    `gcloud monitoring dashboards describe DASHBOARD_ID --format=json`
+  ///    against an existing dashboard, replacing `DASHBOARD_ID` with the
+  ///    resource ID.)
+  /// 3. Paste the JSON into your Dart source as a raw String and pass it via
+  ///    `dashboardJson: TfArg.literal(...)`.
+  ///
+  /// Programmatic assembly is also fine — `jsonEncode(Map<String, dynamic>)`
+  /// from `dart:convert` produces an equivalent String. Both forms are
+  /// byte-identical at the Terraform layer; pick whichever the codebase
+  /// prefers (raw multi-line String for diff stability, `jsonEncode` when
+  /// the dashboard is parameterized by Dart values).
+  ///
+  /// Example (raw String, exported from Cloud Console):
+  /// ```dart
+  /// final overview = GoogleMonitoringDashboard(
+  ///   localName: 'service_overview',
+  ///   dashboardJson: TfArg.literal('''
+  /// {
+  ///   "displayName": "Service overview",
+  ///   "mosaicLayout": {
+  ///     "columns": 12,
+  ///     "tiles": [
+  ///       {
+  ///         "width": 6,
+  ///         "height": 4,
+  ///         "widget": {
+  ///           "title": "Request rate",
+  ///           "xyChart": {
+  ///             "dataSets": [
+  ///               {
+  ///                 "timeSeriesQuery": {
+  ///                   "timeSeriesFilter": {
+  ///                     "filter": "metric.type=\\"run.googleapis.com/request_count\\""
+  ///                   }
+  ///                 }
+  ///               }
+  ///             ]
+  ///           }
+  ///         }
+  ///       }
+  ///     ]
+  ///   }
+  /// }
+  /// '''),
+  /// );
+  /// ```
+  ///
+  /// Example (programmatic assembly via `dart:convert`):
+  /// ```dart
+  /// import 'dart:convert';
+  ///
+  /// final dashboard = GoogleMonitoringDashboard(
+  ///   localName: 'service_overview',
+  ///   dashboardJson: TfArg.literal(jsonEncode(<String, dynamic>{
+  ///     'displayName': 'Service overview',
+  ///     'mosaicLayout': {'columns': 12, 'tiles': <Map<String, dynamic>>[]},
+  ///   })),
+  /// );
+  /// ```
+  ///
+  /// Composition pattern: extends `Resource<$GoogleMonitoringDashboard>` for
+  /// runtime behavior. There are no nested helper classes — the entire
+  /// dashboard body lives inside the [dashboardJson] String.
+
+# `dashboard_json` first as the required payload, then optional `project`.
+# Computed-only attrs (`id`) and the `timeouts` meta-arg block are filtered
+# out — they're not constructor inputs.
+paramOrder:
+  - dashboard_json
+  - project

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_monitoring_metric_descriptor.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_monitoring_metric_descriptor.yaml
@@ -1,0 +1,219 @@
+outputDir: monitoring
+
+classDocComment: |-
+  /// Factory wrapper for `google_monitoring_metric_descriptor` (provider
+  /// `hashicorp/google ~> 7.0`).
+  ///
+  /// Required identity:
+  /// - [localName]: Terraform local name (the address segment after
+  ///   `google_monitoring_metric_descriptor.`).
+  /// - `type`: the fully-qualified metric type. User-defined metrics must use
+  ///   one of the reserved DNS prefixes (`custom.googleapis.com/`,
+  ///   `external.googleapis.com/`, or `logging.googleapis.com/user/`), e.g.
+  ///   `'custom.googleapis.com/myapp/requests'`. The relative part is limited
+  ///   to 100 characters of `[A-Za-z0-9_/]`.
+  /// - `metricKind`: whether the metric records instantaneous values
+  ///   ([MonitoringMetricKind.gauge]), deltas
+  ///   ([MonitoringMetricKind.delta]), or running totals
+  ///   ([MonitoringMetricKind.cumulative]). Not every
+  ///   `(metricKind, valueType)` combination is supported by the API; consult
+  ///   the [Cloud Monitoring docs](https://cloud.google.com/monitoring/api/v3/kinds-and-types).
+  /// - `valueType`: the value kind recorded per data point. See
+  ///   [MonitoringValueType].
+  /// - `description`: human-readable description shown in documentation /
+  ///   metric pickers (required by the API).
+  ///
+  /// Modeling notes:
+  /// - `labels` is a nested-block set. Use [MonitoringMetricDescriptorLabel]
+  ///   entries to declare the label schema; per-label `valueType` is a
+  ///   narrower enum than the descriptor's (no `DOUBLE` / `DISTRIBUTION`).
+  /// - `metadata` is a `max_items: 1` block exposing the sampling /
+  ///   ingest-delay hints (Duration strings, e.g. `'60s'`).
+  /// - `monitoredResourceTypes` is a server-populated set and not a
+  ///   constructor input.
+  ///
+  /// Example (custom DELTA / INT64 counter):
+  /// ```dart
+  /// final descriptor = GoogleMonitoringMetricDescriptor(
+  ///   localName: 'app_requests',
+  ///   type: TfArg.literal('custom.googleapis.com/myapp/requests'),
+  ///   metricKind: TfArg.literal(MonitoringMetricKind.delta),
+  ///   valueType: TfArg.literal(MonitoringValueType.int64),
+  ///   description: TfArg.literal('Number of requests received by myapp.'),
+  ///   displayName: TfArg.literal('App requests'),
+  ///   unit: TfArg.literal('1'),
+  ///   labels: const [
+  ///     MonitoringMetricDescriptorLabel(
+  ///       key: TfArgLiteral('route'),
+  ///       valueType: TfArgLiteral(MonitoringMetricLabelValueType.string),
+  ///       description: TfArgLiteral('HTTP route template.'),
+  ///     ),
+  ///   ],
+  /// );
+  /// ```
+  ///
+  /// Manages a Cloud Monitoring user-defined metric descriptor. Composition
+  /// pattern: extends `Resource<$GoogleMonitoringMetricDescriptor>` for
+  /// runtime behavior. The nested-block helpers
+  /// ([MonitoringMetricDescriptorLabel],
+  /// [MonitoringMetricDescriptorMetadata]) and the enum wrappers
+  /// ([MonitoringMetricKind], [MonitoringValueType],
+  /// [MonitoringMetricLabelValueType], [MonitoringMetricLaunchStage]) live
+  /// in the `prelude` below.
+
+# Required identity (type / metric_kind / value_type / description) first, then
+# optional metadata (display_name, unit), then nested blocks (labels +
+# metadata), then optional release-management (launch_stage) and project.
+# Computed-only attrs (id, name, monitored_resource_types) are filtered out —
+# they're not constructor inputs. `timeouts` is also filtered (Terraform
+# meta-arg).
+paramOrder:
+  - type
+  - metric_kind
+  - value_type
+  - description
+  - display_name
+  - unit
+  - labels
+  - metadata
+  - launch_stage
+  - project
+
+extraGetters: |2
+    /// Reference to `id` attribute (the metric descriptor's full resource
+    /// name, `projects/{project}/metricDescriptors/{type}`).
+    TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+    /// Reference to `name` attribute (same shape as [id]; populated by Cloud
+    /// Monitoring on create).
+    TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
+
+    /// Reference to `monitored_resource_types` — the set of monitored
+    /// resource types this descriptor may be associated with. Server-managed.
+    TfRef<List<String>> get monitoredResourceTypes =>
+        TfRef.attribute<List<String>>(this, 'monitored_resource_types');
+
+dartTypeOverrides:
+  metric_kind: MonitoringMetricKind
+  value_type: MonitoringValueType
+  launch_stage: MonitoringMetricLaunchStage
+
+prelude: |
+  // ===========================================================================
+  // Top-level enums
+  // ===========================================================================
+
+  /// `metric_kind` — whether the metric records instantaneous values, deltas,
+  /// or running totals. Not every `(metricKind, valueType)` combination is
+  /// supported by the Cloud Monitoring API.
+  enum MonitoringMetricKind {
+    unspecified('METRIC_KIND_UNSPECIFIED'),
+    gauge('GAUGE'),
+    delta('DELTA'),
+    cumulative('CUMULATIVE');
+
+    const MonitoringMetricKind(this.terraformValue);
+    final String terraformValue;
+  }
+
+  /// `value_type` — the value kind recorded per data point. Use
+  /// [MonitoringValueType.distribution] together with the histogram-bucket
+  /// configuration on the metric's time series; the schema does **not**
+  /// include `MONEY` or a `VALUE_TYPE_UNSPECIFIED` sentinel.
+  enum MonitoringValueType {
+    boolean('BOOL'),
+    int64('INT64'),
+    doubleValue('DOUBLE'),
+    string('STRING'),
+    distribution('DISTRIBUTION');
+
+    const MonitoringValueType(this.terraformValue);
+    final String terraformValue;
+  }
+
+  /// `labels[].value_type` — the data type of a label attached to this
+  /// metric. The label-level value space is narrower than the descriptor's
+  /// (no `DOUBLE` / `DISTRIBUTION`). Defaults to
+  /// [MonitoringMetricLabelValueType.string] when omitted.
+  enum MonitoringMetricLabelValueType {
+    string('STRING'),
+    boolean('BOOL'),
+    int64('INT64');
+
+    const MonitoringMetricLabelValueType(this.terraformValue);
+    final String terraformValue;
+  }
+
+  /// `launch_stage` — release-management stage of this metric definition.
+  /// Defaults to [MonitoringMetricLaunchStage.ga] / unset for stable metrics.
+  enum MonitoringMetricLaunchStage {
+    unspecified('LAUNCH_STAGE_UNSPECIFIED'),
+    unimplemented('UNIMPLEMENTED'),
+    prelaunch('PRELAUNCH'),
+    earlyAccess('EARLY_ACCESS'),
+    alpha('ALPHA'),
+    beta('BETA'),
+    ga('GA'),
+    deprecated('DEPRECATED');
+
+    const MonitoringMetricLaunchStage(this.terraformValue);
+    final String terraformValue;
+  }
+
+  // ===========================================================================
+  // labels + metadata helpers
+  // ===========================================================================
+
+  /// One entry in `labels` — describes a label key that values of this
+  /// metric carry. The label-level [valueType] is narrower than the
+  /// descriptor's top-level [MonitoringValueType] (no `DOUBLE` /
+  /// `DISTRIBUTION`).
+  class MonitoringMetricDescriptorLabel {
+    const MonitoringMetricDescriptorLabel({
+      required this.key,
+      this.valueType,
+      this.description,
+    });
+
+    final TfArg<String> key;
+    final TfArg<MonitoringMetricLabelValueType>? valueType;
+    final TfArg<String>? description;
+
+    Map<String, Object?> toArgMap() => {
+          'key': key.toTfJson(),
+          if (valueType != null) 'value_type': valueType!.toTfJson(),
+          if (description != null) 'description': description!.toTfJson(),
+        };
+  }
+
+  /// `metadata` block (max=1) — sampling / ingest-delay hints for the
+  /// metric. Both fields are [Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration)-format
+  /// strings (e.g. `'60s'`, `'300s'`).
+  class MonitoringMetricDescriptorMetadata {
+    const MonitoringMetricDescriptorMetadata({
+      this.samplePeriod,
+      this.ingestDelay,
+    });
+
+    /// Period at which the source writes data points. Metrics with a higher
+    /// granularity have a smaller sampling period.
+    final TfArg<String>? samplePeriod;
+
+    /// Maximum delay between when a data point is produced and when it
+    /// becomes readable. Data points older than this age are guaranteed to
+    /// be available.
+    final TfArg<String>? ingestDelay;
+
+    Map<String, Object?> toArgMap() => {
+          if (samplePeriod != null) 'sample_period': samplePeriod!.toTfJson(),
+          if (ingestDelay != null) 'ingest_delay': ingestDelay!.toTfJson(),
+        };
+  }
+
+customSlots:
+  labels:
+    paramDeclaration: 'List<MonitoringMetricDescriptorLabel>? labels'
+    argMapEntry: "if (labels != null) 'labels': TfArg.literal(labels.map((l) => l.toArgMap()).toList()),"
+  metadata:
+    paramDeclaration: 'MonitoringMetricDescriptorMetadata? metadata'
+    argMapEntry: "if (metadata != null) 'metadata': TfArg.literal([metadata.toArgMap()]),"

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_monitoring_notification_channel.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_monitoring_notification_channel.yaml
@@ -1,0 +1,222 @@
+outputDir: monitoring
+
+classDocComment: |-
+  /// Factory wrapper for `google_monitoring_notification_channel` (provider
+  /// `hashicorp/google ~> 7.0`).
+  ///
+  /// Required identity:
+  /// - [localName]: Terraform local name (the address segment after
+  ///   `google_monitoring_notification_channel.`).
+  /// - `type`: the notification channel **type registry key**. Google
+  ///   maintains the canonical list server-side (the API returns it from
+  ///   `projects.notificationChannelDescriptors.list`) and adds new
+  ///   transports asynchronously, so this slot is intentionally a free-form
+  ///   `String` rather than a Dart enum — pinning an enum here would force
+  ///   a terradart release every time Google ships a new descriptor.
+  ///
+  /// Common `type` values and the channel-specific keys they expect in
+  /// [labels] (the canonical reference is the `NotificationChannelDescriptor`
+  /// for each type):
+  /// - `"email"` — `labels: {'email_address': 'oncall@example.com'}`.
+  /// - `"slack"` — `labels: {'channel_name': '#alerts',
+  ///   'team': 'T01234ABCD'}`. The bot OAuth token goes in
+  ///   [sensitiveLabels].`authToken` (NOT in `labels`).
+  /// - `"pagerduty"` — `labels: {'service_name': 'prod-oncall'}`. The
+  ///   integration service key goes in [sensitiveLabels].`serviceKey`.
+  /// - `"sms"` — `labels: {'number': '+15551234567'}` (E.164 format,
+  ///   pre-verified phone numbers only).
+  /// - `"webhook_basicauth"` — `labels: {'url': 'https://...'}` +
+  ///   [sensitiveLabels].`password` (with the basic-auth username embedded
+  ///   in the URL or in `labels`).
+  /// - `"webhook_tokenauth"` — `labels: {'url': 'https://...'}` +
+  ///   [sensitiveLabels].`authToken` for the bearer token.
+  /// - `"pubsub"` — `labels: {'topic': 'projects/<p>/topics/<t>'}`. The
+  ///   service account that posts to the topic is managed via IAM, not
+  ///   via this resource.
+  ///
+  /// Credentials handling: any value containing a secret (Slack token,
+  /// PagerDuty service key, webhook auth token / basic-auth password) MUST
+  /// be placed in [sensitiveLabels] rather than [labels]. The provider
+  /// rejects configurations that supply the same logical secret in both
+  /// places, and only [sensitiveLabels] entries are masked from plan
+  /// output. The 3 plaintext slots (`authToken`, `password`, `serviceKey`)
+  /// are flagged sensitive by the provider schema and also enumerated in
+  /// [extraSensitiveFields] (belt-and-suspenders); the 6
+  /// write-only-API siblings (`*_wo` + `*_wo_version`) keep the plaintext
+  /// out of Terraform state entirely on Terraform 1.11+ — prefer them
+  /// when your CLI version supports it, bumping the `*_wo_version` int to
+  /// force rotation.
+  ///
+  /// Verification: [verificationStatus] reflects whether the channel has
+  /// passed Google's out-of-band verification step (e.g. clicking a link
+  /// in a confirmation email, replying to an SMS). Channels in the
+  /// `UNVERIFIED` state do not deliver notifications. Verification cannot
+  /// be triggered through this resource — call
+  /// `gcloud alpha monitoring channels verify` or the
+  /// `projects.notificationChannels.verify` REST endpoint after apply.
+  ///
+  /// Example (Slack channel):
+  /// ```dart
+  /// final slack = GoogleMonitoringNotificationChannel(
+  ///   localName: 'oncall_slack',
+  ///   displayName: TfArg.literal('#oncall alerts'),
+  ///   type: TfArg.literal('slack'),
+  ///   labels: TfArg.literal(const {
+  ///     'channel_name': '#oncall',
+  ///     'team': 'T01234ABCD',
+  ///   }),
+  ///   sensitiveLabels: MonitoringNotificationChannelSensitiveLabels(
+  ///     authTokenWo: TfArg.ref(slackBotTokenSecret.versionRef),
+  ///     authTokenWoVersion: TfArg.literal('1'),
+  ///   ),
+  ///   userLabels: TfArg.literal(const {'team': 'platform'}),
+  /// );
+  /// ```
+  ///
+  /// Manages a Cloud Monitoring notification channel. Composition pattern:
+  /// extends `Resource<$GoogleMonitoringNotificationChannel>` for runtime
+  /// behavior. The nested [MonitoringNotificationChannelSensitiveLabels]
+  /// helper is modeled in the `prelude` below.
+
+# User-settable attrs first (type is the only schema-required slot;
+# display_name is technically optional but operationally required for
+# anything that surfaces in dashboards). Labels next (channel-type
+# config), then sensitive labels, then metadata + lifecycle flags, then
+# project. Computed-only attrs (id, name, verification_status) are
+# filtered out — they're not constructor inputs. `timeouts` is also
+# filtered (Terraform meta-arg).
+paramOrder:
+  - display_name
+  - type
+  - labels
+  - sensitive_labels
+  - user_labels
+  - description
+  - enabled
+  - force_delete
+  - project
+
+# Schema-flagged `sensitive: true` fields under `sensitive_labels.*`
+# (auth_token, password, service_key) auto-populate the generated
+# `$sensitiveFields` set with their dotted snake_case paths. We restate
+# them here so the contract is visible in the override file itself — a
+# reviewer scanning this file does not have to cross-reference the
+# schema to confirm the masking surface. Duplicates collapse via the
+# underlying Set, so this is purely additive belt-and-suspenders.
+extraSensitiveFields:
+  - sensitive_labels.auth_token
+  - sensitive_labels.password
+  - sensitive_labels.service_key
+
+extraGetters: |2
+    /// Reference to `id` attribute (the channel's full REST resource name,
+    /// `projects/{project}/notificationChannels/{channel_id}`). Alert
+    /// policies consume this value via their `notification_channels` list.
+    TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+    /// Reference to `name` attribute. Identical in shape to [id]; the
+    /// provider populates both with the same full resource name on create.
+    TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
+
+    /// Reference to the computed `verification_status` attribute. One of
+    /// `STATE_UNSPECIFIED`, `UNVERIFIED`, `VERIFIED`. Channels with
+    /// `UNVERIFIED` status do not deliver notifications — kick off
+    /// verification out-of-band (`gcloud alpha monitoring channels verify`
+    /// or the REST `verify` endpoint) after apply.
+    TfRef<String> get verificationStatus =>
+        TfRef.attribute<String>(this, 'verification_status');
+
+prelude: |
+  // ===========================================================================
+  // sensitive_labels nested block (max=1)
+  // ===========================================================================
+
+  /// `sensitive_labels` block (max=1) — credential slots for notification
+  /// channel types that need an out-of-band secret. Each transport uses a
+  /// different subset:
+  ///
+  /// - `slack` → [authToken] (or [authTokenWo] + [authTokenWoVersion] for
+  ///   the write-only API).
+  /// - `webhook_basicauth` → [password] (or [passwordWo] +
+  ///   [passwordWoVersion]).
+  /// - `webhook_tokenauth` → [authToken] / [authTokenWo].
+  /// - `pagerduty` → [serviceKey] (or [serviceKeyWo] +
+  ///   [serviceKeyWoVersion]).
+  ///
+  /// The plaintext slots ([authToken], [password], [serviceKey]) are
+  /// schema-flagged sensitive and round-trip through the wrapper's
+  /// `$sensitiveFields` set — synth masks them in plan output. Prefer the
+  /// write-only variants (`*Wo` + `*WoVersion`) on Terraform 1.11+: the
+  /// plaintext never enters Terraform state, and bumping the integer
+  /// `*WoVersion` slot forces a credential rotation on next apply.
+  ///
+  /// Credentials must NOT also be supplied via [GoogleMonitoringNotificationChannel.labels]
+  /// — the provider rejects configurations that double-specify the same
+  /// logical secret.
+  class MonitoringNotificationChannelSensitiveLabels {
+    const MonitoringNotificationChannelSensitiveLabels({
+      this.authToken,
+      this.authTokenWo,
+      this.authTokenWoVersion,
+      this.password,
+      this.passwordWo,
+      this.passwordWoVersion,
+      this.serviceKey,
+      this.serviceKeyWo,
+      this.serviceKeyWoVersion,
+    });
+
+    /// Slack bot OAuth token / webhook bearer token. Sensitive — masked
+    /// from plan output and surfaced in `$sensitiveFields`.
+    final TfArg<String>? authToken;
+
+    /// Write-only sibling of [authToken] (Terraform 1.11+). Bump
+    /// [authTokenWoVersion] to rotate.
+    final TfArg<String>? authTokenWo;
+
+    /// Monotonic counter that triggers a rotation of [authTokenWo].
+    final TfArg<String>? authTokenWoVersion;
+
+    /// Basic-auth password for `webhook_basicauth` channels. Sensitive.
+    final TfArg<String>? password;
+
+    /// Write-only sibling of [password] (Terraform 1.11+).
+    final TfArg<String>? passwordWo;
+
+    /// Monotonic counter that triggers a rotation of [passwordWo].
+    final TfArg<String>? passwordWoVersion;
+
+    /// PagerDuty integration service key. Sensitive.
+    final TfArg<String>? serviceKey;
+
+    /// Write-only sibling of [serviceKey] (Terraform 1.11+).
+    final TfArg<String>? serviceKeyWo;
+
+    /// Monotonic counter that triggers a rotation of [serviceKeyWo].
+    final TfArg<String>? serviceKeyWoVersion;
+
+    Map<String, Object?> toArgMap() => {
+          if (authToken != null) 'auth_token': authToken!.toTfJson(),
+          if (authTokenWo != null) 'auth_token_wo': authTokenWo!.toTfJson(),
+          if (authTokenWoVersion != null)
+            'auth_token_wo_version': authTokenWoVersion!.toTfJson(),
+          if (password != null) 'password': password!.toTfJson(),
+          if (passwordWo != null) 'password_wo': passwordWo!.toTfJson(),
+          if (passwordWoVersion != null)
+            'password_wo_version': passwordWoVersion!.toTfJson(),
+          if (serviceKey != null) 'service_key': serviceKey!.toTfJson(),
+          if (serviceKeyWo != null) 'service_key_wo': serviceKeyWo!.toTfJson(),
+          if (serviceKeyWoVersion != null)
+            'service_key_wo_version': serviceKeyWoVersion!.toTfJson(),
+        };
+  }
+
+customSlots:
+  # The schema models `sensitive_labels` as a `list` with `max_items: 1`.
+  # The IR would carry it as a `TfArg<Map<String, dynamic>>` slot; the
+  # wrapper exposes a typed [MonitoringNotificationChannelSensitiveLabels]
+  # helper instead. The argMap entry wraps the single block in a `[...]`
+  # list to match the schema's `list` nesting mode.
+  sensitive_labels:
+    paramDeclaration: 'MonitoringNotificationChannelSensitiveLabels? sensitiveLabels'
+    argMapEntry: "if (sensitiveLabels != null) 'sensitive_labels': TfArg.literal([sensitiveLabels.toArgMap()]),"

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_monitoring_service.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_monitoring_service.yaml
@@ -1,0 +1,140 @@
+outputDir: monitoring
+
+classDocComment: |-
+  /// Factory wrapper for `google_monitoring_service` (provider
+  /// `hashicorp/google ~> 7.0`).
+  ///
+  /// Required identity:
+  /// - [localName]: Terraform local name (the address segment after
+  ///   `google_monitoring_service.`).
+  /// - `serviceId`: user-supplied service identifier. The full resource name
+  ///   exposed by Cloud Monitoring will be
+  ///   `projects/{project}/services/{serviceId}`.
+  ///
+  /// Modeling notes:
+  /// - The Cloud Monitoring API has multiple service-type variants
+  ///   (`basic_service`, `cloud_endpoints`, `app_engine`, `mesh_istio`,
+  ///   `cluster_istio`, `cloud_run`, `gke_namespace`, `gke_workload`,
+  ///   `gke_service`), but the terraform-provider-google schema for this
+  ///   resource only surfaces [basicService]. Use the auto-detected
+  ///   variants by creating the service through the GCP API directly, or
+  ///   omit [basicService] entirely to register an opaque "custom" service
+  ///   identified solely by [serviceId].
+  /// - [telemetry] is server-populated (the underlying API derives the
+  ///   monitored resource name on create) and is therefore exposed as a
+  ///   getter, not a constructor input. See [telemetry].
+  /// - `userLabels` accepts up to 64 entries; both keys and values are
+  ///   capped at 63 characters (and 128 bytes).
+  ///
+  /// Example (custom service identified by [serviceId] only):
+  /// ```dart
+  /// final svc = GoogleMonitoringService(
+  ///   localName: 'checkout_api',
+  ///   serviceId: TfArg.literal('checkout-api'),
+  ///   displayName: TfArg.literal('Checkout API'),
+  ///   userLabels: TfArg.literal(const {'team': 'payments'}),
+  /// );
+  /// ```
+  ///
+  /// Example (well-known basic service with labels — selecting the service
+  /// instance that emits the monitoring data):
+  /// ```dart
+  /// final svc = GoogleMonitoringService(
+  ///   localName: 'app_engine_default',
+  ///   serviceId: TfArg.literal('appengine-default'),
+  ///   displayName: TfArg.literal('App Engine default service'),
+  ///   basicService: MonitoringServiceBasicService(
+  ///     serviceType: TfArgLiteral('APP_ENGINE'),
+  ///     serviceLabels: TfArgLiteral(const {'module_id': 'default'}),
+  ///   ),
+  /// );
+  /// ```
+  ///
+  /// Manages a Cloud Monitoring [Service](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/services).
+  /// Composition pattern: extends `Resource<$GoogleMonitoringService>` for
+  /// runtime behavior. The nested-block helper
+  /// ([MonitoringServiceBasicService]) and the telemetry view-model
+  /// ([MonitoringServiceTelemetry]) live in the `prelude` below.
+
+# Required identity (service_id) first, then display label, then the basic
+# service variant block, then optional user labels and project.  Computed-only
+# attrs (id, name, telemetry) are filtered out — they're not constructor
+# inputs.  `timeouts` is also filtered (Terraform meta-arg).
+paramOrder:
+  - service_id
+  - display_name
+  - basic_service
+  - user_labels
+  - project
+
+extraGetters: |2
+    /// Reference to `id` attribute (the service's full resource name,
+    /// `projects/{project}/services/{service_id}`).
+    TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+    /// Reference to `name` attribute (same shape as [id]; populated by
+    /// Cloud Monitoring on create).
+    TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
+
+    /// Reference to the server-populated `telemetry` block. The Cloud
+    /// Monitoring API derives the monitored resource name from the chosen
+    /// service-type variant, so this is exposed as a read-only reference
+    /// rather than a constructor input.
+    TfRef<List<Map<String, Object?>>> get telemetry =>
+        TfRef.attribute<List<Map<String, Object?>>>(this, 'telemetry');
+
+prelude: |
+  // ===========================================================================
+  // basic_service helper
+  // ===========================================================================
+
+  /// `basic_service` block (max=1) — a well-known service type defined by
+  /// its [serviceType] (e.g. `'APP_ENGINE'`, `'CLOUD_ENDPOINTS'`,
+  /// `'CLUSTER_ISTIO'`, `'MESH_ISTIO'`) and a set of [serviceLabels] that
+  /// pin the variant to a specific service instance. See the
+  /// [SLO monitoring docs](https://cloud.google.com/stackdriver/docs/solutions/slo-monitoring/api/api-structures#basic-svc-w-basic-sli)
+  /// for the valid `(serviceType, serviceLabels)` combinations.
+  class MonitoringServiceBasicService {
+    const MonitoringServiceBasicService({
+      this.serviceType,
+      this.serviceLabels,
+    });
+
+    /// Well-known service type. Examples: `'APP_ENGINE'`,
+    /// `'CLOUD_ENDPOINTS'`, `'CLUSTER_ISTIO'`, `'MESH_ISTIO'`.
+    final TfArg<String>? serviceType;
+
+    /// Labels that pin the basic service to a specific monitored resource
+    /// (e.g. `{'module_id': 'default'}` for App Engine).
+    final TfArg<Map<String, String>>? serviceLabels;
+
+    Map<String, Object?> toArgMap() => {
+          if (serviceType != null) 'service_type': serviceType!.toTfJson(),
+          if (serviceLabels != null)
+            'service_labels': serviceLabels!.toTfJson(),
+        };
+  }
+
+  // ===========================================================================
+  // telemetry view-model
+  // ===========================================================================
+
+  /// Read-only view of the server-populated `telemetry` block. Cloud
+  /// Monitoring derives [resourceName] from the chosen service-type
+  /// variant; consumers may read it via [GoogleMonitoringService.telemetry].
+  class MonitoringServiceTelemetry {
+    const MonitoringServiceTelemetry({this.resourceName});
+
+    /// Fully-qualified monitored-resource name that the service is
+    /// associated with.
+    final TfArg<String>? resourceName;
+
+    Map<String, Object?> toArgMap() => {
+          if (resourceName != null) 'resource_name': resourceName!.toTfJson(),
+        };
+  }
+
+customSlots:
+  basic_service:
+    paramDeclaration: 'MonitoringServiceBasicService? basicService'
+    argMapEntry: "if (basicService != null) 'basic_service': TfArg.literal([basicService.toArgMap()]),"

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_monitoring_uptime_check_config.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_monitoring_uptime_check_config.yaml
@@ -1,0 +1,666 @@
+outputDir: monitoring
+
+classDocComment: |-
+  /// Factory wrapper for `google_monitoring_uptime_check_config` (provider
+  /// `hashicorp/google ~> 7.0`).
+  ///
+  /// Manages a Cloud Monitoring **uptime check** — a periodic probe (HTTP /
+  /// HTTPS, plain TCP, or a Synthetic Monitor Cloud Function) launched from
+  /// Google-managed checker pools (or your own VPC checkers) against a
+  /// target resource.
+  ///
+  /// Required identity:
+  /// - [localName]: Terraform local name (the address segment after
+  ///   `google_monitoring_uptime_check_config.`).
+  /// - `displayName`: human-friendly label shown in the Monitoring console.
+  /// - `timeout`: Duration string for the per-probe budget (e.g. `'10s'`).
+  ///   Valid range 1-60 seconds.
+  ///
+  /// ## Probe shape — pick exactly one
+  ///
+  /// The Terraform provider enforces an `exactly_one_of` contract across
+  /// the probe-type blocks. Set **exactly one** of:
+  /// - [httpCheck] — HTTP or HTTPS probe (toggle [HttpCheckConfig.useSsl]
+  ///   for HTTPS).
+  /// - [tcpCheck] — raw TCP connect probe.
+  /// - [syntheticMonitor] — invoke a Cloud Functions V2 instance that runs
+  ///   custom probe logic.
+  ///
+  /// ## Target shape — pick exactly one
+  ///
+  /// Also pick **exactly one** target descriptor:
+  /// - [monitoredResource] — directly target a single
+  ///   [MonitoringUptimeCheckMonitoredResource] (e.g. an `uptime_url`).
+  /// - [resourceGroup] — target every member of a `google_monitoring_group`
+  ///   resource (referenced by [MonitoringUptimeCheckResourceGroup.groupId]).
+  ///
+  /// ## Period / region semantics
+  ///
+  /// - `period` is the cadence between probes. The GCP API accepts only
+  ///   the four discrete Duration strings `'60s'`, `'300s'`, `'600s'`,
+  ///   `'900s'`. Defaults to `'300s'` when unset.
+  /// - `selectedRegions` controls where probes originate. Must include
+  ///   enough regions to cover at least 3 distinct locations, or the
+  ///   API rejects the request. Leave unset to probe from every region.
+  ///
+  /// ## Checker pool
+  ///
+  /// `checkerType` selects between Google-managed public checkers
+  /// ([MonitoringUptimeCheckCheckerType.staticIpCheckers]) and
+  /// VPC-internal checkers ([MonitoringUptimeCheckCheckerType.vpcCheckers]).
+  /// The latter is mandatory when [monitoredResource] has type
+  /// `'servicedirectory_service'`.
+  ///
+  /// Example (HTTPS uptime check against a public URL):
+  /// ```dart
+  /// final apiUptime = GoogleMonitoringUptimeCheckConfig(
+  ///   localName: 'api_uptime',
+  ///   displayName: TfArg.literal('Public API healthz'),
+  ///   timeout: TfArg.literal('10s'),
+  ///   period: TfArg.literal('60s'),
+  ///   httpCheck: const MonitoringUptimeCheckHttpCheck(
+  ///     path: '/healthz',
+  ///     port: 443,
+  ///     useSsl: true,
+  ///     validateSsl: true,
+  ///     requestMethod: MonitoringUptimeCheckHttpMethod.get,
+  ///   ),
+  ///   monitoredResource: const MonitoringUptimeCheckMonitoredResource(
+  ///     type: 'uptime_url',
+  ///     labels: {'host': 'api.example.com', 'project_id': 'my-project'},
+  ///   ),
+  ///   contentMatchers: const [
+  ///     MonitoringUptimeCheckContentMatcher(
+  ///       content: '"status":"ok"',
+  ///       matcher: MonitoringUptimeCheckMatcher.containsString,
+  ///     ),
+  ///   ],
+  ///   selectedRegions: [
+  ///     MonitoringUptimeCheckRegion.usa,
+  ///     MonitoringUptimeCheckRegion.europe,
+  ///     MonitoringUptimeCheckRegion.asiaPacific,
+  ///   ],
+  /// );
+  /// ```
+  ///
+  /// Composition pattern: extends `Resource<$GoogleMonitoringUptimeCheckConfig>`
+  /// for runtime behavior. Nested-block helpers ([MonitoringUptimeCheckHttpCheck],
+  /// [MonitoringUptimeCheckTcpCheck], [MonitoringUptimeCheckContentMatcher],
+  /// [MonitoringUptimeCheckMonitoredResource], [MonitoringUptimeCheckResourceGroup],
+  /// [MonitoringUptimeCheckSyntheticMonitor], etc.) are modeled in the
+  /// `prelude` below.
+
+# Required attrs first (display_name + timeout), then probe-target identity
+# (monitored_resource / resource_group), then probe-type configs
+# (http_check / tcp_check / synthetic_monitor), then content matchers,
+# then cadence / checker controls, then metadata. Computed-only attrs
+# (id, name, uptime_check_id) are filtered out — they're not constructor
+# inputs. `timeouts` is also filtered (Terraform meta-arg).
+paramOrder:
+  - display_name
+  - timeout
+  - period
+  - selected_regions
+  - checker_type
+  - monitored_resource
+  - resource_group
+  - http_check
+  - tcp_check
+  - synthetic_monitor
+  - content_matchers
+  - log_check_failures
+  - user_labels
+  - project
+
+extraGetters: |2
+    /// Reference to `id` attribute (the uptime check's full resource name,
+    /// `projects/{project}/uptimeCheckConfigs/{uptime_check_id}`).
+    TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+    /// Reference to `name` attribute (same shape as [id]; populated by
+    /// Cloud Monitoring on create).
+    TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
+
+    /// Reference to `uptime_check_id` (the bare ID segment, without the
+    /// `projects/.../uptimeCheckConfigs/` prefix).
+    TfRef<String> get uptimeCheckIdRef =>
+        TfRef.attribute<String>(this, 'uptime_check_id');
+
+extraSensitiveFields:
+  - http_check.auth_info.password
+
+dartTypeOverrides:
+  checker_type: MonitoringUptimeCheckCheckerType
+
+prelude: |
+  // ===========================================================================
+  // Top-level enums
+  // ===========================================================================
+
+  /// Checker pool selector for `google_monitoring_uptime_check_config.checker_type`.
+  ///
+  /// Schema enum_values: `["STATIC_IP_CHECKERS", "VPC_CHECKERS"]`.
+  enum MonitoringUptimeCheckCheckerType {
+    staticIpCheckers('STATIC_IP_CHECKERS'),
+    vpcCheckers('VPC_CHECKERS');
+
+    const MonitoringUptimeCheckCheckerType(this.terraformValue);
+    final String terraformValue;
+  }
+
+  /// Region selector for `google_monitoring_uptime_check_config.selected_regions`.
+  ///
+  /// The Terraform schema declares `selected_regions` as a plain
+  /// `list(string)` (no `enum_values` block) — the valid set is documented
+  /// in the GCP Cloud Monitoring uptime check API reference. The values
+  /// below mirror that documented set. Callers that need a region not
+  /// covered here can still pass a raw `TfArg<List<String>>` via
+  /// [GoogleMonitoringUptimeCheckConfig.selectedRegions] (the API
+  /// surface accepts string values directly).
+  enum MonitoringUptimeCheckRegion {
+    usa('USA'),
+    usaOregon('USA_OREGON'),
+    usaIowa('USA_IOWA'),
+    usaVirginia('USA_VIRGINIA'),
+    europe('EUROPE'),
+    southAmerica('SOUTH_AMERICA'),
+    asiaPacific('ASIA_PACIFIC');
+
+    const MonitoringUptimeCheckRegion(this.terraformValue);
+    final String terraformValue;
+  }
+
+  // ===========================================================================
+  // HTTP check enums
+  // ===========================================================================
+
+  /// HTTP method for `http_check.request_method`.
+  ///
+  /// Schema enum_values: `["METHOD_UNSPECIFIED", "GET", "POST"]`.
+  /// Defaults to `GET` when unset.
+  enum MonitoringUptimeCheckHttpMethod {
+    methodUnspecified('METHOD_UNSPECIFIED'),
+    get('GET'),
+    post('POST');
+
+    const MonitoringUptimeCheckHttpMethod(this.terraformValue);
+    final String terraformValue;
+  }
+
+  /// Content-type for `http_check.content_type` (the standard
+  /// `Content-Type` header sent on probe requests).
+  ///
+  /// Schema enum_values: `["TYPE_UNSPECIFIED", "URL_ENCODED", "USER_PROVIDED"]`.
+  /// When `USER_PROVIDED` is selected, the caller must also set
+  /// [MonitoringUptimeCheckHttpCheck.customContentType] with the literal
+  /// header value. Using `URL_ENCODED` together with `customContentType`
+  /// is rejected by the API.
+  enum MonitoringUptimeCheckContentType {
+    typeUnspecified('TYPE_UNSPECIFIED'),
+    urlEncoded('URL_ENCODED'),
+    userProvided('USER_PROVIDED');
+
+    const MonitoringUptimeCheckContentType(this.terraformValue);
+    final String terraformValue;
+  }
+
+  /// Service Agent authentication mode for
+  /// `http_check.service_agent_authentication.type`.
+  ///
+  /// Schema enum_values:
+  /// `["SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED", "OIDC_TOKEN"]`.
+  enum MonitoringUptimeCheckServiceAgentAuthType {
+    serviceAgentAuthenticationTypeUnspecified(
+        'SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED'),
+    oidcToken('OIDC_TOKEN');
+
+    const MonitoringUptimeCheckServiceAgentAuthType(this.terraformValue);
+    final String terraformValue;
+  }
+
+  /// HTTP status class for `http_check.accepted_response_status_codes[].status_class`.
+  ///
+  /// Schema enum_values: `["STATUS_CLASS_1XX", "STATUS_CLASS_2XX",
+  /// "STATUS_CLASS_3XX", "STATUS_CLASS_4XX", "STATUS_CLASS_5XX",
+  /// "STATUS_CLASS_ANY"]`.
+  enum MonitoringUptimeCheckStatusClass {
+    statusClass1xx('STATUS_CLASS_1XX'),
+    statusClass2xx('STATUS_CLASS_2XX'),
+    statusClass3xx('STATUS_CLASS_3XX'),
+    statusClass4xx('STATUS_CLASS_4XX'),
+    statusClass5xx('STATUS_CLASS_5XX'),
+    statusClassAny('STATUS_CLASS_ANY');
+
+    const MonitoringUptimeCheckStatusClass(this.terraformValue);
+    final String terraformValue;
+  }
+
+  // ===========================================================================
+  // Content-matcher enums
+  // ===========================================================================
+
+  /// Match mode for `content_matchers[].matcher`. Defaults to
+  /// [containsString] on the GCP API.
+  ///
+  /// Schema enum_values: `["CONTAINS_STRING", "NOT_CONTAINS_STRING",
+  /// "MATCHES_REGEX", "NOT_MATCHES_REGEX", "MATCHES_JSON_PATH",
+  /// "NOT_MATCHES_JSON_PATH"]`.
+  enum MonitoringUptimeCheckMatcher {
+    containsString('CONTAINS_STRING'),
+    notContainsString('NOT_CONTAINS_STRING'),
+    matchesRegex('MATCHES_REGEX'),
+    notMatchesRegex('NOT_MATCHES_REGEX'),
+    matchesJsonPath('MATCHES_JSON_PATH'),
+    notMatchesJsonPath('NOT_MATCHES_JSON_PATH');
+
+    const MonitoringUptimeCheckMatcher(this.terraformValue);
+    final String terraformValue;
+  }
+
+  /// JSONPath match mode for
+  /// `content_matchers[].json_path_matcher.json_matcher`.
+  /// Defaults to [exactMatch] on the GCP API.
+  ///
+  /// Schema enum_values: `["EXACT_MATCH", "REGEX_MATCH"]`.
+  enum MonitoringUptimeCheckJsonMatcher {
+    exactMatch('EXACT_MATCH'),
+    regexMatch('REGEX_MATCH');
+
+    const MonitoringUptimeCheckJsonMatcher(this.terraformValue);
+    final String terraformValue;
+  }
+
+  // ===========================================================================
+  // Resource-group enum
+  // ===========================================================================
+
+  /// Member-resource type for `resource_group.resource_type`.
+  ///
+  /// Schema enum_values: `["RESOURCE_TYPE_UNSPECIFIED", "INSTANCE",
+  /// "AWS_ELB_LOAD_BALANCER"]`.
+  enum MonitoringUptimeCheckResourceType {
+    resourceTypeUnspecified('RESOURCE_TYPE_UNSPECIFIED'),
+    instance('INSTANCE'),
+    awsElbLoadBalancer('AWS_ELB_LOAD_BALANCER');
+
+    const MonitoringUptimeCheckResourceType(this.terraformValue);
+    final String terraformValue;
+  }
+
+  // ===========================================================================
+  // monitored_resource + resource_group (mutually exclusive target descriptors)
+  // ===========================================================================
+
+  /// `monitored_resource` block (max=1). Directly target a single monitored
+  /// resource (e.g. an `uptime_url` against a public hostname, or a
+  /// `gce_instance`). Mutually exclusive with [MonitoringUptimeCheckResourceGroup].
+  class MonitoringUptimeCheckMonitoredResource {
+    const MonitoringUptimeCheckMonitoredResource({
+      required this.type,
+      required this.labels,
+    });
+
+    /// Monitored-resource type, e.g. `'uptime_url'`, `'gce_instance'`,
+    /// `'gae_app'`, `'aws_ec2_instance'`, `'k8s_service'`,
+    /// `'servicedirectory_service'`.
+    final String type;
+
+    /// Values for every label declared by the monitored-resource
+    /// descriptor (e.g. `{'host': 'api.example.com', 'project_id': '...'}`
+    /// for `uptime_url`).
+    final Map<String, String> labels;
+
+    Map<String, Object?> toArgMap() => {
+          'type': type,
+          'labels': labels,
+        };
+  }
+
+  /// `resource_group` block (max=1). Target every member of a Cloud
+  /// Monitoring group resource. Mutually exclusive with
+  /// [MonitoringUptimeCheckMonitoredResource].
+  class MonitoringUptimeCheckResourceGroup {
+    const MonitoringUptimeCheckResourceGroup({
+      this.groupId,
+      this.resourceType,
+    });
+
+    /// The `name` of a `google_monitoring_group` resource.
+    final String? groupId;
+
+    /// Member-resource type filter applied within the group.
+    final MonitoringUptimeCheckResourceType? resourceType;
+
+    Map<String, Object?> toArgMap() => {
+          if (groupId != null) 'group_id': groupId,
+          if (resourceType != null)
+            'resource_type': resourceType!.terraformValue,
+        };
+  }
+
+  // ===========================================================================
+  // http_check + nested helpers (auth_info, ping_config,
+  // accepted_response_status_codes, service_agent_authentication)
+  // ===========================================================================
+
+  /// `http_check.auth_info` block (max=1) — Basic-auth username/password
+  /// pair. `password` is **schema-flagged sensitive** and is automatically
+  /// masked on synth (see `extraSensitiveFields` in this resource's
+  /// wrapper override). Do not use alongside
+  /// [MonitoringUptimeCheckServiceAgentAuthentication].
+  class MonitoringUptimeCheckHttpAuthInfo {
+    const MonitoringUptimeCheckHttpAuthInfo({
+      required this.username,
+      this.password,
+      this.passwordWo,
+      this.passwordWoVersion,
+    });
+
+    final String username;
+
+    /// **Sensitive.** Plaintext password — masked in rendered Terraform JSON.
+    final String? password;
+
+    /// Write-only variant of [password] (Terraform 1.11+ write-only
+    /// attribute). Use this when the password is sourced from a secret
+    /// store and should never be tracked in state.
+    final String? passwordWo;
+
+    /// Bump this version string whenever [passwordWo] changes so Terraform
+    /// recognizes the rotation.
+    final String? passwordWoVersion;
+
+    Map<String, Object?> toArgMap() => {
+          'username': username,
+          if (password != null) 'password': password,
+          if (passwordWo != null) 'password_wo': passwordWo,
+          if (passwordWoVersion != null)
+            'password_wo_version': passwordWoVersion,
+        };
+  }
+
+  /// `http_check.ping_config` / `tcp_check.ping_config` block (max=1) —
+  /// configures ICMP pings emitted alongside the main probe (max 3 pings).
+  class MonitoringUptimeCheckPingConfig {
+    const MonitoringUptimeCheckPingConfig({required this.pingsCount});
+
+    /// Number of ICMP pings (max 3).
+    final int pingsCount;
+
+    Map<String, Object?> toArgMap() => {
+          'pings_count': pingsCount,
+        };
+  }
+
+  /// `http_check.accepted_response_status_codes[]` entry. Either
+  /// [statusClass] (a code range bucket) or [statusValue] (a literal
+  /// status code) should be set per entry. When the list is empty,
+  /// the API accepts the default 200-299 range.
+  class MonitoringUptimeCheckAcceptedResponseStatus {
+    const MonitoringUptimeCheckAcceptedResponseStatus({
+      this.statusClass,
+      this.statusValue,
+    });
+
+    final MonitoringUptimeCheckStatusClass? statusClass;
+    final int? statusValue;
+
+    Map<String, Object?> toArgMap() => {
+          if (statusClass != null)
+            'status_class': statusClass!.terraformValue,
+          if (statusValue != null) 'status_value': statusValue,
+        };
+  }
+
+  /// `http_check.service_agent_authentication` block (max=1) — emit an
+  /// OIDC token signed by the Monitoring service agent on the probe
+  /// request. Mutually exclusive with [MonitoringUptimeCheckHttpAuthInfo].
+  class MonitoringUptimeCheckServiceAgentAuthentication {
+    const MonitoringUptimeCheckServiceAgentAuthentication({this.type});
+
+    final MonitoringUptimeCheckServiceAgentAuthType? type;
+
+    Map<String, Object?> toArgMap() => {
+          if (type != null) 'type': type!.terraformValue,
+        };
+  }
+
+  /// `http_check` block (max=1). Mutually exclusive with [tcpCheck] and
+  /// [syntheticMonitor] on the parent resource — the Terraform provider
+  /// enforces the `exactly_one_of` contract at apply time.
+  class MonitoringUptimeCheckHttpCheck {
+    const MonitoringUptimeCheckHttpCheck({
+      this.requestMethod,
+      this.contentType,
+      this.customContentType,
+      this.port,
+      this.path,
+      this.useSsl,
+      this.validateSsl,
+      this.maskHeaders,
+      this.headers,
+      this.body,
+      this.authInfo,
+      this.serviceAgentAuthentication,
+      this.acceptedResponseStatusCodes,
+      this.pingConfig,
+    });
+
+    /// HTTP method to issue. Defaults to
+    /// [MonitoringUptimeCheckHttpMethod.get] when unset.
+    final MonitoringUptimeCheckHttpMethod? requestMethod;
+
+    /// `Content-Type` header strategy.
+    final MonitoringUptimeCheckContentType? contentType;
+
+    /// Literal Content-Type header value. Required when [contentType] is
+    /// [MonitoringUptimeCheckContentType.userProvided]; must be left
+    /// unset when [contentType] is
+    /// [MonitoringUptimeCheckContentType.urlEncoded].
+    final String? customContentType;
+
+    /// TCP port. Defaults to 80 when [useSsl] is false, 443 when true.
+    final int? port;
+
+    /// Request path. Defaults to `'/'`. A leading `/` is auto-prepended
+    /// when missing.
+    final String? path;
+
+    /// `true` switches the probe to HTTPS.
+    final bool? useSsl;
+
+    /// Validate the SSL certificate chain (only meaningful when [useSsl]
+    /// is true and [monitoredResource] type is `'uptime_url'`).
+    final bool? validateSsl;
+
+    /// Encrypt header values in stored configs; on Get/List the server
+    /// returns `'******'` for masked headers.
+    final bool? maskHeaders;
+
+    /// Extra request headers (max 100 entries). Duplicate keys are
+    /// rejected by the API — comma-join duplicates as a single value.
+    final Map<String, String>? headers;
+
+    /// Request body. Base64-encoded over the wire — pass the raw bytes
+    /// here; the codegen layer handles encoding. Required to be empty
+    /// when [requestMethod] is [MonitoringUptimeCheckHttpMethod.get].
+    final String? body;
+
+    /// Basic auth credentials. Mutually exclusive with
+    /// [serviceAgentAuthentication].
+    final MonitoringUptimeCheckHttpAuthInfo? authInfo;
+
+    /// Service Agent OIDC authentication. Mutually exclusive with
+    /// [authInfo]. Requires [useSsl] = true.
+    final MonitoringUptimeCheckServiceAgentAuthentication?
+        serviceAgentAuthentication;
+
+    /// Custom set of HTTP status codes to treat as healthy. When unset,
+    /// the API accepts 200-299.
+    final List<MonitoringUptimeCheckAcceptedResponseStatus>?
+        acceptedResponseStatusCodes;
+
+    /// Optional companion ICMP ping configuration.
+    final MonitoringUptimeCheckPingConfig? pingConfig;
+
+    Map<String, Object?> toArgMap() => {
+          if (requestMethod != null)
+            'request_method': requestMethod!.terraformValue,
+          if (contentType != null)
+            'content_type': contentType!.terraformValue,
+          if (customContentType != null)
+            'custom_content_type': customContentType,
+          if (port != null) 'port': port,
+          if (path != null) 'path': path,
+          if (useSsl != null) 'use_ssl': useSsl,
+          if (validateSsl != null) 'validate_ssl': validateSsl,
+          if (maskHeaders != null) 'mask_headers': maskHeaders,
+          if (headers != null) 'headers': headers,
+          if (body != null) 'body': body,
+          if (authInfo != null) 'auth_info': [authInfo!.toArgMap()],
+          if (serviceAgentAuthentication != null)
+            'service_agent_authentication': [
+              serviceAgentAuthentication!.toArgMap()
+            ],
+          if (acceptedResponseStatusCodes != null)
+            'accepted_response_status_codes':
+                acceptedResponseStatusCodes!.map((s) => s.toArgMap()).toList(),
+          if (pingConfig != null) 'ping_config': [pingConfig!.toArgMap()],
+        };
+  }
+
+  // ===========================================================================
+  // tcp_check
+  // ===========================================================================
+
+  /// `tcp_check` block (max=1). Mutually exclusive with [httpCheck] and
+  /// [syntheticMonitor] on the parent resource.
+  class MonitoringUptimeCheckTcpCheck {
+    const MonitoringUptimeCheckTcpCheck({
+      required this.port,
+      this.pingConfig,
+    });
+
+    /// TCP port to connect to (combined with the host derived from
+    /// [monitoredResource]).
+    final int port;
+
+    /// Optional companion ICMP ping configuration.
+    final MonitoringUptimeCheckPingConfig? pingConfig;
+
+    Map<String, Object?> toArgMap() => {
+          'port': port,
+          if (pingConfig != null) 'ping_config': [pingConfig!.toArgMap()],
+        };
+  }
+
+  // ===========================================================================
+  // synthetic_monitor + cloud_function_v2
+  // ===========================================================================
+
+  /// `synthetic_monitor.cloud_function_v2` block (min=1, max=1) — target
+  /// Cloud Functions V2 instance that implements the probe logic.
+  class MonitoringUptimeCheckCloudFunctionV2 {
+    const MonitoringUptimeCheckCloudFunctionV2({required this.name});
+
+    /// Fully-qualified Cloud Functions V2 function name, e.g.
+    /// `'projects/p/locations/us-central1/functions/my-probe'`.
+    final String name;
+
+    Map<String, Object?> toArgMap() => {
+          'name': name,
+        };
+  }
+
+  /// `synthetic_monitor` block (max=1). Mutually exclusive with
+  /// [httpCheck] and [tcpCheck] on the parent resource.
+  class MonitoringUptimeCheckSyntheticMonitor {
+    const MonitoringUptimeCheckSyntheticMonitor({
+      required this.cloudFunctionV2,
+    });
+
+    final MonitoringUptimeCheckCloudFunctionV2 cloudFunctionV2;
+
+    Map<String, Object?> toArgMap() => {
+          'cloud_function_v2': [cloudFunctionV2.toArgMap()],
+        };
+  }
+
+  // ===========================================================================
+  // content_matchers + json_path_matcher
+  // ===========================================================================
+
+  /// `content_matchers[].json_path_matcher` block (max=1). Used by the
+  /// `MATCHES_JSON_PATH` / `NOT_MATCHES_JSON_PATH` parent matchers.
+  class MonitoringUptimeCheckJsonPathMatcher {
+    const MonitoringUptimeCheckJsonPathMatcher({
+      required this.jsonPath,
+      this.jsonMatcher,
+    });
+
+    /// JSONPath expression to resolve before applying the [jsonMatcher].
+    final String jsonPath;
+    final MonitoringUptimeCheckJsonMatcher? jsonMatcher;
+
+    Map<String, Object?> toArgMap() => {
+          'json_path': jsonPath,
+          if (jsonMatcher != null)
+            'json_matcher': jsonMatcher!.terraformValue,
+        };
+  }
+
+  /// One entry in `google_monitoring_uptime_check_config.content_matchers`.
+  ///
+  /// Only the first entry is currently honored by the GCP API — the
+  /// schema reserves the list shape for future expansion.
+  class MonitoringUptimeCheckContentMatcher {
+    const MonitoringUptimeCheckContentMatcher({
+      required this.content,
+      this.matcher,
+      this.jsonPathMatcher,
+    });
+
+    /// Content to match (max 1024 bytes). Interpretation depends on
+    /// [matcher] — literal substring for `CONTAINS_*`, regex for
+    /// `MATCHES_REGEX*`, etc.
+    final String content;
+
+    /// Match mode. Defaults to
+    /// [MonitoringUptimeCheckMatcher.containsString] on the API side.
+    final MonitoringUptimeCheckMatcher? matcher;
+
+    /// Required when [matcher] is
+    /// [MonitoringUptimeCheckMatcher.matchesJsonPath] or
+    /// [MonitoringUptimeCheckMatcher.notMatchesJsonPath].
+    final MonitoringUptimeCheckJsonPathMatcher? jsonPathMatcher;
+
+    Map<String, Object?> toArgMap() => {
+          'content': content,
+          if (matcher != null) 'matcher': matcher!.terraformValue,
+          if (jsonPathMatcher != null)
+            'json_path_matcher': [jsonPathMatcher!.toArgMap()],
+        };
+  }
+
+customSlots:
+  selected_regions:
+    paramDeclaration: 'List<MonitoringUptimeCheckRegion>? selectedRegions'
+    argMapEntry: "if (selectedRegions != null) 'selected_regions': TfArg.literal(selectedRegions.map((r) => r.terraformValue).toList()),"
+  monitored_resource:
+    paramDeclaration: 'MonitoringUptimeCheckMonitoredResource? monitoredResource'
+    argMapEntry: "if (monitoredResource != null) 'monitored_resource': TfArg.literal([monitoredResource.toArgMap()]),"
+  resource_group:
+    paramDeclaration: 'MonitoringUptimeCheckResourceGroup? resourceGroup'
+    argMapEntry: "if (resourceGroup != null) 'resource_group': TfArg.literal([resourceGroup.toArgMap()]),"
+  http_check:
+    paramDeclaration: 'MonitoringUptimeCheckHttpCheck? httpCheck'
+    argMapEntry: "if (httpCheck != null) 'http_check': TfArg.literal([httpCheck.toArgMap()]),"
+  tcp_check:
+    paramDeclaration: 'MonitoringUptimeCheckTcpCheck? tcpCheck'
+    argMapEntry: "if (tcpCheck != null) 'tcp_check': TfArg.literal([tcpCheck.toArgMap()]),"
+  synthetic_monitor:
+    paramDeclaration: 'MonitoringUptimeCheckSyntheticMonitor? syntheticMonitor'
+    argMapEntry: "if (syntheticMonitor != null) 'synthetic_monitor': TfArg.literal([syntheticMonitor.toArgMap()]),"
+  content_matchers:
+    paramDeclaration: 'List<MonitoringUptimeCheckContentMatcher>? contentMatchers'
+    argMapEntry: "if (contentMatchers != null) 'content_matchers': TfArg.literal(contentMatchers.map((c) => c.toArgMap()).toList()),"

--- a/packages/terradart_codegen/test/cli/wrap_command_test.dart
+++ b/packages/terradart_codegen/test/cli/wrap_command_test.dart
@@ -68,7 +68,7 @@ void main() {
             files.add(p.relative(ent.path, from: tmpOut.path));
           }
         }
-        expect(files, hasLength(108));
+        expect(files, hasLength(113));
         expect(files, contains(p.join('pubsub', 'google_pubsub_topic.dart')));
         expect(files, contains(p.join('data', 'google_project.dart')));
         // Plan 5.X: Layer 1 files are no longer emitted.

--- a/packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart
@@ -690,7 +690,7 @@ classDocComment: |-
           rootDir:
               p.absolute('lib', 'src', 'codegen', 'wrapper_overrides', 'yaml'),
         );
-        expect(loaded.resources.length, 107);
+        expect(loaded.resources.length, 112);
         expect(loaded.dataSources.length, 1);
         expect(loaded.dataSources.keys.first, 'google_project');
       },

--- a/packages/terradart_google/lib/monitoring.dart
+++ b/packages/terradart_google/lib/monitoring.dart
@@ -1,6 +1,6 @@
 // packages/terradart_google/lib/monitoring.dart
-/// Cloud Monitoring alert policies (threshold, absent, MQL, PromQL, SQL,
-/// matched-log conditions).
+/// Cloud Monitoring: alert policies, notification channels, uptime probes,
+/// dashboards, custom metric descriptors, and SLO service objects.
 library;
 
 export 'src/monitoring/google_monitoring_alert_policy.dart'
@@ -34,3 +34,47 @@ export 'src/monitoring/google_monitoring_alert_policy.dart'
         SqlScheduleDaily,
         SqlScheduleHourly,
         SqlScheduleMinutes;
+export 'src/monitoring/google_monitoring_dashboard.dart'
+    show GoogleMonitoringDashboard;
+export 'src/monitoring/google_monitoring_metric_descriptor.dart'
+    show
+        GoogleMonitoringMetricDescriptor,
+        MonitoringMetricDescriptorLabel,
+        MonitoringMetricDescriptorMetadata,
+        MonitoringMetricKind,
+        MonitoringMetricLabelValueType,
+        MonitoringMetricLaunchStage,
+        MonitoringValueType;
+export 'src/monitoring/google_monitoring_notification_channel.dart'
+    show
+        GoogleMonitoringNotificationChannel,
+        MonitoringNotificationChannelSensitiveLabels;
+export 'src/monitoring/google_monitoring_service.dart'
+    show
+        GoogleMonitoringService,
+        MonitoringServiceBasicService,
+        MonitoringServiceTelemetry;
+export 'src/monitoring/google_monitoring_uptime_check_config.dart'
+    show
+        GoogleMonitoringUptimeCheckConfig,
+        MonitoringUptimeCheckAcceptedResponseStatus,
+        MonitoringUptimeCheckCheckerType,
+        MonitoringUptimeCheckCloudFunctionV2,
+        MonitoringUptimeCheckContentMatcher,
+        MonitoringUptimeCheckContentType,
+        MonitoringUptimeCheckHttpAuthInfo,
+        MonitoringUptimeCheckHttpCheck,
+        MonitoringUptimeCheckHttpMethod,
+        MonitoringUptimeCheckJsonMatcher,
+        MonitoringUptimeCheckJsonPathMatcher,
+        MonitoringUptimeCheckMatcher,
+        MonitoringUptimeCheckMonitoredResource,
+        MonitoringUptimeCheckPingConfig,
+        MonitoringUptimeCheckRegion,
+        MonitoringUptimeCheckResourceGroup,
+        MonitoringUptimeCheckResourceType,
+        MonitoringUptimeCheckServiceAgentAuthType,
+        MonitoringUptimeCheckServiceAgentAuthentication,
+        MonitoringUptimeCheckStatusClass,
+        MonitoringUptimeCheckSyntheticMonitor,
+        MonitoringUptimeCheckTcpCheck;

--- a/packages/terradart_google/lib/src/monitoring/google_monitoring_dashboard.dart
+++ b/packages/terradart_google/lib/src/monitoring/google_monitoring_dashboard.dart
@@ -1,0 +1,117 @@
+// GENERATED FILE - DO NOT EDIT
+// Run `terradart wrap` to regenerate.
+// ignore_for_file: prefer_relative_imports
+import 'package:terradart_core/terradart_core.dart';
+
+/// Sensitive field paths for `google_monitoring_dashboard`.
+const Set<String> _googleMonitoringDashboardSensitive = <String>{};
+
+/// Factory wrapper for `google_monitoring_dashboard` (provider
+/// `hashicorp/google ~> 7.0`).
+///
+/// Manages a Cloud Monitoring dashboard. Dashboards in this version are
+/// modeled **deliberately minimally**: the entire dashboard layout — rows,
+/// columns, mosaics, widgets, charts, thresholds, etc. — is passed as a
+/// **single JSON string** via [dashboardJson]. There is no typed Dart
+/// widget model in v0.0.x; the Cloud Console UI is the source of truth
+/// for the dashboard schema, which is large, fluid, and well-supported
+/// by the in-product editor.
+///
+/// Required identity:
+/// - [localName]: Terraform local name (the address segment after
+///   `google_monitoring_dashboard.`).
+/// - `dashboardJson`: full dashboard JSON payload as a Dart `String`. Must
+///   conform to
+///   <https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards>.
+///
+/// ## Authoring workflow
+///
+/// 1. Build the dashboard interactively in the Cloud Console
+///    (Monitoring -> Dashboards -> Create dashboard).
+/// 2. Once it looks right, open `Settings -> JSON` and copy the full JSON
+///    body. (Equivalently, run
+///    `gcloud monitoring dashboards describe DASHBOARD_ID --format=json`
+///    against an existing dashboard, replacing `DASHBOARD_ID` with the
+///    resource ID.)
+/// 3. Paste the JSON into your Dart source as a raw String and pass it via
+///    `dashboardJson: TfArg.literal(...)`.
+///
+/// Programmatic assembly is also fine — `jsonEncode(Map<String, dynamic>)`
+/// from `dart:convert` produces an equivalent String. Both forms are
+/// byte-identical at the Terraform layer; pick whichever the codebase
+/// prefers (raw multi-line String for diff stability, `jsonEncode` when
+/// the dashboard is parameterized by Dart values).
+///
+/// Example (raw String, exported from Cloud Console):
+/// ```dart
+/// final overview = GoogleMonitoringDashboard(
+///   localName: 'service_overview',
+///   dashboardJson: TfArg.literal('''
+/// {
+///   "displayName": "Service overview",
+///   "mosaicLayout": {
+///     "columns": 12,
+///     "tiles": [
+///       {
+///         "width": 6,
+///         "height": 4,
+///         "widget": {
+///           "title": "Request rate",
+///           "xyChart": {
+///             "dataSets": [
+///               {
+///                 "timeSeriesQuery": {
+///                   "timeSeriesFilter": {
+///                     "filter": "metric.type=\\"run.googleapis.com/request_count\\""
+///                   }
+///                 }
+///               }
+///             ]
+///           }
+///         }
+///       }
+///     ]
+///   }
+/// }
+/// '''),
+/// );
+/// ```
+///
+/// Example (programmatic assembly via `dart:convert`):
+/// ```dart
+/// import 'dart:convert';
+///
+/// final dashboard = GoogleMonitoringDashboard(
+///   localName: 'service_overview',
+///   dashboardJson: TfArg.literal(jsonEncode(<String, dynamic>{
+///     'displayName': 'Service overview',
+///     'mosaicLayout': {'columns': 12, 'tiles': <Map<String, dynamic>>[]},
+///   })),
+/// );
+/// ```
+///
+/// Composition pattern: extends `Resource<$GoogleMonitoringDashboard>` for
+/// runtime behavior. There are no nested helper classes — the entire
+/// dashboard body lives inside the [dashboardJson] String.
+final class GoogleMonitoringDashboard extends Resource {
+  // ignore: constant_identifier_names
+  static const String $tfType = 'google_monitoring_dashboard';
+
+  GoogleMonitoringDashboard({
+    required super.localName,
+    required TfArg<String> dashboardJson,
+    TfArg<String>? project,
+    super.lifecycle,
+    super.dependsOn,
+  }) : super(
+         terraformType: $tfType,
+         argMap: {
+           'dashboard_json': dashboardJson,
+           if (project != null) 'project': project,
+         },
+       );
+
+  @override
+  // ignore: non_constant_identifier_names
+  Set<String> get $sensitiveFields => _googleMonitoringDashboardSensitive;
+}

--- a/packages/terradart_google/lib/src/monitoring/google_monitoring_metric_descriptor.dart
+++ b/packages/terradart_google/lib/src/monitoring/google_monitoring_metric_descriptor.dart
@@ -1,0 +1,232 @@
+// GENERATED FILE - DO NOT EDIT
+// Run `terradart wrap` to regenerate.
+// ignore_for_file: prefer_relative_imports
+import 'package:terradart_core/terradart_core.dart';
+
+/// Sensitive field paths for `google_monitoring_metric_descriptor`.
+const Set<String> _googleMonitoringMetricDescriptorSensitive = <String>{};
+
+// ===========================================================================
+// Top-level enums
+// ===========================================================================
+
+/// `metric_kind` — whether the metric records instantaneous values, deltas,
+/// or running totals. Not every `(metricKind, valueType)` combination is
+/// supported by the Cloud Monitoring API.
+enum MonitoringMetricKind {
+  unspecified('METRIC_KIND_UNSPECIFIED'),
+  gauge('GAUGE'),
+  delta('DELTA'),
+  cumulative('CUMULATIVE');
+
+  const MonitoringMetricKind(this.terraformValue);
+  final String terraformValue;
+}
+
+/// `value_type` — the value kind recorded per data point. Use
+/// [MonitoringValueType.distribution] together with the histogram-bucket
+/// configuration on the metric's time series; the schema does **not**
+/// include `MONEY` or a `VALUE_TYPE_UNSPECIFIED` sentinel.
+enum MonitoringValueType {
+  boolean('BOOL'),
+  int64('INT64'),
+  doubleValue('DOUBLE'),
+  string('STRING'),
+  distribution('DISTRIBUTION');
+
+  const MonitoringValueType(this.terraformValue);
+  final String terraformValue;
+}
+
+/// `labels[].value_type` — the data type of a label attached to this
+/// metric. The label-level value space is narrower than the descriptor's
+/// (no `DOUBLE` / `DISTRIBUTION`). Defaults to
+/// [MonitoringMetricLabelValueType.string] when omitted.
+enum MonitoringMetricLabelValueType {
+  string('STRING'),
+  boolean('BOOL'),
+  int64('INT64');
+
+  const MonitoringMetricLabelValueType(this.terraformValue);
+  final String terraformValue;
+}
+
+/// `launch_stage` — release-management stage of this metric definition.
+/// Defaults to [MonitoringMetricLaunchStage.ga] / unset for stable metrics.
+enum MonitoringMetricLaunchStage {
+  unspecified('LAUNCH_STAGE_UNSPECIFIED'),
+  unimplemented('UNIMPLEMENTED'),
+  prelaunch('PRELAUNCH'),
+  earlyAccess('EARLY_ACCESS'),
+  alpha('ALPHA'),
+  beta('BETA'),
+  ga('GA'),
+  deprecated('DEPRECATED');
+
+  const MonitoringMetricLaunchStage(this.terraformValue);
+  final String terraformValue;
+}
+
+// ===========================================================================
+// labels + metadata helpers
+// ===========================================================================
+
+/// One entry in `labels` — describes a label key that values of this
+/// metric carry. The label-level [valueType] is narrower than the
+/// descriptor's top-level [MonitoringValueType] (no `DOUBLE` /
+/// `DISTRIBUTION`).
+class MonitoringMetricDescriptorLabel {
+  const MonitoringMetricDescriptorLabel({
+    required this.key,
+    this.valueType,
+    this.description,
+  });
+
+  final TfArg<String> key;
+  final TfArg<MonitoringMetricLabelValueType>? valueType;
+  final TfArg<String>? description;
+
+  Map<String, Object?> toArgMap() => {
+    'key': key.toTfJson(),
+    if (valueType != null) 'value_type': valueType!.toTfJson(),
+    if (description != null) 'description': description!.toTfJson(),
+  };
+}
+
+/// `metadata` block (max=1) — sampling / ingest-delay hints for the
+/// metric. Both fields are [Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration)-format
+/// strings (e.g. `'60s'`, `'300s'`).
+class MonitoringMetricDescriptorMetadata {
+  const MonitoringMetricDescriptorMetadata({
+    this.samplePeriod,
+    this.ingestDelay,
+  });
+
+  /// Period at which the source writes data points. Metrics with a higher
+  /// granularity have a smaller sampling period.
+  final TfArg<String>? samplePeriod;
+
+  /// Maximum delay between when a data point is produced and when it
+  /// becomes readable. Data points older than this age are guaranteed to
+  /// be available.
+  final TfArg<String>? ingestDelay;
+
+  Map<String, Object?> toArgMap() => {
+    if (samplePeriod != null) 'sample_period': samplePeriod!.toTfJson(),
+    if (ingestDelay != null) 'ingest_delay': ingestDelay!.toTfJson(),
+  };
+}
+
+/// Factory wrapper for `google_monitoring_metric_descriptor` (provider
+/// `hashicorp/google ~> 7.0`).
+///
+/// Required identity:
+/// - [localName]: Terraform local name (the address segment after
+///   `google_monitoring_metric_descriptor.`).
+/// - `type`: the fully-qualified metric type. User-defined metrics must use
+///   one of the reserved DNS prefixes (`custom.googleapis.com/`,
+///   `external.googleapis.com/`, or `logging.googleapis.com/user/`), e.g.
+///   `'custom.googleapis.com/myapp/requests'`. The relative part is limited
+///   to 100 characters of `[A-Za-z0-9_/]`.
+/// - `metricKind`: whether the metric records instantaneous values
+///   ([MonitoringMetricKind.gauge]), deltas
+///   ([MonitoringMetricKind.delta]), or running totals
+///   ([MonitoringMetricKind.cumulative]). Not every
+///   `(metricKind, valueType)` combination is supported by the API; consult
+///   the [Cloud Monitoring docs](https://cloud.google.com/monitoring/api/v3/kinds-and-types).
+/// - `valueType`: the value kind recorded per data point. See
+///   [MonitoringValueType].
+/// - `description`: human-readable description shown in documentation /
+///   metric pickers (required by the API).
+///
+/// Modeling notes:
+/// - `labels` is a nested-block set. Use [MonitoringMetricDescriptorLabel]
+///   entries to declare the label schema; per-label `valueType` is a
+///   narrower enum than the descriptor's (no `DOUBLE` / `DISTRIBUTION`).
+/// - `metadata` is a `max_items: 1` block exposing the sampling /
+///   ingest-delay hints (Duration strings, e.g. `'60s'`).
+/// - `monitoredResourceTypes` is a server-populated set and not a
+///   constructor input.
+///
+/// Example (custom DELTA / INT64 counter):
+/// ```dart
+/// final descriptor = GoogleMonitoringMetricDescriptor(
+///   localName: 'app_requests',
+///   type: TfArg.literal('custom.googleapis.com/myapp/requests'),
+///   metricKind: TfArg.literal(MonitoringMetricKind.delta),
+///   valueType: TfArg.literal(MonitoringValueType.int64),
+///   description: TfArg.literal('Number of requests received by myapp.'),
+///   displayName: TfArg.literal('App requests'),
+///   unit: TfArg.literal('1'),
+///   labels: const [
+///     MonitoringMetricDescriptorLabel(
+///       key: TfArgLiteral('route'),
+///       valueType: TfArgLiteral(MonitoringMetricLabelValueType.string),
+///       description: TfArgLiteral('HTTP route template.'),
+///     ),
+///   ],
+/// );
+/// ```
+///
+/// Manages a Cloud Monitoring user-defined metric descriptor. Composition
+/// pattern: extends `Resource<$GoogleMonitoringMetricDescriptor>` for
+/// runtime behavior. The nested-block helpers
+/// ([MonitoringMetricDescriptorLabel],
+/// [MonitoringMetricDescriptorMetadata]) and the enum wrappers
+/// ([MonitoringMetricKind], [MonitoringValueType],
+/// [MonitoringMetricLabelValueType], [MonitoringMetricLaunchStage]) live
+/// in the `prelude` below.
+final class GoogleMonitoringMetricDescriptor extends Resource {
+  // ignore: constant_identifier_names
+  static const String $tfType = 'google_monitoring_metric_descriptor';
+
+  GoogleMonitoringMetricDescriptor({
+    required super.localName,
+    required TfArg<String> type,
+    required TfArg<MonitoringMetricKind> metricKind,
+    required TfArg<MonitoringValueType> valueType,
+    TfArg<String>? description,
+    TfArg<String>? displayName,
+    TfArg<String>? unit,
+    List<MonitoringMetricDescriptorLabel>? labels,
+    MonitoringMetricDescriptorMetadata? metadata,
+    TfArg<MonitoringMetricLaunchStage>? launchStage,
+    TfArg<String>? project,
+    super.lifecycle,
+    super.dependsOn,
+  }) : super(
+         terraformType: $tfType,
+         argMap: {
+           'type': type,
+           'metric_kind': metricKind,
+           'value_type': valueType,
+           if (description != null) 'description': description,
+           if (displayName != null) 'display_name': displayName,
+           if (unit != null) 'unit': unit,
+           if (labels != null)
+             'labels': TfArg.literal(labels.map((l) => l.toArgMap()).toList()),
+           if (metadata != null)
+             'metadata': TfArg.literal([metadata.toArgMap()]),
+           if (launchStage != null) 'launch_stage': launchStage,
+           if (project != null) 'project': project,
+         },
+       );
+
+  @override
+  // ignore: non_constant_identifier_names
+  Set<String> get $sensitiveFields =>
+      _googleMonitoringMetricDescriptorSensitive;
+
+  /// Reference to `id` attribute (the metric descriptor's full resource
+  /// name, `projects/{project}/metricDescriptors/{type}`).
+  TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+  /// Reference to `name` attribute (same shape as [id]; populated by Cloud
+  /// Monitoring on create).
+  TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
+
+  /// Reference to `monitored_resource_types` — the set of monitored
+  /// resource types this descriptor may be associated with. Server-managed.
+  TfRef<List<String>> get monitoredResourceTypes =>
+      TfRef.attribute<List<String>>(this, 'monitored_resource_types');
+}

--- a/packages/terradart_google/lib/src/monitoring/google_monitoring_notification_channel.dart
+++ b/packages/terradart_google/lib/src/monitoring/google_monitoring_notification_channel.dart
@@ -1,0 +1,227 @@
+// GENERATED FILE - DO NOT EDIT
+// Run `terradart wrap` to regenerate.
+// ignore_for_file: prefer_relative_imports
+import 'package:terradart_core/terradart_core.dart';
+
+/// Sensitive field paths for `google_monitoring_notification_channel`.
+const Set<String> _googleMonitoringNotificationChannelSensitive = <String>{
+  'sensitive_labels.auth_token',
+  'sensitive_labels.password',
+  'sensitive_labels.service_key',
+};
+
+// ===========================================================================
+// sensitive_labels nested block (max=1)
+// ===========================================================================
+
+/// `sensitive_labels` block (max=1) — credential slots for notification
+/// channel types that need an out-of-band secret. Each transport uses a
+/// different subset:
+///
+/// - `slack` → [authToken] (or [authTokenWo] + [authTokenWoVersion] for
+///   the write-only API).
+/// - `webhook_basicauth` → [password] (or [passwordWo] +
+///   [passwordWoVersion]).
+/// - `webhook_tokenauth` → [authToken] / [authTokenWo].
+/// - `pagerduty` → [serviceKey] (or [serviceKeyWo] +
+///   [serviceKeyWoVersion]).
+///
+/// The plaintext slots ([authToken], [password], [serviceKey]) are
+/// schema-flagged sensitive and round-trip through the wrapper's
+/// `$sensitiveFields` set — synth masks them in plan output. Prefer the
+/// write-only variants (`*Wo` + `*WoVersion`) on Terraform 1.11+: the
+/// plaintext never enters Terraform state, and bumping the integer
+/// `*WoVersion` slot forces a credential rotation on next apply.
+///
+/// Credentials must NOT also be supplied via [GoogleMonitoringNotificationChannel.labels]
+/// — the provider rejects configurations that double-specify the same
+/// logical secret.
+class MonitoringNotificationChannelSensitiveLabels {
+  const MonitoringNotificationChannelSensitiveLabels({
+    this.authToken,
+    this.authTokenWo,
+    this.authTokenWoVersion,
+    this.password,
+    this.passwordWo,
+    this.passwordWoVersion,
+    this.serviceKey,
+    this.serviceKeyWo,
+    this.serviceKeyWoVersion,
+  });
+
+  /// Slack bot OAuth token / webhook bearer token. Sensitive — masked
+  /// from plan output and surfaced in `$sensitiveFields`.
+  final TfArg<String>? authToken;
+
+  /// Write-only sibling of [authToken] (Terraform 1.11+). Bump
+  /// [authTokenWoVersion] to rotate.
+  final TfArg<String>? authTokenWo;
+
+  /// Monotonic counter that triggers a rotation of [authTokenWo].
+  final TfArg<String>? authTokenWoVersion;
+
+  /// Basic-auth password for `webhook_basicauth` channels. Sensitive.
+  final TfArg<String>? password;
+
+  /// Write-only sibling of [password] (Terraform 1.11+).
+  final TfArg<String>? passwordWo;
+
+  /// Monotonic counter that triggers a rotation of [passwordWo].
+  final TfArg<String>? passwordWoVersion;
+
+  /// PagerDuty integration service key. Sensitive.
+  final TfArg<String>? serviceKey;
+
+  /// Write-only sibling of [serviceKey] (Terraform 1.11+).
+  final TfArg<String>? serviceKeyWo;
+
+  /// Monotonic counter that triggers a rotation of [serviceKeyWo].
+  final TfArg<String>? serviceKeyWoVersion;
+
+  Map<String, Object?> toArgMap() => {
+    if (authToken != null) 'auth_token': authToken!.toTfJson(),
+    if (authTokenWo != null) 'auth_token_wo': authTokenWo!.toTfJson(),
+    if (authTokenWoVersion != null)
+      'auth_token_wo_version': authTokenWoVersion!.toTfJson(),
+    if (password != null) 'password': password!.toTfJson(),
+    if (passwordWo != null) 'password_wo': passwordWo!.toTfJson(),
+    if (passwordWoVersion != null)
+      'password_wo_version': passwordWoVersion!.toTfJson(),
+    if (serviceKey != null) 'service_key': serviceKey!.toTfJson(),
+    if (serviceKeyWo != null) 'service_key_wo': serviceKeyWo!.toTfJson(),
+    if (serviceKeyWoVersion != null)
+      'service_key_wo_version': serviceKeyWoVersion!.toTfJson(),
+  };
+}
+
+/// Factory wrapper for `google_monitoring_notification_channel` (provider
+/// `hashicorp/google ~> 7.0`).
+///
+/// Required identity:
+/// - [localName]: Terraform local name (the address segment after
+///   `google_monitoring_notification_channel.`).
+/// - `type`: the notification channel **type registry key**. Google
+///   maintains the canonical list server-side (the API returns it from
+///   `projects.notificationChannelDescriptors.list`) and adds new
+///   transports asynchronously, so this slot is intentionally a free-form
+///   `String` rather than a Dart enum — pinning an enum here would force
+///   a terradart release every time Google ships a new descriptor.
+///
+/// Common `type` values and the channel-specific keys they expect in
+/// [labels] (the canonical reference is the `NotificationChannelDescriptor`
+/// for each type):
+/// - `"email"` — `labels: {'email_address': 'oncall@example.com'}`.
+/// - `"slack"` — `labels: {'channel_name': '#alerts',
+///   'team': 'T01234ABCD'}`. The bot OAuth token goes in
+///   [sensitiveLabels].`authToken` (NOT in `labels`).
+/// - `"pagerduty"` — `labels: {'service_name': 'prod-oncall'}`. The
+///   integration service key goes in [sensitiveLabels].`serviceKey`.
+/// - `"sms"` — `labels: {'number': '+15551234567'}` (E.164 format,
+///   pre-verified phone numbers only).
+/// - `"webhook_basicauth"` — `labels: {'url': 'https://...'}` +
+///   [sensitiveLabels].`password` (with the basic-auth username embedded
+///   in the URL or in `labels`).
+/// - `"webhook_tokenauth"` — `labels: {'url': 'https://...'}` +
+///   [sensitiveLabels].`authToken` for the bearer token.
+/// - `"pubsub"` — `labels: {'topic': 'projects/<p>/topics/<t>'}`. The
+///   service account that posts to the topic is managed via IAM, not
+///   via this resource.
+///
+/// Credentials handling: any value containing a secret (Slack token,
+/// PagerDuty service key, webhook auth token / basic-auth password) MUST
+/// be placed in [sensitiveLabels] rather than [labels]. The provider
+/// rejects configurations that supply the same logical secret in both
+/// places, and only [sensitiveLabels] entries are masked from plan
+/// output. The 3 plaintext slots (`authToken`, `password`, `serviceKey`)
+/// are flagged sensitive by the provider schema and also enumerated in
+/// [extraSensitiveFields] (belt-and-suspenders); the 6
+/// write-only-API siblings (`*_wo` + `*_wo_version`) keep the plaintext
+/// out of Terraform state entirely on Terraform 1.11+ — prefer them
+/// when your CLI version supports it, bumping the `*_wo_version` int to
+/// force rotation.
+///
+/// Verification: [verificationStatus] reflects whether the channel has
+/// passed Google's out-of-band verification step (e.g. clicking a link
+/// in a confirmation email, replying to an SMS). Channels in the
+/// `UNVERIFIED` state do not deliver notifications. Verification cannot
+/// be triggered through this resource — call
+/// `gcloud alpha monitoring channels verify` or the
+/// `projects.notificationChannels.verify` REST endpoint after apply.
+///
+/// Example (Slack channel):
+/// ```dart
+/// final slack = GoogleMonitoringNotificationChannel(
+///   localName: 'oncall_slack',
+///   displayName: TfArg.literal('#oncall alerts'),
+///   type: TfArg.literal('slack'),
+///   labels: TfArg.literal(const {
+///     'channel_name': '#oncall',
+///     'team': 'T01234ABCD',
+///   }),
+///   sensitiveLabels: MonitoringNotificationChannelSensitiveLabels(
+///     authTokenWo: TfArg.ref(slackBotTokenSecret.versionRef),
+///     authTokenWoVersion: TfArg.literal('1'),
+///   ),
+///   userLabels: TfArg.literal(const {'team': 'platform'}),
+/// );
+/// ```
+///
+/// Manages a Cloud Monitoring notification channel. Composition pattern:
+/// extends `Resource<$GoogleMonitoringNotificationChannel>` for runtime
+/// behavior. The nested [MonitoringNotificationChannelSensitiveLabels]
+/// helper is modeled in the `prelude` below.
+final class GoogleMonitoringNotificationChannel extends Resource {
+  // ignore: constant_identifier_names
+  static const String $tfType = 'google_monitoring_notification_channel';
+
+  GoogleMonitoringNotificationChannel({
+    required super.localName,
+    TfArg<String>? displayName,
+    required TfArg<String> type,
+    TfArg<Map<String, String>>? labels,
+    MonitoringNotificationChannelSensitiveLabels? sensitiveLabels,
+    TfArg<Map<String, String>>? userLabels,
+    TfArg<String>? description,
+    TfArg<bool>? enabled,
+    TfArg<bool>? forceDelete,
+    TfArg<String>? project,
+    super.lifecycle,
+    super.dependsOn,
+  }) : super(
+         terraformType: $tfType,
+         argMap: {
+           if (displayName != null) 'display_name': displayName,
+           'type': type,
+           if (labels != null) 'labels': labels,
+           if (sensitiveLabels != null)
+             'sensitive_labels': TfArg.literal([sensitiveLabels.toArgMap()]),
+           if (userLabels != null) 'user_labels': userLabels,
+           if (description != null) 'description': description,
+           if (enabled != null) 'enabled': enabled,
+           if (forceDelete != null) 'force_delete': forceDelete,
+           if (project != null) 'project': project,
+         },
+       );
+
+  @override
+  // ignore: non_constant_identifier_names
+  Set<String> get $sensitiveFields =>
+      _googleMonitoringNotificationChannelSensitive;
+
+  /// Reference to `id` attribute (the channel's full REST resource name,
+  /// `projects/{project}/notificationChannels/{channel_id}`). Alert
+  /// policies consume this value via their `notification_channels` list.
+  TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+  /// Reference to `name` attribute. Identical in shape to [id]; the
+  /// provider populates both with the same full resource name on create.
+  TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
+
+  /// Reference to the computed `verification_status` attribute. One of
+  /// `STATE_UNSPECIFIED`, `UNVERIFIED`, `VERIFIED`. Channels with
+  /// `UNVERIFIED` status do not deliver notifications — kick off
+  /// verification out-of-band (`gcloud alpha monitoring channels verify`
+  /// or the REST `verify` endpoint) after apply.
+  TfRef<String> get verificationStatus =>
+      TfRef.attribute<String>(this, 'verification_status');
+}

--- a/packages/terradart_google/lib/src/monitoring/google_monitoring_service.dart
+++ b/packages/terradart_google/lib/src/monitoring/google_monitoring_service.dart
@@ -1,0 +1,152 @@
+// GENERATED FILE - DO NOT EDIT
+// Run `terradart wrap` to regenerate.
+// ignore_for_file: prefer_relative_imports
+import 'package:terradart_core/terradart_core.dart';
+
+/// Sensitive field paths for `google_monitoring_service`.
+const Set<String> _googleMonitoringServiceSensitive = <String>{};
+
+// ===========================================================================
+// basic_service helper
+// ===========================================================================
+
+/// `basic_service` block (max=1) — a well-known service type defined by
+/// its [serviceType] (e.g. `'APP_ENGINE'`, `'CLOUD_ENDPOINTS'`,
+/// `'CLUSTER_ISTIO'`, `'MESH_ISTIO'`) and a set of [serviceLabels] that
+/// pin the variant to a specific service instance. See the
+/// [SLO monitoring docs](https://cloud.google.com/stackdriver/docs/solutions/slo-monitoring/api/api-structures#basic-svc-w-basic-sli)
+/// for the valid `(serviceType, serviceLabels)` combinations.
+class MonitoringServiceBasicService {
+  const MonitoringServiceBasicService({this.serviceType, this.serviceLabels});
+
+  /// Well-known service type. Examples: `'APP_ENGINE'`,
+  /// `'CLOUD_ENDPOINTS'`, `'CLUSTER_ISTIO'`, `'MESH_ISTIO'`.
+  final TfArg<String>? serviceType;
+
+  /// Labels that pin the basic service to a specific monitored resource
+  /// (e.g. `{'module_id': 'default'}` for App Engine).
+  final TfArg<Map<String, String>>? serviceLabels;
+
+  Map<String, Object?> toArgMap() => {
+    if (serviceType != null) 'service_type': serviceType!.toTfJson(),
+    if (serviceLabels != null) 'service_labels': serviceLabels!.toTfJson(),
+  };
+}
+
+// ===========================================================================
+// telemetry view-model
+// ===========================================================================
+
+/// Read-only view of the server-populated `telemetry` block. Cloud
+/// Monitoring derives [resourceName] from the chosen service-type
+/// variant; consumers may read it via [GoogleMonitoringService.telemetry].
+class MonitoringServiceTelemetry {
+  const MonitoringServiceTelemetry({this.resourceName});
+
+  /// Fully-qualified monitored-resource name that the service is
+  /// associated with.
+  final TfArg<String>? resourceName;
+
+  Map<String, Object?> toArgMap() => {
+    if (resourceName != null) 'resource_name': resourceName!.toTfJson(),
+  };
+}
+
+/// Factory wrapper for `google_monitoring_service` (provider
+/// `hashicorp/google ~> 7.0`).
+///
+/// Required identity:
+/// - [localName]: Terraform local name (the address segment after
+///   `google_monitoring_service.`).
+/// - `serviceId`: user-supplied service identifier. The full resource name
+///   exposed by Cloud Monitoring will be
+///   `projects/{project}/services/{serviceId}`.
+///
+/// Modeling notes:
+/// - The Cloud Monitoring API has multiple service-type variants
+///   (`basic_service`, `cloud_endpoints`, `app_engine`, `mesh_istio`,
+///   `cluster_istio`, `cloud_run`, `gke_namespace`, `gke_workload`,
+///   `gke_service`), but the terraform-provider-google schema for this
+///   resource only surfaces [basicService]. Use the auto-detected
+///   variants by creating the service through the GCP API directly, or
+///   omit [basicService] entirely to register an opaque "custom" service
+///   identified solely by [serviceId].
+/// - [telemetry] is server-populated (the underlying API derives the
+///   monitored resource name on create) and is therefore exposed as a
+///   getter, not a constructor input. See [telemetry].
+/// - `userLabels` accepts up to 64 entries; both keys and values are
+///   capped at 63 characters (and 128 bytes).
+///
+/// Example (custom service identified by [serviceId] only):
+/// ```dart
+/// final svc = GoogleMonitoringService(
+///   localName: 'checkout_api',
+///   serviceId: TfArg.literal('checkout-api'),
+///   displayName: TfArg.literal('Checkout API'),
+///   userLabels: TfArg.literal(const {'team': 'payments'}),
+/// );
+/// ```
+///
+/// Example (well-known basic service with labels — selecting the service
+/// instance that emits the monitoring data):
+/// ```dart
+/// final svc = GoogleMonitoringService(
+///   localName: 'app_engine_default',
+///   serviceId: TfArg.literal('appengine-default'),
+///   displayName: TfArg.literal('App Engine default service'),
+///   basicService: MonitoringServiceBasicService(
+///     serviceType: TfArgLiteral('APP_ENGINE'),
+///     serviceLabels: TfArgLiteral(const {'module_id': 'default'}),
+///   ),
+/// );
+/// ```
+///
+/// Manages a Cloud Monitoring [Service](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/services).
+/// Composition pattern: extends `Resource<$GoogleMonitoringService>` for
+/// runtime behavior. The nested-block helper
+/// ([MonitoringServiceBasicService]) and the telemetry view-model
+/// ([MonitoringServiceTelemetry]) live in the `prelude` below.
+final class GoogleMonitoringService extends Resource {
+  // ignore: constant_identifier_names
+  static const String $tfType = 'google_monitoring_service';
+
+  GoogleMonitoringService({
+    required super.localName,
+    required TfArg<String> serviceId,
+    TfArg<String>? displayName,
+    MonitoringServiceBasicService? basicService,
+    TfArg<Map<String, String>>? userLabels,
+    TfArg<String>? project,
+    super.lifecycle,
+    super.dependsOn,
+  }) : super(
+         terraformType: $tfType,
+         argMap: {
+           'service_id': serviceId,
+           if (displayName != null) 'display_name': displayName,
+           if (basicService != null)
+             'basic_service': TfArg.literal([basicService.toArgMap()]),
+           if (userLabels != null) 'user_labels': userLabels,
+           if (project != null) 'project': project,
+         },
+       );
+
+  @override
+  // ignore: non_constant_identifier_names
+  Set<String> get $sensitiveFields => _googleMonitoringServiceSensitive;
+
+  /// Reference to `id` attribute (the service's full resource name,
+  /// `projects/{project}/services/{service_id}`).
+  TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+  /// Reference to `name` attribute (same shape as [id]; populated by
+  /// Cloud Monitoring on create).
+  TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
+
+  /// Reference to the server-populated `telemetry` block. The Cloud
+  /// Monitoring API derives the monitored resource name from the chosen
+  /// service-type variant, so this is exposed as a read-only reference
+  /// rather than a constructor input.
+  TfRef<List<Map<String, Object?>>> get telemetry =>
+      TfRef.attribute<List<Map<String, Object?>>>(this, 'telemetry');
+}

--- a/packages/terradart_google/lib/src/monitoring/google_monitoring_uptime_check_config.dart
+++ b/packages/terradart_google/lib/src/monitoring/google_monitoring_uptime_check_config.dart
@@ -1,0 +1,658 @@
+// GENERATED FILE - DO NOT EDIT
+// Run `terradart wrap` to regenerate.
+// ignore_for_file: prefer_relative_imports
+import 'package:terradart_core/terradart_core.dart';
+
+/// Sensitive field paths for `google_monitoring_uptime_check_config`.
+const Set<String> _googleMonitoringUptimeCheckConfigSensitive = <String>{
+  'http_check.auth_info.password',
+};
+
+// ===========================================================================
+// Top-level enums
+// ===========================================================================
+
+/// Checker pool selector for `google_monitoring_uptime_check_config.checker_type`.
+///
+/// Schema enum_values: `["STATIC_IP_CHECKERS", "VPC_CHECKERS"]`.
+enum MonitoringUptimeCheckCheckerType {
+  staticIpCheckers('STATIC_IP_CHECKERS'),
+  vpcCheckers('VPC_CHECKERS');
+
+  const MonitoringUptimeCheckCheckerType(this.terraformValue);
+  final String terraformValue;
+}
+
+/// Region selector for `google_monitoring_uptime_check_config.selected_regions`.
+///
+/// The Terraform schema declares `selected_regions` as a plain
+/// `list(string)` (no `enum_values` block) — the valid set is documented
+/// in the GCP Cloud Monitoring uptime check API reference. The values
+/// below mirror that documented set. Callers that need a region not
+/// covered here can still pass a raw `TfArg<List<String>>` via
+/// [GoogleMonitoringUptimeCheckConfig.selectedRegions] (the API
+/// surface accepts string values directly).
+enum MonitoringUptimeCheckRegion {
+  usa('USA'),
+  usaOregon('USA_OREGON'),
+  usaIowa('USA_IOWA'),
+  usaVirginia('USA_VIRGINIA'),
+  europe('EUROPE'),
+  southAmerica('SOUTH_AMERICA'),
+  asiaPacific('ASIA_PACIFIC');
+
+  const MonitoringUptimeCheckRegion(this.terraformValue);
+  final String terraformValue;
+}
+
+// ===========================================================================
+// HTTP check enums
+// ===========================================================================
+
+/// HTTP method for `http_check.request_method`.
+///
+/// Schema enum_values: `["METHOD_UNSPECIFIED", "GET", "POST"]`.
+/// Defaults to `GET` when unset.
+enum MonitoringUptimeCheckHttpMethod {
+  methodUnspecified('METHOD_UNSPECIFIED'),
+  get('GET'),
+  post('POST');
+
+  const MonitoringUptimeCheckHttpMethod(this.terraformValue);
+  final String terraformValue;
+}
+
+/// Content-type for `http_check.content_type` (the standard
+/// `Content-Type` header sent on probe requests).
+///
+/// Schema enum_values: `["TYPE_UNSPECIFIED", "URL_ENCODED", "USER_PROVIDED"]`.
+/// When `USER_PROVIDED` is selected, the caller must also set
+/// [MonitoringUptimeCheckHttpCheck.customContentType] with the literal
+/// header value. Using `URL_ENCODED` together with `customContentType`
+/// is rejected by the API.
+enum MonitoringUptimeCheckContentType {
+  typeUnspecified('TYPE_UNSPECIFIED'),
+  urlEncoded('URL_ENCODED'),
+  userProvided('USER_PROVIDED');
+
+  const MonitoringUptimeCheckContentType(this.terraformValue);
+  final String terraformValue;
+}
+
+/// Service Agent authentication mode for
+/// `http_check.service_agent_authentication.type`.
+///
+/// Schema enum_values:
+/// `["SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED", "OIDC_TOKEN"]`.
+enum MonitoringUptimeCheckServiceAgentAuthType {
+  serviceAgentAuthenticationTypeUnspecified(
+    'SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED',
+  ),
+  oidcToken('OIDC_TOKEN');
+
+  const MonitoringUptimeCheckServiceAgentAuthType(this.terraformValue);
+  final String terraformValue;
+}
+
+/// HTTP status class for `http_check.accepted_response_status_codes[].status_class`.
+///
+/// Schema enum_values: `["STATUS_CLASS_1XX", "STATUS_CLASS_2XX",
+/// "STATUS_CLASS_3XX", "STATUS_CLASS_4XX", "STATUS_CLASS_5XX",
+/// "STATUS_CLASS_ANY"]`.
+enum MonitoringUptimeCheckStatusClass {
+  statusClass1xx('STATUS_CLASS_1XX'),
+  statusClass2xx('STATUS_CLASS_2XX'),
+  statusClass3xx('STATUS_CLASS_3XX'),
+  statusClass4xx('STATUS_CLASS_4XX'),
+  statusClass5xx('STATUS_CLASS_5XX'),
+  statusClassAny('STATUS_CLASS_ANY');
+
+  const MonitoringUptimeCheckStatusClass(this.terraformValue);
+  final String terraformValue;
+}
+
+// ===========================================================================
+// Content-matcher enums
+// ===========================================================================
+
+/// Match mode for `content_matchers[].matcher`. Defaults to
+/// [containsString] on the GCP API.
+///
+/// Schema enum_values: `["CONTAINS_STRING", "NOT_CONTAINS_STRING",
+/// "MATCHES_REGEX", "NOT_MATCHES_REGEX", "MATCHES_JSON_PATH",
+/// "NOT_MATCHES_JSON_PATH"]`.
+enum MonitoringUptimeCheckMatcher {
+  containsString('CONTAINS_STRING'),
+  notContainsString('NOT_CONTAINS_STRING'),
+  matchesRegex('MATCHES_REGEX'),
+  notMatchesRegex('NOT_MATCHES_REGEX'),
+  matchesJsonPath('MATCHES_JSON_PATH'),
+  notMatchesJsonPath('NOT_MATCHES_JSON_PATH');
+
+  const MonitoringUptimeCheckMatcher(this.terraformValue);
+  final String terraformValue;
+}
+
+/// JSONPath match mode for
+/// `content_matchers[].json_path_matcher.json_matcher`.
+/// Defaults to [exactMatch] on the GCP API.
+///
+/// Schema enum_values: `["EXACT_MATCH", "REGEX_MATCH"]`.
+enum MonitoringUptimeCheckJsonMatcher {
+  exactMatch('EXACT_MATCH'),
+  regexMatch('REGEX_MATCH');
+
+  const MonitoringUptimeCheckJsonMatcher(this.terraformValue);
+  final String terraformValue;
+}
+
+// ===========================================================================
+// Resource-group enum
+// ===========================================================================
+
+/// Member-resource type for `resource_group.resource_type`.
+///
+/// Schema enum_values: `["RESOURCE_TYPE_UNSPECIFIED", "INSTANCE",
+/// "AWS_ELB_LOAD_BALANCER"]`.
+enum MonitoringUptimeCheckResourceType {
+  resourceTypeUnspecified('RESOURCE_TYPE_UNSPECIFIED'),
+  instance('INSTANCE'),
+  awsElbLoadBalancer('AWS_ELB_LOAD_BALANCER');
+
+  const MonitoringUptimeCheckResourceType(this.terraformValue);
+  final String terraformValue;
+}
+
+// ===========================================================================
+// monitored_resource + resource_group (mutually exclusive target descriptors)
+// ===========================================================================
+
+/// `monitored_resource` block (max=1). Directly target a single monitored
+/// resource (e.g. an `uptime_url` against a public hostname, or a
+/// `gce_instance`). Mutually exclusive with [MonitoringUptimeCheckResourceGroup].
+class MonitoringUptimeCheckMonitoredResource {
+  const MonitoringUptimeCheckMonitoredResource({
+    required this.type,
+    required this.labels,
+  });
+
+  /// Monitored-resource type, e.g. `'uptime_url'`, `'gce_instance'`,
+  /// `'gae_app'`, `'aws_ec2_instance'`, `'k8s_service'`,
+  /// `'servicedirectory_service'`.
+  final String type;
+
+  /// Values for every label declared by the monitored-resource
+  /// descriptor (e.g. `{'host': 'api.example.com', 'project_id': '...'}`
+  /// for `uptime_url`).
+  final Map<String, String> labels;
+
+  Map<String, Object?> toArgMap() => {'type': type, 'labels': labels};
+}
+
+/// `resource_group` block (max=1). Target every member of a Cloud
+/// Monitoring group resource. Mutually exclusive with
+/// [MonitoringUptimeCheckMonitoredResource].
+class MonitoringUptimeCheckResourceGroup {
+  const MonitoringUptimeCheckResourceGroup({this.groupId, this.resourceType});
+
+  /// The `name` of a `google_monitoring_group` resource.
+  final String? groupId;
+
+  /// Member-resource type filter applied within the group.
+  final MonitoringUptimeCheckResourceType? resourceType;
+
+  Map<String, Object?> toArgMap() => {
+    if (groupId != null) 'group_id': groupId,
+    if (resourceType != null) 'resource_type': resourceType!.terraformValue,
+  };
+}
+
+// ===========================================================================
+// http_check + nested helpers (auth_info, ping_config,
+// accepted_response_status_codes, service_agent_authentication)
+// ===========================================================================
+
+/// `http_check.auth_info` block (max=1) — Basic-auth username/password
+/// pair. `password` is **schema-flagged sensitive** and is automatically
+/// masked on synth (see `extraSensitiveFields` in this resource's
+/// wrapper override). Do not use alongside
+/// [MonitoringUptimeCheckServiceAgentAuthentication].
+class MonitoringUptimeCheckHttpAuthInfo {
+  const MonitoringUptimeCheckHttpAuthInfo({
+    required this.username,
+    this.password,
+    this.passwordWo,
+    this.passwordWoVersion,
+  });
+
+  final String username;
+
+  /// **Sensitive.** Plaintext password — masked in rendered Terraform JSON.
+  final String? password;
+
+  /// Write-only variant of [password] (Terraform 1.11+ write-only
+  /// attribute). Use this when the password is sourced from a secret
+  /// store and should never be tracked in state.
+  final String? passwordWo;
+
+  /// Bump this version string whenever [passwordWo] changes so Terraform
+  /// recognizes the rotation.
+  final String? passwordWoVersion;
+
+  Map<String, Object?> toArgMap() => {
+    'username': username,
+    if (password != null) 'password': password,
+    if (passwordWo != null) 'password_wo': passwordWo,
+    if (passwordWoVersion != null) 'password_wo_version': passwordWoVersion,
+  };
+}
+
+/// `http_check.ping_config` / `tcp_check.ping_config` block (max=1) —
+/// configures ICMP pings emitted alongside the main probe (max 3 pings).
+class MonitoringUptimeCheckPingConfig {
+  const MonitoringUptimeCheckPingConfig({required this.pingsCount});
+
+  /// Number of ICMP pings (max 3).
+  final int pingsCount;
+
+  Map<String, Object?> toArgMap() => {'pings_count': pingsCount};
+}
+
+/// `http_check.accepted_response_status_codes[]` entry. Either
+/// [statusClass] (a code range bucket) or [statusValue] (a literal
+/// status code) should be set per entry. When the list is empty,
+/// the API accepts the default 200-299 range.
+class MonitoringUptimeCheckAcceptedResponseStatus {
+  const MonitoringUptimeCheckAcceptedResponseStatus({
+    this.statusClass,
+    this.statusValue,
+  });
+
+  final MonitoringUptimeCheckStatusClass? statusClass;
+  final int? statusValue;
+
+  Map<String, Object?> toArgMap() => {
+    if (statusClass != null) 'status_class': statusClass!.terraformValue,
+    if (statusValue != null) 'status_value': statusValue,
+  };
+}
+
+/// `http_check.service_agent_authentication` block (max=1) — emit an
+/// OIDC token signed by the Monitoring service agent on the probe
+/// request. Mutually exclusive with [MonitoringUptimeCheckHttpAuthInfo].
+class MonitoringUptimeCheckServiceAgentAuthentication {
+  const MonitoringUptimeCheckServiceAgentAuthentication({this.type});
+
+  final MonitoringUptimeCheckServiceAgentAuthType? type;
+
+  Map<String, Object?> toArgMap() => {
+    if (type != null) 'type': type!.terraformValue,
+  };
+}
+
+/// `http_check` block (max=1). Mutually exclusive with [tcpCheck] and
+/// [syntheticMonitor] on the parent resource — the Terraform provider
+/// enforces the `exactly_one_of` contract at apply time.
+class MonitoringUptimeCheckHttpCheck {
+  const MonitoringUptimeCheckHttpCheck({
+    this.requestMethod,
+    this.contentType,
+    this.customContentType,
+    this.port,
+    this.path,
+    this.useSsl,
+    this.validateSsl,
+    this.maskHeaders,
+    this.headers,
+    this.body,
+    this.authInfo,
+    this.serviceAgentAuthentication,
+    this.acceptedResponseStatusCodes,
+    this.pingConfig,
+  });
+
+  /// HTTP method to issue. Defaults to
+  /// [MonitoringUptimeCheckHttpMethod.get] when unset.
+  final MonitoringUptimeCheckHttpMethod? requestMethod;
+
+  /// `Content-Type` header strategy.
+  final MonitoringUptimeCheckContentType? contentType;
+
+  /// Literal Content-Type header value. Required when [contentType] is
+  /// [MonitoringUptimeCheckContentType.userProvided]; must be left
+  /// unset when [contentType] is
+  /// [MonitoringUptimeCheckContentType.urlEncoded].
+  final String? customContentType;
+
+  /// TCP port. Defaults to 80 when [useSsl] is false, 443 when true.
+  final int? port;
+
+  /// Request path. Defaults to `'/'`. A leading `/` is auto-prepended
+  /// when missing.
+  final String? path;
+
+  /// `true` switches the probe to HTTPS.
+  final bool? useSsl;
+
+  /// Validate the SSL certificate chain (only meaningful when [useSsl]
+  /// is true and [monitoredResource] type is `'uptime_url'`).
+  final bool? validateSsl;
+
+  /// Encrypt header values in stored configs; on Get/List the server
+  /// returns `'******'` for masked headers.
+  final bool? maskHeaders;
+
+  /// Extra request headers (max 100 entries). Duplicate keys are
+  /// rejected by the API — comma-join duplicates as a single value.
+  final Map<String, String>? headers;
+
+  /// Request body. Base64-encoded over the wire — pass the raw bytes
+  /// here; the codegen layer handles encoding. Required to be empty
+  /// when [requestMethod] is [MonitoringUptimeCheckHttpMethod.get].
+  final String? body;
+
+  /// Basic auth credentials. Mutually exclusive with
+  /// [serviceAgentAuthentication].
+  final MonitoringUptimeCheckHttpAuthInfo? authInfo;
+
+  /// Service Agent OIDC authentication. Mutually exclusive with
+  /// [authInfo]. Requires [useSsl] = true.
+  final MonitoringUptimeCheckServiceAgentAuthentication?
+  serviceAgentAuthentication;
+
+  /// Custom set of HTTP status codes to treat as healthy. When unset,
+  /// the API accepts 200-299.
+  final List<MonitoringUptimeCheckAcceptedResponseStatus>?
+  acceptedResponseStatusCodes;
+
+  /// Optional companion ICMP ping configuration.
+  final MonitoringUptimeCheckPingConfig? pingConfig;
+
+  Map<String, Object?> toArgMap() => {
+    if (requestMethod != null) 'request_method': requestMethod!.terraformValue,
+    if (contentType != null) 'content_type': contentType!.terraformValue,
+    if (customContentType != null) 'custom_content_type': customContentType,
+    if (port != null) 'port': port,
+    if (path != null) 'path': path,
+    if (useSsl != null) 'use_ssl': useSsl,
+    if (validateSsl != null) 'validate_ssl': validateSsl,
+    if (maskHeaders != null) 'mask_headers': maskHeaders,
+    if (headers != null) 'headers': headers,
+    if (body != null) 'body': body,
+    if (authInfo != null) 'auth_info': [authInfo!.toArgMap()],
+    if (serviceAgentAuthentication != null)
+      'service_agent_authentication': [serviceAgentAuthentication!.toArgMap()],
+    if (acceptedResponseStatusCodes != null)
+      'accepted_response_status_codes': acceptedResponseStatusCodes!
+          .map((s) => s.toArgMap())
+          .toList(),
+    if (pingConfig != null) 'ping_config': [pingConfig!.toArgMap()],
+  };
+}
+
+// ===========================================================================
+// tcp_check
+// ===========================================================================
+
+/// `tcp_check` block (max=1). Mutually exclusive with [httpCheck] and
+/// [syntheticMonitor] on the parent resource.
+class MonitoringUptimeCheckTcpCheck {
+  const MonitoringUptimeCheckTcpCheck({required this.port, this.pingConfig});
+
+  /// TCP port to connect to (combined with the host derived from
+  /// [monitoredResource]).
+  final int port;
+
+  /// Optional companion ICMP ping configuration.
+  final MonitoringUptimeCheckPingConfig? pingConfig;
+
+  Map<String, Object?> toArgMap() => {
+    'port': port,
+    if (pingConfig != null) 'ping_config': [pingConfig!.toArgMap()],
+  };
+}
+
+// ===========================================================================
+// synthetic_monitor + cloud_function_v2
+// ===========================================================================
+
+/// `synthetic_monitor.cloud_function_v2` block (min=1, max=1) — target
+/// Cloud Functions V2 instance that implements the probe logic.
+class MonitoringUptimeCheckCloudFunctionV2 {
+  const MonitoringUptimeCheckCloudFunctionV2({required this.name});
+
+  /// Fully-qualified Cloud Functions V2 function name, e.g.
+  /// `'projects/p/locations/us-central1/functions/my-probe'`.
+  final String name;
+
+  Map<String, Object?> toArgMap() => {'name': name};
+}
+
+/// `synthetic_monitor` block (max=1). Mutually exclusive with
+/// [httpCheck] and [tcpCheck] on the parent resource.
+class MonitoringUptimeCheckSyntheticMonitor {
+  const MonitoringUptimeCheckSyntheticMonitor({required this.cloudFunctionV2});
+
+  final MonitoringUptimeCheckCloudFunctionV2 cloudFunctionV2;
+
+  Map<String, Object?> toArgMap() => {
+    'cloud_function_v2': [cloudFunctionV2.toArgMap()],
+  };
+}
+
+// ===========================================================================
+// content_matchers + json_path_matcher
+// ===========================================================================
+
+/// `content_matchers[].json_path_matcher` block (max=1). Used by the
+/// `MATCHES_JSON_PATH` / `NOT_MATCHES_JSON_PATH` parent matchers.
+class MonitoringUptimeCheckJsonPathMatcher {
+  const MonitoringUptimeCheckJsonPathMatcher({
+    required this.jsonPath,
+    this.jsonMatcher,
+  });
+
+  /// JSONPath expression to resolve before applying the [jsonMatcher].
+  final String jsonPath;
+  final MonitoringUptimeCheckJsonMatcher? jsonMatcher;
+
+  Map<String, Object?> toArgMap() => {
+    'json_path': jsonPath,
+    if (jsonMatcher != null) 'json_matcher': jsonMatcher!.terraformValue,
+  };
+}
+
+/// One entry in `google_monitoring_uptime_check_config.content_matchers`.
+///
+/// Only the first entry is currently honored by the GCP API — the
+/// schema reserves the list shape for future expansion.
+class MonitoringUptimeCheckContentMatcher {
+  const MonitoringUptimeCheckContentMatcher({
+    required this.content,
+    this.matcher,
+    this.jsonPathMatcher,
+  });
+
+  /// Content to match (max 1024 bytes). Interpretation depends on
+  /// [matcher] — literal substring for `CONTAINS_*`, regex for
+  /// `MATCHES_REGEX*`, etc.
+  final String content;
+
+  /// Match mode. Defaults to
+  /// [MonitoringUptimeCheckMatcher.containsString] on the API side.
+  final MonitoringUptimeCheckMatcher? matcher;
+
+  /// Required when [matcher] is
+  /// [MonitoringUptimeCheckMatcher.matchesJsonPath] or
+  /// [MonitoringUptimeCheckMatcher.notMatchesJsonPath].
+  final MonitoringUptimeCheckJsonPathMatcher? jsonPathMatcher;
+
+  Map<String, Object?> toArgMap() => {
+    'content': content,
+    if (matcher != null) 'matcher': matcher!.terraformValue,
+    if (jsonPathMatcher != null)
+      'json_path_matcher': [jsonPathMatcher!.toArgMap()],
+  };
+}
+
+/// Factory wrapper for `google_monitoring_uptime_check_config` (provider
+/// `hashicorp/google ~> 7.0`).
+///
+/// Manages a Cloud Monitoring **uptime check** — a periodic probe (HTTP /
+/// HTTPS, plain TCP, or a Synthetic Monitor Cloud Function) launched from
+/// Google-managed checker pools (or your own VPC checkers) against a
+/// target resource.
+///
+/// Required identity:
+/// - [localName]: Terraform local name (the address segment after
+///   `google_monitoring_uptime_check_config.`).
+/// - `displayName`: human-friendly label shown in the Monitoring console.
+/// - `timeout`: Duration string for the per-probe budget (e.g. `'10s'`).
+///   Valid range 1-60 seconds.
+///
+/// ## Probe shape — pick exactly one
+///
+/// The Terraform provider enforces an `exactly_one_of` contract across
+/// the probe-type blocks. Set **exactly one** of:
+/// - [httpCheck] — HTTP or HTTPS probe (toggle [HttpCheckConfig.useSsl]
+///   for HTTPS).
+/// - [tcpCheck] — raw TCP connect probe.
+/// - [syntheticMonitor] — invoke a Cloud Functions V2 instance that runs
+///   custom probe logic.
+///
+/// ## Target shape — pick exactly one
+///
+/// Also pick **exactly one** target descriptor:
+/// - [monitoredResource] — directly target a single
+///   [MonitoringUptimeCheckMonitoredResource] (e.g. an `uptime_url`).
+/// - [resourceGroup] — target every member of a `google_monitoring_group`
+///   resource (referenced by [MonitoringUptimeCheckResourceGroup.groupId]).
+///
+/// ## Period / region semantics
+///
+/// - `period` is the cadence between probes. The GCP API accepts only
+///   the four discrete Duration strings `'60s'`, `'300s'`, `'600s'`,
+///   `'900s'`. Defaults to `'300s'` when unset.
+/// - `selectedRegions` controls where probes originate. Must include
+///   enough regions to cover at least 3 distinct locations, or the
+///   API rejects the request. Leave unset to probe from every region.
+///
+/// ## Checker pool
+///
+/// `checkerType` selects between Google-managed public checkers
+/// ([MonitoringUptimeCheckCheckerType.staticIpCheckers]) and
+/// VPC-internal checkers ([MonitoringUptimeCheckCheckerType.vpcCheckers]).
+/// The latter is mandatory when [monitoredResource] has type
+/// `'servicedirectory_service'`.
+///
+/// Example (HTTPS uptime check against a public URL):
+/// ```dart
+/// final apiUptime = GoogleMonitoringUptimeCheckConfig(
+///   localName: 'api_uptime',
+///   displayName: TfArg.literal('Public API healthz'),
+///   timeout: TfArg.literal('10s'),
+///   period: TfArg.literal('60s'),
+///   httpCheck: const MonitoringUptimeCheckHttpCheck(
+///     path: '/healthz',
+///     port: 443,
+///     useSsl: true,
+///     validateSsl: true,
+///     requestMethod: MonitoringUptimeCheckHttpMethod.get,
+///   ),
+///   monitoredResource: const MonitoringUptimeCheckMonitoredResource(
+///     type: 'uptime_url',
+///     labels: {'host': 'api.example.com', 'project_id': 'my-project'},
+///   ),
+///   contentMatchers: const [
+///     MonitoringUptimeCheckContentMatcher(
+///       content: '"status":"ok"',
+///       matcher: MonitoringUptimeCheckMatcher.containsString,
+///     ),
+///   ],
+///   selectedRegions: [
+///     MonitoringUptimeCheckRegion.usa,
+///     MonitoringUptimeCheckRegion.europe,
+///     MonitoringUptimeCheckRegion.asiaPacific,
+///   ],
+/// );
+/// ```
+///
+/// Composition pattern: extends `Resource<$GoogleMonitoringUptimeCheckConfig>`
+/// for runtime behavior. Nested-block helpers ([MonitoringUptimeCheckHttpCheck],
+/// [MonitoringUptimeCheckTcpCheck], [MonitoringUptimeCheckContentMatcher],
+/// [MonitoringUptimeCheckMonitoredResource], [MonitoringUptimeCheckResourceGroup],
+/// [MonitoringUptimeCheckSyntheticMonitor], etc.) are modeled in the
+/// `prelude` below.
+final class GoogleMonitoringUptimeCheckConfig extends Resource {
+  // ignore: constant_identifier_names
+  static const String $tfType = 'google_monitoring_uptime_check_config';
+
+  GoogleMonitoringUptimeCheckConfig({
+    required super.localName,
+    required TfArg<String> displayName,
+    required TfArg<String> timeout,
+    TfArg<String>? period,
+    List<MonitoringUptimeCheckRegion>? selectedRegions,
+    TfArg<MonitoringUptimeCheckCheckerType>? checkerType,
+    MonitoringUptimeCheckMonitoredResource? monitoredResource,
+    MonitoringUptimeCheckResourceGroup? resourceGroup,
+    MonitoringUptimeCheckHttpCheck? httpCheck,
+    MonitoringUptimeCheckTcpCheck? tcpCheck,
+    MonitoringUptimeCheckSyntheticMonitor? syntheticMonitor,
+    List<MonitoringUptimeCheckContentMatcher>? contentMatchers,
+    TfArg<bool>? logCheckFailures,
+    TfArg<Map<String, String>>? userLabels,
+    TfArg<String>? project,
+    super.lifecycle,
+    super.dependsOn,
+  }) : super(
+         terraformType: $tfType,
+         argMap: {
+           'display_name': displayName,
+           'timeout': timeout,
+           if (period != null) 'period': period,
+           if (selectedRegions != null)
+             'selected_regions': TfArg.literal(
+               selectedRegions.map((r) => r.terraformValue).toList(),
+             ),
+           if (checkerType != null) 'checker_type': checkerType,
+           if (monitoredResource != null)
+             'monitored_resource': TfArg.literal([
+               monitoredResource.toArgMap(),
+             ]),
+           if (resourceGroup != null)
+             'resource_group': TfArg.literal([resourceGroup.toArgMap()]),
+           if (httpCheck != null)
+             'http_check': TfArg.literal([httpCheck.toArgMap()]),
+           if (tcpCheck != null)
+             'tcp_check': TfArg.literal([tcpCheck.toArgMap()]),
+           if (syntheticMonitor != null)
+             'synthetic_monitor': TfArg.literal([syntheticMonitor.toArgMap()]),
+           if (contentMatchers != null)
+             'content_matchers': TfArg.literal(
+               contentMatchers.map((c) => c.toArgMap()).toList(),
+             ),
+           if (logCheckFailures != null) 'log_check_failures': logCheckFailures,
+           if (userLabels != null) 'user_labels': userLabels,
+           if (project != null) 'project': project,
+         },
+       );
+
+  @override
+  // ignore: non_constant_identifier_names
+  Set<String> get $sensitiveFields =>
+      _googleMonitoringUptimeCheckConfigSensitive;
+
+  /// Reference to `id` attribute (the uptime check's full resource name,
+  /// `projects/{project}/uptimeCheckConfigs/{uptime_check_id}`).
+  TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+  /// Reference to `name` attribute (same shape as [id]; populated by
+  /// Cloud Monitoring on create).
+  TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
+
+  /// Reference to `uptime_check_id` (the bare ID segment, without the
+  /// `projects/.../uptimeCheckConfigs/` prefix).
+  TfRef<String> get uptimeCheckIdRef =>
+      TfRef.attribute<String>(this, 'uptime_check_id');
+}


### PR DESCRIPTION
## Summary

Wave 7 Batch 3 of 4: adds 5 GA Cloud Monitoring resources, extending the existing ``monitoring.dart`` barrel from 1 entry (``alert_policy``) to 6. No new per-service barrels (count stays at 27).

### Resources

| Resource | Notes |
| --- | --- |
| ``google_monitoring_notification_channel`` | ``type`` is free-form String (Google maintains channel-type registry server-side); ``sensitive_labels`` block has 3 plaintext sensitive fields + 6 write-only siblings for the Terraform 1.11+ rotation pattern |
| ``google_monitoring_uptime_check_config`` | HTTP / TCP / synthetic probes; 9 schema-verified enums, 12 nested helpers, ``http_check.auth_info.password`` sensitive |
| ``google_monitoring_dashboard`` | Deliberately minimal — ``dashboard_json`` is a free-form String; Cloud Console UI → Export JSON workflow documented |
| ``google_monitoring_metric_descriptor`` | 4 schema-verified enums (metric_kind, value_type, labels.value_type, launch_stage); all prefixed ``Monitoring*`` to avoid collision with ``LoggingMetric*`` from Batch 2 |
| ``google_monitoring_service`` | SLO service object; **only ``basic_service`` is exposed in the provider schema** (the 8 other variants listed in the plan are not present in ``hashicorp/google`` and cannot be set via Terraform; documented inline) |

### Plan deviations (driven by schema-of-truth, pitfall #4)

1. ``monitoring_metric_descriptor.value_type`` has 5 variants only (``BOOL`` / ``INT64`` / ``DOUBLE`` / ``STRING`` / ``DISTRIBUTION``); the plan listed 7 (including ``MONEY`` and ``VALUE_TYPE_UNSPECIFIED``).
2. ``monitoring_metric_descriptor.description`` is ``optional`` per schema, not required.
3. ``monitoring_notification_channel.display_name`` is ``optional`` per schema, not required.
4. ``monitoring_uptime_check_config.selected_regions`` is ``list(string)`` (no schema enum); modeled as a typed-enum helper with raw-String escape hatch.
5. ``monitoring_uptime_check_config`` picked up a ``service_agent_authentication`` HTTP-check sub-block not enumerated in the plan (GA, schema-present).
6. ``monitoring_service``: only ``basic_service`` is curated (see table).

### Count assertion bump (partial PR strategy, pitfall #10)

- ``wrap_command_test.dart``: 108 → 113 emitted files
- ``yaml_loader_test.dart``: 107 → 112 curated resources

terradart_google now ships **113 emitted Dart files (112 resource factories + 1 data source)** across **27 per-service barrels**.

Final Wave 7 target after Batch 4 (+6) lands at **119/118**.

## Test plan

- [x] All 4 universal QA gates green
- [x] Per-service-barrel invariant green (27 service barrels)
- [x] Synth round-trip green (57 tests, +2 sensitive coverage)
- [x] ``dart analyze packages/ --fatal-infos --fatal-warnings``: no issues
- [x] ``terradart wrap --check``: all 113 files match
- [x] Full ``terradart_codegen`` suite: 309 passed
- [x] Full ``terradart_google`` suite: 167 passed
- [x] CI green on PR