### PR TITLE
v0.12.1 — fix MCP structuredContent (object, not array) + Intel macOS binary

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -14,18 +14,30 @@ jobs:
         include:
           - os: macos-14
             asset: terradart-mcp-darwin-arm64
-          - os: macos-13
+            dart_arch: arm64
+          # Intel macOS: Dart has no cross-compile, and GitHub's Intel
+          # (macos-13) runners are scarce, so build the x64 binary on an Apple
+          # Silicon runner using the x64 Dart SDK under Rosetta 2.
+          - os: macos-14
             asset: terradart-mcp-darwin-amd64
+            dart_arch: x64
+            rosetta: true
           - os: ubuntu-22.04
             asset: terradart-mcp-linux-amd64
+            dart_arch: x64
           - os: windows-latest
             asset: terradart-mcp-windows-amd64.exe
+            dart_arch: x64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+      - name: Install Rosetta 2 (for the x64 Dart SDK on Apple Silicon)
+        if: matrix.rosetta
+        run: sudo softwareupdate --install-rosetta --agree-to-license
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable
+          architecture: ${{ matrix.dart_arch }}
       - run: dart pub get
       - name: Compile binary
         working-directory: packages/terradart_agent

--- a/README.md
+++ b/README.md
@@ -125,13 +125,13 @@ GoogleCloudRunV2Service(
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 ```
 
 ```bash
 dart pub get
-dart pub global activate terradart_codegen ^0.12.0      # only if you need
+dart pub global activate terradart_codegen ^0.12.1      # only if you need
                                                          # codegen for non-curated
                                                          # google_* resources
 dart run bin/infra.dart                                  # synth → tf-out/
@@ -191,7 +191,7 @@ Application platform & operations
 
 ## Status
 
-Pre-1.0 (v0.12.0). No SemVer guarantees until v1.0.0; pin to a specific `^0.12.x` minor and read [`MIGRATING.md`](MIGRATING.md) before bumping. Breaking changes are still permitted within the 0.x line and are documented per-release.
+Pre-1.0 (v0.12.1). No SemVer guarantees until v1.0.0; pin to a specific `^0.12.x` minor and read [`MIGRATING.md`](MIGRATING.md) before bumping. Breaking changes are still permitted within the 0.x line and are documented per-release.
 
 ## Schema-bump automation (Plan 5.E)
 

--- a/examples/bigquery_quickstart/pubspec.yaml
+++ b/examples/bigquery_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_build_quickstart/pubspec.yaml
+++ b/examples/cloud_build_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_functions_quickstart/pubspec.yaml
+++ b/examples/cloud_functions_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_quickstart/pubspec.yaml
+++ b/examples/cloud_run_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_scheduler_quickstart/pubspec.yaml
+++ b/examples/cloud_scheduler_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_sql_quickstart/pubspec.yaml
+++ b/examples/cloud_sql_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_tasks_quickstart/pubspec.yaml
+++ b/examples/cloud_tasks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_lb_quickstart/pubspec.yaml
+++ b/examples/compute_lb_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_quickstart/pubspec.yaml
+++ b/examples/compute_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dns_quickstart/pubspec.yaml
+++ b/examples/dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_check_quickstart/pubspec.yaml
+++ b/examples/firebase_app_check_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_hosting_quickstart/pubspec.yaml
+++ b/examples/firebase_app_hosting_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_data_connect_quickstart/pubspec.yaml
+++ b/examples/firebase_data_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_remote_config_quickstart/pubspec.yaml
+++ b/examples/firebase_remote_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_document_quickstart/pubspec.yaml
+++ b/examples/firestore_document_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_quickstart/pubspec.yaml
+++ b/examples/firestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iam_quickstart/pubspec.yaml
+++ b/examples/iam_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_quickstart/pubspec.yaml
+++ b/examples/kms_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/monitoring_quickstart/pubspec.yaml
+++ b/examples/monitoring_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ops_quickstart/pubspec.yaml
+++ b/examples/ops_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/pubsub_quickstart/pubspec.yaml
+++ b/examples/pubsub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/secret_manager_quickstart/pubspec.yaml
+++ b/examples/secret_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_quickstart/pubspec.yaml
+++ b/examples/storage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/terradart_agent/CHANGELOG.md
+++ b/packages/terradart_agent/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.1
+
+- **Fixed** — `list_resources` and `list_barrels` now return a JSON object (`{"resources": [...]}` / `{"barrels": [...]}`) instead of a bare array. MCP requires a tool result's `structuredContent` to be an object (record), so strict clients (e.g. Cursor) rejected the previous array form with "expected record, received array".
+- **Added** — Intel macOS (`terradart-mcp-darwin-amd64`) binary, built on an Apple Silicon runner via Rosetta 2 (Dart has no cross-compile, and GitHub's Intel runners are scarce).
+
 ## 0.12.0
 
 Initial release.

--- a/packages/terradart_agent/lib/src/server.dart
+++ b/packages/terradart_agent/lib/src/server.dart
@@ -53,18 +53,25 @@ Future<GenkitMcpServer> buildTerradartMcpServer() async {
         ),
       },
     ),
