### PR TITLE
docs: align v0.12.x docs, site, and consistency checks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-or-question.yml
+++ b/.github/ISSUE_TEMPLATE/bug-or-question.yml
@@ -6,8 +6,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to file. terradart is a pre-alpha (v0.0.x)
-        single-maintainer project; triage is best-effort.
+        Thanks for taking the time to file. terradart is **pre-alpha** on
+        **0.12.x** today (beta planned from v0.13.0). Single-maintainer;
+        triage is best-effort. See https://terradart.dev/docs/status/
 
         **PII note**: synthesized `.tf.json`, error output, and schema excerpts
         may contain GCP project IDs, GCS bucket names, service account emails,

--- a/.github/workflows/docs-consistency.yml
+++ b/.github/workflows/docs-consistency.yml
@@ -1,0 +1,31 @@
+name: Docs consistency
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: docs-consistency-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docs_consistency:
+    name: docs consistency + pubsub smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - run: dart pub get
+      - name: Docs caret + catalog count
+        run: dart tool/check_docs_consistency.dart
+      - name: Pub/Sub quickstart smoke
+        run: |
+          chmod +x tool/smoke_quickstart.sh
+          tool/smoke_quickstart.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,30 @@
 
 All notable changes to terradart are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-Per-package changelogs live alongside each package and are the system of record for `terradart_core`, `terradart_codegen`, and `terradart_google` — this top-level file summarises cross-cutting milestones.
+Per-package changelogs live alongside each package and are the system of record for `terradart_core`, `terradart_codegen`, `terradart_google`, and `terradart_agent` — this top-level file summarises cross-cutting milestones.
 
