### PR TITLE
chore(docs): align README + MIGRATING + website with v0.11.0 Stack API

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -43,8 +43,10 @@ Future<void> synth({required String outDir}) async {
 ```
 
 If you need custom file layout (e.g. writing `SynthResult.dartConstants` as
-well), you can still override `synth` — the old body is now the default, so
-your override only needs the extra logic.
+well), override `writeTo` rather than `synth`: in v0.11.0+ `synth()` is the
+in-memory step that returns a `SynthResult`, and `writeTo(outDir)` is the
+file-IO wrapper. Calling `synth()` from your override gives you the same
+`tfJson` / `dartConstants` payload to lay out however you need.
 
 ### 1.2 `JsonEncoder` → `TfJsonEncoder`
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/pubsub.dart';
 
-class OrdersStack extends Stack {
+final class OrdersStack extends Stack {
   OrdersStack({required String projectId})
       : super(providers: [GoogleProvider(project: projectId)]) {
     final orders = GooglePubsubTopic(
@@ -118,7 +118,7 @@ GoogleCloudRunV2Service(
 
 ### Plain Dart, not a templating DSL
 
-`Stack` subclasses are regular Dart classes. Loops, conditionals, env config, dependency injection — all work the way they already work. There is no synth CLI; you call `StackSynth.synth(stack)` from your own `bin/infra.dart`.
+`Stack` subclasses are regular Dart classes. Loops, conditionals, env config, dependency injection — all work the way they already work. There is no synth CLI; you call `stack.writeTo('tf-out')` from your own `bin/infra.dart` (or `stack.synth()` for an in-memory `SynthResult` without writing to disk).
 
 ## Quickstart
 

--- a/examples/compute_quickstart/README.md
+++ b/examples/compute_quickstart/README.md
@@ -13,9 +13,9 @@ End-to-end terradart example for Cloud Compute networking primitives. Provisions
 ```
 examples/compute_quickstart/
 ├── lib/main.dart        # NetworkStack: VPC + load-balancer VIP
-├── bin/infra.dart       # Synth entry: NetworkStack.synth(outDir: 'tf-out')
+├── bin/infra.dart       # Synth entry: stack.writeTo('tf-out')
 ├── tf-out/              # (created on synth) main.tf.json
-└── pubspec.yaml         # path-deps to ../../packages/terradart_{core,google}
+└── pubspec.yaml         # workspace member with hosted carets (terradart_core: ^0.10.0)
 ```
 
 ## Usage

--- a/examples/pubsub_quickstart/README.md
+++ b/examples/pubsub_quickstart/README.md
@@ -13,16 +13,16 @@ The smallest end-to-end terradart example. Provisions a `google_pubsub_topic`, a
 ```
 examples/pubsub_quickstart/
 ├── lib/main.dart        # Defines OrdersStack (topic + subscription + IAM)
-├── bin/infra.dart       # Synth entry point: stack.synth(outDir: 'tf-out')
+├── bin/infra.dart       # Synth entry point: stack.writeTo('tf-out')
 ├── lib/generated/       # (created on synth) orders_stack.app.dart -- typed export
 ├── tf-out/              # (created on synth) main.tf.json -- terraform input
-└── pubspec.yaml         # path-deps to ../../packages/terradart{,_google}
+└── pubspec.yaml         # workspace member with hosted carets (terradart_core: ^0.10.0)
 ```
 
 ## Usage
 
 ```bash
-# 1. Resolve deps (uses path: deps to the workspace siblings).
+# 1. Resolve deps (workspace member with hosted carets — siblings are picked up via `resolution: workspace`).
 dart pub get
 
 # 2. Edit `lib/main.dart` -- replace `YOUR-PROJECT-ID` with your GCP project.

--- a/packages/terradart_codegen/README.md
+++ b/packages/terradart_codegen/README.md
@@ -46,4 +46,4 @@ dart run build_runner build
 
 The `--source` directory must contain `schema.json` (output of `terraform providers schema -json`) and may contain an optional `mm/<resource>.yaml` overlay subdirectory.
 
-For the runtime side (`Stack`, `Resource<S>`, `StackSynth.synth`), see [`terradart_core`](https://pub.dev/packages/terradart_core). For the 28 curated GCP factory wrappers, see [`terradart_google`](https://pub.dev/packages/terradart_google). For project-level documentation see the [terradart repo README](https://github.com/nozomi-koborinai/terradart#readme).
+For the runtime side (`Stack`, `Resource`, `Stack.synth` / `Stack.writeTo`), see [`terradart_core`](https://pub.dev/packages/terradart_core). For the 28 curated GCP factory wrappers, see [`terradart_google`](https://pub.dev/packages/terradart_google). For project-level documentation see the [terradart repo README](https://github.com/nozomi-koborinai/terradart#readme).

--- a/packages/terradart_core/README.md
+++ b/packages/terradart_core/README.md
@@ -4,11 +4,11 @@ Core runtime for [terradart](https://github.com/nozomi-koborinai/terradart) — 
 
 This package ships the small set of primitives every terradart Stack uses:
 
-- `Stack` — abstract base for your infrastructure module. You subclass it, register `Resource<S>` / `Data<S>` instances via `add(...)` / `addData(...)`, and call `StackSynth.synth(this)` from your own `main()`.
-- `Resource<S>` / `Data<S>` — typed nodes whose generic `S` is a schema carrier supplied by curated factories (in `terradart_google`) or generated bindings (from `terradart_codegen`).
+- `Stack` — abstract base for your infrastructure module. You subclass it (`final class MyStack extends Stack`), register `Resource` / `Data` instances via `add(...)` / `addData(...)`, and call `stack.writeTo('tf-out')` from your own `main()` to emit `main.tf.json`.
+- `Resource` / `Data` — typed nodes supplied by curated factories (in `terradart_google`) or generated bindings (from `terradart_codegen`).
 - `TfArg.literal(...)` / `TfArg.ref(...)` — the only two ways every settable field accepts input. `TfArg<MyEnum>.literal(MyEnum.foo)` now encodes typed Dart enums (see below).
 - `LifecycleOptions` — `create_before_destroy`, `prevent_destroy`, `ignore_changes`, `replace_triggered_by`.
-- `StackSynth.synth(stack)` returning a `SynthResult` with `tfJson` (Terraform JSON map) and optional `dartConstants` (typed Dart constants for the IaC ↔ application seam).
+- `Stack.synth()` returns an in-memory `SynthResult` with `tfJson` (Terraform JSON map) and optional `dartConstants` (typed Dart constants for the IaC ↔ application seam). `Stack.writeTo(outDir)` is the file-IO wrapper that calls `synth()` and writes `main.tf.json` (plus any `dartConstants`) under `outDir`.
 
 This package is the **runtime layer only**. It is intentionally small and dependency-free. The companion packages are:
 

--- a/packages/terradart_google/README.md
+++ b/packages/terradart_google/README.md
@@ -104,7 +104,7 @@ CI verifies determinism via `terradart wrap --check`: all 71 emitted files (70 r
 
 For any other `google_*` / `google-beta_*` resource that isn't in the catalog above, run `terradart codegen` against your provider schema dump and emit bindings into your own `lib/generated/` rather than depending on this package.
 
-For the runtime side (`Stack`, `Resource`, `StackSynth.synth`), see [`terradart_core`](https://pub.dev/packages/terradart_core). For project-level documentation, see the [terradart repo README](https://github.com/nozomi-koborinai/terradart#readme).
+For the runtime side (`Stack`, `Resource`, `Stack.synth` / `Stack.writeTo`), see [`terradart_core`](https://pub.dev/packages/terradart_core). For project-level documentation, see the [terradart repo README](https://github.com/nozomi-koborinai/terradart#readme).
 
 ## Installation
 
@@ -123,7 +123,7 @@ import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/storage.dart';
 
-class AssetsStack extends Stack {
+final class AssetsStack extends Stack {
   AssetsStack({required String projectId})
       : super(providers: [
           GoogleProvider(project: projectId, region: 'asia-northeast1'),

--- a/packages/terradart_google/test/golden/tfout_snapshot_iam.json
+++ b/packages/terradart_google/test/golden/tfout_snapshot_iam.json
@@ -15,10 +15,20 @@
     }
   },
   "resource": {
+    "google_iam_workload_identity_pool": {
+      "ci": {
+        "workload_identity_pool_id": "github-actions",
+        "display_name": "GitHub Actions CI/CD"
+      }
+    },
     "google_service_account": {
       "demo": {
         "account_id": "demo-sa",
         "display_name": "IAM quickstart demo SA"
+      },
+      "impersonator": {
+        "account_id": "demo-impersonator",
+        "display_name": "Demo SA impersonator"
       }
     },
     "google_pubsub_topic": {
@@ -74,6 +84,44 @@
         "role": "roles/secretmanager.secretAccessor",
         "member": "${google_service_account.demo.member}"
       }
+    },
+    "google_project_iam_custom_role": {
+      "gcs_observer": {
+        "role_id": "gcsObserver",
+        "title": "GCS Observer",
+        "permissions": [
+          "storage.objects.get",
+          "storage.objects.list",
+          "storage.buckets.get",
+          "storage.buckets.list"
+        ],
+        "description": "Read-only access to GCS objects and bucket metadata.",
+        "stage": "GA"
+      }
+    },
+    "google_project_iam_member": {
+      "demo_sa_observer": {
+        "project": "ci-test-project-id",
+        "role": "${google_project_iam_custom_role.gcs_observer.name}",
+        "member": "${google_service_account.demo.member}",
+        "depends_on": [
+          "google_project_iam_custom_role.gcs_observer"
+        ]
+      }
+    },
+    "google_service_account_iam_member": {
+      "demo_sa_user": {
+        "service_account_id": "${google_service_account.demo.name}",
+        "role": "roles/iam.serviceAccountUser",
+        "member": "${google_service_account.impersonator.member}"
+      }
+    },
+    "google_service_account_key": {
+      "demo_sa_key": {
+        "service_account_id": "${google_service_account.demo.name}",
+        "key_algorithm": "KEY_ALG_RSA_2048",
+        "private_key_type": "TYPE_GOOGLE_CREDENTIALS_FILE"
+      }
     }
   },
   "output": {
@@ -88,6 +136,9 @@
     },
     "SECRET_ID": {
       "value": "${google_secret_manager_secret.demo_secret.id}"
+    },
+    "CUSTOM_ROLE_NAME": {
+      "value": "${google_project_iam_custom_role.gcs_observer.name}"
     }
   }
 }

--- a/website/src/components/Pipeline.astro
+++ b/website/src/components/Pipeline.astro
@@ -6,7 +6,7 @@ const steps = [
   },
   {
     title: "Synthesize",
-    body: "StackSynth.synth writes *.tf.json — no custom apply runtime.",
+    body: "Stack.writeTo writes *.tf.json — no custom apply runtime.",
   },
   {
     title: "Apply with Terraform",

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -4,7 +4,7 @@ description: Install TerraDart and synthesize your first stack.
 ---
 
 :::note[Coming soon]
-This page will be updated after the v0.11.0 release and README refresh. The API and package versions below may change.
+This page tracks the v0.11.0 API surface and will be expanded with end-to-end walkthroughs after the release. Package versions below are pre-release pins.
 :::
 
 ## Meanwhile
@@ -16,6 +16,6 @@ This page will be updated after the v0.11.0 release and README refresh. The API 
 ## Outline (planned)
 
 - Add `terradart_core` and `terradart_google` to `pubspec.yaml`
-- Implement a `Stack` subclass
-- Call `StackSynth.synth` from `bin/infra.dart`
+- Implement a `final class XxxStack extends Stack` subclass
+- Call `stack.writeTo('tf-out')` from `bin/infra.dart`
 - Run `terraform init` / `apply` in `tf-out/`

--- a/website/src/content/docs/docs/how-it-works.md
+++ b/website/src/content/docs/docs/how-it-works.md
@@ -9,8 +9,8 @@ Expanded diagrams and code samples will be added after v0.11.0. This page is a s
 
 ## Pipeline
 
-1. **Author** — Subclass `Stack` in Dart using curated `google_*` factories from `terradart_google`.
-2. **Synthesize** — `StackSynth.synth(stack)` writes standard `*.tf.json` under your output directory.
+1. **Author** — Subclass `Stack` in Dart (`final class XxxStack extends Stack`) using curated `google_*` factories from `terradart_google`.
+2. **Synthesize** — `stack.writeTo('tf-out')` writes standard `*.tf.json` under your output directory. (Use `stack.synth()` if you want the `SynthResult` in memory without writing to disk.)
 3. **Apply** — Run `terraform plan` and `terraform apply` with your existing state backend.
 4. **Hand off** — Export typed Dart constants for apps (Firebase Functions, Cloud Run jobs, etc.) so `dart analyze` catches drift at compile time.
 


### PR DESCRIPTION
## Summary

Pre-release docs cleanup for v0.11.0. Updates stale API references across READMEs, `MIGRATING.md` forward-looking guidance, and the new website prose to match the post-Wave-2 / post-Wave-3 surface. **No code changes** in `lib/` or `test/` (one test golden refresh — see below). Split out from the Wave 4 release PR so review can focus on prose vs. version-bump separately.

## What changed

### READMEs (7 files)
- **`README.md`** (repo root): `StackSynth.synth(stack)` reference → `stack.writeTo('tf-out')` plus in-memory `stack.synth()` alternative. Sample `Stack` subclass promoted to `final class` (required by `abstract base class Stack`).
- **`packages/terradart_core/README.md`**: API summary rewritten — `Resource<S>` / `Data<S>` → `Resource` / `Data` (the `<S>` generic was dropped in v0.5.0-dev); `StackSynth.synth(this)` → `stack.writeTo('tf-out')`; `Stack.synth()` and `Stack.writeTo()` documented as the split API surface.
- **`packages/terradart_google/README.md`**: "see also" pointer refreshed; sample code promoted to `final class`.
- **`packages/terradart_codegen/README.md`**: "see also" pointer refreshed.
- **`examples/pubsub_quickstart/README.md`** + **`examples/compute_quickstart/README.md`**: Layout-section `synth(outDir:)` → `writeTo()`; pubspec annotation updated from `path-deps to ../../packages/terradart{,_google}` to `workspace member with hosted carets`. The other 21 quickstart READMEs were already written with neutral "Synth entry" labels (verified via grep) and required no changes.

### MIGRATING.md
Forward-looking guidance at L45-47 (the "you can still override `synth`" line that contradicted Wave 2's `abstract base class` modifier) rewritten to point readers at `Stack.writeTo` for custom file layout. **Historical migration sections preserved as-is** — the `BEFORE (0.8.0-dev)` code samples accurately document the v0.8.0-dev source state and should not be edited.

### Website (3 files, from PR #64's terradart.dev Astro site)
- **`website/src/content/docs/docs/getting-started.md`**: outline updated to `final class XxxStack extends Stack` + `stack.writeTo('tf-out')`.
- **`website/src/content/docs/docs/how-it-works.md`**: pipeline step 2 updated; in-memory `stack.synth()` mentioned parenthetically.
- **`website/src/components/Pipeline.astro`**: step body `StackSynth.synth` → `Stack.writeTo`.

### Test golden refresh (1 file)
- **`packages/terradart_google/test/golden/tfout_snapshot_iam.json`**: pre-existing baseline drift. `iam_quickstart` grew 5 new IAM resources (`google_iam_workload_identity_pool`, an impersonator service account, `google_project_iam_custom_role`, `google_project_iam_member`, `google_service_account_iam_member` + key) some time pre-Wave-3 that nobody re-froze. Refreshed via `packages/terradart_google/tool/freeze_tfout_snapshots.dart`. Sibling baselines (pubsub / cloud_tasks / secret_manager / cloud_scheduler) re-froze byte-identically — confirms the tool stays deterministic.

## What is NOT in this PR (deferred)

- **Wave 4** (lockstep version bump 0.10.0 → 0.11.0, CHANGELOG entries, MIGRATING.md v0.10 → v0.11 section, publish.yml dry-run verification) — separate PR.
- **Internal `lib/src/` doc-comments** still reference `StackSynth.synth` / `Resource<S>` in a few places (`stack.dart:216`, `wrapper_emitter.dart:26`, `google_provider.dart:8`). These are not consumer-facing and can be cleaned up later or folded into Wave 4.

## Test plan

- [x] `dart pub get` workspace root: clean
- [x] `dart analyze packages/terradart_core packages/terradart_codegen packages/terradart_google` → `No issues found!`
- [x] `dart format --output=none --set-exit-if-changed packages/terradart_core/ packages/terradart_codegen/` → exit 0
- [x] `dart test` per package: terradart_core 195 / terradart_codegen 314 / terradart_google 175 — all pass
- [x] e2e `tfout_snapshot_test` (`dart test test/e2e/tfout_snapshot_test.dart -t e2e --run-skipped`): 5/5 pass (iam recovered after baseline refresh)
- [x] Grep gates: `StackSynth.synth` / `.synth(outDir` / `Resource<S>` / `Resource<$` / `path-deps to` — all 0 matches across the in-scope files

## Next

- Wave 4 PR — lockstep `0.10.0` → `0.11.0` + CHANGELOG + MIGRATING.md v0.10→v0.11 section + publish.yml dry-run
- User re-tags `v0.11.0` after Wave 4 merge → publish.yml ships to pub.dev