-    fn: (input, _) async => listResources(
-      terradartCatalog,
-      barrel: input['barrel'] as String?,
-    ).map((r) => r.toJson()).toList(),
+    // Wrapped in an object: MCP requires `structuredContent` to be a JSON
+    // object (record), not a bare array, or strict clients reject the result.
+    fn: (input, _) async => <String, Object?>{
+      'resources': listResources(
+        terradartCatalog,
+        barrel: input['barrel'] as String?,
+      ).map((r) => r.toJson()).toList(),
+    },
   );
 
   ai.defineTool<Map<String, dynamic>, Object>(
     name: 'list_barrels',
     description: 'List per-service barrels with resource counts.',
     inputSchema: _objectSchema(),
-    fn: (input, _) async =>
-        listBarrels(terradartCatalog).map((b) => b.toJson()).toList(),
+    // Wrapped in an object (see list_resources): `structuredContent` must be
+    // a JSON object, not a bare array.
+    fn: (input, _) async => <String, Object?>{
+      'barrels': listBarrels(terradartCatalog).map((b) => b.toJson()).toList(),
+    },
   );
 
   ai.defineTool<Map<String, dynamic>, Object>(

--- a/packages/terradart_agent/lib/src/version.dart
+++ b/packages/terradart_agent/lib/src/version.dart
@@ -1,4 +1,4 @@
 /// The terradart-mcp binary version, kept in lockstep with pubspec.yaml's
 /// `version:` field by `tool/bump_version.sh`. The lockstep is guarded by
 /// test/version_test.dart so the two can never silently drift.
-const String packageVersion = '0.12.0';
+const String packageVersion = '0.12.1';

--- a/packages/terradart_agent/pubspec.yaml
+++ b/packages/terradart_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_agent
 description: terradart-mcp — MCP server exposing the curated GCP factory catalog of TerraDart.
-version: 0.12.0
+version: 0.12.1
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -16,8 +16,8 @@ executables:
   terradart-mcp: terradart_mcp
 
 dependencies:
-  terradart_core: ^0.12.0
-  terradart_google: ^0.12.0
+  terradart_core: ^0.12.1
+  terradart_google: ^0.12.1
   genkit: ^0.13.2
   genkit_mcp: ^0.1.7
   schemantic: ^0.1.3

--- a/packages/terradart_agent/test/server_test.dart
+++ b/packages/terradart_agent/test/server_test.dart
@@ -10,8 +10,8 @@ void main() {
       'method': 'tools/list',
       'id': 1,
     });
