### PR TITLE
v0.11.0-dev wave 2: Stack API surface (synth/writeTo split, abstract base class)

### DIFF
--- a/examples/bigquery_quickstart/bin/infra.dart
+++ b/examples/bigquery_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = AnalyticsStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/bigquery_quickstart/lib/main.dart
+++ b/examples/bigquery_quickstart/lib/main.dart
@@ -16,9 +16,6 @@
 /// the table — covering both granularities of BigQuery IAM in one stack.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/bigquery.dart';
 import 'package:terradart_google/iam.dart';
@@ -114,16 +111,6 @@ final class AnalyticsStack extends Stack {
         role: TfArg.literal('roles/bigquery.dataEditor'),
         member: TfArg.ref(ingestor.iamMember),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/bigquery_quickstart/lib/main.dart
+++ b/examples/bigquery_quickstart/lib/main.dart
@@ -24,7 +24,7 @@ import 'package:terradart_google/bigquery.dart';
 import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/provider.dart';
 
-class AnalyticsStack extends Stack {
+final class AnalyticsStack extends Stack {
   AnalyticsStack({required String projectId})
       : super(
           providers: [

--- a/examples/cloud_build_quickstart/bin/infra.dart
+++ b/examples/cloud_build_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = CloudBuildStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/cloud_build_quickstart/lib/main.dart
+++ b/examples/cloud_build_quickstart/lib/main.dart
@@ -24,9 +24,6 @@
 ///     to `main`, and dispatches the work to the private pool.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/artifact_registry.dart';
 import 'package:terradart_google/cloud_build.dart';
@@ -170,16 +167,6 @@ final class CloudBuildStack extends Stack {
         // delegates pool selection to the in-repo build config.)
         substitutions: TfArg.literal({'_WORKER_POOL': lbPool.id.interpolation}),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/cloud_build_quickstart/lib/main.dart
+++ b/examples/cloud_build_quickstart/lib/main.dart
@@ -32,7 +32,7 @@ import 'package:terradart_google/artifact_registry.dart';
 import 'package:terradart_google/cloud_build.dart';
 import 'package:terradart_google/provider.dart';
 
-class CloudBuildStack extends Stack {
+final class CloudBuildStack extends Stack {
   CloudBuildStack({required String projectId})
       : super(
           providers: [

--- a/examples/cloud_functions_quickstart/bin/infra.dart
+++ b/examples/cloud_functions_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = HttpFunctionStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/cloud_functions_quickstart/lib/main.dart
+++ b/examples/cloud_functions_quickstart/lib/main.dart
@@ -21,7 +21,7 @@ import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/storage.dart';
 
-class HttpFunctionStack extends Stack {
+final class HttpFunctionStack extends Stack {
   HttpFunctionStack({required String projectId})
       : super(
           providers: [

--- a/examples/cloud_functions_quickstart/lib/main.dart
+++ b/examples/cloud_functions_quickstart/lib/main.dart
@@ -12,9 +12,6 @@
 /// and the typed enum coverage from `google_cloudfunctions2_function`.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/cloud_functions.dart';
 import 'package:terradart_google/iam.dart';
@@ -41,7 +38,9 @@ final class HttpFunctionStack extends Stack {
       localName: 'fn_source_zip',
       bucket: TfArg.ref(sourceBucket.nameRef),
       name: TfArg.literal('hello-http.zip'),
-      body: StorageBucketObjectBucketObjectFromSource(source: TfArg.literal('./hello-http.zip')),
+      body: StorageBucketObjectBucketObjectFromSource(
+        source: TfArg.literal('./hello-http.zip'),
+      ),
     );
     add(sourceObject);
 
@@ -80,16 +79,6 @@ final class HttpFunctionStack extends Stack {
           environmentVariables: TfArg.literal({'LOG_LEVEL': 'info'}),
         ),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/cloud_run_quickstart/bin/infra.dart
+++ b/examples/cloud_run_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = ApiServiceStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/cloud_run_quickstart/lib/main.dart
+++ b/examples/cloud_run_quickstart/lib/main.dart
@@ -24,9 +24,6 @@
 /// pattern).
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/cloud_run.dart';
 import 'package:terradart_google/iam.dart';
@@ -45,7 +42,9 @@ final class ApiServiceStack extends Stack {
         localName: 'db_password',
         secretId: TfArg.literal('api-db-password'),
         replication: SecretManagerSecretReplication.userManaged([
-          SecretManagerSecretReplica(location: TfArg.literal('asia-northeast1')),
+          SecretManagerSecretReplica(
+            location: TfArg.literal('asia-northeast1'),
+          ),
         ]),
       ),
     );
@@ -62,7 +61,8 @@ final class ApiServiceStack extends Stack {
             env: [
               CloudRunV2ServiceEnvVar(
                 name: TfArg.literal('LOG_LEVEL'),
-                source: CloudRunV2ServiceEnvVarFromLiteral(TfArg.literal('info')),
+                source:
+                    CloudRunV2ServiceEnvVarFromLiteral(TfArg.literal('info')),
               ),
               CloudRunV2ServiceEnvVar(
                 name: TfArg.literal('DB_PASSWORD'),
@@ -72,7 +72,9 @@ final class ApiServiceStack extends Stack {
                 ),
               ),
             ],
-            ports: CloudRunV2ServiceContainerPort(containerPort: TfArg.literal(8080)),
+            ports: CloudRunV2ServiceContainerPort(
+              containerPort: TfArg.literal(8080),
+            ),
             resources: CloudRunV2ServiceContainerResources(
               limits: TfArg.literal({'cpu': '1', 'memory': '512Mi'}),
               cpuIdle: TfArg.literal(true),
@@ -163,16 +165,6 @@ final class ApiServiceStack extends Stack {
         member: TfArg.ref(schedulerSa.iamMember),
         location: TfArg.literal('asia-northeast1'),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/cloud_run_quickstart/lib/main.dart
+++ b/examples/cloud_run_quickstart/lib/main.dart
@@ -33,7 +33,7 @@ import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/secret_manager.dart';
 
-class ApiServiceStack extends Stack {
+final class ApiServiceStack extends Stack {
   ApiServiceStack({required String projectId})
       : super(
           providers: [

--- a/examples/cloud_scheduler_quickstart/bin/infra.dart
+++ b/examples/cloud_scheduler_quickstart/bin/infra.dart
@@ -11,5 +11,5 @@ import 'package:terradart_example_cloud_scheduler_quickstart/main.dart';
 Future<void> main() async {
   final projectId = Platform.environment['GCP_PROJECT_ID'] ?? 'YOUR-PROJECT-ID';
   final stack = NightlyCleanupStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
 }

--- a/examples/cloud_scheduler_quickstart/lib/main.dart
+++ b/examples/cloud_scheduler_quickstart/lib/main.dart
@@ -9,9 +9,6 @@
 /// that publishes to it every night at 03:00 JST.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/cloud_scheduler.dart';
 import 'package:terradart_google/provider.dart';
@@ -64,24 +61,5 @@ final class NightlyCleanupStack extends Stack {
     );
 
     setAppExportsOutputPath('lib/generated/nightly_cleanup_stack.app.dart');
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
-    );
-
-    final dartConstants = result.dartConstants;
-    final dartPath = result.dartConstantsPath;
-    if (dartConstants != null && dartPath != null) {
-      final dartFile = File(dartPath);
-      await dartFile.parent.create(recursive: true);
-      await dartFile.writeAsString(dartConstants);
-    }
   }
 }

--- a/examples/cloud_scheduler_quickstart/lib/main.dart
+++ b/examples/cloud_scheduler_quickstart/lib/main.dart
@@ -18,7 +18,7 @@ import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/pubsub.dart';
 
 /// Cloud Scheduler job + Pub/Sub topic Stack.
-class NightlyCleanupStack extends Stack {
+final class NightlyCleanupStack extends Stack {
   NightlyCleanupStack({required String projectId})
       : super(
           providers: [

--- a/examples/cloud_sql_quickstart/bin/infra.dart
+++ b/examples/cloud_sql_quickstart/bin/infra.dart
@@ -17,6 +17,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = CloudSqlStack(projectId: projectId, dbPassword: dbPassword);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/cloud_sql_quickstart/lib/main.dart
+++ b/examples/cloud_sql_quickstart/lib/main.dart
@@ -26,7 +26,7 @@ import 'package:terradart_google/compute.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/service_networking.dart';
 
-class CloudSqlStack extends Stack {
+final class CloudSqlStack extends Stack {
   CloudSqlStack({
     required String projectId,
     required String dbPassword,

--- a/examples/cloud_sql_quickstart/lib/main.dart
+++ b/examples/cloud_sql_quickstart/lib/main.dart
@@ -17,9 +17,6 @@
 ///    from `DB_PASSWORD`; it is sensitive and masked at synth time.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/cloud_sql.dart';
 import 'package:terradart_google/compute.dart';
@@ -132,16 +129,6 @@ final class CloudSqlStack extends Stack {
         passwordWo: TfArg.literal(dbPassword),
         passwordWoVersion: TfArg.literal(1),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/cloud_tasks_quickstart/bin/infra.dart
+++ b/examples/cloud_tasks_quickstart/bin/infra.dart
@@ -6,5 +6,5 @@ import 'package:terradart_example_cloud_tasks_quickstart/main.dart';
 
 Future<void> main() async {
   final stack = EmailJobsStack(projectId: 'YOUR-PROJECT-ID');
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
 }

--- a/examples/cloud_tasks_quickstart/lib/main.dart
+++ b/examples/cloud_tasks_quickstart/lib/main.dart
@@ -14,7 +14,7 @@ import 'package:terradart_google/cloud_tasks.dart';
 import 'package:terradart_google/provider.dart';
 
 /// Cloud Tasks queue + IAM enqueuer Stack.
-class EmailJobsStack extends Stack {
+final class EmailJobsStack extends Stack {
   EmailJobsStack({required String projectId})
       : super(
           providers: [

--- a/examples/cloud_tasks_quickstart/lib/main.dart
+++ b/examples/cloud_tasks_quickstart/lib/main.dart
@@ -6,9 +6,6 @@
 /// constant for application-side use.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/cloud_tasks.dart';
 import 'package:terradart_google/provider.dart';
@@ -63,24 +60,5 @@ final class EmailJobsStack extends Stack {
     );
 
     setAppExportsOutputPath('lib/generated/email_jobs_stack.app.dart');
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
-    );
-
-    final dartConstants = result.dartConstants;
-    final dartPath = result.dartConstantsPath;
-    if (dartConstants != null && dartPath != null) {
-      final dartFile = File(dartPath);
-      await dartFile.parent.create(recursive: true);
-      await dartFile.writeAsString(dartConstants);
-    }
   }
 }

--- a/examples/compute_lb_quickstart/bin/infra.dart
+++ b/examples/compute_lb_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = ComputeLbStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/compute_lb_quickstart/lib/main.dart
+++ b/examples/compute_lb_quickstart/lib/main.dart
@@ -37,9 +37,6 @@
 ///     L7 LB.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/compute.dart';
 import 'package:terradart_google/provider.dart';
@@ -286,16 +283,6 @@ final class ComputeLbStack extends Stack {
         ),
         target: TfArg.ref(lbHttpsProxy.selfLink),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/compute_lb_quickstart/lib/main.dart
+++ b/examples/compute_lb_quickstart/lib/main.dart
@@ -44,7 +44,7 @@ import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/compute.dart';
 import 'package:terradart_google/provider.dart';
 
-class ComputeLbStack extends Stack {
+final class ComputeLbStack extends Stack {
   ComputeLbStack({required String projectId})
       : super(
           providers: [

--- a/examples/compute_quickstart/bin/infra.dart
+++ b/examples/compute_quickstart/bin/infra.dart
@@ -18,6 +18,6 @@ Future<void> main() async {
   }
 
   final stack = NetworkStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/compute_quickstart/lib/main.dart
+++ b/examples/compute_quickstart/lib/main.dart
@@ -21,7 +21,7 @@ import 'package:terradart_google/compute.dart';
 import 'package:terradart_google/provider.dart';
 
 /// Network stack: a VPC + a public IP for a load balancer.
-class NetworkStack extends Stack {
+final class NetworkStack extends Stack {
   NetworkStack({required String projectId})
       : super(
           providers: [

--- a/examples/compute_quickstart/lib/main.dart
+++ b/examples/compute_quickstart/lib/main.dart
@@ -13,9 +13,6 @@
 /// keeps service projects and tenants from over-reaching.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/compute.dart';
 import 'package:terradart_google/provider.dart';
@@ -129,19 +126,10 @@ final class NetworkStack extends Stack {
         name: TfArg.literal('persistent-data-disk'),
         role: TfArg.literal('roles/compute.storageAdmin'),
         member: TfArg.literal(
-            'serviceAccount:backup@example.iam.gserviceaccount.com',),
+          'serviceAccount:backup@example.iam.gserviceaccount.com',
+        ),
         zone: TfArg.literal('asia-northeast1-a'),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/dns_quickstart/bin/infra.dart
+++ b/examples/dns_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = InternalDnsStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/dns_quickstart/lib/main.dart
+++ b/examples/dns_quickstart/lib/main.dart
@@ -17,9 +17,6 @@
 /// owns its own subdomain without project-wide DNS admin.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/compute.dart';
 import 'package:terradart_google/dns.dart';
@@ -94,16 +91,6 @@ final class InternalDnsStack extends Stack {
         role: TfArg.literal('roles/dns.admin'),
         member: TfArg.ref(zoneAdmin.iamMember),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/dns_quickstart/lib/main.dart
+++ b/examples/dns_quickstart/lib/main.dart
@@ -26,7 +26,7 @@ import 'package:terradart_google/dns.dart';
 import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/provider.dart';
 
-class InternalDnsStack extends Stack {
+final class InternalDnsStack extends Stack {
   InternalDnsStack({required String projectId})
       : super(
           providers: [

--- a/examples/firebase_app_check_quickstart/bin/infra.dart
+++ b/examples/firebase_app_check_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = AppCheckStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/firebase_app_check_quickstart/lib/main.dart
+++ b/examples/firebase_app_check_quickstart/lib/main.dart
@@ -19,7 +19,7 @@ import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/firebase_app_check.dart';
 import 'package:terradart_google/provider.dart';
 
-class AppCheckStack extends Stack {
+final class AppCheckStack extends Stack {
   AppCheckStack({required String projectId})
       : super(
           providers: [

--- a/examples/firebase_app_check_quickstart/lib/main.dart
+++ b/examples/firebase_app_check_quickstart/lib/main.dart
@@ -12,9 +12,6 @@
 /// enforcement config (which decides what happens to unverified requests).
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/firebase_app_check.dart';
 import 'package:terradart_google/provider.dart';
@@ -47,16 +44,6 @@ final class AppCheckStack extends Stack {
         serviceId: TfArg.literal('firestore.googleapis.com'),
         enforcementMode: TfArg.literal(AppCheckEnforcementMode.enforced),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/firebase_app_hosting_quickstart/bin/infra.dart
+++ b/examples/firebase_app_hosting_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = AppHostingStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/firebase_app_hosting_quickstart/lib/main.dart
+++ b/examples/firebase_app_hosting_quickstart/lib/main.dart
@@ -20,7 +20,7 @@ import 'package:terradart_google/firebase_app_hosting.dart';
 import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/provider.dart';
 
-class AppHostingStack extends Stack {
+final class AppHostingStack extends Stack {
   AppHostingStack({required String projectId})
       : super(
           providers: [

--- a/examples/firebase_app_hosting_quickstart/lib/main.dart
+++ b/examples/firebase_app_hosting_quickstart/lib/main.dart
@@ -12,9 +12,6 @@
 /// cross-reference, and the custom domain helper pattern.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/firebase_app_hosting.dart';
 import 'package:terradart_google/iam.dart';
@@ -61,16 +58,6 @@ final class AppHostingStack extends Stack {
         location: TfArg.literal('us-central1'),
         domainId: TfArg.literal('apphosting.example.com'),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/firebase_data_connect_quickstart/bin/infra.dart
+++ b/examples/firebase_data_connect_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = DataConnectStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/firebase_data_connect_quickstart/lib/main.dart
+++ b/examples/firebase_data_connect_quickstart/lib/main.dart
@@ -23,7 +23,7 @@ import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/firebase_data_connect.dart';
 import 'package:terradart_google/provider.dart';
 
-class DataConnectStack extends Stack {
+final class DataConnectStack extends Stack {
   DataConnectStack({required String projectId})
       : super(
           providers: [

--- a/examples/firebase_data_connect_quickstart/lib/main.dart
+++ b/examples/firebase_data_connect_quickstart/lib/main.dart
@@ -16,9 +16,6 @@
 /// cross-reference getter.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/firebase_data_connect.dart';
 import 'package:terradart_google/provider.dart';
@@ -45,16 +42,6 @@ final class DataConnectStack extends Stack {
         // production to guard against accidental teardown.
         deletionPolicy: TfArg.literal(DataConnectDeletionPolicy.force),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/firebase_remote_config_quickstart/bin/infra.dart
+++ b/examples/firebase_remote_config_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = RemoteConfigStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/firebase_remote_config_quickstart/lib/main.dart
+++ b/examples/firebase_remote_config_quickstart/lib/main.dart
@@ -22,7 +22,7 @@ import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/firebase_remote_config.dart';
 import 'package:terradart_google/provider.dart';
 
-class RemoteConfigStack extends Stack {
+final class RemoteConfigStack extends Stack {
   RemoteConfigStack({required String projectId})
       : super(
           providers: [

--- a/examples/firebase_remote_config_quickstart/lib/main.dart
+++ b/examples/firebase_remote_config_quickstart/lib/main.dart
@@ -15,9 +15,6 @@
 /// - [RemoteConfigTagColor] and [RemoteConfigValueType] enum usage.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/firebase_remote_config.dart';
 import 'package:terradart_google/provider.dart';
@@ -30,7 +27,8 @@ final class RemoteConfigStack extends Stack {
           ],
         ) {
     // A condition that fires for users in Japan.
-    final japanCondition = FirebaseRemoteConfigRemoteConfigRemoteConfigCondition(
+    final japanCondition =
+        FirebaseRemoteConfigRemoteConfigRemoteConfigCondition(
       name: TfArg.literal('is_japan'),
       expression: TfArg.literal("device.country in ['JP']"),
       tagColor: RemoteConfigTagColor.blue,
@@ -45,7 +43,8 @@ final class RemoteConfigStack extends Stack {
           FirebaseRemoteConfigRemoteConfigRemoteConfigParameter(
             parameterName: TfArg.literal('enable_new_checkout'),
             valueType: RemoteConfigValueType.boolean,
-            defaultValue: FirebaseRemoteConfigRemoteConfigRemoteConfigDefaultValue(
+            defaultValue:
+                FirebaseRemoteConfigRemoteConfigRemoteConfigDefaultValue(
               value: TfArg.literal('false'),
             ),
             conditionalValues: [
@@ -60,7 +59,8 @@ final class RemoteConfigStack extends Stack {
           FirebaseRemoteConfigRemoteConfigRemoteConfigParameter(
             parameterName: TfArg.literal('welcome_banner_text'),
             valueType: RemoteConfigValueType.string,
-            defaultValue: FirebaseRemoteConfigRemoteConfigRemoteConfigDefaultValue(
+            defaultValue:
+                FirebaseRemoteConfigRemoteConfigRemoteConfigDefaultValue(
               value: TfArg.literal('Welcome!'),
             ),
             conditionalValues: [
@@ -80,7 +80,8 @@ final class RemoteConfigStack extends Stack {
               FirebaseRemoteConfigRemoteConfigRemoteConfigParameter(
                 parameterName: TfArg.literal('enable_dark_mode'),
                 valueType: RemoteConfigValueType.boolean,
-                defaultValue: FirebaseRemoteConfigRemoteConfigRemoteConfigDefaultValue(
+                defaultValue:
+                    FirebaseRemoteConfigRemoteConfigRemoteConfigDefaultValue(
                   value: TfArg.literal('false'),
                 ),
               ),
@@ -88,16 +89,6 @@ final class RemoteConfigStack extends Stack {
           ),
         ],
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/firestore_document_quickstart/bin/infra.dart
+++ b/examples/firestore_document_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = FirestoreDocumentQuickstart(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/firestore_document_quickstart/lib/main.dart
+++ b/examples/firestore_document_quickstart/lib/main.dart
@@ -13,9 +13,6 @@
 /// [FirestoreFields.encode] helper introduced in terradart v0.10.0.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/firestore.dart';
 import 'package:terradart_google/project.dart';
@@ -69,16 +66,6 @@ final class FirestoreDocumentQuickstart extends Stack {
         }),
         dependsOn: [ResourceDependency(db)],
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/firestore_document_quickstart/lib/main.dart
+++ b/examples/firestore_document_quickstart/lib/main.dart
@@ -21,7 +21,7 @@ import 'package:terradart_google/firestore.dart';
 import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
 
-class FirestoreDocumentQuickstart extends Stack {
+final class FirestoreDocumentQuickstart extends Stack {
   FirestoreDocumentQuickstart({required String projectId})
       : super(
           providers: [

--- a/examples/firestore_quickstart/bin/infra.dart
+++ b/examples/firestore_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = MessagesStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/firestore_quickstart/lib/main.dart
+++ b/examples/firestore_quickstart/lib/main.dart
@@ -12,9 +12,6 @@
 /// and the sealed `IndexFieldSpec` dispatch from `google_firestore_index`.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/firestore.dart';
 import 'package:terradart_google/provider.dart';
@@ -56,16 +53,6 @@ final class MessagesStack extends Stack {
           ),
         ],
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/firestore_quickstart/lib/main.dart
+++ b/examples/firestore_quickstart/lib/main.dart
@@ -19,7 +19,7 @@ import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/firestore.dart';
 import 'package:terradart_google/provider.dart';
 
-class MessagesStack extends Stack {
+final class MessagesStack extends Stack {
   MessagesStack({required String projectId})
       : super(
           providers: [

--- a/examples/iam_quickstart/bin/infra.dart
+++ b/examples/iam_quickstart/bin/infra.dart
@@ -13,5 +13,5 @@ Future<void> main() async {
   final stack = IamShowcaseStack(
     projectId: projectId,
   );
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
 }

--- a/examples/iam_quickstart/lib/main.dart
+++ b/examples/iam_quickstart/lib/main.dart
@@ -41,7 +41,7 @@ import 'package:terradart_google/pubsub.dart';
 import 'package:terradart_google/secret_manager.dart';
 
 /// IAM showcase Stack.
-class IamShowcaseStack extends Stack {
+final class IamShowcaseStack extends Stack {
   IamShowcaseStack({
     required String projectId,
   }) : super(

--- a/examples/iam_quickstart/lib/main.dart
+++ b/examples/iam_quickstart/lib/main.dart
@@ -30,9 +30,6 @@
 /// is needed.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/cloud_tasks.dart';
 import 'package:terradart_google/iam.dart';
@@ -267,24 +264,5 @@ final class IamShowcaseStack extends Stack {
     );
 
     setAppExportsOutputPath('lib/generated/iam_showcase_stack.app.dart');
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
-    );
-
-    final dartConstants = result.dartConstants;
-    final dartPath = result.dartConstantsPath;
-    if (dartConstants != null && dartPath != null) {
-      final dartFile = File(dartPath);
-      await dartFile.parent.create(recursive: true);
-      await dartFile.writeAsString(dartConstants);
-    }
   }
 }

--- a/examples/kms_quickstart/bin/infra.dart
+++ b/examples/kms_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = CryptoStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/kms_quickstart/lib/main.dart
+++ b/examples/kms_quickstart/lib/main.dart
@@ -22,7 +22,7 @@ import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/kms.dart';
 import 'package:terradart_google/provider.dart';
 
-class CryptoStack extends Stack {
+final class CryptoStack extends Stack {
   CryptoStack({required String projectId})
       : super(
           providers: [

--- a/examples/kms_quickstart/lib/main.dart
+++ b/examples/kms_quickstart/lib/main.dart
@@ -14,9 +14,6 @@
 /// every key under this ring" without granting per-key encrypt/decrypt.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/kms.dart';
@@ -98,16 +95,6 @@ final class CryptoStack extends Stack {
         role: TfArg.literal('roles/cloudkms.viewer'),
         member: TfArg.ref(ringInventory.iamMember),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/monitoring_quickstart/bin/infra.dart
+++ b/examples/monitoring_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = LatencyAlertStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/monitoring_quickstart/lib/main.dart
+++ b/examples/monitoring_quickstart/lib/main.dart
@@ -23,7 +23,7 @@ import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/monitoring.dart';
 import 'package:terradart_google/provider.dart';
 
-class LatencyAlertStack extends Stack {
+final class LatencyAlertStack extends Stack {
   LatencyAlertStack({required String projectId})
       : super(
           providers: [

--- a/examples/monitoring_quickstart/lib/main.dart
+++ b/examples/monitoring_quickstart/lib/main.dart
@@ -16,9 +16,6 @@
 /// `EvaluationMissingData` enums, and the `AlertStrategy` helper.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/monitoring.dart';
 import 'package:terradart_google/provider.dart';
@@ -68,20 +65,11 @@ final class LatencyAlertStack extends Stack {
         ],
         alertStrategy: MonitoringAlertPolicyAlertStrategy(
           autoClose: TfArg.literal('1800s'),
-          notificationRateLimit:
-              MonitoringAlertPolicyNotificationRateLimit(period: TfArg.literal('300s')),
+          notificationRateLimit: MonitoringAlertPolicyNotificationRateLimit(
+            period: TfArg.literal('300s'),
+          ),
         ),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/ops_quickstart/bin/infra.dart
+++ b/examples/ops_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = AuditPipelineStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/ops_quickstart/lib/main.dart
+++ b/examples/ops_quickstart/lib/main.dart
@@ -18,7 +18,7 @@ import 'package:terradart_google/bigquery.dart';
 import 'package:terradart_google/logging.dart';
 import 'package:terradart_google/provider.dart';
 
-class AuditPipelineStack extends Stack {
+final class AuditPipelineStack extends Stack {
   AuditPipelineStack({required String projectId})
       : super(
           providers: [

--- a/examples/ops_quickstart/lib/main.dart
+++ b/examples/ops_quickstart/lib/main.dart
@@ -10,9 +10,6 @@
 /// `LogSinkExclusion` list-entry helper from `google_logging_project_sink`.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/bigquery.dart';
 import 'package:terradart_google/logging.dart';
@@ -55,16 +52,6 @@ final class AuditPipelineStack extends Stack {
           ),
         ],
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/pubsub_quickstart/bin/infra.dart
+++ b/examples/pubsub_quickstart/bin/infra.dart
@@ -22,6 +22,6 @@ Future<void> main() async {
   }
 
   final stack = OrdersStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/pubsub_quickstart/lib/main.dart
+++ b/examples/pubsub_quickstart/lib/main.dart
@@ -21,7 +21,7 @@ import 'package:terradart_google/pubsub.dart';
 /// `addExport` registers a typed Dart constant ("ORDERS_TOPIC_ID") whose
 /// value is the topic's full resource path -- consumed by Firebase Functions
 /// Dart subscribers via the generated `<stack>.app.dart` file.
-class OrdersStack extends Stack {
+final class OrdersStack extends Stack {
   OrdersStack({required String projectId})
       : super(
           providers: [

--- a/examples/pubsub_quickstart/lib/main.dart
+++ b/examples/pubsub_quickstart/lib/main.dart
@@ -9,9 +9,6 @@
 /// `Stack.addExport`. Run `bin/infra.dart` to synth into `tf-out/`.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/pubsub.dart';
@@ -62,24 +59,5 @@ final class OrdersStack extends Stack {
 
     // Tell the synth pipeline where to drop the generated `.dart` file.
     setAppExportsOutputPath('lib/generated/orders_stack.app.dart');
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
-    );
-
-    final dartConstants = result.dartConstants;
-    final dartPath = result.dartConstantsPath;
-    if (dartConstants != null && dartPath != null) {
-      final dartFile = File(dartPath);
-      await dartFile.parent.create(recursive: true);
-      await dartFile.writeAsString(dartConstants);
-    }
   }
 }

--- a/examples/secret_manager_quickstart/bin/infra.dart
+++ b/examples/secret_manager_quickstart/bin/infra.dart
@@ -26,5 +26,5 @@ Future<void> main() async {
     dbPasswordCleartext: cleartext,
     secretVersion: 1, // bump this on rotation
   );
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
 }

--- a/examples/secret_manager_quickstart/lib/main.dart
+++ b/examples/secret_manager_quickstart/lib/main.dart
@@ -9,9 +9,6 @@
 /// Bump `secretDataWoVersion` to rotate.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/secret_manager.dart';
@@ -72,24 +69,5 @@ final class DbCredentialsStack extends Stack {
     );
 
     setAppExportsOutputPath('lib/generated/db_credentials_stack.app.dart');
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
-    );
-
-    final dartConstants = result.dartConstants;
-    final dartPath = result.dartConstantsPath;
-    if (dartConstants != null && dartPath != null) {
-      final dartFile = File(dartPath);
-      await dartFile.parent.create(recursive: true);
-      await dartFile.writeAsString(dartConstants);
-    }
   }
 }

--- a/examples/secret_manager_quickstart/lib/main.dart
+++ b/examples/secret_manager_quickstart/lib/main.dart
@@ -17,7 +17,7 @@ import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/secret_manager.dart';
 
 /// Secret Manager secret + version + IAM accessor Stack.
-class DbCredentialsStack extends Stack {
+final class DbCredentialsStack extends Stack {
   DbCredentialsStack({
     required String projectId,
     required String dbPasswordCleartext,

--- a/examples/storage_quickstart/bin/infra.dart
+++ b/examples/storage_quickstart/bin/infra.dart
@@ -12,6 +12,6 @@ Future<void> main() async {
     exit(64);
   }
   final stack = AssetsStack(projectId: projectId);
-  await stack.synth(outDir: 'tf-out');
+  await stack.writeTo('tf-out');
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/storage_quickstart/lib/main.dart
+++ b/examples/storage_quickstart/lib/main.dart
@@ -15,9 +15,6 @@
 /// pattern for a static-assets bucket.
 library;
 
-import 'dart:convert' as dart_convert;
-import 'dart:io';
-
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/provider.dart';
@@ -83,16 +80,6 @@ final class AssetsStack extends Stack {
         role: TfArg.literal('roles/storage.objectViewer'),
         member: TfArg.ref(reader.iamMember),
       ),
-    );
-  }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    await Directory(outDir).create(recursive: true);
-    final tfFile = File('$outDir/main.tf.json');
-    await tfFile.writeAsString(
-      const dart_convert.JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
   }
 }

--- a/examples/storage_quickstart/lib/main.dart
+++ b/examples/storage_quickstart/lib/main.dart
@@ -23,7 +23,7 @@ import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/storage.dart';
 
-class AssetsStack extends Stack {
+final class AssetsStack extends Stack {
   AssetsStack({required String projectId})
       : super(
           providers: [

--- a/packages/terradart_core/example/main.dart
+++ b/packages/terradart_core/example/main.dart
@@ -5,13 +5,10 @@ import 'package:terradart_core/terradart_core.dart';
 /// Minimal example: empty Stack synth.
 final class EmptyStack extends Stack {
   EmptyStack() : super(providers: const []);
-
-  @override
-  Future<void> synth({required String outDir}) async =>
-      throw UnimplementedError('use StackSynth.synth(...) directly');
 }
 
 void main() {
-  final result = StackSynth.synth(EmptyStack());
+  final result = EmptyStack().synth();
+  // ignore: avoid_print
   print(const JsonEncoder.withIndent('  ').convert(result.tfJson));
 }

--- a/packages/terradart_core/example/main.dart
+++ b/packages/terradart_core/example/main.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:terradart_core/terradart_core.dart';
 
 /// Minimal example: empty Stack synth.
-class EmptyStack extends Stack {
+final class EmptyStack extends Stack {
   EmptyStack() : super(providers: const []);
 
   @override

--- a/packages/terradart_core/lib/src/data.dart
+++ b/packages/terradart_core/lib/src/data.dart
@@ -5,7 +5,7 @@ import 'resource.dart';
 /// Parallel to `Resource`. The two share `Stack`-level dedup via
 /// `(kind, terraformType, localName)`. `Data` does not accept `lifecycle`
 /// (Terraform forbids it on data sources).
-abstract class Data extends Resource {
+abstract base class Data extends Resource {
   Data({
     required super.terraformType,
     required super.localName,

--- a/packages/terradart_core/lib/src/resource.dart
+++ b/packages/terradart_core/lib/src/resource.dart
@@ -15,7 +15,7 @@ enum ResourceKind {
 /// the schemantic-backed dead chain that motivated them is fully retired.
 /// `Resource` is now flat: factories pass `argMap` and `$sensitiveFields`,
 /// synth consumes both directly.
-abstract class Resource implements TfAddressed {
+abstract base class Resource implements TfAddressed {
   Resource({
     required this.terraformType,
     required this.localName,

--- a/packages/terradart_core/lib/src/stack.dart
+++ b/packages/terradart_core/lib/src/stack.dart
@@ -201,24 +201,51 @@ abstract base class Stack {
     return data;
   }
 
-  /// Synth entry point. The default implementation calls
-  /// [StackSynth.synth] and writes the resulting Terraform JSON to
-  /// `${outDir}/main.tf.json` with two-space indentation, creating
-  /// [outDir] recursively if it doesn't exist.
+  /// Synthesise this Stack into an in-memory [SynthResult] bundle.
   ///
-  /// Subclasses may override to customise file layout — e.g. to also
-  /// write the optional Dart constants file produced by
-  /// [SynthResult.dartConstants] — but most consumers can rely on the
-  /// default.
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    final dir = Directory(outDir);
-    if (!await dir.exists()) {
-      await dir.create(recursive: true);
+  /// Pure / side-effect-free: produces the Terraform JSON map plus any
+  /// generated Dart constants source as values, without touching the
+  /// filesystem. Use [writeTo] to persist the result to disk under a
+  /// chosen output directory.
+  ///
+  /// `stackName` overrides the generated Dart class name when AppExports
+  /// are emitted. Defaults to the runtime type name of the Stack
+  /// subclass (e.g. `OrdersStack` → `OrdersStackExports`).
+  SynthResult synth({String? stackName}) =>
+      StackSynth.synth(this, stackName: stackName);
+
+  /// Synthesise this Stack and write the result to [outDir].
+  ///
+  /// Always writes `${outDir}/main.tf.json` with two-space indentation,
+  /// creating [outDir] recursively if it does not exist. When
+  /// AppExports produced Dart constants AND
+  /// [setAppExportsOutputPath] was called, also writes the generated
+  /// constants file at that path (creating its parent directories
+  /// recursively).
+  ///
+  /// Throws [StateError] when exports were registered via [addExport]
+  /// but no output path was set via [setAppExportsOutputPath] — the
+  /// generated constants would otherwise be silently dropped.
+  Future<void> writeTo(String outDir) async {
+    final result = synth();
+    await Directory(outDir).create(recursive: true);
+    await File('$outDir/main.tf.json').writeAsString(
+      const JsonEncoder.withIndent('  ').convert(result.tfJson),
+    );
+
+    if (result.dartConstants != null) {
+      if (result.dartConstantsPath == null) {
+        throw StateError(
+          'AppExport constants were registered (addExport called) '
+          'but no output path was set. Call '
+          'setAppExportsOutputPath() in your Stack constructor '
+          'before writeTo().',
+        );
+      }
+      final f = File(result.dartConstantsPath!);
+      await f.parent.create(recursive: true);
+      await f.writeAsString(result.dartConstants!);
     }
-    const encoder = JsonEncoder.withIndent('  ');
-    await File('$outDir/main.tf.json')
-        .writeAsString(encoder.convert(result.tfJson));
   }
 }
 

--- a/packages/terradart_core/lib/src/stack.dart
+++ b/packages/terradart_core/lib/src/stack.dart
@@ -73,7 +73,7 @@ abstract interface class StackProvider {
 /// - `setBackend(...)` / `backend` — late binding for backend config
 ///   (alternative to passing it via constructor; useful when backend
 ///   config depends on values resolved during stack construction).
-abstract class Stack {
+abstract base class Stack {
   Stack({
     required List<StackProvider> providers,
     StackBackend? backend,

--- a/packages/terradart_core/lib/src/stack.dart
+++ b/packages/terradart_core/lib/src/stack.dart
@@ -58,8 +58,9 @@ abstract interface class StackProvider {
 /// User-extended IaC composition root.
 ///
 /// User subclasses construct resources inside their own constructor and
-/// register them via `add` / `addData`. `StackSynth.synth(stack)` walks the
-/// internal collections to emit Terraform JSON.
+/// register them via `add` / `addData`. `synth()` returns the in-memory
+/// [SynthResult] bundle (Terraform JSON map plus any generated Dart
+/// constants source); `writeTo(outDir)` persists that bundle to disk.
 ///
 /// Coordination surface for synth and concrete providers:
 ///
@@ -228,20 +229,26 @@ abstract base class Stack {
   /// generated constants would otherwise be silently dropped.
   Future<void> writeTo(String outDir) async {
     final result = synth();
+
+    // Guard before any I/O so the failure mode is atomic — a writeTo call
+    // that throws StateError must NOT have produced a partial main.tf.json
+    // on disk. Otherwise users see a confusing tf-out/ directory next to
+    // the exception and assume the synth half-succeeded.
+    if (result.dartConstants != null && result.dartConstantsPath == null) {
+      throw StateError(
+        'AppExport constants were registered (addExport called) '
+        'but no output path was set. Call '
+        'setAppExportsOutputPath() in your Stack constructor '
+        'before writeTo().',
+      );
+    }
+
     await Directory(outDir).create(recursive: true);
     await File('$outDir/main.tf.json').writeAsString(
       const JsonEncoder.withIndent('  ').convert(result.tfJson),
     );
 
     if (result.dartConstants != null) {
-      if (result.dartConstantsPath == null) {
-        throw StateError(
-          'AppExport constants were registered (addExport called) '
-          'but no output path was set. Call '
-          'setAppExportsOutputPath() in your Stack constructor '
-          'before writeTo().',
-        );
-      }
       final f = File(result.dartConstantsPath!);
       await f.parent.create(recursive: true);
       await f.writeAsString(result.dartConstants!);

--- a/packages/terradart_core/lib/src/synth/stack_synth.dart
+++ b/packages/terradart_core/lib/src/synth/stack_synth.dart
@@ -1,3 +1,4 @@
+import 'package:meta/meta.dart';
 import 'package:terradart_core/src/stack.dart';
 import 'package:terradart_core/src/synth/dart_constants_emitter.dart';
 import 'package:terradart_core/src/synth/json_encoder.dart';
@@ -34,6 +35,11 @@ class SynthResult {
 /// This is a thin orchestrator over the building blocks in `synth/`:
 /// [LiteralResolver] (Pass 1) → [OutputEmitter] (Pass 2) → assemble
 /// JSON via [TfJsonEncoder], render Dart via [DartConstantsEmitter].
+///
+/// Internal: callers should use [Stack.synth] (in-memory) or
+/// [Stack.writeTo] (file write) — the public surface routes through
+/// the Stack-level API, not this orchestrator class directly.
+@internal
 class StackSynth {
   /// Synthesise [stack] into a [SynthResult].
   ///

--- a/packages/terradart_core/lib/terradart_core.dart
+++ b/packages/terradart_core/lib/terradart_core.dart
@@ -26,7 +26,7 @@ export 'src/synth/output_emitter.dart'
         OutputEmitter,
         TerraformOutputSpec;
 export 'src/synth/sensitive_literal_error.dart' show SensitiveLiteralError;
-export 'src/synth/stack_synth.dart' show StackSynth, SynthResult;
+export 'src/synth/stack_synth.dart' show SynthResult;
 export 'src/tf_arg.dart' show TfArg, TfArgLiteral, TfArgRef, TfArgVariable;
 export 'src/tf_ref.dart'
     show AttributeRef, DataRef, ResourceRef, TfAddressed, TfRef;

--- a/packages/terradart_core/test/data_test.dart
+++ b/packages/terradart_core/test/data_test.dart
@@ -4,7 +4,7 @@ import 'package:terradart_core/src/tf_arg.dart';
 import 'package:terradart_core/src/tf_ref.dart';
 import 'package:test/test.dart';
 
-class _FakeProjectData extends Data {
+final class _FakeProjectData extends Data {
   _FakeProjectData({
     required super.localName,
     required TfArg<String> projectId,

--- a/packages/terradart_core/test/helpers/fake_resources.dart
+++ b/packages/terradart_core/test/helpers/fake_resources.dart
@@ -44,14 +44,14 @@ class FakeStackProvider implements StackProvider {
 
 /// Minimal concrete `Stack` subclass for tests. Uses the default
 /// [Stack.synth] implementation.
-class TestStack extends Stack {
+final class TestStack extends Stack {
   TestStack({super.providers = const [], super.backend, super.devMode});
 }
 
 /// Generic non-capable fake resource for injection tests.
 /// `terraformType` is `'fake_thing'`; `$supportsDeletionProtection` defaults
 /// to `false` (base class behaviour).
-class FakeResource extends Resource {
+final class FakeResource extends Resource {
   FakeResource({
     required super.localName,
     required TfArg<String> name,
@@ -64,7 +64,7 @@ class FakeResource extends Resource {
   Set<String> get $sensitiveFields => const {};
 }
 
-class FakePubsubTopic extends Resource {
+final class FakePubsubTopic extends Resource {
   FakePubsubTopic({
     required super.localName,
     required super.argMap,
@@ -85,7 +85,7 @@ class FakePubsubTopic extends Resource {
   Set<String> get $sensitiveFields => const {};
 }
 
-class FakePubsubSubscription extends Resource {
+final class FakePubsubSubscription extends Resource {
   FakePubsubSubscription({
     required super.localName,
     required super.argMap,
@@ -97,7 +97,7 @@ class FakePubsubSubscription extends Resource {
   Set<String> get $sensitiveFields => const {};
 }
 
-class FakeSecretVersion extends Resource {
+final class FakeSecretVersion extends Resource {
   FakeSecretVersion({
     required super.localName,
     required super.argMap,
@@ -109,7 +109,7 @@ class FakeSecretVersion extends Resource {
   Set<String> get $sensitiveFields => const {'secret_data'};
 }
 
-class FakeProjectData extends Data {
+final class FakeProjectData extends Data {
   FakeProjectData({
     required super.localName,
     required super.argMap,

--- a/packages/terradart_core/test/public_api_test.dart
+++ b/packages/terradart_core/test/public_api_test.dart
@@ -38,11 +38,10 @@ void main() {
       TerraformOutputSpec,
       DartConstantsEmitter,
       TfJsonEncoder,
-      StackSynth,
       SynthResult,
       DuplicateResourceError,
     ];
-    expect(symbols, hasLength(35));
+    expect(symbols, hasLength(34));
   });
 
   test('TerraformDurationExt is accessible (extension method)', () {

--- a/packages/terradart_core/test/resource_test.dart
+++ b/packages/terradart_core/test/resource_test.dart
@@ -3,7 +3,7 @@ import 'package:terradart_core/src/resource.dart';
 import 'package:terradart_core/src/tf_arg.dart';
 import 'package:test/test.dart';
 
-class _FakeResource extends Resource {
+final class _FakeResource extends Resource {
   _FakeResource({
     required super.localName,
     required TfArg<String> name,
@@ -89,7 +89,7 @@ void main() {
   });
 }
 
-class _CapableResource extends Resource {
+final class _CapableResource extends Resource {
   _CapableResource({required super.localName, required TfArg<String> name})
       : super(
           terraformType: 'fake_capable_thing',

--- a/packages/terradart_core/test/stack_coordination_test.dart
+++ b/packages/terradart_core/test/stack_coordination_test.dart
@@ -50,7 +50,7 @@ class _FakeProvider implements StackProvider {
   Map<String, Object?> toTfJson() => configArgs;
 }
 
-class _S extends Stack {
+final class _S extends Stack {
   _S({super.providers = const [], super.backend});
 
   @override

--- a/packages/terradart_core/test/stack_coordination_test.dart
+++ b/packages/terradart_core/test/stack_coordination_test.dart
@@ -52,10 +52,6 @@ class _FakeProvider implements StackProvider {
 
 final class _S extends Stack {
   _S({super.providers = const [], super.backend});
-
-  @override
-  Future<void> synth({required String outDir}) async =>
-      throw UnimplementedError();
 }
 
 void main() {

--- a/packages/terradart_core/test/stack_dedup_test.dart
+++ b/packages/terradart_core/test/stack_dedup_test.dart
@@ -4,7 +4,7 @@ import 'package:terradart_core/src/resource.dart';
 import 'package:terradart_core/src/stack.dart';
 import 'package:test/test.dart';
 
-class _R extends Resource {
+final class _R extends Resource {
   _R({required super.localName, required String type})
       : super(
           terraformType: type,
@@ -15,7 +15,7 @@ class _R extends Resource {
   Set<String> get $sensitiveFields => const {};
 }
 
-class _D extends Data {
+final class _D extends Data {
   _D({required super.localName, required String type})
       : super(
           terraformType: type,
@@ -26,7 +26,7 @@ class _D extends Data {
   Set<String> get $sensitiveFields => const {};
 }
 
-class _S extends Stack {
+final class _S extends Stack {
   _S() : super(providers: const []);
 
   @override

--- a/packages/terradart_core/test/stack_dedup_test.dart
+++ b/packages/terradart_core/test/stack_dedup_test.dart
@@ -28,10 +28,6 @@ final class _D extends Data {
 
 final class _S extends Stack {
   _S() : super(providers: const []);
-
-  @override
-  Future<void> synth({required String outDir}) async =>
-      throw UnimplementedError();
 }
 
 void main() {

--- a/packages/terradart_core/test/stack_synth_default_test.dart
+++ b/packages/terradart_core/test/stack_synth_default_test.dart
@@ -138,8 +138,7 @@ void main() {
         expect(
           await File('${tempDir.path}/main.tf.json').exists(),
           isFalse,
-          reason:
-              'writeTo must fail before any I/O; a partial main.tf.json on '
+          reason: 'writeTo must fail before any I/O; a partial main.tf.json on '
               'disk would mislead users into thinking synth half-succeeded.',
         );
       },

--- a/packages/terradart_core/test/stack_synth_default_test.dart
+++ b/packages/terradart_core/test/stack_synth_default_test.dart
@@ -1,12 +1,52 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:terradart_core/src/app_export.dart';
+import 'package:terradart_core/src/stack.dart';
 import 'package:test/test.dart';
 
 import 'helpers/fake_resources.dart';
 
+/// Stack that registers a Dart-emitting export but does NOT set an output
+/// path. Used to exercise the [StateError] path in [Stack.writeTo].
+final class _StackWithUnsetExportPath extends Stack {
+  _StackWithUnsetExportPath()
+      : super(
+          providers: const [
+            FakeStackProvider(
+              providerName: 'google',
+              source: 'hashicorp/google',
+              versionConstraint: '~> 7.0',
+            ),
+          ],
+        ) {
+    addExport('FOO', StringExport('bar'));
+  }
+}
+
+/// Stack with both an export AND an output path set — the happy path
+/// where [Stack.writeTo] writes both `main.tf.json` and the constants
+/// `.dart` file.
+final class _StackWithExportPath extends Stack {
+  _StackWithExportPath({required this.constantsPath})
+      : super(
+          providers: const [
+            FakeStackProvider(
+              providerName: 'google',
+              source: 'hashicorp/google',
+              versionConstraint: '~> 7.0',
+            ),
+          ],
+        ) {
+    addExport('FOO', StringExport('bar'));
+    setAppExportsOutputPath(constantsPath);
+  }
+
+  final String constantsPath;
+}
+
 void main() {
-  group('Stack.synth default', () {
+  group('Stack.writeTo', () {
     late Directory tempDir;
 
     setUp(() async {
@@ -30,7 +70,7 @@ void main() {
         ],
       );
 
-      await stack.synth(outDir: tempDir.path);
+      await stack.writeTo(tempDir.path);
 
       final tfJsonFile = File('${tempDir.path}/main.tf.json');
       expect(await tfJsonFile.exists(), isTrue);
@@ -55,7 +95,7 @@ void main() {
       );
 
       final nested = '${tempDir.path}/nested/tf-out';
-      await stack.synth(outDir: nested);
+      await stack.writeTo(nested);
 
       expect(await File('$nested/main.tf.json').exists(), isTrue);
     });
@@ -71,10 +111,76 @@ void main() {
         ],
       );
 
-      await stack.synth(outDir: tempDir.path);
+      await stack.writeTo(tempDir.path);
 
       final content = await File('${tempDir.path}/main.tf.json').readAsString();
       expect(content, contains('  "terraform"'));
+    });
+
+    test(
+      'throws StateError when AppExports produced Dart constants '
+      'but no output path was set',
+      () async {
+        final stack = _StackWithUnsetExportPath();
+
+        expect(
+          () async => stack.writeTo(tempDir.path),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              contains('setAppExportsOutputPath'),
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'writes both main.tf.json and the constants .dart file when '
+      'setAppExportsOutputPath is set',
+      () async {
+        final constantsPath = '${tempDir.path}/gen/exports.dart';
+        final stack = _StackWithExportPath(constantsPath: constantsPath);
+
+        await stack.writeTo(tempDir.path);
+
+        expect(await File('${tempDir.path}/main.tf.json').exists(), isTrue);
+        expect(await File(constantsPath).exists(), isTrue);
+
+        final dartSource = await File(constantsPath).readAsString();
+        expect(dartSource, contains("r'bar'"));
+      },
+    );
+  });
+
+  group('Stack.synth (in-memory)', () {
+    test('returns a SynthResult; does not touch the filesystem', () {
+      final stack = TestStack(
+        providers: const [
+          FakeStackProvider(
+            providerName: 'google',
+            source: 'hashicorp/google',
+            versionConstraint: '~> 7.0',
+          ),
+        ],
+      );
+
+      final result = stack.synth();
+
+      expect(result.tfJson, isA<Map<String, dynamic>>());
+      expect(result.tfJson.containsKey('terraform'), isTrue);
+      // No exports registered → no Dart constants emitted.
+      expect(result.dartConstants, isNull);
+    });
+
+    test('stackName override is forwarded to StackSynth', () {
+      final stack = _StackWithExportPath(constantsPath: '/tmp/ignored.dart');
+
+      final result = stack.synth(stackName: 'CustomName');
+      // Constants file should reference the override-derived class name.
+      expect(result.dartConstants, isNotNull);
+      expect(result.dartConstants, contains('CustomNameExports'));
     });
   });
 }

--- a/packages/terradart_core/test/stack_synth_default_test.dart
+++ b/packages/terradart_core/test/stack_synth_default_test.dart
@@ -123,7 +123,7 @@ void main() {
       () async {
         final stack = _StackWithUnsetExportPath();
 
-        expect(
+        await expectLater(
           () async => stack.writeTo(tempDir.path),
           throwsA(
             isA<StateError>().having(
@@ -132,6 +132,15 @@ void main() {
               contains('setAppExportsOutputPath'),
             ),
           ),
+        );
+
+        // Atomic failure: nothing should have been written under outDir.
+        expect(
+          await File('${tempDir.path}/main.tf.json').exists(),
+          isFalse,
+          reason:
+              'writeTo must fail before any I/O; a partial main.tf.json on '
+              'disk would mislead users into thinking synth half-succeeded.',
         );
       },
     );

--- a/packages/terradart_core/test/stack_test.dart
+++ b/packages/terradart_core/test/stack_test.dart
@@ -4,7 +4,7 @@ import 'package:terradart_core/src/stack.dart';
 import 'package:terradart_core/src/tf_arg.dart';
 import 'package:test/test.dart';
 
-class _FakeResource extends Resource {
+final class _FakeResource extends Resource {
   _FakeResource({required super.localName, required TfArg<String> name})
       : super(
           terraformType: 'fake_thing',
@@ -15,7 +15,7 @@ class _FakeResource extends Resource {
   Set<String> get $sensitiveFields => const {};
 }
 
-class _FakeData extends Data {
+final class _FakeData extends Data {
   _FakeData({required super.localName, required TfArg<String> name})
       : super(
           terraformType: 'fake_thing',
@@ -26,7 +26,7 @@ class _FakeData extends Data {
   Set<String> get $sensitiveFields => const {};
 }
 
-class _TestStack extends Stack {
+final class _TestStack extends Stack {
   _TestStack() : super(providers: const []);
 }
 

--- a/packages/terradart_core/test/synth/devmode_injection_test.dart
+++ b/packages/terradart_core/test/synth/devmode_injection_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 import '../helpers/fake_resources.dart';
 
-class _CapableResource extends Resource {
+final class _CapableResource extends Resource {
   _CapableResource({required super.localName, required TfArg<String> name})
       : super(
           terraformType: 'fake_protected_thing',
@@ -19,7 +19,7 @@ class _CapableResource extends Resource {
   bool get $supportsDeletionProtection => true;
 }
 
-class _CapableResourceWithExplicitDP extends Resource {
+final class _CapableResourceWithExplicitDP extends Resource {
   _CapableResourceWithExplicitDP({
     required super.localName,
     required TfArg<String> name,

--- a/packages/terradart_google/example/main.dart
+++ b/packages/terradart_google/example/main.dart
@@ -8,19 +8,15 @@ final class HelloStack extends Stack {
   HelloStack({required String projectId})
       : super(
           providers: [
-            GoogleProvider(project: projectId, region: 'us-central1')
+            GoogleProvider(project: projectId, region: 'us-central1'),
           ],
         ) {
     add(GooglePubsubTopic(localName: 'hello', name: TfArg.literal('hello')));
   }
-
-  @override
-  Future<void> synth({required String outDir}) async {
-    final result = StackSynth.synth(this);
-    print(const JsonEncoder.withIndent('  ').convert(result.tfJson));
-  }
 }
 
-void main() async {
-  await HelloStack(projectId: 'YOUR-PROJECT-ID').synth(outDir: '.');
+void main() {
+  final result = HelloStack(projectId: 'YOUR-PROJECT-ID').synth();
+  // ignore: avoid_print
+  print(const JsonEncoder.withIndent('  ').convert(result.tfJson));
 }

--- a/packages/terradart_google/example/main.dart
+++ b/packages/terradart_google/example/main.dart
@@ -4,7 +4,7 @@ import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/terradart_google.dart';
 
 /// Minimal example: a single Pub/Sub topic, synthesized to Terraform JSON.
-class HelloStack extends Stack {
+final class HelloStack extends Stack {
   HelloStack({required String projectId})
       : super(
           providers: [

--- a/packages/terradart_google/test/_helpers.dart
+++ b/packages/terradart_google/test/_helpers.dart
@@ -4,7 +4,7 @@ import 'package:terradart_core/terradart_core.dart';
 /// `packages/terradart/test/helpers/fake_resources.dart`. We can't import
 /// test-private helpers from the sibling package, so we redeclare the
 /// trivial subclass here.
-class TestStack extends Stack {
+final class TestStack extends Stack {
   TestStack({super.providers = const [], super.backend});
 
   @override

--- a/packages/terradart_google/test/_helpers.dart
+++ b/packages/terradart_google/test/_helpers.dart
@@ -6,8 +6,4 @@ import 'package:terradart_core/terradart_core.dart';
 /// trivial subclass here.
 final class TestStack extends Stack {
   TestStack({super.providers = const [], super.backend});
-
-  @override
-  Future<void> synth({required String outDir}) async =>
-      throw UnimplementedError('use StackSynth.synth(...) directly in tests');
 }

--- a/packages/terradart_google/test/full_stack_e2e_test.dart
+++ b/packages/terradart_google/test/full_stack_e2e_test.dart
@@ -126,7 +126,7 @@ void main() {
         ),
       );
 
-      final actual = StackSynth.synth(stack).tfJson;
+      final actual = stack.synth().tfJson;
       final golden = jsonDecode(
         await File('test/golden/full_stack.tf.json').readAsString(),
       ) as Map<String, dynamic>;

--- a/packages/terradart_google/test/goldens_test.dart
+++ b/packages/terradart_google/test/goldens_test.dart
@@ -42,7 +42,7 @@ void main() {
     );
 
     expect(
-      StackSynth.synth(stack).tfJson,
+      stack.synth().tfJson,
       equals(await _readGolden('pubsub_topic_iam_member.tf.json')),
     );
   });
@@ -74,7 +74,7 @@ void main() {
     );
 
     expect(
-      StackSynth.synth(stack).tfJson,
+      stack.synth().tfJson,
       equals(await _readGolden('pubsub_subscription_iam_member.tf.json')),
     );
   });
@@ -99,7 +99,7 @@ void main() {
       );
 
     expect(
-      StackSynth.synth(stack).tfJson,
+      stack.synth().tfJson,
       equals(await _readGolden('cloud_tasks_queue.tf.json')),
     );
   });
@@ -126,7 +126,7 @@ void main() {
     );
 
     expect(
-      StackSynth.synth(stack).tfJson,
+      stack.synth().tfJson,
       equals(await _readGolden('cloud_tasks_queue_iam_member.tf.json')),
     );
   });
@@ -142,7 +142,7 @@ void main() {
       );
 
     expect(
-      StackSynth.synth(stack).tfJson,
+      stack.synth().tfJson,
       equals(await _readGolden('secret_manager_secret.tf.json')),
     );
   });
@@ -176,7 +176,7 @@ void main() {
       // through unmasked here. The legacy `secret_data` path (used in the
       // unit test for that field) is masked.
       expect(
-        StackSynth.synth(stack).tfJson,
+        stack.synth().tfJson,
         equals(await _readGolden('secret_manager_secret_version.tf.json')),
       );
     },
@@ -203,7 +203,7 @@ void main() {
     );
 
     expect(
-      StackSynth.synth(stack).tfJson,
+      stack.synth().tfJson,
       equals(await _readGolden('secret_manager_secret_iam_member.tf.json')),
     );
   });
@@ -230,7 +230,7 @@ void main() {
     );
 
     expect(
-      StackSynth.synth(stack).tfJson,
+      stack.synth().tfJson,
       equals(await _readGolden('cloud_scheduler_job_pubsub.tf.json')),
     );
   });
@@ -251,7 +251,7 @@ void main() {
       );
 
     expect(
-      StackSynth.synth(stack).tfJson,
+      stack.synth().tfJson,
       equals(await _readGolden('cloud_scheduler_job_http.tf.json')),
     );
   });

--- a/packages/terradart_google/test/pubsub/google_pubsub_subscription_golden_test.dart
+++ b/packages/terradart_google/test/pubsub/google_pubsub_subscription_golden_test.dart
@@ -30,7 +30,7 @@ void main() {
       ),
     );
 
-    final actual = StackSynth.synth(stack).tfJson;
+    final actual = stack.synth().tfJson;
     final expected = jsonDecode(
       await File(
         'test/golden/pubsub_subscription_push.tf.json',

--- a/packages/terradart_google/test/pubsub/google_pubsub_topic_golden_test.dart
+++ b/packages/terradart_google/test/pubsub/google_pubsub_topic_golden_test.dart
@@ -21,7 +21,7 @@ void main() {
         ),
       );
 
-    final actual = StackSynth.synth(stack).tfJson;
+    final actual = stack.synth().tfJson;
     final expected = jsonDecode(
       await File('test/golden/pubsub_topic.tf.json').readAsString(),
     ) as Map<String, dynamic>;


### PR DESCRIPTION
## Summary

Second of four waves toward v0.11.0. Redesigns the `Stack` API surface so the default API covers the production case (two-file output) and `StackSynth` exits the public barrel. Breaking change; all 23 quickstart examples and 2 package-level examples migrated in lockstep. Golden snapshots remain byte-identical — no behaviour change in synth output.

## What changed

- **`Stack.synth()` returns `SynthResult`** (in-memory bundle: tf.json map + optional Dart constants source). **`Stack.writeTo(outDir)`** is the new file-writing convenience covering the 99% case in a single line: `await stack.writeTo('tf-out')`. The old `Stack.synth({required outDir})` returning `Future<void>` is gone.
- **`writeTo` fails atomically** when `addExport(...)` was called but `setAppExportsOutputPath(...)` was not — the guard runs before any I/O so no partial `main.tf.json` is left on disk. The `StateError` message points users at `setAppExportsOutputPath` as the fix. Regression-guarded by an explicit `File(...).exists() == isFalse` assertion in the test.
- **`StackSynth` removed from the `terradart_core` public barrel** and annotated `@internal`. `SynthResult` stays exported (return type of `Stack.synth()`).
- **`Stack` / `Resource` / `Data` promoted to `abstract base class`.** `extends` continues to work (every quickstart and cookbook uses it); `implements` is forbidden, eliminating a state-bypass foot-gun and aligning the modifier with `AppExport`'s existing `abstract base class`.
- **23 quickstart examples + 2 package-level examples** migrated: the boilerplate `Future<void> synth({required outDir})` override is gone from each Stack subclass, `main()` now calls `await stack.writeTo(...)` directly. `setAppExportsOutputPath` calls (where present) stay in the constructor — `writeTo` reads them via `SynthResult.dartConstantsPath`.
- **Test infrastructure updated** (mechanical): `StackSynth.synth(stack).tfJson` → `stack.synth().tfJson` substitution across 5 terradart_google test files and several terradart_core test fakes; `class _X extends Stack/Resource/Data` → `final class _X extends ...` per the new `abstract base` constraint.

## Why

`terradart_agent` design starts after v0.11.0 ships. Aligning the Stack API with Dart 3 idioms now keeps the agent's code-emission template clean — no more emitting a boilerplate `synth()` override per stack.

## Breaking changes (Dart-side)

- `Stack.synth({required String outDir}) → Future<void>` is gone; replace with `await stack.writeTo(outDir)` or `final result = stack.synth(); /* use result.tfJson, result.dartConstants */`.
- `StackSynth` is no longer reachable from `package:terradart_core/terradart_core.dart`; use `stack.synth()` instead.
- `implements Stack` / `implements Resource` / `implements Data` no longer permitted; the original `extends` pattern continues to work.
- User `Stack` subclasses must be declared `final class XxxStack extends Stack` (or `base` / `sealed`) per Dart's `abstract base` modifier rules.

## Diff size

67 files, +292 / -488 = **net -196 lines** (mainly the 23 quickstart `synth()` boilerplate removals).

## Test plan

- [x] `dart analyze packages/terradart_core packages/terradart_codegen packages/terradart_google` → `No issues found!`
- [x] `dart test` per package: terradart_core 195, terradart_codegen 314, terradart_google 175 — all pass
- [x] `dart pub get` at workspace root: clean
- [x] 3 representative examples (`pubsub_quickstart`, `firestore_document_quickstart`, `compute_lb_quickstart`) run via `dart run bin/infra.dart` → emit `tf-out/main.tf.json`
- [x] Golden snapshots byte-identical (synth output unchanged across the API rewrite)
- [x] `writeTo` StateError path: negative test uses `await expectLater(...)` (live-verified by temporarily removing the guard) + atomicity regression assertion
- [x] Grep checks: no `Future<void> synth(`, no `StackSynth.synth(this)`, no `implements Stack/Resource/Data`, no `StackSynth` in barrel

## Follow-ups for Wave 4

- MIGRATING.md needs a "Stack API redesign" section for v0.10 → v0.11 (before/after for `synth()` / `writeTo()` / `final class` requirement).
- README.md and per-package README.md reference the old `StackSynth.synth(stack)` shape and need refreshing.
- CHANGELOG.md per-package entries for v0.11.0 will list these changes.

## Next waves

- **Wave 3** — Codegen identifier rename: `$tfType` → `tfType`, `$sensitiveFields` → `sensitiveFields` + `@protected`, `TerraformEnum` interface, 118 wrappers regen.
- **Wave 4** — Lockstep `0.10.0` → `0.11.0` bump + CHANGELOG + MIGRATING.md.