### PR TITLE
chore(google): shorten pubspec description (pub.dev score 150 → 160)

### DIFF
--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,5 +1,5 @@
 name: terradart_google
-description: terradart curated GCP factory wrappers — 118 google_* resources + 1 data source (Compute + LB stack, Cloud Build, Artifact Registry, Eventarc, BigQuery + Data ops, KMS, Cloud Storage + notifications, DNS, Cloud Run v2, Logging + sinks, Monitoring + uptime + SLO, Pub/Sub + schema, Cloud Tasks, Secret Manager, Cloud Scheduler, IAM, Cloud SQL, Service Networking) for Dart-first Terraform stacks.
+description: Curated factory wrappers for 118 Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.
 version: 0.9.0
 publish_to: none  # Removed by tool/prepare_publish.sh before dart pub publish.
 homepage: https://github.com/nozomi-koborinai/terradart


### PR DESCRIPTION
## Why

`terradart_google` scored 150/160 pub points on pub.dev while `terradart_core` scored 160/160. The 10-point loss was on the "Follow Dart file conventions / Provide a valid `pubspec.yaml`" check, with the failure reason:

> The package description is too long.

The previous description was 397 chars (long barrel enumeration); pub.dev's limit is 180 chars.

## Fix

New description (156 chars):

> Curated factory wrappers for 118 Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.

Trade-off: drops the exhaustive barrel enumeration; users now get a representative sample with `...` indicating more. The full list lives in the README + dart doc.

## Effect on pub.dev score

Score updates only when a new version publishes. This fix lands on pub.dev when v0.9.1 (or whatever next version) ships. The fix is single-line + zero risk; can be bundled with any future patch/minor release.

## Test plan

- [x] `dart test` passes in all 3 packages
- [x] `dart format --set-exit-if-changed`、 `dart analyze --fatal-infos --fatal-warnings` clean (no spec change beyond pubspec text)
- [x] After next release, verify pub.dev rebuild reports 160/160