### PR TITLE
chore: split GitHub issue templates by kind

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
-name: Bug or question
-description: Report a bug, ask a question, or request a feature.
+name: Bug report
+description: Something doesn't work as documented or expected.
 title: "[bug] "
-labels: ["triage"]
+labels: ["bug", "triage"]
 body:
   - type: markdown
     attributes:
@@ -16,23 +16,11 @@ body:
         (e.g. `my-prod-1234` → `REDACTED-PROJECT`). If redacting is difficult,
         use the [private security advisory](https://github.com/nozomi-koborinai/terradart/security/advisories/new) instead.
 
-  - type: dropdown
-    id: kind
-    attributes:
-      label: What kind of issue?
-      options:
-        - Bug — something doesn't work
-        - Question — how do I ...?
-        - Feature request — I'd like ...
-        - Codegen — `terradart codegen` output problem
-    validations:
-      required: true
-
   - type: input
     id: terradart_version
     attributes:
       label: terradart version
-      placeholder: "0.1.0-dev"
+      placeholder: "0.12.0"
     validations:
       required: false
 
@@ -47,8 +35,8 @@ body:
   - type: textarea
     id: details
     attributes:
-      label: Details
-      description: What happened? What did you expect? Include the failing Dart Stack snippet or terraform output if applicable. Remember to redact PII.
+      label: What happened?
+      description: What did you expect instead? Include a failing Dart stack trace or terraform output if applicable. Remember to redact PII.
       render: dart
     validations:
       required: true
@@ -56,7 +44,7 @@ body:
   - type: textarea
     id: repro
     attributes:
-      label: Reproduction steps (if a bug)
+      label: Reproduction steps
       description: Minimal commands / Dart code to reproduce.
     validations:
-      required: false
+      required: true

--- a/.github/ISSUE_TEMPLATE/codegen.yml
+++ b/.github/ISSUE_TEMPLATE/codegen.yml
@@ -1,0 +1,51 @@
+name: Codegen issue
+description: Report a problem with `terradart codegen` output (legacy path).
+title: "[codegen] "
+labels: ["triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file. terradart is **pre-alpha** on
+        **0.12.x** today (beta planned from v0.13.0). Single-maintainer;
+        triage is best-effort. See https://terradart.dev/docs/status/
+
+        **Note**: `terradart codegen` is a legacy maintainer path. Curated
+        Google factories ship via `terradart_google`; new curated resources
+        go through `terradart wrap`.
+
+        **PII note**: schema excerpts may contain project-specific names.
+        Please redact before pasting.
+
+  - type: input
+    id: terradart_version
+    attributes:
+      label: terradart_codegen version
+      placeholder: "0.12.0"
+    validations:
+      required: false
+
+  - type: input
+    id: provider
+    attributes:
+      label: Terraform provider
+      placeholder: "hashicorp/google"
+    validations:
+      required: false
+
+  - type: input
+    id: resource_type
+    attributes:
+      label: Resource or data source type
+      placeholder: "google_pubsub_topic"
+    validations:
+      required: false
+
+  - type: textarea
+    id: details
+    attributes:
+      label: What went wrong?
+      description: Describe the unexpected codegen output. Include the command you ran and a minimal schema excerpt if applicable.
+      render: dart
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security advisory
+    url: https://github.com/nozomi-koborinai/terradart/security/advisories/new
+    about: Report a security issue privately (preferred for sensitive details).

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest a new feature, provider, or curated resource.
+title: "[feature] "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file. terradart is **pre-alpha** on
+        **0.12.x** today (beta planned from v0.13.0). Single-maintainer;
+        triage is best-effort. See https://terradart.dev/docs/status/
+
+        Feature requests are welcome — no timeline promises, but they help
+        prioritize the roadmap.
+
+  - type: input
+    id: terradart_version
+    attributes:
+      label: terradart version
+      placeholder: "0.12.0"
+    validations:
+      required: false
+
+  - type: textarea
+    id: details
+    attributes:
+      label: What would you like?
+      description: Describe the feature, your use case, and links to relevant docs or providers if applicable.
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: How are you solving this today? Any workarounds you've tried?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,38 @@
+name: Question
+description: Ask how to use terradart or clarify expected behavior.
+title: "[question] "
+labels: ["question", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to ask. terradart is **pre-alpha** on
+        **0.12.x** today (beta planned from v0.13.0). Single-maintainer;
+        triage is best-effort. See https://terradart.dev/docs/status/
+
+        Docs: https://terradart.dev/docs/getting-started/
+
+  - type: input
+    id: terradart_version
+    attributes:
+      label: terradart version
+      placeholder: "0.12.0"
+    validations:
+      required: false
+
+  - type: input
+    id: dart_version
+    attributes:
+      label: Dart SDK version
+      placeholder: "3.10.0"
+    validations:
+      required: false
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Your question
+      description: What are you trying to do? Include a minimal Dart snippet if it helps.
+      render: dart
+    validations:
+      required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ terradart's surface splits into two layers:
 
 Within a **minor** line (`^0.12.x`), we aim to avoid breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (stricter from v0.13.0 beta — see [status](https://terradart.dev/docs/status/)).
 
-Bug reports / questions: see the [Bug or question](.github/ISSUE_TEMPLATE/bug-or-question.yml) template.
+Bug reports / questions / feature requests: pick a template when [opening an issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
 
 ## Dev setup
 

--- a/tool/check_docs_consistency.dart
+++ b/tool/check_docs_consistency.dart
@@ -29,7 +29,14 @@ void main() {
     minor,
     'website/src/content/docs/docs/getting-started.md',
   );
-  _checkCaretMinor(errors, minor, '.github/ISSUE_TEMPLATE/bug-or-question.yml');
+  for (final template in [
+    '.github/ISSUE_TEMPLATE/bug.yml',
+    '.github/ISSUE_TEMPLATE/feature.yml',
+    '.github/ISSUE_TEMPLATE/question.yml',
+    '.github/ISSUE_TEMPLATE/codegen.yml',
+  ]) {
+    _checkCaretMinor(errors, minor, template);
+  }
 
   for (final example in _exampleDirs()) {
     final pubspec = File('examples/$example/pubspec.yaml');


### PR DESCRIPTION
## Summary

- Replace the monolithic `bug-or-question.yml` template with four focused templates: **Bug report**, **Feature request**, **Question**, and **Codegen issue**
- Each template sets the correct title prefix (`[bug]`, `[feature]`, etc.) and default labels at creation time, preventing misclassified titles when the kind dropdown and default title disagree
- Add `config.yml` with a template chooser and a Security advisory contact link; disable blank issues
- Update `CONTRIBUTING.md` and extend `check_docs_consistency.dart` to cover all new templates

## Motivation

The old template always pre-filled `[bug]` in the title regardless of the dropdown selection. A recent feature request shipped with a bug title, requiring manual triage correction.

## Test plan

- [x] `dart tool/check_docs_consistency.dart` passes locally
- [x] After merge, open https://github.com/nozomi-koborinai/terradart/issues/new/choose and confirm four templates appear with correct default titles/labels