-## [0.11.0] - 2026-MM-DD
+## [0.12.1] - 2026-05-25
+
+Lockstep patch across the workspace. **No breaking changes** to `terradart_core` or `terradart_google`.
+
+### Fixed
+
+- **`terradart-mcp`** — `list_resources` and `list_barrels` return JSON objects (`{"resources": [...]}`) instead of bare arrays so strict MCP clients (e.g. Cursor) accept `structuredContent`.
+
+### Added
+
+- **`terradart-mcp`** — Intel macOS (`darwin-amd64`) release binary.
+
+## [0.12.0] - 2026-05-25
+
+Pre-alpha milestone: static curated catalog, optional MCP agent tooling. **No breaking changes** to `terradart_core` or `terradart_google` vs `0.11.0`. See [MIGRATING.md](MIGRATING.md#011x--012x) (0.11.x → 0.12.x).
+
+### Added
+
+- **`terradart_google`** — generated static catalog (`terradartCatalog`) for discovery and MCP; 119 curated factories + 1 data source unchanged.
+- **`terradart_agent` / `terradart-mcp`** — read-only MCP server (four catalog tools); Homebrew + GitHub Releases binary (`publish_to: none`).
+
+## [0.11.0] - 2026-05-23
 
 Pre-1.0 polish wave focused on the `terradart_core` public surface. All three packages bump from 0.10.0 to 0.11.0 in lockstep. Coordinated breaking changes from ADR-0016 (codegen identifier rename) and ADR-0017 (Stack API surface). See [MIGRATING.md](MIGRATING.md) for before / after snippets covering every breaking change in this release.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
 # Contributing to terradart
 
-Thanks for taking time to look at this. terradart is a pre-alpha single-maintainer project; contributions are welcome on a best-effort basis.
+Thanks for taking time to look at this. terradart is a **pre-alpha** single-maintainer project (0.12.x today; [beta planned at v0.13.0](https://terradart.dev/docs/status/#beta-readiness-checklist)). Contributions are welcome on a best-effort basis.
 
 ## What kind of contribution?
 
 terradart's surface splits into two layers:
 
-- **Built-in factories** — the curated `google_*` factory wrappers that ship in [`terradart_google`](packages/terradart_google/README.md) (28 resources + 1 data source as of v0.1.0-dev). Bug fixes, test cases, doc improvements welcome. New resources are accepted as curated `wrap` overrides — open an issue first to discuss scope.
+- **Built-in factories** — the curated `google_*` factory wrappers that ship in [`terradart_google`](packages/terradart_google/README.md) (**119 curated resource factories + 1 data source** as of 0.12.x). Bug fixes, test cases, doc improvements welcome. New resources are accepted as curated `wrap` overrides — open an issue first to discuss scope.
 - **Generated bindings** — output of `terradart codegen` for every other `google_*` / `google-beta_*` resource. Best-effort; codegen template fixes welcome.
 
-Both are pre-alpha (v0.x.y-dev) — emitted Dart symbol names may change between dev releases.
+Within a **minor** line (`^0.12.x`), we aim to avoid breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (stricter from v0.13.0 beta — see [status](https://terradart.dev/docs/status/)).
 
 Bug reports / questions: see the [Bug or question](.github/ISSUE_TEMPLATE/bug-or-question.yml) template.
 
@@ -33,6 +33,10 @@ dart test
 # Run static analysis (must pass with zero issues)
 dart analyze --fatal-infos --fatal-warnings
 
+# Docs / quickstart consistency (same as CI)
+dart tool/check_docs_consistency.dart
+tool/smoke_quickstart.sh
+
 # Format check
 dart format --set-exit-if-changed .
 ```
@@ -49,6 +53,8 @@ Before opening a PR:
 
 - [ ] `dart analyze --fatal-infos --fatal-warnings` passes.
 - [ ] `dart test` passes (full suite, not just one package).
+- [ ] `dart tool/check_docs_consistency.dart` passes when you touch versions or catalog counts.
+- [ ] `tool/smoke_quickstart.sh` passes when you touch `pubsub_quickstart` or synth/export paths.
 - [ ] `dart format` was run.
 
 ## Review cadence

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,3 +1,39 @@
+# Migrating terradart
+
+## 0.11.x → 0.12.x
+
+There are **no breaking changes** to the `terradart_core` or `terradart_google`
+public APIs compared with `0.11.0`. Bump all three pub packages in lockstep:
+
+```yaml
+dependencies:
+  terradart_core: ^0.12.0
+  terradart_google: ^0.12.0
+```
+
+```bash
+dart pub global activate terradart_codegen ^0.12.0
+```
+
+(`0.12.1` is a lockstep patch for `terradart_agent` / MCP — same steps.)
+
+### Additive in 0.12.0
+
+- **`terradart_google`** — static `terradartCatalog` in
+  `package:terradart_google/catalog.dart` (metadata only; factory APIs unchanged).
+  Still **119 curated resource factories + 1 data source**.
+- **`terradart-mcp`** (optional) — MCP catalog server binary; not on pub.dev.
+  See [Agent install](https://terradart.dev/docs/agent/install/).
+
+### 0.12.1
+
+- MCP `list_resources` / `list_barrels` return JSON objects, not bare arrays
+  (strict MCP `structuredContent` clients).
+
+No Stack source edits are required when upgrading from `0.11.0`.
+
+---
+
 # Migrating from terradart 0.10.0 to 0.11.0
 
 This guide covers every breaking change introduced between `0.10.0` and

--- a/README.md
+++ b/README.md
@@ -202,13 +202,13 @@ GoogleCloudRunV2Service(
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.12.1
-  terradart_google: ^0.12.1
+  terradart_core: ^0.12.x
+  terradart_google: ^0.12.x
 ```
 
 ```bash
 dart pub get
-dart pub global activate terradart_codegen ^0.12.1      # only if you need
+dart pub global activate terradart_codegen ^0.12.x      # only if you need
                                                          # codegen for non-curated
                                                          # google_* resources
 dart run bin/infra.dart                                  # synth → tf-out/
@@ -279,7 +279,7 @@ Application platform & operations
 
 ## Status
 
-**Pre-alpha**, pre-1.0 (v0.12.1). No SemVer guarantees until v1.0.0; pin to a specific `^0.12.x` minor and read [`MIGRATING.md`](MIGRATING.md) before bumping. Breaking changes are still permitted within the 0.x line and are documented per-release. Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
+**Pre-alpha**, pre-1.0 (0.12.x). No SemVer guarantees until v1.0.0; pin `^0.12.x` and read [`MIGRATING.md`](MIGRATING.md) before every minor bump. Beta is planned from **v0.13.0** once [readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met. Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
 
 ## Schema-bump automation (Plan 5.E)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,14 +31,17 @@ What does **not** count:
 
 ## Supported versions
 
+Pin dependencies with `^0.12.x` on [pub.dev](https://pub.dev/packages/terradart_core) today.
+
 | Version | Status | Security fixes |
 |---|---|---|
-| 0.0.x (pre-alpha) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
-| 0.1.x | TBD on release | Will be supported per the policy below once 0.1.0 ships |
+| **0.12.x** (pre-alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
+| **0.11.x and older** | Unsupported | Upgrade to 0.12.x; see [MIGRATING.md](MIGRATING.md) |
+| **0.13.x** (beta, planned) | Best-effort with clearer minor-boundary policy | See [status on terradart.dev](https://terradart.dev/docs/status/) |
 
 ## Disclosure policy
 
-**Best-effort, target 90 days** from confirmed-report to public advisory. As a single-maintainer pre-alpha (v0.0.x), we cannot guarantee this window — straightforward fixes typically ship within 30 days; fixes requiring upstream changes (provider schema, Dart SDK) may exceed 90 days. Reporters will be kept informed of timeline shifts on the embargoed advisory thread.
+**Best-effort, target 90 days** from confirmed-report to public advisory. As a single-maintainer pre-alpha project, we cannot guarantee this window — straightforward fixes typically ship within 30 days; fixes requiring upstream changes (provider schema, Dart SDK) may exceed 90 days. Reporters will be kept informed of timeline shifts on the embargoed advisory thread.
 
 CVE IDs are requested via GitHub's CNA on advisory publication.
 
@@ -50,4 +53,4 @@ Single-maintainer project. If you receive no acknowledgement within 10 business 
 
 ## Supply-chain assurance
 
-terradart is published to pub.dev by `nozomi-koborinai` via GitHub Actions OIDC trusted publishing (see `.github/workflows/publish.yml`). Verify the [pub.dev publisher](https://pub.dev/packages/terradart/publisher) before depending on releases. Report any package on pub.dev impersonating terradart through the channels above.
+terradart is published to pub.dev by `nozomi-koborinai` via GitHub Actions OIDC trusted publishing (see `.github/workflows/publish.yml`). Verify the [pub.dev publisher](https://pub.dev/packages/terradart_core/publisher) before depending on releases. Report any package on pub.dev impersonating terradart through the channels above.

--- a/examples/compute_quickstart/README.md
+++ b/examples/compute_quickstart/README.md
@@ -15,7 +15,7 @@ examples/compute_quickstart/
 ├── lib/main.dart        # NetworkStack: VPC + load-balancer VIP
 ├── bin/infra.dart       # Synth entry: stack.writeTo('tf-out')
 ├── tf-out/              # (created on synth) main.tf.json
-└── pubspec.yaml         # workspace member with hosted carets (terradart_core: ^0.10.0)
+└── pubspec.yaml         # workspace member (terradart_core: ^0.12.x)
 ```
 
 ## Usage

--- a/examples/pubsub_quickstart/README.md
+++ b/examples/pubsub_quickstart/README.md
@@ -1,6 +1,6 @@
 # Pub/Sub quickstart
 
-The smallest end-to-end terradart example. Provisions a `google_pubsub_topic`, a `google_pubsub_subscription` (push mode), and a `google_pubsub_topic_iam_member` -- and exports the topic's resource ID as a typed Dart constant for a subscriber to import.
+The smallest end-to-end terradart example. Provisions a `google_pubsub_topic`, a `google_pubsub_subscription` (push mode), and a `google_pubsub_topic_iam_member` — and exports the topic name as a typed Dart constant for a subscriber to import.
 
 ## Prerequisites
 
@@ -12,25 +12,31 @@ The smallest end-to-end terradart example. Provisions a `google_pubsub_topic`, a
 
 ```
 examples/pubsub_quickstart/
-├── lib/main.dart        # Defines OrdersStack (topic + subscription + IAM)
-├── bin/infra.dart       # Synth entry point: stack.writeTo('tf-out')
-├── lib/generated/       # (created on synth) orders_stack.app.dart -- typed export
-├── tf-out/              # (created on synth) main.tf.json -- terraform input
-└── pubspec.yaml         # workspace member with hosted carets (terradart_core: ^0.10.0)
+├── lib/main.dart           # OrdersStack (topic + subscription + exports)
+├── lib/subscriber_stub.dart # Imports generated constants (boundary demo)
+├── bin/infra.dart          # Synth: stack.writeTo('tf-out')
+├── lib/generated/          # (created on synth) orders_stack.app.dart
+├── tf-out/                 # (created on synth) main.tf.json
+└── pubspec.yaml
 ```
 
 ## Usage
 
 ```bash
-# 1. Resolve deps (workspace member with hosted carets — siblings are picked up via `resolution: workspace`).
+# 1. From repo root (workspace member):
 dart pub get
+cd examples/pubsub_quickstart && dart pub get
 
-# 2. Edit `lib/main.dart` -- replace `YOUR-PROJECT-ID` with your GCP project.
+# 2. Set your GCP project:
+export GCP_PROJECT_ID=YOUR-PROJECT-ID
 
-# 3. Synth:
+# 3. Synth (writes tf-out/ and lib/generated/orders_stack.app.dart):
 dart run bin/infra.dart
 
-# 4. Apply with Terraform:
+# 4. Verify the boundary stub analyzes:
+dart analyze .
+
+# 5. Apply with Terraform:
 cd tf-out
 terraform init
 terraform plan
@@ -42,6 +48,7 @@ terraform apply
 - A Pub/Sub topic `orders-prod` with 7-day retention.
 - A push subscription `orders-push` targeting `https://app.example.com/push` (replace with your real endpoint).
 - An IAM grant of `roles/pubsub.publisher` to a publisher service account.
+- Terraform outputs for computed IDs; Dart constant `OrdersStackExports.ORDERS_TOPIC_NAME` for the literal topic name.
 
 ## Expected `tf-out/main.tf.json` (excerpt)
 
@@ -57,33 +64,18 @@ terraform apply
   "resource": {
     "google_pubsub_topic": {
       "orders": { "name": "orders-prod", "message_retention_duration": "604800s" }
-    },
-    "google_pubsub_subscription": {
-      "orders_push": {
-        "name": "orders-push",
-        "topic": "${google_pubsub_topic.orders.id}",
-        "ack_deadline_seconds": 60,
-        "push_config": { "push_endpoint": "https://app.example.com/push" }
-      }
-    },
-    "google_pubsub_topic_iam_member": {
-      "orders_publisher": {
-        "topic": "${google_pubsub_topic.orders.name}",
-        "role": "roles/pubsub.publisher",
-        "member": "serviceAccount:publisher@YOUR-PROJECT-ID.iam.gserviceaccount.com"
-      }
     }
   },
   "output": {
-    "ORDERS_TOPIC_ID": {
-      "value": "${google_pubsub_topic.orders.id}"
-    }
+    "ORDERS_TOPIC_NAME": { "value": "orders-prod" },
+    "ORDERS_TOPIC_ID": { "value": "${google_pubsub_topic.orders.id}" }
   }
 }
 ```
 
-The seam: `lib/generated/orders_stack.app.dart` will contain `OrdersStackExports.ORDERS_TOPIC_ID` -- a typed Dart constant that a Firebase Functions Dart subscriber imports directly. No `terraform output` JSON parsing needed.
+The seam: `lib/generated/orders_stack.app.dart` contains `OrdersStackExports.ORDERS_TOPIC_NAME` — import it from app code (see `lib/subscriber_stub.dart`) instead of hand-typing `"orders-prod"`.
 
 ## Next steps
 
 - See [iam_quickstart](../iam_quickstart/) for all four curated IAM resources at once.
+- See [terradart.dev — Getting Started](https://terradart.dev/docs/getting-started/) for the full walkthrough.

--- a/examples/pubsub_quickstart/bin/infra.dart
+++ b/examples/pubsub_quickstart/bin/infra.dart
@@ -1,9 +1,9 @@
 /// Synth entry point. Run `dart run bin/infra.dart` to emit
 /// `tf-out/main.tf.json`.
 ///
-/// Note: `topic.id` is a Terraform-computed reference, so the Dart
-/// constants file is not generated at synth time — use `terraform output`
-/// to read `orders_topic_id` after apply.
+/// Writes `tf-out/main.tf.json` and `lib/generated/orders_stack.app.dart`
+/// (literal exports such as `ORDERS_TOPIC_NAME`). Computed exports like
+/// `ORDERS_TOPIC_ID` appear as Terraform outputs only.
 ///
 /// Requires the GCP_PROJECT_ID environment variable.
 library;

--- a/examples/pubsub_quickstart/lib/generated/orders_stack.app.dart
+++ b/examples/pubsub_quickstart/lib/generated/orders_stack.app.dart
@@ -1,0 +1,10 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// terradart synth output for stack: OrdersStack
+// dart format off
+// ignore_for_file: type=lint
+
+abstract final class OrdersStackExports {
+  OrdersStackExports._();
+
+  static const String ORDERS_TOPIC_NAME = r'orders-prod';
+}

--- a/examples/pubsub_quickstart/lib/main.dart
+++ b/examples/pubsub_quickstart/lib/main.dart
@@ -49,9 +49,14 @@ final class OrdersStack extends Stack {
       ),
     );
 
-    // The seam: export topic.id as a Dart constant for the subscriber.
-    // Emit a Terraform `output` so subscribers without Dart codegen can also
-    // resolve it via `terraform output orders_topic_id`.
+    // Literal topic name — emitted as a Dart constant at synth time (see
+    // lib/generated/orders_stack.app.dart). Subscribers compare against this.
+    addExport(
+      'ORDERS_TOPIC_NAME',
+      ResourceIdExport(topic.nameRef, emitTerraformOutput: true),
+    );
+
+    // Full resource ID — Terraform output only (computed until after apply).
     addExport(
       'ORDERS_TOPIC_ID',
       ResourceIdExport(topic.id, emitTerraformOutput: true),

--- a/examples/pubsub_quickstart/lib/subscriber_stub.dart
+++ b/examples/pubsub_quickstart/lib/subscriber_stub.dart
@@ -1,0 +1,10 @@
+/// Illustrates the IaC ↔ app seam: import synth-generated exports instead of
+/// hand-typing topic names. Run `dart run bin/infra.dart` first to refresh
+/// `lib/generated/orders_stack.app.dart`.
+library;
+
+import 'generated/orders_stack.app.dart';
+
+/// Example handler shape (not wired to a real Pub/Sub runtime).
+bool acceptsTopic(String eventTopic) =>
+    eventTopic == OrdersStackExports.ORDERS_TOPIC_NAME;

--- a/packages/terradart_codegen/README.md
+++ b/packages/terradart_codegen/README.md
@@ -5,18 +5,18 @@ Codegen for [terradart](https://github.com/nozomi-koborinai/terradart). Parses `
 This package ships the `terradart` CLI with three subcommands:
 
 - **`terradart codegen`** — for any `google_*` resource that isn't already in [`terradart_google`](https://pub.dev/packages/terradart_google). Emits annotated abstract Dart classes into your own `lib/generated/` directory; you then run `build_runner` to produce the concrete bindings.
-- **`terradart wrap`** — used by `terradart_google` maintainers to regenerate the 28 curated factory wrappers + their schema carriers from YAML overrides under `lib/src/codegen/wrapper_overrides/yaml/`. Run with `--check` in CI to verify the wrap output stays byte-identical (deterministic codegen guarantee).
+- **`terradart wrap`** — used by `terradart_google` maintainers to regenerate the **119 curated** factory wrappers + their schema carriers from YAML overrides under `wrapper_overrides/yaml/`. Run with `--check` in CI to verify the wrap output stays byte-identical (deterministic codegen guarantee).
 - **`terradart wrap-promote`** — scans a curated override yaml against the parsed schema and proposes `enum_values` blocks + `dartTypeOverrides` entries for fields whose schema declares a fixed value set. Authors review and integrate manually so naming choices stay with the human.
 
 ## Installation
 
-`terradart_codegen` ships the `terradart` CLI. terradart is a SemVer pre-release, so activate with an explicit version:
+`terradart_codegen` ships the `terradart` CLI. Activate on the same minor line as your workspace:
 
 ```bash
-dart pub global activate terradart_codegen 0.1.0-dev
+dart pub global activate terradart_codegen ^0.12.x
 ```
 
-(`dart pub global activate terradart_codegen` without an explicit version skips pre-releases.)
+Check [pub.dev](https://pub.dev/packages/terradart_codegen) for the latest patch.
 
 ## Quickstart: emit bindings for any other resource
 

--- a/packages/terradart_core/README.md
+++ b/packages/terradart_core/README.md
@@ -6,47 +6,37 @@ This package ships the small set of primitives every terradart Stack uses:
 
 - `Stack` — abstract base for your infrastructure module. You subclass it (`final class MyStack extends Stack`), register `Resource` / `Data` instances via `add(...)` / `addData(...)`, and call `stack.writeTo('tf-out')` from your own `main()` to emit `main.tf.json`.
 - `Resource` / `Data` — typed nodes supplied by curated factories (in `terradart_google`) or generated bindings (from `terradart_codegen`).
-- `TfArg.literal(...)` / `TfArg.ref(...)` — the only two ways every settable field accepts input. `TfArg<MyEnum>.literal(MyEnum.foo)` now encodes typed Dart enums (see below).
+- `TfArg.literal(...)` / `TfArg.ref(...)` — the only two ways every settable field accepts input. `TfArg<MyEnum>.literal(MyEnum.foo)` encodes typed Dart enums (see below).
 - `LifecycleOptions` — `create_before_destroy`, `prevent_destroy`, `ignore_changes`, `replace_triggered_by`.
 - `Stack.synth()` returns an in-memory `SynthResult` with `tfJson` (Terraform JSON map) and optional `dartConstants` (typed Dart constants for the IaC ↔ application seam). `Stack.writeTo(outDir)` is the file-IO wrapper that calls `synth()` and writes `main.tf.json` (plus any `dartConstants`) under `outDir`.
 
 This package is the **runtime layer only**. It is intentionally small and dependency-free. The companion packages are:
 
 - [`terradart_codegen`](https://pub.dev/packages/terradart_codegen) — the codegen / `terradart` CLI that turns `terraform providers schema -json` into typed Dart bindings.
-- [`terradart_google`](https://pub.dev/packages/terradart_google) — 28 curated GCP factory wrappers + 1 data source, plus generated schema carriers.
+- [`terradart_google`](https://pub.dev/packages/terradart_google) — **119 curated GCP factories + 1 data source**, plus generated schema carriers.
 
-For project-level documentation, see the [terradart repo README](https://github.com/nozomi-koborinai/terradart#readme).
+For project-level documentation, see the [terradart repo README](https://github.com/nozomi-koborinai/terradart#readme) and [terradart.dev](https://terradart.dev/docs/getting-started/).
 
 ## Typed enum serialization
 
-`TfArgLiteral.toTfJson()` detects values that satisfy a small convention and serializes them to the Terraform string:
+Hand-rolled and codegen-emitted enums implement `TerraformEnum` with a `terraformValue` getter. `TfArgLiteral.toTfJson()` encodes them to Terraform strings; missing conventions throw `ArgumentError` at synth time.
 
 ```dart
-enum RoutingMode {
+enum RoutingMode implements TerraformEnum {
   regional('REGIONAL'),
   global('GLOBAL');
 
   const RoutingMode(this.terraformValue);
+  @override
   final String terraformValue;
 }
-
-// In your Stack:
-GoogleComputeNetwork(
-  localName: 'main',
-  name: TfArg.literal('main-vpc'),
-  routingMode: TfArg.literal(RoutingMode.regional), // encodes to "REGIONAL"
-);
 ```
-
-The runtime throws `ArgumentError` (not silent wrong-output) if you pass an enum value whose type does not implement the `.terraformValue` getter, so missing-getter bugs surface at synth time rather than as bad Terraform JSON. String / int / num / bool literals pass through unchanged.
-
-`terradart_google` 0.1.0-dev uses this convention for every fixed-value-set field in its 28 curated resources.
 
 ## Installation
 
-terradart is a SemVer pre-release. By default `dart pub get` skips pre-release versions; opt in explicitly:
-
 ```yaml
 dependencies:
-  terradart_core: ^0.1.0-dev
+  terradart_core: ^0.12.x
 ```
+
+Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch. Read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before minor bumps.

--- a/packages/terradart_google/README.md
+++ b/packages/terradart_google/README.md
@@ -1,120 +1,24 @@
 # terradart_google
 
-Curated GCP factory wrappers for [terradart](https://github.com/nozomi-koborinai/terradart). 70 curated resource factories + 1 data source, each shipping with typed Dart enums for fixed-value-set fields, typed helper classes for every nested block, and golden-tested deterministic codegen.
+Curated GCP factory wrappers for [terradart](https://github.com/nozomi-koborinai/terradart). Ships **119 curated resource factories + 1 data source** (120 catalog entries) with typed enums, sealed nested blocks, and golden-tested deterministic codegen.
 
-## Resources
-
-### BigQuery (4)
-
-- `GoogleBigqueryDataset` (8-variant sealed `Access` hierarchy), `GoogleBigqueryTable`, `GoogleBigqueryDatasetIamMember`, `GoogleBigqueryTableIamMember`.
-
-### Cloud Functions (2)
-
-- `GoogleCloudfunctions2Function` (Gen 2; typed `BuildConfig`, `ServiceConfig`, `EventTrigger`), `GoogleCloudfunctions2FunctionIamMember`.
-
-### Cloud Run v2 (4)
-
-- `GoogleCloudRunV2Service` (sealed `EnvVarSource`, sealed `VolumeSource`; typed `Ingress`, `LaunchStage`, `Template`, `ServiceContainer`, etc.), `GoogleCloudRunV2Job`, `GoogleCloudRunV2ServiceIamMember`, `GoogleCloudRunV2JobIamMember`.
-
-### Cloud Scheduler (1)
-
-- `GoogleCloudSchedulerJob` (Pub/Sub / HTTP / AppEngine targets).
-
-### Cloud SQL (3)
-
-- `GoogleSqlDatabaseInstance` (typed `DatabaseVersion`, `SqlActivationPolicy`, `IpConfiguration`, `BackupConfiguration`, `InsightsConfig`), `GoogleSqlDatabase`, `GoogleSqlUser`.
-
-### Cloud Tasks (2)
-
-- `GoogleCloudTasksQueue` (typed `RateLimits`, `RetryConfig`, `QueueHttpTarget`), `GoogleCloudTasksQueueIamMember`.
-
-### Compute (9)
-
-- `GoogleComputeNetwork`, `GoogleComputeAddress`, `GoogleComputeSubnetwork`, `GoogleComputeFirewall`, `GoogleComputeInstance` (typed `BootDisk`, `NetworkInterface`, `Scheduling`, etc.), `GoogleComputeGlobalAddress`, `GoogleComputeInstanceIamMember`, `GoogleComputeDiskIamMember`, `GoogleComputeSubnetworkIamMember`.
-
-### DNS (2)
-
-- `GoogleDnsManagedZone` (typed `DnsZoneVisibility`, `DnssecState`; helpers for private visibility / DNSSEC / peering / forwarding), `GoogleDnsManagedZoneIamMember`.
-
-### Firebase App Check (7)
-
-- `GoogleFirebaseAppCheckRecaptchaEnterpriseConfig`, `GoogleFirebaseAppCheckPlayIntegrityConfig`, `GoogleFirebaseAppCheckAppAttestConfig`, `GoogleFirebaseAppCheckDeviceCheckConfig`, `GoogleFirebaseAppCheckServiceConfig` (shared `AppCheckEnforcementMode` enum), `GoogleFirebaseAppCheckDebugToken`, `GoogleFirebaseAppCheckResourcePolicy`.
-
-### Firebase App Hosting (5)
-
-- `GoogleFirebaseAppHostingBackend`, `GoogleFirebaseAppHostingBuild`, `GoogleFirebaseAppHostingDefaultDomain`, `GoogleFirebaseAppHostingDomain`, `GoogleFirebaseAppHostingTraffic`.
-
-### Firebase Data Connect (1)
-
-- `GoogleFirebaseDataConnectService`.
-
-### Firebase Remote Config (1)
-
-- `GoogleFirebaseRemoteConfigRemoteConfig`.
-
-### Firestore (5)
-
-- `GoogleFirestoreDatabase`, `GoogleFirestoreField`, `GoogleFirestoreIndex`, `GoogleFirestoreBackupSchedule`, `GoogleFirestoreUserCreds`.
-
-### IAM (6)
-
-- `GoogleServiceAccount` (pre-formatted `member` ref), `GoogleProjectIamMember`, `GoogleProjectIamCustomRole` (typed `CustomRoleStage`), `GoogleServiceAccountIamMember`, `GoogleServiceAccountKey` (typed `KeyAlgorithm`, `PrivateKeyType`; `private_key` masked at synth time), `GoogleIamWorkloadIdentityPool` (typed `WorkloadIdentityPoolMode`).
-
-### KMS (4)
-
-- `GoogleKmsKeyRing`, `GoogleKmsCryptoKey` (typed `KmsKeyPurpose`, `KmsProtectionLevel`, `VersionTemplate`), `GoogleKmsCryptoKeyIamMember`, `GoogleKmsKeyRingIamMember`.
-
-### Logging (1)
-
-- `GoogleLoggingProjectSink` (typed `BigqueryOptions`, `LogSinkExclusion`).
-
-### Monitoring (1)
-
-- `GoogleMonitoringAlertPolicy` (typed `Comparison`, `Aligner` 19 variants, `Reducer` 14 variants; `AlertCondition` covering 6 mutually-exclusive condition variants).
-
-### Project enablement (1)
-
-- `GoogleProjectService`.
-
-### Pub/Sub (4)
-
-- `GooglePubsubTopic`, `GooglePubsubSubscription` (typed `PushConfig`, `BigQueryConfig`, `CloudStorageConfig`, `DeadLetterPolicy`, `RetryPolicy`), `GooglePubsubTopicIamMember`, `GooglePubsubSubscriptionIamMember`.
-
-### Secret Manager (3)
-
-- `GoogleSecretManagerSecret` (sealed `Replication` for auto / userManaged variants), `GoogleSecretManagerSecretVersion` (write-only `secret_data_wo`), `GoogleSecretManagerSecretIamMember`.
-
-### Service Networking (1)
-
-- `GoogleServiceNetworkingConnection`.
-
-### Cloud Storage (3)
-
-- `GoogleStorageBucket` (typed `BucketStorageClass`, `LifecycleRule`, `Versioning`, `RetentionPolicy`, etc.), `GoogleStorageBucketObject` (sealed `BucketObjectContent` for source / content exactly-one-of), `GoogleStorageBucketIamMember`.
-
-### Data sources (1)
-
-- `GoogleProject` (project number lookup).
+The full per-service breakdown lives in the [repo README — What ships](https://github.com/nozomi-koborinai/terradart#what-ships). Discover factories programmatically via `package:terradart_google/catalog.dart` (`terradartCatalog`).
 
 ## How resources are built
 
-The factory wrappers under `lib/src/<service>/` are emitted by `terradart wrap` from curated overrides under [`terradart_codegen`](https://pub.dev/packages/terradart_codegen). They are committed to the package so consumers can depend on `terradart_google` directly without running any codegen themselves.
+Factory wrappers under `lib/src/<service>/` are emitted by `terradart wrap` from curated overrides in [`terradart_codegen`](https://pub.dev/packages/terradart_codegen). They are committed so consumers depend on `terradart_google` without running codegen.
 
-CI verifies determinism via `terradart wrap --check`: all 71 emitted files (70 resource wrappers + 1 data source) must stay byte-identical across PRs.
+CI verifies determinism via `terradart wrap --check`. For any other `google_*` resource, run `terradart codegen` in your own project.
 
-For any other `google_*` / `google-beta_*` resource that isn't in the catalog above, run `terradart codegen` against your provider schema dump and emit bindings into your own `lib/generated/` rather than depending on this package.
-
-For the runtime side (`Stack`, `Resource`, `Stack.synth` / `Stack.writeTo`), see [`terradart_core`](https://pub.dev/packages/terradart_core). For project-level documentation, see the [terradart repo README](https://github.com/nozomi-koborinai/terradart#readme).
+Runtime primitives (`Stack`, `TfArg`, `writeTo`) live in [`terradart_core`](https://pub.dev/packages/terradart_core).
 
 ## Installation
 
 ```yaml
 dependencies:
-  terradart_core: ^0.1.0-dev
-  terradart_google: ^0.1.0-dev
+  terradart_core: ^0.12.x
+  terradart_google: ^0.12.x
 ```
-
-terradart is a SemVer pre-release; explicit `^0.1.0-dev` constraints are required because `dart pub get` skips pre-releases by default.
 
 ## Usage example
 
@@ -128,26 +32,13 @@ final class AssetsStack extends Stack {
       : super(providers: [
           GoogleProvider(project: projectId, region: 'asia-northeast1'),
         ]) {
-    add(
-      GoogleStorageBucket(
-        localName: 'assets',
-        name: TfArg.literal('my-app-assets-prod'),
-        location: TfArg.literal('ASIA-NORTHEAST1'),
-        storageClass: TfArg.literal(BucketStorageClass.standard), // typed enum
-        versioning: const Versioning(enabled: true),              // typed helper
-        lifecycleRule: const [
-          LifecycleRule(
-            action: LifecycleAction(
-              type: LifecycleActionType.setStorageClass,
-              storageClass: BucketStorageClass.archive,
-            ),
-            condition: LifecycleCondition(age: 365),
-          ),
-        ],
-      ),
-    );
+    add(GoogleStorageBucket(
+      localName: 'assets',
+      name: TfArg.literal('my-app-assets-prod'),
+      storageClass: TfArg.literal(BucketStorageClass.standard),
+    ));
   }
 }
 ```
 
-See the 20 runnable quickstart projects under [`examples/`](https://github.com/nozomi-koborinai/terradart/tree/main/examples) for end-to-end usage of every service.
+See [examples/](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [pubsub quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart) for AppExport / boundary patterns.

--- a/packages/terradart_google/test/catalog/catalog_count_test.dart
+++ b/packages/terradart_google/test/catalog/catalog_count_test.dart
@@ -4,12 +4,10 @@ import 'package:test/test.dart';
 void main() {
   test('terradartCatalog holds one entry per curated resource + data source',
       () {
-    // 119 curated resources + 1 data source (google_project). This must move
-    // in lockstep with the wrap file-count assertion in
-    // terradart_codegen/test/cli/wrap_command_test.dart (121 = 120 wrappers
-    // + the generated _catalog.g.dart). If `terradart wrap` regenerates a
-    // different count, update both together.
-    expect(terradartCatalog, hasLength(120));
+    // Sync catalogEntryCount in tool/doc_expectations.dart (also checked by
+    // tool/check_docs_consistency.dart). Must move in lockstep with wrap
+    // file-count in terradart_codegen/test/cli/wrap_command_test.dart.
+    expect(terradartCatalog, hasLength(120)); // catalogEntryCount
   });
 
   test('every catalog entry is well-formed', () {

--- a/tool/check_docs_consistency.dart
+++ b/tool/check_docs_consistency.dart
@@ -1,0 +1,123 @@
+// check_docs_consistency.dart — verifies docs caret minors and catalog counts.
+//
+// Run from repo root: dart tool/check_docs_consistency.dart
+// ignore_for_file: avoid_print
+
+import 'dart:io';
+
+import 'doc_expectations.dart';
+
+void main() {
+  final errors = <String>[];
+
+  final minor = _workspaceMinor();
+  print('Workspace minor: 0.$minor.x (from packages/terradart_core/pubspec.yaml)');
+
+  _checkCaretMinor(
+    errors,
+    minor,
+    'README.md',
+    mustContain: [curatedCatalogPhrase, catalogEntriesPhrase],
+  );
+  _checkCaretMinor(errors, minor, 'CONTRIBUTING.md', mustContain: [curatedCatalogPhrase]);
+  _checkCaretMinor(errors, minor, 'SECURITY.md');
+  _checkCaretMinor(errors, minor, 'packages/terradart_core/README.md');
+  _checkCaretMinor(errors, minor, 'packages/terradart_google/README.md', mustContain: [curatedCatalogPhrase]);
+  _checkCaretMinor(errors, minor, 'packages/terradart_codegen/README.md');
+  _checkCaretMinor(
+    errors,
+    minor,
+    'website/src/content/docs/docs/getting-started.md',
+  );
+  _checkCaretMinor(errors, minor, '.github/ISSUE_TEMPLATE/bug-or-question.yml');
+
+  for (final example in _exampleDirs()) {
+    final pubspec = File('examples/$example/pubspec.yaml');
+    if (!pubspec.existsSync()) continue;
+    final text = pubspec.readAsStringSync();
+    if (!text.contains('^0.$minor.')) {
+      errors.add('examples/$example/pubspec.yaml: expected caret ^0.$minor.x');
+    }
+  }
+
+  for (final readme in _exampleReadmes()) {
+    final text = File(readme).readAsStringSync();
+    if (text.contains(RegExp(r'\^0\.(\d+)\.0-dev'))) {
+      errors.add('$readme: stale ^0.x.0-dev constraint');
+    }
+    if (text.contains('^0.') && !text.contains('^0.$minor.')) {
+      final hasOld =
+          RegExp(r'\^0\.(10|11|1)\.').hasMatch(text) || text.contains('^0.1.0-dev');
+      if (hasOld) {
+        errors.add('$readme: caret minor should be ^0.$minor.x');
+      }
+    }
+  }
+
+  if (errors.isEmpty) {
+    print('check_docs_consistency: OK');
+    exit(0);
+  }
+  stderr.writeln('check_docs_consistency: FAILED');
+  for (final e in errors) {
+    stderr.writeln('  - $e');
+  }
+  exit(1);
+}
+
+int _workspaceMinor() {
+  final pubspec = File('packages/terradart_core/pubspec.yaml').readAsStringSync();
+  final match = RegExp(r'^version:\s*0\.(\d+)\.\d+', multiLine: true).firstMatch(pubspec);
+  if (match == null) {
+    stderr.writeln('Could not parse packages/terradart_core/pubspec.yaml version');
+    exit(2);
+  }
+  return int.parse(match.group(1)!);
+}
+
+void _checkCaretMinor(
+  List<String> errors,
+  int minor,
+  String path, {
+  List<String> mustContain = const [],
+}) {
+  final file = File(path);
+  if (!file.existsSync()) {
+    errors.add('Missing file: $path');
+    return;
+  }
+  final text = file.readAsStringSync();
+  final caret = '^0.$minor.x';
+  if (!text.contains(caret) && !text.contains('^0.$minor.')) {
+    if (path.endsWith('.yml')) {
+      if (!text.contains('0.$minor')) {
+        errors.add('$path: expected reference to 0.$minor.x line');
+      }
+    } else {
+      errors.add('$path: expected $caret (or ^0.$minor.N patch caret)');
+    }
+  }
+  for (final phrase in mustContain) {
+    if (!text.contains(phrase)) {
+      errors.add('$path: expected phrase "$phrase"');
+    }
+  }
+}
+
+List<String> _exampleDirs() {
+  return Directory('examples')
+      .listSync()
+      .whereType<Directory>()
+      .map((d) => d.path.split('/').last)
+      .where((name) => name.endsWith('_quickstart'))
+      .toList();
+}
+
+List<String> _exampleReadmes() {
+  return Directory('examples')
+      .listSync()
+      .whereType<Directory>()
+      .map((d) => '${d.path}/README.md')
+      .where((p) => File(p).existsSync())
+      .toList();
+}

--- a/tool/doc_expectations.dart
+++ b/tool/doc_expectations.dart
@@ -1,0 +1,10 @@
+/// Single source of truth for docs consistency checks and catalog tests.
+///
+/// Update [catalogEntryCount] in lockstep with
+/// `packages/terradart_google/test/catalog/catalog_count_test.dart`.
+library;
+
+const catalogEntryCount = 120;
+const curatedFactoryCount = 119;
+const curatedCatalogPhrase = '119 curated';
+const catalogEntriesPhrase = '120 catalog';

--- a/tool/smoke_quickstart.sh
+++ b/tool/smoke_quickstart.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Smoke-test the pubsub quickstart (boundary / AppExport path).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+EXAMPLE="$ROOT/examples/pubsub_quickstart"
+
+cd "$ROOT"
+dart pub get
+
+cd "$EXAMPLE"
+export GCP_PROJECT_ID="${GCP_PROJECT_ID:-ci-test-project-id}"
+dart pub get
+dart run bin/infra.dart
+dart analyze --fatal-infos --fatal-warnings .
+
+echo "smoke_quickstart: OK"

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,9 +1,18 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 import starlight from "@astrojs/starlight";
 import mdx from "@astrojs/mdx";
 import rehypeMermaid from "rehype-mermaid";
 import starlightLlmsTxt from "starlight-llms-txt";
+
+const websiteDir = dirname(fileURLToPath(import.meta.url));
+const mermaidInit = readFileSync(
+  join(websiteDir, "src/scripts/mermaid-init.mjs"),
+  "utf8",
+);
 
 // https://astro.build/config
 export default defineConfig({
@@ -77,10 +86,7 @@ export default defineConfig({
         {
           tag: "script",
           attrs: { type: "module" },
-          content: `
-import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-mermaid.initialize({ startOnLoad: true });
-          `.trim(),
+          content: mermaidInit,
         },
       ],
     }),

--- a/website/src/components/Pipeline.astro
+++ b/website/src/components/Pipeline.astro
@@ -14,25 +14,92 @@ interface Props {
 const { eyebrow = "Pipeline", heading, steps, footnote } = Astro.props;
 ---
 
-<section class="section rule-top">
-  <div class="container-edit section-inner">
-    <p class="section-label">{eyebrow}</p>
-    <h2 class="display-section">{heading}</h2>
+<section class="td-pipeline">
+  <p class="td-pipeline-eyebrow">{eyebrow}</p>
+  <h2 class="td-pipeline-heading">{heading}</h2>
 
-    <ol class="pipeline">
-      {
-        steps.map((step, i) => (
-          <li class="pipeline-step">
-            <span class="pipeline-index">{i + 1}</span>
-            <div class="pipeline-body">
-              <h3 class="pipeline-title">{step.title}</h3>
-              <p set:html={step.body} />
-            </div>
-          </li>
-        ))
-      }
-    </ol>
-
-    {footnote && <p class="section-footnote" set:html={footnote} />}
+  <div class="td-pipeline-list" role="list">
+    {
+      steps.map((step, i) => (
+        <div class="td-pipeline-step" role="listitem">
+          <span class="td-pipeline-index" aria-hidden="true">
+            {i + 1}
+          </span>
+          <div class="td-pipeline-body">
+            <h3 class="td-pipeline-title">{step.title}</h3>
+            <p set:html={step.body} />
+          </div>
+        </div>
+      ))
+    }
   </div>
+
+  {footnote && <p class="td-pipeline-footnote" set:html={footnote} />}
 </section>
+
+<style is:global>
+  .td-pipeline {
+    margin: 2rem 0;
+  }
+
+  .td-pipeline-eyebrow {
+    font-family: var(--font-mono, var(--sl-font-mono));
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-mute, var(--sl-color-gray-3));
+    margin: 0 0 0.5rem;
+  }
+
+  .td-pipeline-heading {
+    font-size: 1.5rem;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    margin: 0 0 0.5rem;
+  }
+
+  .td-pipeline-list {
+    display: grid;
+    gap: 0;
+    margin: 1.5rem 0 0;
+    padding: 0;
+  }
+
+  .td-pipeline-step {
+    display: grid;
+    grid-template-columns: 2.5rem 1fr;
+    gap: 1.25rem;
+    padding: 1.75rem 0;
+    border-top: 1px solid var(--color-rule, var(--sl-color-hairline));
+  }
+
+  .td-pipeline-step:last-child {
+    border-bottom: 1px solid var(--color-rule, var(--sl-color-hairline));
+  }
+
+  .td-pipeline-index {
+    font-family: var(--font-mono, var(--sl-font-mono));
+    font-size: 0.8125rem;
+    color: var(--color-accent, var(--sl-color-accent));
+    padding-top: 0.15rem;
+  }
+
+  .td-pipeline-title {
+    font-size: 1.0625rem;
+    font-weight: 500;
+    margin: 0 0 0.35rem;
+  }
+
+  .td-pipeline-body p {
+    font-size: 0.95rem;
+    color: var(--color-mute, var(--sl-color-gray-3));
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  .td-pipeline-footnote {
+    margin-top: 1rem;
+    font-size: 0.9rem;
+    color: var(--color-mute, var(--sl-color-gray-3));
+  }
+</style>

--- a/website/src/components/StarlightSiteTitle.astro
+++ b/website/src/components/StarlightSiteTitle.astro
@@ -21,7 +21,20 @@ if (typeof config.title === "string") {
 ---
 
 <a href="/" class="site-title">
-  <img src="/logo-horizontal.svg" alt="" width="140" height="28" class="site-title-logo" />
+  <img
+    src="/logo-horizontal.svg"
+    alt=""
+    width="140"
+    height="28"
+    class="site-title-logo site-title-logo--light"
+  />
+  <img
+    src="/logo-horizontal-dark.svg"
+    alt=""
+    width="140"
+    height="28"
+    class="site-title-logo site-title-logo--dark"
+  />
   <span class="sr-only">{title}</span>
 </a>
 
@@ -44,5 +57,17 @@ if (typeof config.title === "string") {
     overflow: hidden;
     clip: rect(0, 0, 0, 0);
     border: 0;
+  }
+</style>
+
+<style is:global>
+  .site-title-logo--dark {
+    display: none;
+  }
+  html[data-theme="dark"] .site-title-logo--light {
+    display: none;
+  }
+  html[data-theme="dark"] .site-title-logo--dark {
+    display: inline;
   }
 </style>

--- a/website/src/content/docs/docs/agent/index.md
+++ b/website/src/content/docs/docs/agent/index.md
@@ -10,7 +10,7 @@ It is built with [genkit_mcp](https://pub.dev/packages/genkit_mcp) (Genkit's MCP
 ## How it fits together
 
 ```mermaid
-flowchart TB
+graph LR
   agent["coding agent<br/>(Claude Code / Cursor / Claude Desktop)"]
   mcp["terradart-mcp<br/>list_barrels · list_resources<br/>get_resource_schema · get_quickstart"]
   catalog["static catalog in terradart_google<br/>120 entries · 26 service barrels"]

--- a/website/src/content/docs/docs/agent/install.md
+++ b/website/src/content/docs/docs/agent/install.md
@@ -38,7 +38,7 @@ sudo mv terradart-mcp-darwin-arm64 /usr/local/bin/terradart-mcp
 
 ```sh
 terradart-mcp --version
-# terradart-mcp 0.12.1
+# terradart-mcp 0.12.x
 ```
 
 If you see the version printed, the binary is ready. Next, point an MCP client at it: [Connecting clients](/docs/agent/clients/).

--- a/website/src/content/docs/docs/architecture.mdx
+++ b/website/src/content/docs/docs/architecture.mdx
@@ -102,7 +102,7 @@ Two export kinds cover most cases:
 - **`ResourceIdExport`** — for values that aren't known until apply time, like a Cloud Run service URL. Pass `emitTerraformOutput: true` and Terraform writes the resolved value into its output. Application code can fetch it via `terraform output -raw <name>`.
 - **`StringExport`** — for literals known at synth time (service name, region, project ID). These materialize as `static const` declarations on the generated `<StackName>Exports` class in your `.app.dart` file — `dart analyze` catches rename drift before you ever `terraform apply`.
 
-Calling `setAppExportsOutputPath(...)` is what triggers the `.app.dart` emission. With only `ResourceIdExport`s registered, the generated constants file would have nothing to put on the class, and `writeTo` skips writing it.
+Calling `setAppExportsOutputPath(...)` is what triggers the `.app.dart` emission. Exports whose values are only known after apply (for example `ResourceIdExport(topic.id)`) emit Terraform `output` blocks only; literal-resolvable exports (for example `ResourceIdExport(topic.nameRef)`) become typed Dart constants. Runnable pattern: [pubsub quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart) (`lib/subscriber_stub.dart`).
 
 A worked end-to-end example lives in the [terradart-cookbook `single-project-app` recipe](https://github.com/nozomi-koborinai/terradart-cookbook/tree/main/recipes/single-project-app), exporting `coffee_service_uri` (Terraform output), `SERVICE_NAME`, and `REGION` (Dart constants).
 

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -3,19 +3,103 @@ title: Getting Started
 description: Install TerraDart and generate your first *.tf.json from a Stack.
 ---
 
-:::note[Coming soon]
-This page tracks the v0.12.0 API surface and will be expanded with end-to-end walkthroughs after the release.
-:::
+This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.12.x** line. TerraDart is **pre-alpha** until [beta gates](/docs/status/#beta-readiness-checklist) are complete (planned label: **v0.13.0**).
 
-## Meanwhile
+## Prerequisites
 
-1. Read the [README Quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) on GitHub.
-2. Run the [Pub/Sub quickstart example](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart).
-3. Pin the published packages with `^0.12.0` (see the current version on [pub.dev](https://pub.dev/packages/terradart_core)).
+- Dart SDK ≥ 3.6
+- Terraform CLI ≥ 1.11.0
+- A GCP project with Pub/Sub enabled and Application Default Credentials (`gcloud auth application-default login`)
 
-## Outline (planned)
+## 1. Add dependencies
 
-- Add `terradart_core` and `terradart_google` to `pubspec.yaml`
-- Implement a `final class XxxStack extends Stack` subclass
-- Call `stack.writeTo('tf-out')` from `bin/infra.dart`
-- Run `terraform init` / `apply` in `tf-out/`
+```yaml
+# pubspec.yaml
+dependencies:
+  terradart_core: ^0.12.x
+  terradart_google: ^0.12.x
+```
+
+Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch, then run:
+
+```bash
+dart pub get
+```
+
+Codegen for non-curated `google_*` resources is optional:
+
+```bash
+dart pub global activate terradart_codegen ^0.12.x
+```
+
+## 2. Define a Stack
+
+Create `lib/orders_stack.dart` (or follow the [pubsub quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart)):
+
+```dart
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/provider.dart';
+import 'package:terradart_google/pubsub.dart';
+
+final class OrdersStack extends Stack {
+  OrdersStack({required String projectId})
+      : super(providers: [GoogleProvider(project: projectId)]) {
+    final topic = add(GooglePubsubTopic(
+      localName: 'orders',
+      name: TfArg.literal('orders-prod'),
+    ));
+    addExport('ORDERS_TOPIC_NAME', ResourceIdExport(topic.nameRef));
+    setAppExportsOutputPath('lib/generated/orders_stack.app.dart');
+  }
+}
+```
+
+## 3. Synth Terraform JSON
+
+From `bin/infra.dart`:
+
+```dart
+import 'package:my_pkg/orders_stack.dart';
+
+Future<void> main() async {
+  final stack = OrdersStack(projectId: 'YOUR-PROJECT-ID');
+  await stack.writeTo('tf-out');
+}
+```
+
+```bash
+dart run bin/infra.dart
+```
+
+This writes `tf-out/main.tf.json` and, when exports are literal-resolvable, `lib/generated/orders_stack.app.dart`.
+
+## 4. Plan and apply
+
+```bash
+cd tf-out
+terraform init
+terraform plan
+terraform apply
+```
+
+Your existing remote state backend and modules stay unchanged — TerraDart only replaces HCL/JSON authoring.
+
+## 5. The boundary (optional)
+
+Import generated constants in app code instead of string literals:
+
+```dart
+import 'generated/orders_stack.app.dart';
+
+bool acceptsTopic(String eventTopic) =>
+    eventTopic == OrdersStackExports.ORDERS_TOPIC_NAME;
+```
+
+Rename `orders-prod` in the Stack without updating the subscriber and `dart analyze` fails. See [Architecture — AppExport](/docs/architecture/#appexport-the-iac--app-seam) and the runnable [pubsub quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart) (`lib/subscriber_stub.dart`).
+
+## Next steps
+
+- [Why TerraDart](/docs/why-terradart/) — motivation and comparisons
+- [Architecture](/docs/architecture/) — `synth()`, `writeTo()`, curated coverage
+- [Status & versioning](/docs/status/) — pre-alpha vs beta vs 1.0
+- [Examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and [cookbook](https://github.com/nozomi-koborinai/terradart-cookbook) for fuller stacks

--- a/website/src/content/docs/docs/index.md
+++ b/website/src/content/docs/docs/index.md
@@ -5,14 +5,14 @@ description: Guides for TerraDart — type-safe Google Cloud IaC for Dart.
 
 Welcome to the TerraDart docs.
 
-Several guides are **in progress** while the v0.12.x API surface stabilizes. Until they are complete, use the [README on GitHub](https://github.com/nozomi-koborinai/terradart/blob/main/README.md) and the [examples directory](https://github.com/nozomi-koborinai/terradart/tree/main/examples).
+Guides track the **0.12.x** line on pub.dev. The repo [README](https://github.com/nozomi-koborinai/terradart/blob/main/README.md) and [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) stay the deepest references; this site mirrors onboarding and release expectations.
 
 ## Guides
 
+- [Getting Started](/docs/getting-started/) — install, first `*.tf.json`, boundary export
 - [Why TerraDart](/docs/why-terradart/) — motivation, comparison, and curated coverage
 - [Architecture](/docs/architecture/) — generate `*.tf.json`, `synth()` / `writeTo()`, AppExport
-- [Getting Started](/docs/getting-started/) — installation and first output (coming soon)
-- [Status & versioning](/docs/status/) — pre-alpha expectations
+- [Status & versioning](/docs/status/) — pre-alpha, beta readiness (from v0.13.0), 1.0
 
 ## For AI assistants
 

--- a/website/src/content/docs/docs/status.md
+++ b/website/src/content/docs/docs/status.md
@@ -1,20 +1,67 @@
 ---
 title: Status & versioning
-description: Pre-alpha expectations for TerraDart releases.
+description: Pre-alpha expectations, beta readiness, and how TerraDart versions releases.
 ---
 
-TerraDart is **pre-alpha**. There are no SemVer guarantees until v1.0.0.
+TerraDart is **pre-alpha** on the **0.12.x** line today. We remain pre-alpha until the [beta readiness](#beta-readiness-checklist) required gates are all complete; we plan to label the project **beta** starting with **v0.13.0**, not retroactively on 0.12.x.
 
-## What to expect
+There are no SemVer guarantees until **v1.0.0**. Pin with `^0.12.x` and read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before every **minor** bump. Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch.
 
-- Surface and emitted Terraform JSON may change between dev releases.
-- Pin tightly to explicit pre-release constraints on pub.dev.
-- `dart pub get` skips pre-releases by default — opt in with `^0.1.0-dev` (or the current dev version).
+## Release phases
+
+| Phase | Version line | What we promise |
+| --- | --- | --- |
+| **Pre-alpha** | 0.12.x (current) | Docs and automation are catching up. Breaking changes may land in any 0.x release until beta policy applies. |
+| **Beta** | from **0.13.0** (planned) | Trustworthy onboarding on terradart.dev and GitHub. **No breaking changes within a minor** (`^0.N.x`); breaking changes only on minor bumps, always documented in `MIGRATING.md`. Not SemVer-frozen until 1.0.0. |
+| **1.0.0** | TBD | Stable SemVer for `terradart_core`, `terradart_google`, and `terradart_codegen`. |
+
+## What to expect today (pre-alpha)
+
+- Surface and emitted Terraform JSON may change between releases, especially across **minor** bumps.
+- Use hosted `^0.12.x` carets on [pub.dev](https://pub.dev/packages/terradart_core) — not legacy `0.x.y-dev` pre-release tags.
+- `terradart codegen` output for non-curated resources has **no** stability guarantee.
+
+## Beta change policy (applies from v0.13.0)
+
+When we declare beta:
+
+- **Patch releases** (`0.N.x` → `0.N.y`): no intentional breaking changes to `terradart_core` / `terradart_google` public APIs.
+- **Minor releases** (`0.N.x` → `0.M.x`): breaking changes allowed only with a `MIGRATING.md` section for the previous minor.
+- **Curated factory additions** continue (additive waves); renaming or removing curated factories still counts as breaking.
+
+## Beta readiness checklist
+
+We will label the project **beta** starting with **v0.13.0** when every **required** item below is done.
+
+### Required (all must be ✅ before v0.13.0)
+
+- [x] **Getting Started** on terradart.dev matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart); no “Coming soon” placeholders on Status or Getting Started.
+- [x] **`tool/check_docs_consistency`** runs in CI and passes (workspace + examples caret minor, catalog count, key meta docs). Workflow: [`.github/workflows/docs-consistency.yml`](https://github.com/nozomi-koborinai/terradart/blob/main/.github/workflows/docs-consistency.yml).
+- [x] **`tool/smoke_quickstart.sh`** runs in CI and passes (`pubsub_quickstart`: pub get → synth → analyze including export consumer stub).
+- [x] **Examples matrix** on `main` stays green (per-example synth + `terraform validate` on `tf-out/`).
+- [x] **Boundary demo**: [pubsub_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart) documents `addExport` / generated `.app.dart` and includes a subscriber stub that `dart analyze` accepts.
+- [x] **Meta docs aligned** with the current minor: CONTRIBUTING, SECURITY, issue templates, package READMEs, and root README agree on pre-alpha/beta wording, `^0.N.x` pins, and **119 curated factories + 1 data source**.
+- [x] **Beta change policy** published on this page (see [Beta change policy](#beta-change-policy-applies-from-v0130)).
+
+### Optional (does not block beta)
+
+- [ ] **`MIGRATING.md` covers the last two minors** (e.g. 0.11→0.12 and 0.12→0.13). *Each new minor must add a section; two-minor depth is a quality bar.*
+- [ ] **External quickstart**: someone outside the core team completes the README path once; feedback captured in an issue or discussion.
+- [ ] **Real apply dogfood** via [terradart-cookbook](https://github.com/nozomi-koborinai/terradart-cookbook): at least one non-trivial recipe documents a successful `terraform apply`.
+- [ ] **`terradart-mcp`**: [Agent install](/docs/agent/install/) verified on a clean machine (Homebrew or release binary + four tools).
+- [ ] **1.0.0 criteria** drafted (what “stable” means for curated names, codegen output, and `terradart_core` API).
+
+## What beta does *not* mean
+
+- **Not** a freeze on new curated factories.
+- **Not** [constructs / composite frameworks](https://github.com/nozomi-koborinai/terradart#non-goals).
+- **Not** SemVer until 1.0.0.
+- **Not** a guarantee that `terradart codegen` output is stable.
 
 ## Reporting issues
 
 Use the [bug or question template](https://github.com/nozomi-koborinai/terradart/issues/new/choose) on GitHub.
 
-:::note[Coming soon]
-Version-specific migration notes will land here after v0.12.0.
-:::
+## Maintainer notes
+
+Maintainer session notes stay in the gitignored repo-root `docs/` tree locally (not published).

--- a/website/src/scripts/mermaid-init.mjs
+++ b/website/src/scripts/mermaid-init.mjs
@@ -1,0 +1,107 @@
+/**
+ * TerraDart docs — Mermaid themes aligned with BRAND.md (Dart cyan / blue).
+ * Re-renders when Starlight toggles data-theme.
+ */
+import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+
+const lightVariables = {
+  fontFamily: 'Inter, "Helvetica Neue", system-ui, sans-serif',
+  background: "#F6F3EC",
+  mainBkg: "#FFFFFF",
+  primaryColor: "#D6ECFA",
+  primaryTextColor: "#0F1116",
+  primaryBorderColor: "#0175C2",
+  secondaryColor: "#E8F4FC",
+  secondaryTextColor: "#0F1116",
+  secondaryBorderColor: "#0175C2",
+  tertiaryColor: "#F6F3EC",
+  tertiaryTextColor: "#0F1116",
+  tertiaryBorderColor: "#1E2A56",
+  lineColor: "#0175C2",
+  arrowheadColor: "#0175C2",
+  textColor: "#0F1116",
+  nodeTextColor: "#0F1116",
+  titleColor: "#0175C2",
+  clusterBkg: "#F6F3EC",
+  clusterBorder: "#0175C2",
+  edgeLabelBackground: "#FFFFFF",
+  nodeBorder: "#0175C2",
+};
+
+const darkVariables = {
+  fontFamily: 'Inter, "Helvetica Neue", system-ui, sans-serif',
+  background: "#0B0D12",
+  mainBkg: "#1A2A66",
+  primaryColor: "#1A3A5C",
+  primaryTextColor: "#F6F3EC",
+  primaryBorderColor: "#4DD0FE",
+  secondaryColor: "#243B6B",
+  secondaryTextColor: "#F6F3EC",
+  secondaryBorderColor: "#13B9FD",
+  tertiaryColor: "#0B0D12",
+  tertiaryTextColor: "#F6F3EC",
+  tertiaryBorderColor: "#3B4A82",
+  lineColor: "#4DD0FE",
+  arrowheadColor: "#13B9FD",
+  textColor: "#F6F3EC",
+  nodeTextColor: "#F6F3EC",
+  titleColor: "#4DD0FE",
+  clusterBkg: "#0B0D12",
+  clusterBorder: "#4DD0FE",
+  edgeLabelBackground: "#1A2A66",
+  nodeBorder: "#4DD0FE",
+  darkMode: "true",
+};
+
+function isDarkTheme() {
+  return document.documentElement.getAttribute("data-theme") === "dark";
+}
+
+function stashMermaidSources() {
+  document.querySelectorAll("pre.mermaid").forEach((el) => {
+    if (el.dataset.tdSource) return;
+    const code = el.querySelector("code");
+    const text = (code?.textContent ?? el.textContent)?.trim();
+    if (text) el.dataset.tdSource = text;
+  });
+}
+
+function resetMermaidBlocks() {
+  document.querySelectorAll("pre.mermaid").forEach((el) => {
+    const src = el.dataset.tdSource;
+    if (!src) return;
+    el.textContent = src;
+    el.removeAttribute("data-processed");
+  });
+}
+
+async function renderMermaid() {
+  mermaid.initialize({
+    startOnLoad: false,
+    theme: "base",
+    themeVariables: isDarkTheme() ? darkVariables : lightVariables,
+  });
+  const nodes = document.querySelectorAll("pre.mermaid");
+  if (nodes.length === 0) return;
+  await mermaid.run({ nodes });
+}
+
+function boot() {
+  stashMermaidSources();
+  void renderMermaid();
+
+  const observer = new MutationObserver(() => {
+    resetMermaidBlocks();
+    void renderMermaid();
+  });
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["data-theme"],
+  });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", boot);
+} else {
+  boot();
+}

--- a/website/src/styles/starlight-overrides.css
+++ b/website/src/styles/starlight-overrides.css
@@ -10,8 +10,10 @@
   --sl-color-accent: #0175c2;
   --sl-color-accent-high: #015a99;
   --sl-color-text-accent: #0f1116;
+  /* Paper band on the header only; sidebar + main stay neutral white for reading. */
   --sl-color-bg-nav: #f6f3ec;
-  --sl-color-bg-sidebar: #f6f3ec;
+  --sl-color-bg-sidebar: #ffffff;
+  --sl-color-bg: #ffffff;
   --sl-color-hairline: #d8d4ca;
   --sl-color-hairline-shade: #d8d4ca;
   --sl-color-hairline-light: #e8e4da;
@@ -21,20 +23,39 @@
   --sl-color-accent-low: #1a2a66;
   --sl-color-accent: #4dd0fe;
   --sl-color-accent-high: #c2e8ff;
-  --sl-color-text-accent: #f6f3ec;
+  /* Links — neutral; do not reuse for sidebar highlight (Starlight uses text-accent as bg). */
+  --sl-color-text-accent: var(--sl-color-gray-2);
   --sl-color-bg: #0b0d12;
   --sl-color-bg-nav: #0b0d12;
   --sl-color-bg-sidebar: #0f1116;
   --sl-color-hairline: #2a3142;
   --sl-color-hairline-shade: #2a3142;
   --sl-color-hairline-light: #1a2332;
-  --sl-color-gray-1: #f6f3ec;
-  --sl-color-gray-2: #c2e8ff;
-  --sl-color-gray-3: #8eb4d4;
-  --sl-color-gray-4: #4a5a78;
-  --sl-color-gray-5: #1a2332;
-  --sl-color-gray-6: #0b0d12;
-  --sl-color-black: #f6f3ec;
+  /* Keep Starlight gray-1…black scale — black is used for search + code tab bars in dark mode. */
+}
+
+/* Sidebar current page: accent tint, not link color */
+:root[data-theme="dark"] #starlight__sidebar a[aria-current="page"],
+:root[data-theme="dark"] #starlight__sidebar a[aria-current="page"]:hover,
+:root[data-theme="dark"] #starlight__sidebar a[aria-current="page"]:focus {
+  background-color: var(--sl-color-accent-low);
+  color: var(--sl-color-gray-1);
+}
+
+:root[data-theme="light"] #starlight__sidebar a[aria-current="page"],
+:root[data-theme="light"] #starlight__sidebar a[aria-current="page"]:hover,
+:root[data-theme="light"] #starlight__sidebar a[aria-current="page"]:focus {
+  background-color: var(--sl-color-accent-low);
+  color: var(--sl-color-text);
+}
+
+/* Code blocks — dark chrome; syntax stays Night Owl, frames follow Starlight tokens */
+:root[data-theme="dark"] .expressive-code {
+  --ec-frm-edTabBarBg: var(--sl-color-gray-6);
+  --ec-frm-trmTtbBg: var(--sl-color-gray-6);
+  --ec-frm-edActTabBg: var(--sl-color-gray-5);
+  --ec-frm-edBg: var(--sl-color-gray-6);
+  --ec-frm-trmBg: var(--sl-color-gray-6);
 }
 
 :where(h1, h2, h3, h4, h5, h6) {

--- a/website/src/styles/starlight-overrides.css
+++ b/website/src/styles/starlight-overrides.css
@@ -22,10 +22,58 @@
   --sl-color-accent: #4dd0fe;
   --sl-color-accent-high: #c2e8ff;
   --sl-color-text-accent: #f6f3ec;
+  --sl-color-bg: #0b0d12;
+  --sl-color-bg-nav: #0b0d12;
+  --sl-color-bg-sidebar: #0f1116;
+  --sl-color-hairline: #2a3142;
+  --sl-color-hairline-shade: #2a3142;
+  --sl-color-hairline-light: #1a2332;
+  --sl-color-gray-1: #f6f3ec;
+  --sl-color-gray-2: #c2e8ff;
+  --sl-color-gray-3: #8eb4d4;
+  --sl-color-gray-4: #4a5a78;
+  --sl-color-gray-5: #1a2332;
+  --sl-color-gray-6: #0b0d12;
+  --sl-color-black: #f6f3ec;
 }
 
 :where(h1, h2, h3, h4, h5, h6) {
   font-family: "Inter", "Helvetica Neue", system-ui, sans-serif;
   font-weight: 400;
   letter-spacing: -0.02em;
+}
+
+/* Mermaid — Dart palette; CSS fallback if client theme lags */
+:root[data-theme="light"] pre.mermaid {
+  --td-mermaid-line: #0175c2;
+  --td-mermaid-node: #d6ecfa;
+}
+
+:root[data-theme="dark"] pre.mermaid {
+  --td-mermaid-line: #4dd0fe;
+  --td-mermaid-node: #1a3a5c;
+}
+
+:root[data-theme="dark"] .mermaid svg .edgePath .path,
+:root[data-theme="dark"] .mermaid svg .flowchart-link,
+:root[data-theme="dark"] .mermaid svg .messageLine0,
+:root[data-theme="dark"] .mermaid svg .messageLine1 {
+  stroke: var(--td-mermaid-line) !important;
+}
+
+:root[data-theme="dark"] .mermaid svg .arrowheadPath,
+:root[data-theme="dark"] .mermaid svg marker path {
+  fill: var(--td-mermaid-line) !important;
+  stroke: var(--td-mermaid-line) !important;
+}
+
+:root[data-theme="light"] .mermaid svg .edgePath .path,
+:root[data-theme="light"] .mermaid svg .flowchart-link {
+  stroke: var(--td-mermaid-line) !important;
+}
+
+:root[data-theme="light"] .mermaid svg .arrowheadPath,
+:root[data-theme="light"] .mermaid svg marker path {
+  fill: var(--td-mermaid-line) !important;
+  stroke: var(--td-mermaid-line) !important;
 }


### PR DESCRIPTION
## Summary

- Align pre-alpha / `^0.12.x` messaging across README, package READMEs, CONTRIBUTING, SECURITY, and issue templates (119 curated factories + 1 data source).
- Document **0.12.x** in root `CHANGELOG.md` and `MIGRATING.md` (no breaking API changes vs 0.11.0).
- Fill terradart.dev **Getting Started** and **Status** (beta readiness checklist; label flip planned at **v0.13.0**, still pre-alpha on 0.12.x).
- Fix Pipeline double numbering on docs pages (`<div role="list">` + scoped styles).
- Strengthen **pubsub_quickstart** boundary demo: `ORDERS_TOPIC_NAME` export, committed `orders_stack.app.dart`, `subscriber_stub.dart`.
- Add `tool/check_docs_consistency.dart`, `tool/smoke_quickstart.sh`, and `.github/workflows/docs-consistency.yml` CI job.

## Test plan

- [x] `dart tool/check_docs_consistency.dart`
- [x] `tool/smoke_quickstart.sh`
- [x] GitHub Actions **Docs consistency** workflow green on this PR
- [x] Spot-check terradart.dev preview: Architecture pipeline steps show `1` not `1. 1`

## Notes

- Project remains **pre-alpha** until v0.13.0 per status checklist (all required gates targeted here; optional cookbook/external dogfood still open).
- Repo-root `docs/` and `RESUME.md` stay **gitignored** (maintainer-local); not part of this PR.