### PR TITLE
feat(website): refresh landing page copy and align docs

### DIFF
--- a/website/bun.lock
+++ b/website/bun.lock
@@ -10,6 +10,7 @@
         "astro": "^6.2.2",
         "playwright": "^1.60.0",
         "rehype-mermaid": "^3.0.0",
+        "shiki": "^4.1.0",
         "starlight-llms-txt": "^0.8.1",
         "tailwindcss": "^4.2.4",
       },

--- a/website/package.json
+++ b/website/package.json
@@ -22,6 +22,7 @@
     "astro": "^6.2.2",
     "playwright": "^1.60.0",
     "rehype-mermaid": "^3.0.0",
+    "shiki": "^4.1.0",
     "starlight-llms-txt": "^0.8.1",
     "tailwindcss": "^4.2.4"
   },

--- a/website/src/components/Comparison.astro
+++ b/website/src/components/Comparison.astro
@@ -9,15 +9,20 @@ interface Props {
   heading: string;
   columns: string[]; // header column titles (across the top, excluding the first row-label column)
   rows: ComparisonRow[];
+  intro?: string; // raw HTML
+  footnote?: string; // raw HTML
 }
 
-const { eyebrow = "Compare", heading, columns, rows } = Astro.props;
+const { eyebrow = "Compare", heading, columns, rows, intro, footnote } =
+  Astro.props;
 ---
 
 <section class="section rule-top">
   <div class="container-edit section-inner">
     <p class="section-label">{eyebrow}</p>
     <h2 class="display-section">{heading}</h2>
+
+    {intro && <p class="compare-intro" set:html={intro} />}
 
     <div class="compare-wrap">
       <table class="compare-table">
@@ -39,5 +44,7 @@ const { eyebrow = "Compare", heading, columns, rows } = Astro.props;
         </tbody>
       </table>
     </div>
+
+    {footnote && <p class="compare-footnote" set:html={footnote} />}
   </div>
 </section>

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -14,7 +14,7 @@ const year = new Date().getFullYear();
           class="h-7 w-auto"
         />
         <p class="text-mute mt-3 text-sm max-w-md">
-          Type-safe Google Cloud IaC for Dart. Synthesizes standard
+          Type-safe Google Cloud IaC for Dart. Generates standard
           <code class="font-mono text-[0.85em]">*.tf.json</code> — your existing
           <code class="font-mono text-[0.85em]">terraform apply</code> pipeline
           runs unchanged.

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -13,10 +13,9 @@ import HeroMark from "./HeroMark.astro";
       </h1>
 
       <p class="body-lead hero-lead">
-        Google Cloud infrastructure as real Dart — typed, refactor-safe,
-        IDE-aware. TerraDart re-implements Terraform&rsquo;s authoring surface in
-        Dart and emits <code>*.tf.json</code> for the
-        <code>terraform apply</code> you already run.
+        Terraform stays. <strong>You author in Dart.</strong> Define typed GCP
+        resources and emit standard <code>*.tf.json</code> for the
+        <code>terraform apply</code> pipeline you already run.
       </p>
 
       <div class="terra-stratum" aria-hidden="true"></div>
@@ -31,15 +30,12 @@ import HeroMark from "./HeroMark.astro";
         <a href="https://pub.dev/packages/terradart_core" class="btn-secondary">
           pub.dev
         </a>
-        <a href="/docs/" class="btn-secondary">Docs</a>
+        <a href="/docs/why-terradart/" class="btn-secondary">Docs</a>
       </div>
     </div>
 
     <div class="hero-visual">
       <HeroMark />
-      <p class="hero-visual-caption">
-        The dart points down&nbsp;&mdash; into the infrastructure layer.
-      </p>
     </div>
   </div>
 </section>

--- a/website/src/components/Pipeline.astro
+++ b/website/src/components/Pipeline.astro
@@ -26,7 +26,7 @@ const { eyebrow = "Pipeline", heading, steps, footnote } = Astro.props;
             <span class="pipeline-index">{i + 1}</span>
             <div class="pipeline-body">
               <h3 class="pipeline-title">{step.title}</h3>
-              <p>{step.body}</p>
+              <p set:html={step.body} />
             </div>
           </li>
         ))

