### PR TITLE
fix(website): align Pipeline section layout on LP and docs

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -61,7 +61,10 @@ export default defineConfig({
       components: {
         SiteTitle: "./src/components/StarlightSiteTitle.astro",
       },
-      customCss: ["./src/styles/starlight-overrides.css"],
+      customCss: [
+        "./src/styles/starlight-overrides.css",
+        "./src/styles/pipeline.css",
+      ],
       head: [
         {
           tag: "link",

--- a/website/src/components/Pipeline.astro
+++ b/website/src/components/Pipeline.astro
@@ -14,92 +14,23 @@ interface Props {
 const { eyebrow = "Pipeline", heading, steps, footnote } = Astro.props;
 ---
 
-<section class="td-pipeline">
-  <p class="td-pipeline-eyebrow">{eyebrow}</p>
-  <h2 class="td-pipeline-heading">{heading}</h2>
+<p class="section-label">{eyebrow}</p>
+<h2 class="display-section">{heading}</h2>
 
-  <div class="td-pipeline-list" role="list">
-    {
-      steps.map((step, i) => (
-        <div class="td-pipeline-step" role="listitem">
-          <span class="td-pipeline-index" aria-hidden="true">
-            {i + 1}
-          </span>
-          <div class="td-pipeline-body">
-            <h3 class="td-pipeline-title">{step.title}</h3>
-            <p set:html={step.body} />
-          </div>
+<div class="pipeline" role="list">
+  {
+    steps.map((step, i) => (
+      <div class="pipeline-step" role="listitem">
+        <span class="pipeline-index" aria-hidden="true">
+          {i + 1}
+        </span>
+        <div class="pipeline-body">
+          <h3 class="pipeline-title">{step.title}</h3>
+          <p set:html={step.body} />
         </div>
-      ))
-    }
-  </div>
-
-  {footnote && <p class="td-pipeline-footnote" set:html={footnote} />}
-</section>
-
-<style is:global>
-  .td-pipeline {
-    margin: 2rem 0;
+      </div>
+    ))
   }
+</div>
 
-  .td-pipeline-eyebrow {
-    font-family: var(--font-mono, var(--sl-font-mono));
-    font-size: 0.75rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--color-mute, var(--sl-color-gray-3));
-    margin: 0 0 0.5rem;
-  }
-
-  .td-pipeline-heading {
-    font-size: 1.5rem;
-    font-weight: 500;
-    letter-spacing: -0.02em;
-    margin: 0 0 0.5rem;
-  }
-
-  .td-pipeline-list {
-    display: grid;
-    gap: 0;
-    margin: 1.5rem 0 0;
-    padding: 0;
-  }
-
-  .td-pipeline-step {
-    display: grid;
-    grid-template-columns: 2.5rem 1fr;
-    gap: 1.25rem;
-    padding: 1.75rem 0;
-    border-top: 1px solid var(--color-rule, var(--sl-color-hairline));
-  }
-
-  .td-pipeline-step:last-child {
-    border-bottom: 1px solid var(--color-rule, var(--sl-color-hairline));
-  }
-
-  .td-pipeline-index {
-    font-family: var(--font-mono, var(--sl-font-mono));
-    font-size: 0.8125rem;
-    color: var(--color-accent, var(--sl-color-accent));
-    padding-top: 0.15rem;
-  }
-
-  .td-pipeline-title {
-    font-size: 1.0625rem;
-    font-weight: 500;
-    margin: 0 0 0.35rem;
-  }
-
-  .td-pipeline-body p {
-    font-size: 0.95rem;
-    color: var(--color-mute, var(--sl-color-gray-3));
-    line-height: 1.5;
-    margin: 0;
-  }
-
-  .td-pipeline-footnote {
-    margin-top: 1rem;
-    font-size: 0.9rem;
-    color: var(--color-mute, var(--sl-color-gray-3));
-  }
-</style>
+{footnote && <p class="section-footnote" set:html={footnote} />}

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -65,25 +65,29 @@ import Footer from "../components/Footer.astro";
         >See full comparison →</a
       >
     </p>
-    <Pipeline
-      eyebrow="Pipeline"
-      heading="How it works in three steps"
-      steps={[
-        {
-          title: "Author in Dart",
-          body: "Subclass Stack with curated google_* factories from terradart_google.",
-        },
-        {
-          title: "Generate Terraform JSON",
-          body: "stack.writeTo(...) writes *.tf.json — no custom apply runtime.",
-        },
-        {
-          title: "Apply with Terraform",
-          body: "terraform plan and apply unchanged; state stays where it is.",
-        },
-      ]}
-      footnote={`Details: <a href="/docs/architecture/" class="link-mark">/docs/architecture</a> · <a href="https://github.com/nozomi-koborinai/terradart/blob/main/README.md" class="link-mark">README</a>`}
-    />
+    <section class="section rule-top">
+      <div class="container-edit section-inner">
+        <Pipeline
+          eyebrow="Pipeline"
+          heading="How it works in three steps"
+          steps={[
+            {
+              title: "Author in Dart",
+              body: "Subclass Stack with curated google_* factories from terradart_google.",
+            },
+            {
+              title: "Generate Terraform JSON",
+              body: "stack.writeTo(...) writes *.tf.json — no custom apply runtime.",
+            },
+            {
+              title: "Apply with Terraform",
+              body: "terraform plan and apply unchanged; state stays where it is.",
+            },
+          ]}
+          footnote={`Details: <a href="/docs/architecture/" class="link-mark">/docs/architecture</a> · <a href="https://github.com/nozomi-koborinai/terradart/blob/main/README.md" class="link-mark">README</a>`}
+        />
+      </div>
+    </section>
   </main>
   <Footer />
 </Layout>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -411,45 +411,7 @@
     color: var(--color-ink);
   }
 
-  /* Pipeline */
-  .pipeline {
-    list-style: none;
-    padding: 0;
-    margin: 2.5rem 0 0;
-    display: grid;
-    gap: 0;
-  }
-
-  .pipeline-step {
-    display: grid;
-    grid-template-columns: 2.5rem 1fr;
-    gap: 1.25rem;
-    padding: 1.75rem 0;
-    border-top: 1px solid var(--color-rule);
-  }
-
-  .pipeline-step:last-child {
-    border-bottom: 1px solid var(--color-rule);
-  }
-
-  .pipeline-index {
-    font-family: var(--font-mono);
-    font-size: 0.8125rem;
-    color: var(--color-accent);
-    padding-top: 0.15rem;
-  }
-
-  .pipeline-title {
-    font-size: 1.0625rem;
-    font-weight: 500;
-    margin-bottom: 0.35rem;
-  }
-
-  .pipeline-body p {
-    font-size: 0.95rem;
-    color: var(--color-mute);
-    line-height: 1.5;
-  }
+  @import "./pipeline.css";
 
   /* Compare */
   .compare-wrap {

--- a/website/src/styles/pipeline.css
+++ b/website/src/styles/pipeline.css
@@ -1,0 +1,40 @@
+/* Pipeline steps — shared by LP (global.css) and Starlight docs (customCss). */
+.pipeline {
+  list-style: none;
+  padding: 0;
+  margin: 2.5rem 0 0;
+  display: grid;
+  gap: 0;
+}
+
+.pipeline-step {
+  display: grid;
+  grid-template-columns: 2.5rem 1fr;
+  gap: 1.25rem;
+  padding: 1.75rem 0;
+  border-top: 1px solid var(--color-rule, var(--sl-color-hairline));
+}
+
+.pipeline-step:last-child {
+  border-bottom: 1px solid var(--color-rule, var(--sl-color-hairline));
+}
+
+.pipeline-index {
+  font-family: var(--font-mono, var(--sl-font-mono));
+  font-size: 0.8125rem;
+  color: var(--color-accent, var(--sl-color-accent));
+  padding-top: 0.15rem;
+}
+
+.pipeline-title {
+  font-size: 1.0625rem;
+  font-weight: 500;
+  margin: 0 0 0.35rem;
+}
+
+.pipeline-body p {
+  font-size: 0.95rem;
+  color: var(--color-mute, var(--sl-color-gray-3));
+  line-height: 1.5;
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- Wrap the landing-page Pipeline block in the same `section rule-top` + `container-edit section-inner` shell used by Mission and Comparison, fixing left-edge misalignment with the footer.
- Refactor `Pipeline.astro` to use shared LP typography (`section-label`, `display-section`, `section-footnote`) and shared step classes.
- Extract step styles into `pipeline.css` and load it from both `global.css` (LP) and Starlight `customCss` (docs), so numbered steps render in a grid on `/docs/architecture` instead of stacking vertically.

## Test plan
- [x] `npm run build` in `website/`
- [x] LP `/` — Pipeline section aligns with other sections and footer
- [x] Docs `/docs/architecture/` — step numbers sit beside titles in a grid