### PR TITLE
Add agent_verify.sh and Cursor stop hook

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "stop": [
+      {
+        "command": ".cursor/hooks/on-stop-verify.sh",
+        "loop_limit": 3
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/on-stop-verify.sh
+++ b/.cursor/hooks/on-stop-verify.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# stop hook: run agent_verify before the agent marks work complete (local IDE).
+# Cloud agents do not run the stop hook yet; they should run tool/agent_verify.sh
+# explicitly per AGENTS.md.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+input="$(cat)"
+
+status="$(printf '%s' "$input" | jq -r '.status // empty')"
+loop_count="$(printf '%s' "$input" | jq -r '.loop_count // 0')"
+
+# Only verify successful completions; skip aborted/error stops.
+if [[ "$status" != "completed" ]]; then
+  exit 0
+fi
+
+# Avoid hammering verify on repeated stop follow-up loops.
+if [[ "$loop_count" -ge 2 ]]; then
+  echo "on-stop-verify: loop_count=$loop_count, skipping verify" >&2
+  exit 0
+fi
+
+if ! "$ROOT/tool/agent_verify.sh" >&2; then
+  jq -n --arg msg "agent_verify.sh failed. Read stderr above, fix the issues, and continue. Re-run: tool/agent_verify.sh from the repo root before finishing." \
+    '{followup_message: $msg}'
+  exit 0
+fi
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,23 +29,33 @@ The supported maintainer generation path is `terradart wrap`.
 - Root `CONTEXT.md` is a glossary only. Do not put implementation plans, chat transcripts, or ADR content there.
 - Public website docs live under `website/src/content/docs/docs/`.
 
-## Useful Commands
+## Agent verification
 
-Prefer task-specific scripts and CI for final verification. These commands are useful starting points:
+Before claiming work is done, run from the repository root:
 
 ```bash
-dart pub get
-dart analyze packages/ --fatal-infos --fatal-warnings
-dart test --reporter=expanded
-dart tool/check_docs_consistency.dart
-tool/smoke_quickstart.sh
+tool/agent_verify.sh
 ```
 
-Wrapper determinism:
+This is the shared agent gate (docs consistency, analyze, four-package tests, `terradart wrap --check`, pubsub smoke). It does **not** run the full `terraform_validate` example matrix; GitHub Actions still enforces that on merge.
+
+Optional flags:
 
 ```bash
-cd packages/terradart_codegen
-dart run bin/terradart.dart wrap \
+tool/agent_verify.sh --format       # scoped dart format (core, codegen, agent)
+tool/agent_verify.sh --maintainer   # add wrap-init / wrap-promote e2e tests
+```
+
+Local Cursor IDE runs `tool/agent_verify.sh` on agent completion via `.cursor/hooks.json` (`stop` hook). Cursor Cloud Agent does not run the `stop` hook yet — run `tool/agent_verify.sh` explicitly before finishing.
+
+## Useful Commands
+
+Targeted checks when `agent_verify.sh` is too broad:
+
+```bash
+dart tool/check_docs_consistency.dart
+tool/smoke_quickstart.sh
+cd packages/terradart_codegen && dart run bin/terradart.dart wrap \
   --provider hashicorp/google \
   --source test/fixtures/wrap/source \
   --output ../terradart_google/lib/src \
@@ -64,7 +74,7 @@ Cloud agents such as Devin, Cursor Cloud Agent, and Claude Code on the Web shoul
 4. Create or update only the required `wrapper_overrides/yaml/<terraform_type>.yaml` entries.
 5. Run `terradart wrap` for the target resource when the source inputs are available, then run full `wrap --check`.
 6. Inspect generated `terradart_google` API diffs for constructor names, helper types, getters, enum use, sealed types, and sensitive-field behavior.
-7. Run targeted tests first, then the verification commands above as needed.
+7. Run targeted tests first, then `tool/agent_verify.sh` (or `--maintainer` when touching wrap-init/promote).
 
 ### Handle Provider Schema Or MM YAML Drift
 
@@ -97,4 +107,4 @@ Cloud agents such as Devin, Cursor Cloud Agent, and Claude Code on the Web shoul
 - Do not rely on Gitignored `docs/` as authoritative context for cloud-agent work.
 - If a cloud agent needs durable guidance, prefer checked-in tooling/CI; otherwise add concise guidance to `AGENTS.md` or vocabulary to `CONTEXT.md`.
 - Keep long-form design notes in `docs/` unless they are intentionally being promoted into public docs or committed agent guidance.
-- After substantive edits, run the narrowest useful verification and report what did or did not run.
+- After substantive edits, run `tool/agent_verify.sh` when feasible and report what did or did not run.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,10 @@ dart test
 # Run static analysis (must pass with zero issues)
 dart analyze --fatal-infos --fatal-warnings
 
-# Docs / quickstart consistency (same as CI)
+# Agent gate (subset of CI; no terraform matrix)
+tool/agent_verify.sh
+
+# Docs / quickstart only
 dart tool/check_docs_consistency.dart
 tool/smoke_quickstart.sh
 
@@ -50,8 +53,7 @@ tool/run_tests.sh
 
 Before opening a PR:
 
-- [ ] `dart analyze --fatal-infos --fatal-warnings` passes.
-- [ ] `dart test` passes (full suite, not just one package).
+- [ ] `tool/agent_verify.sh` passes (or explain what you could not run).
 - [ ] `dart tool/check_docs_consistency.dart` passes when you touch versions or catalog counts.
 - [ ] `tool/smoke_quickstart.sh` passes when you touch `pubsub_quickstart` or synth/export paths.
 - [ ] `dart format` was run.

--- a/tool/agent_verify.sh
+++ b/tool/agent_verify.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Agent verification gate — fast local/CI-adjacent checks before claiming work done.
+#
+# Usage (from repo root):
+#   tool/agent_verify.sh
+#   tool/agent_verify.sh --format      # add scoped dart format (hand-written packages)
+#   tool/agent_verify.sh --maintainer  # add wrap-init / wrap-promote e2e tests
+#
+# Does not run the full terraform_validate example matrix; GitHub Actions still
+# enforces that on merge.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+WITH_FORMAT=0
+WITH_MAINTAINER=0
+for arg in "$@"; do
+  case "$arg" in
+    --format) WITH_FORMAT=1 ;;
+    --maintainer) WITH_MAINTAINER=1 ;;
+    -h | --help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "agent_verify.sh: unknown argument: $arg" >&2
+      exit 64
+      ;;
+  esac
+done
+
+echo ">> dart pub get"
+dart pub get
+
+echo ">> check_docs_consistency"
+dart tool/check_docs_consistency.dart
+
+echo ">> dart analyze"
+dart analyze packages/ --fatal-infos --fatal-warnings
+
+if [[ "$WITH_FORMAT" == "1" ]]; then
+  echo ">> dart format (terradart_core, terradart_codegen, terradart_agent)"
+  dart format --output=none --set-exit-if-changed \
+    packages/terradart_core/ \
+    packages/terradart_codegen/ \
+    packages/terradart_agent/
+fi
+
+PACKAGES=(terradart_core terradart_codegen terradart_google terradart_agent)
+for pkg in "${PACKAGES[@]}"; do
+  echo ">> dart test packages/$pkg"
+  (cd "packages/$pkg" && dart test --reporter=expanded)
+done
+
+echo ">> terradart wrap --check"
+(
+  cd packages/terradart_codegen
+  dart run bin/terradart.dart wrap \
+    --provider hashicorp/google \
+    --source test/fixtures/wrap/source \
+    --output ../terradart_google/lib/src \
+    --check
+)
+
+echo ">> smoke_quickstart"
+chmod +x tool/smoke_quickstart.sh
+tool/smoke_quickstart.sh
+
+if [[ "$WITH_MAINTAINER" == "1" ]]; then
+  echo ">> wrap-init e2e"
+  (
+    cd packages/terradart_codegen
+    dart test --run-skipped -t e2e --name 'wrap-init'
+  )
+  echo ">> wrap-promote e2e"
+  (
+    cd packages/terradart_codegen
+    dart test --run-skipped -t e2e --name 'wrap-promote'
+  )
+fi
+
+echo "agent_verify: OK"


### PR DESCRIPTION
## Summary

- Add `tool/agent_verify.sh` as the shared agent verification gate (docs consistency, analyze, four-package tests, `wrap --check`, pubsub smoke). Optional `--format` and `--maintainer` flags.
- Add `.cursor/hooks.json` with a `stop` hook that runs `agent_verify.sh` on local Cursor IDE completion (with `followup_message` on failure).
- Update `AGENTS.md` and `CONTRIBUTING.md` to point agents and contributors at the script. Full `terraform_validate` matrix remains GitHub Actions only.

## Test plan

- [x] `tool/agent_verify.sh` from repo root (~37s locally)
- [x] CI green on this PR

## Notes

- Cursor Cloud Agent does not run the `stop` hook yet; cloud agents should run `tool/agent_verify.sh` explicitly per `AGENTS.md`.
- `stop` hook requires `jq` (used in `on-stop-verify.sh`).