--- a/website/src/components/PitchCode.astro
+++ b/website/src/components/PitchCode.astro
@@ -1,0 +1,135 @@
+---
+import { codeToHtml } from "shiki";
+import githubLight from "shiki/themes/github-light.mjs";
+
+/** Site paper token — keep in sync with global.css @theme --color-paper */
+const paperBg = "#f6f3ec";
+
+const terradartPaper = {
+  ...githubLight,
+  name: "terradart-paper",
+  colors: {
+    ...githubLight.colors,
+    "editor.background": paperBg,
+  },
+};
+
+/** LP pitch snippet — Cloud SQL + Cloud Run with cloud-sql-proxy sidecar (illustrative). */
+const code = `// infra/lib/app_infra.dart
+// A Stack is one Terraform root module of GCP resources, written in Dart.
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/cloud_run.dart';
+import 'package:terradart_google/cloud_sql.dart';
+import 'package:terradart_google/iam.dart';
+import 'package:terradart_google/provider.dart';
+
+final class AppInfraStack extends Stack {
+  AppInfraStack({required String projectId})
+      : super(providers: [
+          GoogleProvider(project: projectId, region: 'asia-northeast1'),
+        ]) {
+    add(GoogleSqlDatabaseInstance(
+      localName: 'app_sql',
+      name: TfArg.literal('app-sql'),
+      databaseVersion: TfArg.literal(DatabaseVersion.postgres15),
+      region: TfArg.literal('asia-northeast1'),
+      settings: SqlDatabaseInstanceSettings(
+        tier: TfArg.literal('db-f1-micro'),
+      ),
+    ));
+
+    final runSa = add(GoogleServiceAccount(
+      localName: 'run_sa',
+      accountId: TfArg.literal('app-run-sa'),
+    ));
+    add(GoogleProjectIamMember(
+      localName: 'run_sa_sql_client',
+      project: TfArg.literal(projectId),
+      role: TfArg.literal('roles/cloudsql.client'),
+      member: TfArg.ref(runSa.iamMember),
+    ));
+
+    add(GoogleCloudRunV2Service(
+      localName: 'app',
+      name: TfArg.literal('app'),
+      location: TfArg.literal('asia-northeast1'),
+      template: CloudRunV2ServiceTemplate(
+        serviceAccount: TfArg.ref(runSa.email),
+        containers: [
+          CloudRunV2ServiceServiceContainer(
+            name: TfArg.literal('app'),
+            image: TfArg.literal('gcr.io/cloudrun/hello'),
+            ports: CloudRunV2ServiceContainerPort(
+              containerPort: TfArg.literal(8080),
+            ),
+            env: [
+              CloudRunV2ServiceEnvVar(
+                name: TfArg.literal('DATABASE_URL'),
+                source: CloudRunV2ServiceEnvVarFromLiteral(
+                  TfArg.literal(
+                    'postgresql://app-client@\${projectId}.iam@localhost:5432/app',
+                  ),
+                ),
+              ),
+            ],
+          ),
+          CloudRunV2ServiceServiceContainer(
+            name: TfArg.literal('cloud-sql-proxy'),
+            image: TfArg.literal(
+              'gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.18.1',
+            ),
+            args: TfArg.literal([
+              '--port=5432',
+              '--auto-iam-authn',
+              '\${projectId}:asia-northeast1:app-sql',
+            ]),
+          ),
+        ],
+      ),
+    ));
+  }
+}`;
+
+const highlightedHtml = await codeToHtml(code, {
+  lang: "dart",
+  theme: terradartPaper,
+});
+---
+
+<section class="section rule-top pitch-code-section">
+  <div class="container-edit section-inner">
+    <p class="section-label">Example</p>
+    <h2 class="display-section">GCP resources in Dart</h2>
+    <p class="pitch-code-lead">
+      Cloud SQL, IAM, and a multi-container Cloud Run service with a
+      <code>cloud-sql-proxy</code> sidecar&nbsp;&mdash; the kind of infrastructure you would
+      otherwise maintain in HCL or the console.
+    </p>
+    <div class="pitch-code-figure">
+      <div class="terra-stratum" aria-hidden="true"></div>
+      <div class="pitch-code-wrap" set:html={highlightedHtml} />
+    </div>
+    <p class="pitch-code-meta">
+      <code>terradart_google</code> ships a <strong>curated</strong> subset of the
+      HashiCorp <code>google</code> provider&nbsp;&mdash; not every resource type yet. Factories
+      expand release by release; see
+      <a href="/docs/status/" class="link-mark">status</a> and
+      <a href="https://pub.dev/packages/terradart_google" class="link-mark">pub.dev</a>.
+      More complete stacks and dogfood patterns live in the
+      <a
+        href="https://github.com/nozomi-koborinai/terradart-cookbook"
+        class="link-mark">cookbook</a
+      >
+      and
+      <a
+        href="https://github.com/nozomi-koborinai/terradart/tree/main/examples"
+        class="link-mark">examples</a
+      >
+      on GitHub (both growing).
+    </p>
+    <p class="section-footnote">
+      A runnable quickstart in
+      <code class="font-mono text-[0.85em]">examples/</code> is on the way.
+    </p>
+  </div>
+</section>