-    final tools = ((resp!['result'] as Map)['tools'] as List)
-        .map((t) => (t as Map)['name'] as String)
+    final tools = ((resp!['result'] as Map<String, Object?>)['tools'] as List)
+        .map((t) => (t as Map<String, Object?>)['name'] as String)
         .toList();
     expect(
       tools,
@@ -24,7 +24,7 @@ void main() {
     );
   });
 
-  test('tools/call round-trips real catalog data', () async {
+  test('tools/call returns object structuredContent with real data', () async {
     final server = await buildTerradartMcpServer();
     Future<Map<String, dynamic>> call(
       String name, [
@@ -39,20 +39,36 @@ void main() {
       return resp!['result'] as Map<String, dynamic>;
     }
 
+    // MCP requires `structuredContent` to be a JSON object (record), not a
+    // bare array; strict clients (e.g. Cursor) reject arrays. Assert every
+    // tool returns an object — this is the regression guard for that bug.
     final barrels = await call('list_barrels', <String, dynamic>{});
     expect(barrels['isError'], isNot(true));
-    expect(barrels['structuredContent'], isA<List<Object?>>());
-    expect(barrels['structuredContent'] as List, isNotEmpty);
+    expect(
+      barrels['structuredContent'],
+      isA<Map<String, Object?>>(),
+      reason: 'structuredContent must be a JSON object, not an array',
+    );
+    expect(
+      (barrels['structuredContent'] as Map<String, Object?>)['barrels'] as List,
+      isNotEmpty,
+    );
 
     final pubsub = await call('list_resources', {'barrel': 'pubsub'});
-    final entries = pubsub['structuredContent'] as List;
+    expect(pubsub['structuredContent'], isA<Map<String, Object?>>());
+    final entries =
+        (pubsub['structuredContent'] as Map<String, Object?>)['resources']
+            as List;
     expect(entries, isNotEmpty);
-    expect(entries.map((e) => (e as Map)['barrel']).toSet(), {'pubsub'});
+    expect(entries.map((e) => (e as Map<String, Object?>)['barrel']).toSet(), {
+      'pubsub',
+    });
 
     final schema = await call('get_resource_schema', {
       'name': 'google_pubsub_topic',
     });
-    final sc = schema['structuredContent'] as Map;
+    expect(schema['structuredContent'], isA<Map<String, Object?>>());
+    final sc = schema['structuredContent'] as Map<String, Object?>;
     expect(sc['found'], isTrue);
     expect(
       sc.keys,
@@ -64,9 +80,15 @@ void main() {
       ]),
     );
 
+    final quickstart = await call('get_quickstart', {
+      'scenario': 'cloud-run-webhook',
+    });
+    expect(quickstart['structuredContent'], isA<Map<String, Object?>>());
+
     // Argument-free call to an optional-param tool must NOT error
     // (regression guard for the null-safe parse fix).
     final noArgs = await call('list_resources');
     expect(noArgs['isError'], isNot(true));
+    expect(noArgs['structuredContent'], isA<Map<String, Object?>>());
   });
 }

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.1
+
+No user-facing changes. Lockstep version bump alongside the `terradart_agent` v0.12.1 fix. `terradart_core` constraint bumped to `^0.12.1`.
+
 ## 0.12.0
 
 Adds static-catalog emission so the curated `terradart_google` surface can be introspected without loading or analyzing the wrapper source. Powers the new `terradart-mcp` server (`terradart_agent`).

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart Stage 1 codegen — parses Terraform provider schema JSON and Magic Modules YAML and emits annotated abstract Dart classes. Ships the terradart CLI.
-version: 0.12.0
+version: 0.12.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -28,7 +28,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.12.0
+  terradart_core: ^0.12.1
 
 dev_dependencies:
   http: ^1.0.0

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.1
+
+No user-facing API changes. Lockstep version bump alongside the `terradart_agent` v0.12.1 fix (MCP `structuredContent` object shape). The `terradart_core` public surface is unchanged from 0.12.0.
+
 ## 0.12.0
 
 No user-facing API changes. Lockstep version bump alongside the rest of the workspace for the v0.12.0 release (`terradart_codegen` static-catalog emission, `terradart_google` generated catalog, and the new `terradart_agent` / `terradart-mcp` package). The `terradart_core` public surface is unchanged from 0.11.0.

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.12.0
+version: 0.12.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.1
+
+No user-facing changes. Lockstep version bump alongside the `terradart_agent` v0.12.1 fix. The generated catalog and public surface are unchanged from 0.12.0.
+
 ## 0.12.0
 
 **ADDED** — ships a generated static catalog of the curated factory surface. Additive change; no breaking modifications to the v0.11.0 API and no resource additions or removals (still 118 curated GCP factories + 1 data source).

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: Curated factory wrappers for 118 Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.
-version: 0.12.0
+version: 0.12.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,11 +18,11 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.0
+  terradart_core: ^0.12.1
   meta: ^1.15.0
 
 dev_dependencies:
-  terradart_codegen: ^0.12.0
+  terradart_codegen: ^0.12.1
   path: ^1.9.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/website/src/content/docs/docs/agent/install.md
+++ b/website/src/content/docs/docs/agent/install.md
@@ -38,7 +38,7 @@ sudo mv terradart-mcp-darwin-arm64 /usr/local/bin/terradart-mcp
 
 ```sh
 terradart-mcp --version
-# terradart-mcp 0.12.0
+# terradart-mcp 0.12.1
 ```
 
 If you see the version printed, the binary is ready. Next, point an MCP client at it: [Connecting clients](/docs/agent/clients/).

--- a/website/src/content/docs/docs/agent/tools-reference.md
+++ b/website/src/content/docs/docs/agent/tools-reference.md
@@ -29,13 +29,15 @@ Lists the per-service barrels with their resource counts. No arguments.
 {}
 ```
 
-**Output** — an array of `{ name, resource_count }`, one entry per barrel (26 in total):
+**Output** — an object with a `barrels` array of `{ name, resource_count }`, one entry per barrel (26 in total):
 
 ```json
-[
-  { "name": "compute", "resource_count": 34 },
-  { "name": "pubsub", "resource_count": 5 }
-]
+{
+  "barrels": [
+    { "name": "compute", "resource_count": 34 },
+    { "name": "pubsub", "resource_count": 5 }
+  ]
+}
 ```
 
 Use this first to see what services TerraDart covers and how large each one is.
@@ -56,21 +58,23 @@ Lists curated resources and data sources. Pass `barrel` to filter to one service
 {}
 ```
 
-**Output** — an array of `{ name, barrel, summary }`:
+**Output** — an object with a `resources` array of `{ name, barrel, summary }`:
 
 ```json
-[
-  {
-    "name": "google_pubsub_topic",
-    "barrel": "pubsub",
-    "summary": "A named resource to which messages are sent by publishers."
-  },
-  {
-    "name": "google_pubsub_subscription",
-    "barrel": "pubsub",
-    "summary": "A named resource representing the stream of messages."
-  }
-]
+{
+  "resources": [
+    {
+      "name": "google_pubsub_topic",
+      "barrel": "pubsub",
+      "summary": "A named resource to which messages are sent by publishers."
+    },
+    {
+      "name": "google_pubsub_subscription",
+      "barrel": "pubsub",
+      "summary": "A named resource representing the stream of messages."
+    }
+  ]
+}
 ```
 
 The `name` is the Terraform type name — exactly what you pass to `get_resource_schema`.


### PR DESCRIPTION
## Summary

- **Fix:** `list_barrels` / `list_resources` now return an object (`{ "barrels": [...] }` / `{ "resources": [...] }`) instead of a bare array — MCP requires `structuredContent` to be a record, so strict clients (e.g. Cursor) rejected the array.
- **Add:** Intel macOS (`terradart-mcp-darwin-amd64`) binary via Rosetta on an Apple Silicon runner.
- Lockstep bump to v0.12.1.