### PR TITLE
ci: add workflow_dispatch to backfill PR labels

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -3,18 +3,34 @@ name: PR labeler
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+  workflow_dispatch:
+    inputs:
+      pr_state:
+        description: Which PRs to label
+        type: choice
+        options: [open, closed, all]
+        default: all
+      max_prs:
+        description: Max PRs to process (most recent first)
+        type: number
+        default: 50
+      add_triage:
+        description: Add triage when missing
+        type: boolean
+        default: true
 
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: pr-labeler-${{ github.event.pull_request.number }}
+  group: pr-labeler-${{ github.event.pull_request.number || format('backfill-{0}', github.run_id) }}
   cancel-in-progress: true
 
 jobs:
   area:
     name: area labels
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -24,7 +40,7 @@ jobs:
 
   triage:
     name: triage on open
-    if: github.event.action == 'opened'
+    if: github.event_name == 'pull_request' && github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v8
@@ -42,11 +58,141 @@ jobs:
 
   type:
     name: type from title
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v8
         with:
           script: |
+            const issue_number = context.payload.pull_request.number;
+            await labelPrByTitle(github, context.repo.owner, context.repo.repo, issue_number);
+
+            async function labelPrByTitle(github, owner, repo, issue_number) {
+              const managed = [
+                'enhancement',
+                'documentation',
+                'bug',
+                'test',
+                'ci',
+                'chore',
+                'maintainer',
+              ];
+              const { data: pr } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: issue_number,
+              });
+              const title = pr.title;
+              const desired = [];
+              if (/^feat(\(|!|:)/.test(title)) desired.push('enhancement');
+              if (/^fix(\(|!|:)/.test(title)) desired.push('bug');
+              if (/^docs(\(|!|:)/.test(title)) desired.push('documentation');
+              if (/^test(\(|!|:)/.test(title)) desired.push('test');
+              if (/^ci(\(|!|:)/.test(title)) desired.push('ci');
+              if (/^chore(\(|!|:)/.test(title)) desired.push('chore');
+              if (/^regen:/.test(title) || /^chore\(schema\):/.test(title)) {
+                desired.push('maintainer');
+              }
+
+              const { data: issue } = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number,
+              });
+              const current = (issue.labels || [])
+                .map((l) => (typeof l === 'string' ? l : l.name))
+                .filter((name) => managed.includes(name));
+
+              const toRemove = current.filter((l) => !desired.includes(l));
+              const toAdd = desired.filter((l) => !current.includes(l));
+
+              for (const name of toRemove) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name,
+                });
+              }
+              if (toAdd.length > 0) {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number,
+                  labels: toAdd,
+                });
+              }
+            }
+
+  backfill-list:
+    name: list PRs for backfill
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.list.outputs.matrix }}
+    steps:
+      - uses: actions/github-script@v8
+        id: list
+        with:
+          script: |
+            const stateFilter = '${{ inputs.pr_state }}';
+            const maxPrs = Number('${{ inputs.max_prs }}') || 50;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const states =
+              stateFilter === 'all' ? ['open', 'closed'] : [stateFilter];
+            const pulls = [];
+            for (const state of states) {
+              const batch = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state,
+                per_page: 100,
+                sort: 'updated',
+                direction: 'desc',
+              });
+              pulls.push(...batch);
+            }
+            pulls.sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at));
+            const numbers = [...new Set(pulls.map((p) => p.number))].slice(
+              0,
+              maxPrs,
+            );
+            if (numbers.length === 0) {
+              core.setOutput('matrix', JSON.stringify({ include: [] }));
+              return;
+            }
+            core.setOutput(
+              'matrix',
+              JSON.stringify({ include: numbers.map((pr) => ({ pr })) }),
+            );
+
+  backfill:
+    name: backfill PR ${{ matrix.pr }}
+    needs: backfill-list
+    if: github.event_name == 'workflow_dispatch' && needs.backfill-list.outputs.matrix != '{"include":[]}'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.backfill-list.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/labeler@v6
+        with:
+          sync-labels: true
+          pr-number: ${{ matrix.pr }}
+
+      - uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ matrix.pr }}
+          ADD_TRIAGE: ${{ inputs.add_triage }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+
             const managed = [
               'enhancement',
               'documentation',
@@ -56,7 +202,12 @@ jobs:
               'chore',
               'maintainer',
             ];
-            const title = context.payload.pull_request.title;
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: issue_number,
+            });
+            const title = pr.title;
             const desired = [];
             if (/^feat(\(|!|:)/.test(title)) desired.push('enhancement');
             if (/^fix(\(|!|:)/.test(title)) desired.push('bug');
@@ -68,19 +219,25 @@ jobs:
               desired.push('maintainer');
             }
 
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const issue_number = context.payload.pull_request.number;
-
             const { data: issue } = await github.rest.issues.get({
               owner,
               repo,
               issue_number,
             });
-            const current = (issue.labels || [])
-              .map((l) => (typeof l === 'string' ? l : l.name))
-              .filter((name) => managed.includes(name));
+            const names = (issue.labels || []).map((l) =>
+              typeof l === 'string' ? l : l.name,
+            );
 
+            if (process.env.ADD_TRIAGE === 'true' && !names.includes('triage')) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels: ['triage'],
+              });
+            }
+
+            const current = names.filter((name) => managed.includes(name));
             const toRemove = current.filter((l) => !desired.includes(l));
             const toAdd = desired.filter((l) => !current.includes(l));
 


### PR DESCRIPTION
## Summary

Adds **workflow_dispatch** to `pr-labeler.yml` so existing PRs (open + closed) can be labeled after the auto-labeler lands on `main`.

## How to backfill (after merge)

1. GitHub → **Actions** → **PR labeler** → **Run workflow**
2. Defaults are usually fine:
   - `pr_state`: **all**
   - `max_prs`: **50** (most recently updated first)
   - `add_triage`: **true** (adds `triage` only when missing)

Each PR gets a matrix job: `area:*` via labeler, type labels from title, optional `triage`.

## Test plan

- [x] Run workflow on `main` after merge
- [x] Spot-check closed PRs #82–#84 for `area:*`, type, and `triage`