--- a/website/src/content/docs/docs/architecture.mdx
+++ b/website/src/content/docs/docs/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: How TerraDart Stacks synthesize to Terraform JSON, how upstream provider changes propagate, and how the IaC/application seam works.
+description: How TerraDart Stacks generate Terraform JSON, how synth() and writeTo() fit together, and how provider coverage and AppExport work.
 ---
 
 import Pipeline from "../../../components/Pipeline.astro";
@@ -13,24 +13,30 @@ TerraDart is a thin authoring layer that produces standard Terraform JSON. The D
   steps={[
     {
       title: "Author",
-      body: "Write final class XxxStack extends Stack using curated google_* factories from terradart_google.",
+      body: "Write <code>final class XxxStack extends Stack</code> using curated <code>google_*</code> factories from terradart_google.",
     },
     {
-      title: "Synthesize",
-      body: "Call stack.writeTo('tf-out') to write *.tf.json, or stack.synth() to keep the SynthResult in memory.",
+      title: "Generate Terraform JSON",
+      body: "Call <code>stack.writeTo('tf-out')</code> to emit <code>*.tf.json</code>, or <code>stack.synth()</code> first if you need the in-memory <code>SynthResult</code>.",
     },
     {
       title: "Apply",
-      body: "Run terraform plan and terraform apply against your existing state backend.",
+      body: "Run <code>terraform plan</code> and <code>terraform apply</code> against your existing state backend.",
     },
     {
       title: "Hand off (optional)",
-      body: "Surface AppExport values as typed Dart constants and Terraform outputs for downstream apps.",
+      body: "Surface <code>AppExport</code> values as typed Dart constants and Terraform outputs for downstream apps.",
     },
   ]}
 />
 
-## Stack lifecycle (synth internals)
+## What is synth?
+
+On the [landing page](/), we say you **generate** `*.tf.json` — plain language for the outcome.
+
+In the API, **synth** is the in-memory step: your `Stack` is walked and assembled into the Terraform JSON tree. Code: `stack.synth()` → `SynthResult`. Writing files is the next step: `stack.writeTo(outDir)`.
+
+## Stack lifecycle (`synth()` internals)
 
 ```mermaid
 graph LR
@@ -48,12 +54,14 @@ graph LR
 `Stack`, `Resource`, and `Data` are `abstract base class`. Your subclasses must declare a class modifier:
 
 ```dart
-final class OrdersStack extends Stack { /* ... */ }
+final class AppInfraStack extends Stack { /* ... */ }
 ```
 
 `base` and `sealed` are also valid; what is rejected is plain `class` (or `implements Stack`, which would bypass the base-class state that synth depends on).
 
 ## Provider integration
+
+[`terradart_google`](https://pub.dev/packages/terradart_google) ships a **curated** subset of the HashiCorp [`google`](https://registry.terraform.io/providers/hashicorp/google/latest) provider — typed factories for common services, expanded release by release. It does not wrap every resource block in the upstream provider yet. See [status](/docs/status/) and the [package README](https://pub.dev/packages/terradart_google) for what is available today; [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart-cookbook) add fuller stacks over time.
 
 TerraDart depends on the Google Terraform provider via two upstream sources, both reconciled automatically on a weekly cadence.
 
@@ -78,7 +86,7 @@ You don't need to track this loop to use TerraDart. The reason it's documented h
 
 ## AppExport: the IaC ↔ application seam
 
-`AppExport` is the typed handoff from your Stack to whatever Dart application code consumes the resources it provisions.
+`AppExport` is the typed handoff from your Stack to whatever Dart application code consumes the resources it provisions (for example Cloud Run functions handlers).
 
 ```mermaid
 graph LR
