### PR TITLE
v0.11.0 — lockstep release (CHANGELOG, MIGRATING, version bump tooling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to terradart are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+Per-package changelogs live alongside each package and are the system of record for `terradart_core`, `terradart_codegen`, and `terradart_google` — this top-level file summarises cross-cutting milestones.
+
+## [0.11.0] - 2026-MM-DD
+
+Pre-1.0 polish wave focused on the `terradart_core` public surface. All three packages bump from 0.10.0 to 0.11.0 in lockstep. Coordinated breaking changes from ADR-0016 (codegen identifier rename) and ADR-0017 (Stack API surface). See [MIGRATING.md](MIGRATING.md) for before / after snippets covering every breaking change in this release.
+
+### Breaking changes
+
+- **Stack API surface (ADR-0017).** `Stack.synth({required outDir})` split into two methods: `Stack.synth() → SynthResult` is the pure in-memory step that returns the encoded tfJson and any AppExports Dart constants, and `Stack.writeTo(outDir) → Future<void>` is the file-IO wrapper that persists `main.tf.json` (and the optional generated Dart constants file when `setAppExportsOutputPath` was called). `writeTo` throws `StateError` atomically — before any disk write — when `addExport` was called without `setAppExportsOutputPath`. `StackSynth` is removed from the `terradart_core` public barrel and annotated `@internal` (still importable via the deep `src/synth/stack_synth.dart` path for advanced use). `Stack`, `Resource`, and `Data` are promoted to `abstract base class`; user subclasses must now be declared `final class XxxStack extends Stack` (or `base` / `sealed`) and `implements Stack` / `implements Resource` / `implements Data` are no longer permitted.
+- **Codegen identifier rename (ADR-0016).** `$tfType` → `tfType`, `$sensitiveFields` → `sensitiveFields`, `$supportsDeletionProtection` → `supportsDeletionProtection`. The two getters are now annotated `@protected` (from `package:meta`); non-subclass reads require an `// ignore: invalid_use_of_protected_member` directive with rationale. All 118 curated `terradart_google` wrappers regenerated with the new identifier names.
+- **`TerraformEnum` interface.** Hand-rolled Terraform-mapped enums must add `implements TerraformEnum` and `@override final String terraformValue;`. Codegen-emitted enums get this automatically.
+
+### Non-breaking improvements
+
+- `encodeArg` / `encodeArgMap` / `encodeArgMapWithSensitive` return types tightened from `dynamic` to `Object?` / `Map<String, Object?>`.
+- `_DedupKey` internal type rewritten as a Dart 3 named record.
+- `dart:convert` import prefixes unified (`as dart_convert` / `as conv` / `as convert` → no prefix everywhere).
+- `terradart_google` pubspec switched from `path:` deps to hosted carets; examples are now workspace members of the monorepo.
+- Stale schemantic-era comments in per-package `analysis_options.yaml` refreshed.
+
 ## [0.1.0-dev] - 2026-05-14
 
 Adds 15 new GCP resource factories (terradart_google grows 13 → 28), typed enum support for `TfArg`, sealed types for exactly-one-of nested blocks, and the `terradart wrap-promote` codegen subcommand. Pre-alpha — pin tightly.

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,3 +1,207 @@
+# Migrating from terradart 0.10.0 to 0.11.0
+
+This guide covers every breaking change introduced between `0.10.0` and
+`0.11.0`. Two coordinated themes: the Stack API surface (§1, ADR-0017) and
+the codegen identifier rename (§2, ADR-0016). All changes are mechanical;
+none require an architectural rethink at the consumer.
+
+`0.9.0` → `0.10.0` was additive (Firestore document curation) and required
+no migration. The 0.9.0 migration guide is preserved below for archival
+reference.
+
+---
+
+## Before you start
+
+All three packages — `terradart_core`, `terradart_codegen`, and
+`terradart_google` — must be bumped in lockstep:
+
+```yaml
+# pubspec.yaml
+dependencies:
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
+```
+
+If you run codegen locally:
+
+```bash
+dart pub global activate terradart_codegen ^0.11.0
+```
+
+---
+
+## 1. Stack API surface changes (ADR-0017)
+
+### 1.1 `Stack.synth({required outDir})` split into `synth()` + `writeTo(outDir)`
+
+`Stack.synth` no longer performs file IO. It is now a pure in-memory step
+that returns a `SynthResult` carrying the encoded `tfJson` plus the optional
+`dartConstants` source for AppExports. The new `Stack.writeTo(outDir)`
+method is the file-IO wrapper that writes `main.tf.json` (and, when
+`setAppExportsOutputPath` was called, the generated Dart constants file).
+
+```dart
+// BEFORE (0.10.0):
+await stack.synth(outDir: 'tf-out');
+
+// AFTER (0.11.0) — same end-to-end behaviour:
+await stack.writeTo('tf-out');
+
+// AFTER (0.11.0) — in-memory only, no disk write:
+final result = stack.synth();
+// result.tfJson, result.dartConstants
+```
+
+`writeTo` throws `StateError` atomically — **before any disk write** — when
+`addExport` was called without `setAppExportsOutputPath`. v0.10.x silently
+dropped the exports in that case; v0.11.x makes the misconfiguration fail
+loudly at synth time.
+
+### 1.2 `StackSynth` removed from the `terradart_core` public barrel
+
+`StackSynth` is annotated `@internal` and is no longer re-exported from
+`package:terradart_core/terradart_core.dart`. Call the public method on
+your `Stack` instance instead.
+
+```dart
+// BEFORE (0.10.0):
+import 'package:terradart_core/terradart_core.dart';
+final result = StackSynth.synth(stack);
+
+// AFTER (0.11.0):
+final result = stack.synth();
+```
+
+If you really need the internal synth function (advanced cases — custom
+tooling that drives synth without a `Stack` instance), import it via the
+deep path; expect no semver protection on that surface:
+
+```dart
+// AFTER (0.11.0) — escape hatch, not recommended:
+import 'package:terradart_core/src/synth/stack_synth.dart';
+```
+
+### 1.3 `Stack`, `Resource`, `Data` promoted to `abstract base class`
+
+The three foundational classes are now `abstract base class` (Dart 3
+class-modifier feature). Their state — dedup maps, lifecycle wiring — is
+owned by the base class and must not be bypassed via `implements`.
+
+```dart
+// BEFORE (0.10.0):
+class OrdersStack extends Stack { ... }
+
+// AFTER (0.11.0):
+final class OrdersStack extends Stack { ... }
+// (or `base class` / `sealed class` if you have a subclass tree)
+```
+
+`implements Stack` / `implements Resource` / `implements Data` are now
+compile errors. This was already a foot-gun in v0.10 — a class that
+satisfied the interface without inheriting the state would silently break
+synth — so the new constraint replaces a runtime hazard with a static
+check.
+
+---
+
+## 2. Codegen identifier rename (ADR-0016)
+
+The dollar-prefixed identifiers on `Resource` subclasses are renamed to
+their canonical Dart names. External code that read them by `$`-prefixed
+name must drop the prefix. The two getters are now annotated `@protected`
+(from `package:meta`).
+
+### 2.1 `$tfType` → `tfType`, `$sensitiveFields` → `sensitiveFields`, `$supportsDeletionProtection` → `supportsDeletionProtection`
+
+```dart
+// BEFORE (0.10.0):
+final String type = MyResource.$tfType;
+final Set<String> sensitive = myResource.$sensitiveFields;
+final bool gated = myResource.$supportsDeletionProtection;
+
+// AFTER (0.11.0):
+final String type = MyResource.tfType;
+// ignore: invalid_use_of_protected_member  // documenting the access pattern
+final Set<String> sensitive = myResource.sensitiveFields;
+// ignore: invalid_use_of_protected_member  // documenting the access pattern
+final bool gated = myResource.supportsDeletionProtection;
+```
+
+The `@protected` annotation means that reads from outside the subclass
+hierarchy trigger an analyzer warning. The synth-time path (`TfJsonEncoder`)
+is the privileged in-library consumer the protected contract permits. If
+you have a legitimate need to read these from outside (introspection,
+custom diagnostics), add an `// ignore: invalid_use_of_protected_member`
+directive **with a justification comment** at the read site.
+
+Mechanical sed recipe for the rename (safe — it only matches the
+`$`-prefixed forms):
+
+```bash
+find . -name '*.dart' \
+  -exec sed -i.bak \
+    -e 's/\$tfType\b/tfType/g' \
+    -e 's/\$sensitiveFields\b/sensitiveFields/g' \
+    -e 's/\$supportsDeletionProtection\b/supportsDeletionProtection/g' \
+    {} \;
+```
+
+Then review each call site and either keep the bare read (if you're inside
+a subclass) or add the `// ignore: invalid_use_of_protected_member`
+directive (if you're outside).
+
+### 2.2 `TerraformEnum` interface
+
+`terradart_core` 0.11.0 introduces `abstract interface class TerraformEnum`
+with a single `String get terraformValue` contract. `TfArgLiteral.toTfJson`
+now routes enum dispatch through `if (v is TerraformEnum)` rather than the
+previous duck-typed `dynamic.terraformValue` cast.
+
+Codegen-emitted enums (everything in `terradart_google`) implement
+`TerraformEnum` automatically — no consumer action needed.
+
+If you hand-rolled a Terraform-mapped enum to pass to
+`TfArg<MyEnum>.literal(...)`, add the `implements` clause and the
+`@override` keyword:
+
+```dart
+// BEFORE (0.10.0):
+enum CustomMode {
+  fooBar('FOO_BAR'),
+  bazQux('BAZ_QUX');
+
+  const CustomMode(this.terraformValue);
+  final String terraformValue;
+}
+
+// AFTER (0.11.0):
+enum CustomMode implements TerraformEnum {
+  fooBar('FOO_BAR'),
+  bazQux('BAZ_QUX');
+
+  const CustomMode(this.terraformValue);
+  @override
+  final String terraformValue;
+}
+```
+
+Without the `implements TerraformEnum` clause, the `is TerraformEnum`
+check at synth time will not recognise your enum and the value will fall
+through to the generic `Object.toString()` path — almost certainly not
+what you want.
+
+---
+
+## 3. Cookbook example
+
+The [`terradart-cookbook`](https://github.com/nozomi-koborinai/terradart-cookbook)
+repo's recipes will be regenerated against v0.11.0. If you cloned a recipe
+before that update, apply the §1 + §2 changes above to the recipe's stack
+file.
+
+---
+
 # Migrating from terradart 0.8.0-dev to 0.9.0
 
 This guide covers every breaking change introduced between `0.8.0-dev` and

--- a/README.md
+++ b/README.md
@@ -123,15 +123,15 @@ GoogleCloudRunV2Service(
 ## Quickstart
 
 ```yaml
-# pubspec.yaml — pre-release explicit constraint required
+# pubspec.yaml
 dependencies:
-  terradart_core: ^0.1.0-dev
-  terradart_google: ^0.1.0-dev
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 ```
 
 ```bash
 dart pub get
-dart pub global activate terradart_codegen 0.1.0-dev    # only if you need
+dart pub global activate terradart_codegen ^0.11.0      # only if you need
                                                          # codegen for non-curated
                                                          # google_* resources
 dart run bin/infra.dart                                  # synth → tf-out/
@@ -191,7 +191,7 @@ Application platform & operations
 
 ## Status
 
-Pre-alpha (v0.1.0-dev). No SemVer guarantees until v1.0.0; pin tightly. Surface and emitted Terraform JSON may change. `dart pub get` skips pre-releases by default — opt in with explicit `^0.1.0-dev` constraints.
+Pre-1.0 (v0.11.0). No SemVer guarantees until v1.0.0; pin to a specific `^0.11.x` minor and read [`MIGRATING.md`](MIGRATING.md) before bumping. Breaking changes are still permitted within the 0.x line and are documented per-release.
 
 ## Schema-bump automation (Plan 5.E)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,51 +1,59 @@
 # Release Checklist
 
-terradart releases 4 packages in lockstep: `terradart_annotations`, `terradart_core`, `terradart_codegen`, `terradart_google`. All 4 share the same version (e.g. `0.0.4-dev`).
+terradart releases 3 packages in lockstep: `terradart_core`, `terradart_codegen`, `terradart_google`. All 3 share the same version (e.g. `0.11.0`).
 
 ## Pre-flight (local)
 
 - [ ] CI green on main
-- [ ] Bump version in all 4 `packages/*/pubspec.yaml` to the target version (e.g. `0.0.4-dev`)
-- [ ] Add `## <version> - YYYY-MM-DD` entry to all 4 `packages/*/CHANGELOG.md`
+- [ ] Bump every pubspec to the target version with a single command:
+
+  ```bash
+  tool/bump_version.sh 0.X.Y
+  ```
+
+  This updates all 3 package pubspecs, their inter-package carets, the 23 example pubspec carets, and the README + website pubspec samples in one shot. Idempotent: re-running with the same version is a no-op. Run `git diff --stat` afterwards to review.
+- [ ] Add `## <version> - YYYY-MM-DD` entry to root `CHANGELOG.md` and to each of the 3 `packages/*/CHANGELOG.md` files. Release notes are prose — the bump script intentionally does not generate them.
+- [ ] If the release is breaking, add a `# Migrating from terradart X.Y.Z to A.B.C` section at the top of `MIGRATING.md` with before / after snippets.
 - [ ] Run pana score check on each package:
 
   ```bash
   dart pub global activate pana
-  for pkg in terradart_annotations terradart_core terradart_codegen terradart_google; do
+  for pkg in terradart_core terradart_codegen terradart_google; do
     (cd "packages/$pkg" && dart pub global run pana --no-warning --exit-code-threshold 100)
   done
   ```
 
-- [ ] Run dry-run after path-deps swap (in a throwaway clone or after `git stash`):
+- [ ] Run dry-run after the pre-publish pubspec mutation (the script edits in-place; restore via `git checkout` after):
 
   ```bash
-  for pkg in terradart_annotations terradart_core terradart_codegen terradart_google; do
-    tool/prepare_publish.sh v0.0.X-dev "$pkg"
+  for pkg in terradart_core terradart_codegen terradart_google; do
+    tool/prepare_publish.sh v0.X.Y "$pkg"
     (cd "packages/$pkg" && dart pub publish --dry-run)
   done
   git checkout packages/*/pubspec.yaml  # restore
   ```
 
-- [ ] Commit pubspec + CHANGELOG bumps to main
+  Note: dry-run for `terradart_codegen` and `terradart_google` may fail version-solving until the previous-phase packages are on pub.dev. This is the documented 3-phase ordering in `publish.yml` and not a regression — only the `terradart_core` dry-run must be clean locally.
+- [ ] Commit the bump + CHANGELOG + MIGRATING.md updates to a feature branch and open a release PR.
 
 ## Publish (preferred: tag-driven via `publish.yml`)
 
 ```bash
-git tag v0.0.X-dev
-git push origin v0.0.X-dev
+git tag v0.X.Y
+git push origin v0.X.Y
 ```
 
-Watch `publish.yml` on GitHub Actions:
+Watch `publish.yml` on GitHub Actions. The workflow ships the 3 packages in 3 serial phases (each waits 5 minutes for pub.dev index propagation before the next):
 
-1. **`publish-leaves`** job: 3 leaves (`terradart_annotations`, `terradart_core`, `terradart_codegen`) publish in parallel via OIDC trusted publisher.
-2. **`publish-google`** job: waits 3 minutes for pub.dev index propagation, then publishes `terradart_google` (which depends on the 3 leaves).
+1. **`publish-no-deps`** job: `terradart_core` (no terradart_* dependencies).
+2. **`publish-codegen`** job: `terradart_codegen` (depends on `terradart_core`).
+3. **`publish-google`** job: `terradart_google` (depends on `terradart_core` + `terradart_codegen`).
 
 `prepare_publish.sh` runs in CI and:
 
-- Verifies `pubspec.yaml` version matches the tag (fails fast if not bumped).
+- Verifies `pubspec.yaml` version matches the tag (fails fast if not bumped — this is the guard that caught the premature v0.11.0 tag attempt on 2026-05-23).
 - Verifies `CHANGELOG.md` has an entry for the version.
-- Strips `publish_to: none` from `terradart_google`.
-- Swaps `path:` deps in `terradart_google` to hosted `^VERSION` constraints.
+- Strips `publish_to: none` and `resolution: workspace` (pub.dev does not recognise workspace mode).
 
 ## Initial publish (OIDC not yet available)
 
@@ -54,44 +62,47 @@ pub.dev's OIDC trusted publisher only works for **previously published** package
 Order: 3 leaves first, wait 3 minutes for index propagation, then `terradart_google`.
 
 ```bash
-# 1. Bump pubspec + CHANGELOG locally first (per pre-flight above), commit, then run:
+# 1. Bump pubspec + CHANGELOG locally first (per pre-flight above), commit, then run
+#    each phase in order (terradart_core has no terradart_* deps; codegen depends on
+#    core; google depends on both — same ordering as publish.yml).
 
-for pkg in terradart_annotations terradart_core terradart_codegen; do
-  tool/prepare_publish.sh v0.0.X-dev "$pkg"
-  (cd "packages/$pkg" && dart pub publish)
-done
+tool/prepare_publish.sh v0.X.Y terradart_core
+(cd packages/terradart_core && dart pub publish)
 
-# 2. Wait for pub.dev to index the leaves.
-sleep 180
+sleep 300  # wait for pub.dev to index terradart_core
 
-# 3. Publish terradart_google (depends on the leaves).
-tool/prepare_publish.sh v0.0.X-dev terradart_google
+tool/prepare_publish.sh v0.X.Y terradart_codegen
+(cd packages/terradart_codegen && dart pub publish)
+
+sleep 300  # wait for pub.dev to index terradart_codegen
+
+tool/prepare_publish.sh v0.X.Y terradart_google
 (cd packages/terradart_google && dart pub publish)
 
-# 4. Restore the path: deps in working tree (CI will redo this on next tag).
+# Restore the in-place edits the script made (CI will redo this on next tag).
 git checkout packages/*/pubspec.yaml
 ```
 
-After all 4 packages exist on pub.dev, set up trusted publisher for each:
+After all 3 packages exist on pub.dev, set up trusted publisher for each:
 
 1. Visit `https://pub.dev/packages/<pkg>/admin` for each package.
 2. **Automated publishing → GitHub Actions → Add**.
-3. Repository: `nozomi-koborinai/terradart`, tag pattern: `v*-dev` (and/or `v*.*.*`).
+3. Repository: `nozomi-koborinai/terradart`, tag pattern: `v*.*.*` (and `v*.*.*-dev` for dev tags).
 
 Subsequent releases use the tag-driven flow above.
 
 ## Manual recovery (`publish.yml` partially failed)
 
-If `publish-leaves` succeeds for some packages but fails for others, or if `publish-google` fails:
+If a phase succeeds for some packages but fails for the next (e.g. `publish-codegen` failed but `publish-no-deps` already shipped `terradart_core`):
 
 1. Fix the underlying issue (CHANGELOG, version, lib naming, etc.) and commit.
-2. Bump all 4 packages to the next version (pub.dev rejects re-publishing an existing version).
+2. Bump all 3 packages to the next version with `tool/bump_version.sh` (pub.dev rejects re-publishing an existing version).
 3. Tag the new version and push.
 
-   All 4 packages will publish at the next version — successful packages from the previous attempt will simply receive a new minor bump (lockstep is preserved). There is no selective skip mechanism.
+   All 3 packages will publish at the next version — successful packages from the previous attempt will simply receive a new bump (lockstep is preserved). There is no selective skip mechanism.
 
 ## Post-flight
 
-- [ ] All 4 listings on pub.dev show the correct version
-- [ ] GitHub Release created (`gh release create v0.0.X-dev --notes ...`)
-- [ ] Verified publisher badge appears on all 4 pub.dev pages
+- [ ] All 3 listings on pub.dev show the correct version
+- [ ] GitHub Release created (`gh release create v0.X.Y --notes ...`)
+- [ ] Verified publisher badge appears on all 3 pub.dev pages

--- a/examples/bigquery_quickstart/pubspec.yaml
+++ b/examples/bigquery_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_build_quickstart/pubspec.yaml
+++ b/examples/cloud_build_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_functions_quickstart/pubspec.yaml
+++ b/examples/cloud_functions_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_quickstart/pubspec.yaml
+++ b/examples/cloud_run_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_scheduler_quickstart/pubspec.yaml
+++ b/examples/cloud_scheduler_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_sql_quickstart/pubspec.yaml
+++ b/examples/cloud_sql_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_tasks_quickstart/pubspec.yaml
+++ b/examples/cloud_tasks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_lb_quickstart/pubspec.yaml
+++ b/examples/compute_lb_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_quickstart/pubspec.yaml
+++ b/examples/compute_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dns_quickstart/pubspec.yaml
+++ b/examples/dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_check_quickstart/pubspec.yaml
+++ b/examples/firebase_app_check_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_hosting_quickstart/pubspec.yaml
+++ b/examples/firebase_app_hosting_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_data_connect_quickstart/pubspec.yaml
+++ b/examples/firebase_data_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_remote_config_quickstart/pubspec.yaml
+++ b/examples/firebase_remote_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_document_quickstart/pubspec.yaml
+++ b/examples/firestore_document_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_quickstart/pubspec.yaml
+++ b/examples/firestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iam_quickstart/pubspec.yaml
+++ b/examples/iam_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_quickstart/pubspec.yaml
+++ b/examples/kms_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/monitoring_quickstart/pubspec.yaml
+++ b/examples/monitoring_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ops_quickstart/pubspec.yaml
+++ b/examples/ops_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/pubsub_quickstart/pubspec.yaml
+++ b/examples/pubsub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/secret_manager_quickstart/pubspec.yaml
+++ b/examples/secret_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_quickstart/pubspec.yaml
+++ b/examples/storage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
-  terradart_google: ^0.10.0
+  terradart_core: ^0.11.0
+  terradart_google: ^0.11.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.11.0 - 2026-MM-DD
+
+**BREAKING** — template-side rename pass that pairs with the `terradart_core` 0.11.0 public-surface change (ADR-0016). v0.x permits breaking changes; emitted wrappers in `terradart_google` 0.11.0 follow the new shape. See [MIGRATING.md](../../MIGRATING.md) for before / after snippets.
+
+- Bumped `terradart_core` constraint to `^0.11.0`.
+- `wrapper_emitter.dart` / `data_source_wrapper_emitter.dart` emit `static const String tfType` and `Set<String> get sensitiveFields` (and `bool get supportsDeletionProtection` when the schema opts in) **without** the dollar prefix. The accompanying `// ignore: constant_identifier_names` and `// ignore: non_constant_identifier_names` directives are dropped.
+- `enum_emitter.dart` appends `implements TerraformEnum` on every emitted enum declaration. The wrapper file already imports `package:terradart_core/terradart_core.dart`, which re-exports the interface — no additional import at the enum-emit site.
+- `valid_values_emitter.dart` (wrap-promote scaffold) emits the same `implements TerraformEnum` clause plus `@override` on the generated `String get terraformValue` body.
+- `universal_invariants/enum_extractor.dart` regex now tolerates the optional `implements TerraformEnum` clause so the extractor stays backwards-compatible with wrap-promote scaffolds that haven't been fleshed out yet.
+- YAML prelude bodies (62 files, 233 enums) updated: `implements TerraformEnum` added to every `enum X {` declaration plus `@override` on the matching `final String terraformValue;` field. Doc-comment / inline-comment references to the dollar-prefixed identifiers are renamed in sync so the regen output and the override YAML stay aligned.
+- `wrapper_override.dart` / `sensitive_set_emitter.dart` dartdoc strings reference `sensitiveFields` / `tfType` without the dollar prefix.
+- No new CLI surface in this release.
+
 ## 0.10.0 - 2026-MM-DD
 
 - Bumped `terradart_core` constraint to `^0.10.0`.

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart Stage 1 codegen — parses Terraform provider schema JSON and Magic Modules YAML and emits annotated abstract Dart classes. Ships the terradart CLI.
-version: 0.10.0
+version: 0.11.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -28,7 +28,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.10.0
+  terradart_core: ^0.11.0
 
 dev_dependencies:
   http: ^1.0.0

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.11.0 - 2026-MM-DD
+
+**BREAKING** — pre-1.0 polish wave on the `terradart_core` public surface. Coordinated changes from ADR-0016 (codegen identifier rename) and ADR-0017 (Stack API surface). v0.x permits breaking changes; the 0.11.x line continues to stage the 1.0 surface. See [MIGRATING.md](../../MIGRATING.md) for before / after snippets covering every item below.
+
+- **`Stack.synth({required outDir})` split** — `Stack.synth() → SynthResult` is now the pure in-memory step that returns the encoded `tfJson` plus the optional `dartConstants` source for AppExports. `Stack.writeTo(outDir) → Future<void>` is the new file-IO wrapper that always writes `main.tf.json` and, when AppExports produced Dart constants AND `setAppExportsOutputPath` was called, also writes the generated constants file at that path. `writeTo` throws `StateError` atomically — before any disk write — when `addExport` was called without `setAppExportsOutputPath`.
+- **`StackSynth` removed from the public barrel** — call `stack.synth()` instead of `StackSynth.synth(stack)`. The class is annotated `@internal`; advanced users may still import it via the deep path `package:terradart_core/src/synth/stack_synth.dart`.
+- **`Stack`, `Resource`, `Data` promoted to `abstract base class`** — user subclasses must now be declared `final class XxxStack extends Stack` (or `base` / `sealed`). `implements Stack` / `implements Resource` / `implements Data` are no longer permitted (was a state-bypass foot-gun).
+- **`Resource.$sensitiveFields` → `Resource.sensitiveFields`** and **`Resource.$supportsDeletionProtection` → `Resource.supportsDeletionProtection`** — dollar-prefix dropped. Both annotated `@protected` (from `package:meta`); non-subclass reads require an `// ignore: invalid_use_of_protected_member` directive with rationale. Privileged in-library consumers (the `TfJsonEncoder` synth call sites) already carry the ignore comment with justification.
+- **`TerraformEnum` interface added** — `abstract interface class TerraformEnum { String get terraformValue; }` is re-exported from the `terradart_core` barrel. `TfArgLiteral.toTfJson` enum dispatch now routes through `if (v is TerraformEnum)`; the previous duck-typed `dynamic.terraformValue` cast and its `// ignore: avoid_dynamic_calls` directive are retired. Hand-rolled Terraform-mapped enums must add `implements TerraformEnum` and `@override final String terraformValue;`; codegen-emitted enums get this automatically.
+
+### Non-breaking improvements
+
+- `encodeArg` / `encodeArgMap` / `encodeArgMapWithSensitive` return types tightened from `dynamic` to `Object?` / `Map<String, Object?>` — non-breaking at runtime, but call sites benefit from static type checking.
+- Internal `_DedupKey` value type rewritten as a Dart 3 named record. Drops the unused `package:meta/meta.dart` import.
+- `dart:convert` import prefixes unified across `lib/` and `test/` (`as dart_convert` / `as conv` / `as convert` → no prefix everywhere).
+
 ## 0.10.0 - 2026-MM-DD
 
 No user-facing API changes. Workspace consistency bump alongside `terradart_google` 0.10.0 (Firestore document curation + `FirestoreFields.encode` helper).

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.10.0
+version: 0.11.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.11.0 - 2026-MM-DD
+
+**BREAKING** — pre-1.0 polish wave consuming the `terradart_core` 0.11.0 / `terradart_codegen` 0.11.0 changes (ADR-0016, ADR-0017). v0.x permits breaking changes. See [MIGRATING.md](../../MIGRATING.md) for before / after snippets.
+
+- Bumped `terradart_core` constraint to `^0.11.0` (and `terradart_codegen` dev-dep to `^0.11.0`).
+- **118 curated GCP factories + 1 data source retained** — no resource additions or removals in this release. The polish wave focuses on identifier-rename propagation and pubspec hygiene.
+- **All 118 wrappers regenerated with unprefixed identifiers.** Every emitted wrapper now exposes `static const String tfType` (was `$tfType`), `Set<String> get sensitiveFields` (was `$sensitiveFields`), and `bool get supportsDeletionProtection` where applicable (was `$supportsDeletionProtection`). External code that read these by `$`-prefixed name must drop the prefix. The two getters are annotated `@protected`; non-subclass reads require an `// ignore: invalid_use_of_protected_member` directive with rationale.
+- **All emitted enums implement `TerraformEnum`.** Every enum declaration emitted by `terradart_codegen` 0.11.0 carries the `implements TerraformEnum` clause and `@override final String terraformValue;`. Mostly invisible to direct users; matters when authoring custom hand-rolled enums (must add the `implements` clause to satisfy `TfArg<MyEnum>.literal`).
+- **Hosted pubspec carets.** Examples no longer carry `path:` deps to sibling packages; they are workspace members of the monorepo and resolve against the published versions on pub.dev.
+
 ## 0.10.0 - 2026-MM-DD
 
 **ADDED** — small Firestore master-data IaC support. Additive change; no breaking modifications to v0.9.0 API.

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: Curated factory wrappers for 118 Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.
-version: 0.10.0
+version: 0.11.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,11 +18,11 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.10.0
+  terradart_core: ^0.11.0
   meta: ^1.15.0
 
 dev_dependencies:
-  terradart_codegen: ^0.10.0
+  terradart_codegen: ^0.11.0
   path: ^1.9.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/tool/bump_version.sh
+++ b/tool/bump_version.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Bump every terradart_* package to a new lockstep version in one shot.
+#
+# Usage:
+#   tool/bump_version.sh <new-version>
+#
+# Examples:
+#   tool/bump_version.sh 0.12.0
+#   tool/bump_version.sh 0.12.0-dev
+#
+# What it touches:
+#   - packages/terradart_core/pubspec.yaml        (version: line)
+#   - packages/terradart_codegen/pubspec.yaml     (version: + terradart_core caret)
+#   - packages/terradart_google/pubspec.yaml      (version: + terradart_core caret + terradart_codegen dev caret)
+#   - examples/*/pubspec.yaml                     (terradart_core + terradart_google carets)
+#   - README.md                                   (Quickstart pubspec sample + `dart pub global activate terradart_codegen ^...` line)
+#   - website/src/content/docs/docs/getting-started.md  (pubspec sample caret note)
+#
+# What it does NOT touch (write these by hand after the bump):
+#   - CHANGELOG.md (root + per-package) — release notes are prose
+#   - MIGRATING.md — migration narrative is prose
+#   - RELEASE.md — process doc, not version-coupled
+#
+# Editing strategy: line-targeted `sed -E` instead of `yq`. Preserves the
+# pubspec layout (blank lines between sections, trailing-comment formatting,
+# etc.) byte-for-byte except on the touched lines. Cross-platform (BSD sed
+# on macOS + GNU sed on Linux).
+#
+# Idempotent: re-running with the same target version is a no-op.
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: $0 <new-version>" >&2
+  echo "  example: $0 0.12.0" >&2
+  echo "  example: $0 0.12.0-dev" >&2
+  exit 64
+fi
+
+NEW="$1"
+
+# Sanity-check the version looks like SemVer (X.Y.Z or X.Y.Z-prerelease).
+if ! [[ "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+  echo "error: '$NEW' does not look like a SemVer (expected X.Y.Z or X.Y.Z-suffix)" >&2
+  exit 65
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Detect current version from terradart_core (the workspace's "leader" package).
+OLD="$(sed -n 's/^version: \(.*\)$/\1/p' packages/terradart_core/pubspec.yaml | head -1)"
+if [ -z "$OLD" ]; then
+  echo "error: could not detect current version from packages/terradart_core/pubspec.yaml" >&2
+  exit 67
+fi
+
+if [ "$OLD" = "$NEW" ]; then
+  echo "==> Already at $NEW; nothing to do."
+  exit 0
+fi
+
+# Escape regex metacharacters in OLD (only `.` and `-` are realistic in SemVer).
+OLD_RE="$(printf '%s' "$OLD" | sed 's/[.]/\\./g')"
+
+echo "==> Bumping $OLD -> $NEW across the workspace"
+echo
+
+# Cross-platform sed -i: GNU uses `-i` (no arg), BSD uses `-i ''` (empty arg).
+# Using `-i.bak` + `rm` works on both.
+sed_inplace() {
+  local script="$1"
+  local file="$2"
+  sed -E -i.bak "$script" "$file"
+  rm -f "${file}.bak"
+}
+
+# Use `#` as the sed delimiter throughout — `|` is the ERE alternation
+# operator and clashes with the more common `s|...|...|` form.
+
+# 1. `version:` field on the three published package pubspecs.
+echo "  Package versions:"
+for pkg in terradart_core terradart_codegen terradart_google; do
+  sed_inplace "s#^version: ${OLD_RE}\$#version: ${NEW}#" "packages/$pkg/pubspec.yaml"
+  echo "    - packages/$pkg/pubspec.yaml -> $NEW"
+done
+
+# 2. Inter-package carets inside terradart_codegen + terradart_google.
+#    Matches `  terradart_<name>: ^X.Y.Z` (any indent, end-of-line).
+echo "  Inter-package carets:"
+sed_inplace "s#^( *terradart_core): \\^${OLD_RE}\$#\\1: ^${NEW}#" packages/terradart_codegen/pubspec.yaml
+echo "    - terradart_codegen.dependencies.terradart_core: ^${NEW}"
+sed_inplace "s#^( *terradart_core): \\^${OLD_RE}\$#\\1: ^${NEW}#" packages/terradart_google/pubspec.yaml
+echo "    - terradart_google.dependencies.terradart_core: ^${NEW}"
+sed_inplace "s#^( *terradart_codegen): \\^${OLD_RE}\$#\\1: ^${NEW}#" packages/terradart_google/pubspec.yaml
+echo "    - terradart_google.dev_dependencies.terradart_codegen: ^${NEW}"
+
+# 3. Every example pubspec: terradart_core + terradart_google carets.
+echo "  Example pubspecs:"
+EXAMPLE_COUNT=0
+for f in examples/*/pubspec.yaml; do
+  sed_inplace "s#^( *terradart_(core|google)): \\^${OLD_RE}\$#\\1: ^${NEW}#" "$f"
+  EXAMPLE_COUNT=$((EXAMPLE_COUNT + 1))
+done
+echo "    - bumped $EXAMPLE_COUNT examples to terradart_{core,google}: ^$NEW"
+
+# 4. Markdown caret samples (README + website getting-started).
+#    Two distinct patterns:
+#    a) Inside a pubspec block: `  terradart_(core|codegen|google): ^X.Y.Z`
+#    b) On a `dart pub global activate` line: `... terradart_codegen ^X.Y.Z`
+echo "  Markdown caret samples:"
+for md in README.md website/src/content/docs/docs/getting-started.md; do
+  if [ -f "$md" ]; then
+    sed_inplace "s#terradart_(core|codegen|google): \\^${OLD_RE}#terradart_\\1: ^${NEW}#g" "$md"
+    sed_inplace "s#(dart pub global activate terradart_codegen) \\^${OLD_RE}#\\1 ^${NEW}#g" "$md"
+    echo "    - $md"
+  fi
+done
+
+echo
+
+# 5. Verify no stale OLD carets / version lines remain in the scoped files.
+echo "==> Verifying no stale '$OLD' references remain"
+set +e
+STALE=$(
+  grep -nE "^version: ${OLD_RE}\$" packages/*/pubspec.yaml 2>/dev/null
+  grep -nE "terradart_(core|codegen|google): \\^${OLD_RE}([^0-9A-Za-z.-]|\$)" \
+    packages/*/pubspec.yaml examples/*/pubspec.yaml \
+    README.md website/src/content/docs/docs/getting-started.md 2>/dev/null
+  grep -nE "dart pub global activate terradart_codegen \\^${OLD_RE}([^0-9A-Za-z.-]|\$)" \
+    README.md website/src/content/docs/docs/getting-started.md 2>/dev/null
+)
+set -e
+
+if [ -n "$STALE" ]; then
+  echo "ERROR: stale '$OLD' references still present:" >&2
+  echo "$STALE" >&2
+  exit 1
+fi
+
+echo "==> Lockstep bump complete: $OLD -> $NEW"
+echo
+echo "Next:"
+echo "  1. Update CHANGELOG.md (root + 3 packages) by hand — release notes are prose."
+echo "  2. If breaking, add a MIGRATING.md section."
+echo "  3. dart pub get && dart analyze packages/terradart_core packages/terradart_codegen packages/terradart_google"
+echo "  4. git diff --stat   # review the bump"
+echo "  5. Commit + push, open release PR."

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -4,14 +4,14 @@ description: Install TerraDart and synthesize your first stack.
 ---
 
 :::note[Coming soon]
-This page tracks the v0.11.0 API surface and will be expanded with end-to-end walkthroughs after the release. Package versions below are pre-release pins.
+This page tracks the v0.11.0 API surface and will be expanded with end-to-end walkthroughs after the release.
 :::
 
 ## Meanwhile
 
 1. Read the [README Quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) on GitHub.
 2. Run the [Pub/Sub quickstart example](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart).
-3. Pin pre-release packages explicitly (`^0.1.0-dev` or the current dev version on [pub.dev](https://pub.dev/packages/terradart_core)).
+3. Pin the published packages with `^0.11.0` (see the current version on [pub.dev](https://pub.dev/packages/terradart_core)).
 
 ## Outline (planned)
 


### PR DESCRIPTION
## Summary

Fourth and final wave of v0.11.0. Bumps `terradart_core` / `terradart_codegen` / `terradart_google` from 0.10.0 → 0.11.0 in lockstep (including caret bumps across the 23 workspace example consumers), writes CHANGELOG entries across 4 files, and adds the `MIGRATING.md` v0.10 → v0.11 migration guide. Also introduces `tool/bump_version.sh` so future lockstep bumps are a one-shot command instead of a 50-file manual edit.

After merge, the user creates the `v0.11.0` git tag. The `publish.yml` workflow then ships all three packages to pub.dev in 3 phases (Phase 1: `terradart_core` → 5min index propagation → Phase 2: `terradart_codegen` → 5min → Phase 3: `terradart_google`).

## What changed

### Version bumps (lockstep across the workspace)

- `packages/terradart_core/pubspec.yaml` — `version: 0.11.0`
- `packages/terradart_codegen/pubspec.yaml` — `version: 0.11.0`, dep `terradart_core: ^0.11.0`
- `packages/terradart_google/pubspec.yaml` — `version: 0.11.0`, dep `terradart_core: ^0.11.0`, dev dep `terradart_codegen: ^0.11.0`
- 23 `examples/*/pubspec.yaml` — `terradart_core: ^0.11.0` + `terradart_google: ^0.11.0` (workspace members resolve to local siblings during dev)

### Documentation

- **`README.md`** — quickstart pubspec sample bumped to `^0.11.0`; `dart pub global activate terradart_codegen` line bumped; "Pre-alpha" status framing dropped (v0.11.0 is a regular pre-1.0 release, not `-dev`).
- **`website/src/content/docs/docs/getting-started.md`** — same caret + framing update.
- **`CHANGELOG.md`** (root) — v0.11.0 entry with Breaking changes + Non-breaking improvements sections; references ADR-0016 + ADR-0017.
- **`packages/terradart_core/CHANGELOG.md`** — user-facing changes affecting `terradart_core` consumers (Stack API, identifier renames, `TerraformEnum`, internal cleanup).
- **`packages/terradart_codegen/CHANGELOG.md`** — codegen template emits unprefixed identifiers + `implements TerraformEnum` on enums.
- **`packages/terradart_google/CHANGELOG.md`** — all 118 wrappers regenerated with new identifier shape; hosted pubspec style.

### MIGRATING.md — v0.10 → v0.11 (new top section, 204 lines)

Covers all five breaking topics with before/after snippets:

1. `Stack.synth({required outDir})` → `synth()` + `writeTo(outDir)` split
2. `StackSynth` removed from public barrel (with deep-import escape hatch)
3. `Stack` / `Resource` / `Data` promoted to `abstract base class` — subclasses must be declared `final class`
4. `$tfType` / `$sensitiveFields` / `$supportsDeletionProtection` dropped `$`-prefix; getters annotated `@protected`
5. `TerraformEnum` interface — codegen-emitted enums get `implements TerraformEnum` automatically; hand-rolled enums must add it manually

Includes a mechanical sed recipe for the rename in §2. Existing 0.8 → 0.9 migration section preserved unchanged.

### Release tooling — `tool/bump_version.sh` (new)

One-shot lockstep bump for future releases:

```bash
tool/bump_version.sh 0.12.0       # bump everything to 0.12.0
tool/bump_version.sh 0.12.0-dev   # `-dev` prerelease also supported
```

Updates in one pass:

- 3 package pubspecs (`version:` + inter-package carets)
- 23 example pubspecs (`terradart_core` + `terradart_google` carets)
- `README.md` Quickstart pubspec sample + `dart pub global activate terradart_codegen ^X.Y.Z` line
- `website/.../getting-started.md` pubspec sample

Out of scope: CHANGELOG / MIGRATING / RELEASE.md prose stay hand-written.

Editing strategy: line-targeted `sed -E` (not `yq`). `yq -i` normalises YAML and strips the blank lines between pubspec sections; sed preserves the file byte-for-byte except on the touched lines. Cross-platform (BSD sed on macOS + GNU sed on Linux); `#` is used as the sed delimiter to avoid clashing with ERE alternation `|`.

Idempotent — re-running with the same target is a no-op exit 0. Verifies at the end that no stale carets remain in the scoped files. Round-trip tested locally (`bump_version.sh 0.99.0` → `bump_version.sh 0.11.0` produces `git status` zero diff).

### `RELEASE.md` refresh

- Header: 4 packages → 3 (`terradart_annotations` was retired before v0.10).
- Pre-flight: manual `Bump version in all 4 pubspecs` checklist replaced by `tool/bump_version.sh 0.X.Y`.
- Initial-publish for-loops drop `terradart_annotations`.
- Tag-driven publish topology corrected from `3 leaves in parallel` to the 3-phase serial ordering (`publish-no-deps` → `publish-codegen` → `publish-google`) that `publish.yml` actually implements.
- `v0.0.X-dev` examples bumped to `v0.X.Y` to reflect the current shape.

## Test plan

- [x] `dart pub get` (workspace root) clean
- [x] `dart analyze packages/terradart_core packages/terradart_codegen packages/terradart_google` → `No issues found!`
- [x] `dart format --output=none --set-exit-if-changed packages/terradart_core/ packages/terradart_codegen/` → exit 0
- [x] `dart test` per package: terradart_core 195 / terradart_codegen 314 / terradart_google 175 — all pass (684 total)
- [x] `git grep '0\.10\.' pubspec.yaml packages/*/pubspec.yaml examples/*/pubspec.yaml` → 0 matches (lockstep verified)
- [x] `dart pub publish --dry-run` for `terradart_core` (after `prepare_publish.sh`) — clean, 1 expected warning ("checked-in file modified in git" from the in-place pubspec edit)
- [x] `dart pub publish --dry-run` for `terradart_codegen` / `terradart_google` — blocks on inter-package version solving (`terradart_core` 0.11.0 not yet on pub.dev), which is the documented 3-phase publish ordering in `publish.yml`
- [x] `bump_version.sh` round-trip test: bump 0.11.0 → 0.99.0 → back to 0.11.0 produces `git status` zero modified files

## After merge

1. User creates `v0.11.0` git tag and pushes to origin.
2. `publish.yml` fires:
   - Phase 1: `terradart_core` → pub.dev
   - 5 min wait for pub.dev index propagation
   - Phase 2: `terradart_codegen` → pub.dev
   - 5 min wait
   - Phase 3: `terradart_google` → pub.dev
3. Cookbook migration is a post-release follow-on (existing recipes pinned to pre-1.0 carets are naturally safe; opt-in `^0.11.0` migration in a separate cookbook PR).

## Known follow-ups (out of Wave 4 scope)

- `tool/run_tests.sh` has a stale reference to the deleted-pre-v0.10 `terradart_annotations` package. CI uses per-package `dart test` invocations and isn't affected; the tooling bitrot can be cleaned up later.
- Internal `lib/src/` doc-comments mentioning `StackSynth.synth` or `Resource<S>` were left in place (not consumer-facing).