### PR TITLE
fix(ci): stop applying triage label on pull requests

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,10 +14,6 @@ on:
         description: Max PRs to process (most recent first)
         type: number
         default: 50
-      add_triage:
-        description: Add triage when missing
-        type: boolean
-        default: true
 
 permissions:
   contents: read
@@ -38,24 +34,6 @@ jobs:
         with:
           sync-labels: true
 
-  triage:
-    name: triage on open
-    if: github.event_name == 'pull_request' && github.event.action == 'opened'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v8
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const issue_number = context.payload.pull_request.number;
-            await github.rest.issues.addLabels({
-              owner,
-              repo,
-              issue_number,
-              labels: ['triage'],
-            });
-
   type:
     name: type from title
     if: github.event_name == 'pull_request'
@@ -65,9 +43,9 @@ jobs:
         with:
           script: |
             const issue_number = context.payload.pull_request.number;
-            await labelPrByTitle(github, context.repo.owner, context.repo.repo, issue_number);
+            await syncPrLabels(github, context.repo.owner, context.repo.repo, issue_number);
 
-            async function labelPrByTitle(github, owner, repo, issue_number) {
+            async function syncPrLabels(github, owner, repo, issue_number) {
               const managed = [
                 'enhancement',
                 'documentation',
@@ -99,10 +77,20 @@ jobs:
                 repo,
                 issue_number,
               });
-              const current = (issue.labels || [])
-                .map((l) => (typeof l === 'string' ? l : l.name))
-                .filter((name) => managed.includes(name));
+              const names = (issue.labels || []).map((l) =>
+                typeof l === 'string' ? l : l.name,
+              );
 
+              if (names.includes('triage')) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name: 'triage',
+                });
+              }
+
+              const current = names.filter((name) => managed.includes(name));
               const toRemove = current.filter((l) => !desired.includes(l));
               const toAdd = desired.filter((l) => !current.includes(l));
 
@@ -186,74 +174,76 @@ jobs:
       - uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ matrix.pr }}
-          ADD_TRIAGE: ${{ inputs.add_triage }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const issue_number = Number(process.env.PR_NUMBER);
+            await syncPrLabels(github, owner, repo, issue_number);
 
-            const managed = [
-              'enhancement',
-              'documentation',
-              'bug',
-              'test',
-              'ci',
-              'chore',
-              'maintainer',
-            ];
-            const { data: pr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: issue_number,
-            });
-            const title = pr.title;
-            const desired = [];
-            if (/^feat(\(|!|:)/.test(title)) desired.push('enhancement');
-            if (/^fix(\(|!|:)/.test(title)) desired.push('bug');
-            if (/^docs(\(|!|:)/.test(title)) desired.push('documentation');
-            if (/^test(\(|!|:)/.test(title)) desired.push('test');
-            if (/^ci(\(|!|:)/.test(title)) desired.push('ci');
-            if (/^chore(\(|!|:)/.test(title)) desired.push('chore');
-            if (/^regen:/.test(title) || /^chore\(schema\):/.test(title)) {
-              desired.push('maintainer');
-            }
+            async function syncPrLabels(github, owner, repo, issue_number) {
+              const managed = [
+                'enhancement',
+                'documentation',
+                'bug',
+                'test',
+                'ci',
+                'chore',
+                'maintainer',
+              ];
+              const { data: pr } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: issue_number,
+              });
+              const title = pr.title;
+              const desired = [];
+              if (/^feat(\(|!|:)/.test(title)) desired.push('enhancement');
+              if (/^fix(\(|!|:)/.test(title)) desired.push('bug');
+              if (/^docs(\(|!|:)/.test(title)) desired.push('documentation');
+              if (/^test(\(|!|:)/.test(title)) desired.push('test');
+              if (/^ci(\(|!|:)/.test(title)) desired.push('ci');
+              if (/^chore(\(|!|:)/.test(title)) desired.push('chore');
+              if (/^regen:/.test(title) || /^chore\(schema\):/.test(title)) {
+                desired.push('maintainer');
+              }
 
-            const { data: issue } = await github.rest.issues.get({
-              owner,
-              repo,
-              issue_number,
-            });
-            const names = (issue.labels || []).map((l) =>
-              typeof l === 'string' ? l : l.name,
-            );
-
-            if (process.env.ADD_TRIAGE === 'true' && !names.includes('triage')) {
-              await github.rest.issues.addLabels({
+              const { data: issue } = await github.rest.issues.get({
                 owner,
                 repo,
                 issue_number,
-                labels: ['triage'],
               });
-            }
+              const names = (issue.labels || []).map((l) =>
+                typeof l === 'string' ? l : l.name,
+              );
 
-            const current = names.filter((name) => managed.includes(name));
-            const toRemove = current.filter((l) => !desired.includes(l));
-            const toAdd = desired.filter((l) => !current.includes(l));
+              if (names.includes('triage')) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name: 'triage',
+                });
+              }
 
-            for (const name of toRemove) {
-              await github.rest.issues.removeLabel({
-                owner,
-                repo,
-                issue_number,
-                name,
-              });
-            }
-            if (toAdd.length > 0) {
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number,
-                labels: toAdd,
-              });
+              const current = names.filter((name) => managed.includes(name));
+              const toRemove = current.filter((l) => !desired.includes(l));
+              const toAdd = desired.filter((l) => !current.includes(l));
+
+              for (const name of toRemove) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name,
+                });
+              }
+              if (toAdd.length > 0) {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number,
+                  labels: toAdd,
+                });
+              }
             }


### PR DESCRIPTION
## Summary

- Remove the `triage on open` job and `add_triage` backfill option from PR labeler.
- **Issues** still get `triage` via issue templates (unchanged).
- **PRs** get `area:*` + type labels only; `triage` is stripped if present (cleans up backfill).

## Test plan

- [x] Merge and run PR labeler backfill once, or edit any PR title — `triage` should disappear from PRs
- [x] New issue from template still has `triage`