@@ -112,4 +120,4 @@ See [README — Non-goals](https://github.com/nozomi-koborinai/terradart#non-goa
 - [`terradart_core` on pub.dev](https://pub.dev/packages/terradart_core) — Stack / TfArg / AppExport API reference.
 - [`terradart_google` on pub.dev](https://pub.dev/packages/terradart_google) — the curated factory catalog.
 - [`terradart_codegen` on pub.dev](https://pub.dev/packages/terradart_codegen) — `wrap` / `codegen` CLI reference.
-- [`examples/` on GitHub](https://github.com/nozomi-koborinai/terradart/tree/main/examples) — 23 runnable quickstart Stacks.
+- [`examples/` on GitHub](https://github.com/nozomi-koborinai/terradart/tree/main/examples) — runnable quickstart Stacks.

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Install TerraDart and synthesize your first stack.
+description: Install TerraDart and generate your first *.tf.json from a Stack.
 ---
 
 :::note[Coming soon]

--- a/website/src/content/docs/docs/index.md
+++ b/website/src/content/docs/docs/index.md
@@ -9,9 +9,10 @@ Several guides are **in progress** while the v0.11.0 API surface stabilizes. Unt
 
 ## Guides
 
-- [Getting Started](/docs/getting-started/) — installation and first synth (coming soon)
+- [Why TerraDart](/docs/why-terradart/) — motivation, comparison, and curated coverage
+- [Architecture](/docs/architecture/) — generate `*.tf.json`, `synth()` / `writeTo()`, AppExport
+- [Getting Started](/docs/getting-started/) — installation and first output (coming soon)
 - [Status & versioning](/docs/status/) — pre-alpha expectations
-- [How it works](/docs/how-it-works/) — Dart → `*.tf.json` → Terraform
 
 ## For AI assistants
 

--- a/website/src/content/docs/docs/why-terradart.mdx
+++ b/website/src/content/docs/docs/why-terradart.mdx
@@ -1,66 +1,58 @@
 ---
 title: Why TerraDart
-description: TerraDart brings the last non-Dart layer of a Dart-centric stack into Dart, by absorbing Terraform's authoring model into typed Dart factories.
+description: Why Dart teams adopt TerraDart — the infra/app boundary, Terraform-compatible generation, curated Google provider factories, and how it compares to HCL, CDKTF, and Pulumi.
 ---
 
-import Mission from "../../../components/Mission.astro";
-import Comparison from "../../../components/Comparison.astro";
+If you read the [landing page](/) first: TerraDart keeps **Terraform as the execution layer** while you **author GCP infrastructure in Dart**. This page goes deeper on motivation, the type system, and where TerraDart sits next to other IaC tools.
 
-If your team is building with Flutter on the client and Dart on the server (Cloud Functions, Cloud Run), there is usually one layer left where Dart's tooling doesn't reach: the infrastructure definitions. TerraDart closes that gap without asking you to give up Terraform itself.
-
-<Mission
-  eyebrow="Why TerraDart"
-  heading="Bring the last non-Dart layer into Dart."
-  cards={[
-    {
-      title: "UI and server are already Dart",
-      body: "Flutter handles the UI. Cloud Functions and Cloud Run services run your Dart. For teams already centered on Dart, infrastructure is often the one layer still outside your repo&nbsp;&mdash; carried in HCL and manual console work, separate from the language your app, tests, and refactors already share.",
-    },
-    {
-      title: "Terraform&rsquo;s surface, absorbed",
-      body: "TerraDart is not a parallel runtime. It is Terraform&rsquo;s authoring model expressed as Dart factories and sealed types, synthesized to standard JSON for the provider you already use.",
-    },
-    {
-      title: "Discipline by design",
-      body: "Fixed-value fields become enums. Exactly-one-of blocks become sealed classes. Plain <code>Stack</code> subclasses&nbsp;&mdash; loops, config, and refactors work the way Dart already does.",
-    },
-  ]}
-/>
+If your team ships Flutter on the client and Dart on the server (**Cloud Run**, **Cloud Run functions**), there is usually one layer left where Dart's tooling does not reach: **infrastructure definitions** — often maintained in HCL, a Terraform-compatible pipeline, or the GCP console. TerraDart closes that gap without asking you to give up Terraform itself.
 
 ## The last non-Dart layer
 
 | Layer | Already Dart? |
 | --- | --- |
 | Mobile UI (Flutter) | ✅ |
-| Backend handlers (Cloud Functions / Cloud Run) | ✅ |
+| Backend handlers (Cloud Run / Cloud Run functions) | ✅ |
 | Application business logic | ✅ |
-| Infrastructure definitions | ❌ — HCL + console clicks |
+| Infrastructure definitions | ❌ — HCL, Terraform-compatible tooling, or console |
 
-When the UI, the server, and the shared business logic all live in Dart, infrastructure is the last layer your refactor doesn't touch. A renamed Pub/Sub topic doesn't propagate to its subscribers via `dart fix`. A typo in a service name isn't a compile error — it's a `terraform apply` error, at best. IAM bindings drift from the code that depends on them, because nothing ties them together at the type system level.
+That bottom row is what people mean by the **last non-Dart layer**: everything above it shares `dart analyze`, refactors, and IDE navigation; infrastructure often does not.
 
-TerraDart pulls infrastructure into the same authoring surface as the rest of your code. `dart analyze` catches resource-name typos. Refactoring a Stack class is the same operation as refactoring any other Dart class. The same `final` / `sealed` discipline that already protects your domain model now protects your network topology.
+### A boundary held together by string literals
 
-## Terraform's surface, absorbed (not a parallel runtime)
+Topic names typed in HCL or the console and again in your Cloud Run functions handlers. Renames do not reach subscribers via `dart fix`. IAM member strings drift with no compiler visibility. Infra values flowing into app code are often the place Dart's type system never sees.
+
+TerraDart pulls infrastructure into the same authoring surface as the rest of your code. `dart analyze` catches resource-name typos. Refactoring a Stack class is the same operation as refactoring any other Dart class. The same `final` / `sealed` discipline that already protects your domain model can protect your network topology.
+
+## Terraform stays the execution layer
 
 TerraDart does not run `terraform apply` for you. It does not own your state file. It does not introduce a new provider or a new lock format.
 
-What it does is take Terraform's authoring model — provider blocks, resource blocks, references, lifecycle hooks — and express it as Dart code that synthesizes to the same `*.tf.json` Terraform would have accepted from HCL. `terraform plan`, `terraform apply`, and your remote state backend stay exactly where they are.
+What it does is take Terraform's authoring model — provider blocks, resource blocks, references, lifecycle hooks — and express it as Dart code that **generates** the same `*.tf.json` Terraform would have accepted from HCL. `terraform plan`, `terraform apply`, and your remote state backend stay exactly where they are.
+
+:::note[API name: synth]
+The in-memory step that builds the JSON tree is called **`synth()`** in code (`stack.synth()` → `SynthResult`, then `writeTo(outDir)`). The landing page uses "generate" for readability. See [Architecture — What is synth?](/docs/architecture/#what-is-synth).
+:::
 
 This is intentionally narrower than Pulumi, which has its own runtime, its own state model, and its own resource graph. With TerraDart the boundary is sharp: Dart is the **authoring** layer, Terraform is the **execution** layer. If you migrate off TerraDart tomorrow, your existing state and your existing modules are unchanged.
 
-CDKTF used to occupy this same "code-first authoring of Terraform" niche, but only for TypeScript / Python / Java / Go — never Dart. CDKTF was archived in December 2025, leaving a Dart-shaped hole that TerraDart now fills.
+CDKTF used to occupy this same "code-first authoring of Terraform" niche, but only for TypeScript / Python / Java / Go — never Dart. CDKTF was [archived in December 2025](https://github.com/hashicorp/terraform-cdk), leaving a Dart-shaped hole that TerraDart now fills.
 
-## Discipline by design (Dart's type system)
+## Dart types where HCL cannot help
 
-Three concrete patterns where the Dart type system catches what HCL can't:
+Three concrete patterns where the Dart type system catches what HCL cannot:
 
-**Enums for fixed-value fields.** Terraform schemas often have fields that accept one of a small, fixed set of strings — `INGRESS_TRAFFIC_ALL` vs `INGRESS_TRAFFIC_INTERNAL_ONLY`, for example. TerraDart emits these as Dart enums:
+### Enums for fixed-value fields
+
+Terraform schemas often have fields that accept one of a small, fixed set of strings — `INGRESS_TRAFFIC_ALL` vs `INGRESS_TRAFFIC_INTERNAL_ONLY`, for example. TerraDart emits these as Dart enums:
 
 ```dart
 ingress: TfArg.literal(Ingress.all)  // typo → compile error
 ```
 
-**Sealed classes for exactly-one-of nested blocks.** Some Terraform blocks accept exactly one variant from a set — for instance, a BigQuery dataset's `access` block has 8 mutually exclusive variants (`user_by_email`, `group_by_email`, `special_group`, `domain`, `iam_member`, `view`, `dataset`, `routine`). TerraDart emits these as a sealed class hierarchy:
+### Sealed classes for exactly-one-of nested blocks
+
+Some Terraform blocks accept exactly one variant from a set — for instance, a BigQuery dataset's `access` block has 8 mutually exclusive variants (`user_by_email`, `group_by_email`, `special_group`, `domain`, `iam_member`, `view`, `dataset`, `routine`). TerraDart emits these as a sealed class hierarchy:
 
 ```dart
 access: [
@@ -71,47 +63,40 @@ access: [
 
 The compiler enforces that exactly one variant is constructed per entry.
 
-**Final classes for Stack subclasses.** `Stack`, `Resource`, and `Data` are declared `abstract base class` since v0.11.0. Your own subclasses must use a class modifier:
+### Final classes for Stack subclasses
+
+`Stack`, `Resource`, and `Data` are declared `abstract base class` since v0.11.0. Your own subclasses must use a class modifier:
 
 ```dart
-final class OrdersStack extends Stack { /* ... */ }
+final class AppInfraStack extends Stack { /* ... */ }
 ```
 
-This prevents two foot-guns: forgetting to extend (using `implements` would skip the base-class state that synth needs), and accidentally subclassing an internal class that wasn't meant to be extended further. Both used to be runtime hazards in pre-v0.11 versions; they're now compile errors.
+This prevents two foot-guns: forgetting to extend (using `implements` would skip the base-class state that synth needs), and accidentally subclassing an internal class that was not meant to be extended further. Both used to be runtime hazards in pre-v0.11 versions; they are now compile errors.
 
 ## How it fits next to other IaC
 
-<Comparison
-  eyebrow="Compare"
-  heading="Where TerraDart sits"
-  columns={["TerraDart", "HCL", "CDKTF", "Pulumi"]}
-  rows={[
-    {
-      label: "Dart authoring",
-      cells: ["Yes", "No", "No", "No"],
-    },
-    {
-      label: "Drop-in for terraform apply",
-      cells: ["Yes", "Yes", "Yes", "Different model"],
-    },
-    {
-      label: "Typed GCP resource API",
-      cells: ["Yes", "No", "No", "No"],
-    },
-    {
-      label: "Project status",
-      cells: ["Pre-alpha", "Mature", "Archived 2025", "Active"],
-    },
-  ]}
-/>
+TerraDart fits teams already centered on **Dart**, already running **Terraform** (or a compatible pipeline) or managing GCP in the **console**, where the seam between infra and app code hurts.
 
-**HCL** is the native, mature option. If your team is comfortable maintaining HCL alongside your Dart application code, there's no urgency to switch. TerraDart's value proposition only matters once the cost of context-switching between Dart and HCL — and the absence of refactor / typecheck across that boundary — starts to bite.
+| | TerraDart | HCL | CDKTF | Pulumi |
+| --- | --- | --- | --- | --- |
+| Dart authoring | Yes | No | No | No |
+| Drop-in for `terraform apply` | Yes | Yes | Yes | Different model |
+| Curated Dart factories for GCP | Yes | No | No | No |
+| Project status | Pre-alpha | Mature | Archived 2025 | Active |
 
-**CDKTF** would have been the obvious model to follow, except it was archived by HashiCorp in December 2025 and never targeted Dart in any case. TerraDart is the Dart-shaped slot CDKTF didn't reach.
+HCL has provider schema types; CDKTF bindings are typed in TypeScript and other languages. TerraDart's difference is **Dart-native authoring** without replacing your Terraform execution pipeline.
 
-**Pulumi** is a different model entirely: its own runtime, its own state, its own resource graph. If you want a code-first IaC platform and you don't already have Terraform investment, Pulumi is a strong choice. TerraDart is for teams who already use Terraform and don't want to give that up.
+**HCL** is the native, mature option. If your team is comfortable maintaining HCL alongside your Dart application code, there is no urgency to switch. TerraDart's value proposition only matters once the cost of context-switching between Dart and HCL — and the absence of refactor / typecheck across that boundary — starts to bite.
 
-**TerraDart** makes sense when you're already centered on Dart (Flutter + Functions / Cloud Run), already using Terraform, and the gap between those two — IaC stuck in HCL — is the part that hurts.
+**CDKTF** would have been the obvious model to follow, except it was archived by HashiCorp in December 2025 and never targeted Dart in any case. TerraDart is the Dart-shaped slot CDKTF did not reach.
+
+**Pulumi** is a different model entirely: its own runtime, its own state, and its own resource graph. If you want a code-first IaC platform and you do not already have Terraform investment, Pulumi is a strong choice. TerraDart is for teams who already use Terraform and do not want to give that up.
+
+**TerraDart** makes sense when you are already centered on Dart (Flutter + Cloud Run / Cloud Run functions), already using Terraform (or heading there), and the gap between those two — IaC stuck outside your Dart repo — is the part that hurts.
+
+## Curated provider coverage
+
+[`terradart_google`](https://pub.dev/packages/terradart_google) does not wrap every resource in the upstream HashiCorp `google` provider. It ships **typed factories for a growing, battle-tested subset** — see [status](/docs/status/) and [Architecture — Provider integration](/docs/architecture/#provider-integration). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart-cookbook) (both expanding).
 
 ## Non-goals
 
@@ -120,4 +105,8 @@ This prevents two foot-guns: forgetting to extend (using `implements` would skip
 - Not a constructs framework in the pre-alpha cycle.
 - Not module-block support — compose Terraform modules in HCL alongside TerraDart-generated `*.tf.json`; both feed the same `terraform apply`.
 
-Ready to see how it fits together? Read the [Architecture](/docs/architecture/) page for the synth pipeline and provider chain.
+## Next steps
+
+- [Architecture](/docs/architecture/) — `synth()` / `writeTo()`, provider integration, AppExport
+- [Getting Started](/docs/getting-started/) — install and first `*.tf.json` output (in progress)
+- [Status](/docs/status/) — pre-alpha expectations

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -9,7 +9,7 @@ interface Props {
 const {
   title = "TerraDart — Type-safe IaC for Dart",
   description =
-    "Google Cloud infrastructure as real Dart code — typed, refactor-safe, drop-in for terraform apply.",
+    "Google Cloud infrastructure as Dart — generate *.tf.json for the terraform apply pipeline you already run.",
 } = Astro.props;
 
 const url = Astro.site

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 import Header from "../components/Header.astro";
 import Hero from "../components/Hero.astro";
+import PitchCode from "../components/PitchCode.astro";
 import Mission from "../components/Mission.astro";
 import Comparison from "../components/Comparison.astro";
 import Pipeline from "../components/Pipeline.astro";
@@ -12,30 +13,33 @@ import Footer from "../components/Footer.astro";
   <Header />
   <main>
     <Hero />
+    <PitchCode />
     <Mission
-      eyebrow="Mission"
-      heading="Bring the last non-Dart layer into Dart."
+      eyebrow="Why TerraDart"
+      heading="Connect infra and app code with types"
       cards={[
         {
-          title: "UI and server are already Dart",
-          body: "Flutter handles the UI. Cloud Functions and Cloud Run services run your Dart. For teams already centered on Dart, infrastructure is often the one layer still outside your repo&nbsp;&mdash; carried in HCL and manual console work, separate from the language your app, tests, and refactors already share.",
+          title: "A boundary held together by string literals",
+          body: "Topic names in HCL or the console and again in your Cloud Run functions handlers. Renames do not reach subscribers via <code>dart fix</code>. IAM members drift with no compiler visibility. Infra values flowing into app code are often the layer Dart&rsquo;s type system never sees.",
         },
         {
-          title: "Terraform&rsquo;s surface, absorbed",
-          body: "TerraDart is not a parallel runtime. It is Terraform&rsquo;s authoring model expressed as Dart factories and sealed types, synthesized to standard JSON for the provider you already use.",
+          title: "Terraform stays the execution layer",
+          body: "TerraDart is not a parallel runtime. Write Terraform&rsquo;s resource model as Dart factories and sealed types, then <strong>generate</strong> <code>*.tf.json</code> for the provider you already use. <code>terraform plan</code>, <code>apply</code>, and remote state stay unchanged.",
         },
         {
-          title: "Discipline by design",
-          body: "Fixed-value fields become enums. Exactly-one-of blocks become sealed classes. Plain <code>Stack</code> subclasses&nbsp;&mdash; loops, config, and refactors work the way Dart already does.",
+          title: "Dart types where HCL cannot help",
+          body: "Fixed values become enums. Exactly-one-of blocks become sealed classes. Your infra module is a <code>final class … extends Stack</code>&nbsp;&mdash; loops, config, and refactors work like any other Dart code.",
         },
       ]}
     />
-    <p style="text-align: center; margin-top: 1.5rem;">
+    <p class="lp-cta">
       <a href="/docs/why-terradart/" class="link-mark">Read the design rationale →</a>
     </p>
     <Comparison
       eyebrow="Compare"
-      heading="Where TerraDart sits"
+      heading="Where TerraDart fits"
+      intro="TerraDart fits teams already centered on <strong>Dart</strong>, already running <strong>Terraform</strong> (or a compatible pipeline) or managing GCP in the <strong>console</strong>, where the seam between infra and app code hurts."
+      footnote="HCL has provider schema types; CDKTF bindings are typed in TypeScript and other languages. TerraDart&rsquo;s difference is <strong>Dart-native authoring</strong> without replacing your Terraform execution pipeline."
       columns={["TerraDart", "HCL", "CDKTF", "Pulumi"]}
       rows={[
         {
@@ -47,7 +51,7 @@ import Footer from "../components/Footer.astro";
           cells: ["Yes", "Yes", "Yes", "Different model"],
         },
         {
-          label: "Typed GCP resource API",
+          label: "Curated Dart factories for GCP",
           cells: ["Yes", "No", "No", "No"],
         },
         {
@@ -56,27 +60,29 @@ import Footer from "../components/Footer.astro";
         },
       ]}
     />
-    <p style="text-align: center; margin-top: 1.5rem;">
-      <a href="/docs/why-terradart/#how-it-fits-next-to-other-iac" class="link-mark">See full comparison →</a>
+    <p class="lp-cta">
+      <a href="/docs/why-terradart/#how-it-fits-next-to-other-iac" class="link-mark"
+        >See full comparison →</a
+      >
     </p>
     <Pipeline
       eyebrow="Pipeline"
-      heading="Dart down into infrastructure"
+      heading="How it works in three steps"
       steps={[
         {
           title: "Author in Dart",
           body: "Subclass Stack with curated google_* factories from terradart_google.",
         },
         {
-          title: "Synthesize",
-          body: "Stack.writeTo writes *.tf.json — no custom apply runtime.",
+          title: "Generate Terraform JSON",
+          body: "stack.writeTo(...) writes *.tf.json — no custom apply runtime.",
         },
         {
           title: "Apply with Terraform",
           body: "terraform plan and apply unchanged; state stays where it is.",
         },
       ]}
-      footnote={`Expanded guide: <a href="/docs/architecture/" class="link-mark">/docs/architecture</a> · <a href="https://github.com/nozomi-koborinai/terradart/blob/main/README.md" class="link-mark">README</a>`}
+      footnote={`Details: <a href="/docs/architecture/" class="link-mark">/docs/architecture</a> · <a href="https://github.com/nozomi-koborinai/terradart/blob/main/README.md" class="link-mark">README</a>`}
     />
   </main>
   <Footer />

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -258,12 +258,85 @@
     }
   }
 
-  .hero-visual-caption {
+  /* Pitch code (LP) */
+  .pitch-code-section .pitch-code-lead {
     margin-top: 1.25rem;
-    max-width: 16rem;
-    font-size: 0.875rem;
-    line-height: 1.45;
+    max-width: 42rem;
+    font-size: 1rem;
+    line-height: 1.55;
     color: var(--color-mute);
+  }
+
+  .pitch-code-section .pitch-code-lead code {
+    color: var(--color-ink);
+    font-size: 0.9em;
+  }
+
+  .pitch-code-figure .terra-stratum {
+    margin-top: 1.75rem;
+    margin-bottom: 0;
+  }
+
+  .pitch-code-wrap {
+    overflow-x: auto;
+    border-bottom: 1px solid var(--color-rule);
+  }
+
+  .pitch-code-wrap :global(pre.shiki) {
+    margin: 0;
+    padding: 1.25rem 0 1.5rem;
+    background-color: var(--color-paper) !important;
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    line-height: 1.55;
+  }
+
+  .pitch-code-wrap :global(pre.shiki code) {
+    font-family: inherit;
+    font-size: inherit;
+  }
+
+  .pitch-code-meta {
+    margin-top: 1.25rem;
+    max-width: 42rem;
+    font-size: 0.9375rem;
+    line-height: 1.55;
+    color: var(--color-mute);
+  }
+
+  .pitch-code-meta code {
+    color: var(--color-ink);
+    font-size: 0.9em;
+  }
+
+  .compare-intro {
+    margin-top: 1.25rem;
+    max-width: 42rem;
+    font-size: 1rem;
+    line-height: 1.55;
+    color: var(--color-mute);
+  }
+
+  .compare-footnote {
+    margin-top: 1.5rem;
+    max-width: 42rem;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    color: var(--color-mute);
+  }
+
+  /* Centered doc links between LP sections (breathing room before rule-top) */
+  .lp-cta {
+    text-align: center;
+    margin: 2rem 0 3.5rem;
+    padding: 0 1.5rem;
+  }
+
+  @media (min-width: 768px) {
+    .lp-cta {
+      margin-bottom: 4.5rem;
+      padding: 0 2.5rem;
+    }
   }
 
   /* Buttons — Inter, not mono (BRAND: Regular humanist) */


### PR DESCRIPTION
## Summary

- Rework the landing page messaging (Hero, example code, mission, comparison, pipeline).
- Add a Shiki-highlighted Dart pitch snippet (Cloud SQL + Cloud Run with cloud-sql-proxy sidecar).
- Rewrite Why TerraDart and Architecture docs to match LP tone; remove duplicated Astro components on the docs page.
- Document `synth()` vs plain-language “generate” on Architecture; note curated `terradart_google` coverage.

## Test plan

- [x] `cd website && bun run build`
- [x] Spot-check `/`, `/docs/why-terradart/`, `/docs/architecture/`