### PR TITLE
feat(codegen): derive curated enums from the merged IR (Phase A1)

### DIFF
--- a/packages/terradart_codegen/lib/src/cli/wrap_command.dart
+++ b/packages/terradart_codegen/lib/src/cli/wrap_command.dart
@@ -12,6 +12,8 @@ import '../codegen/generated_file_header.dart';
 import '../codegen/wrapper_emitter.dart';
 import '../codegen/wrapper_overrides/_registry.dart';
 import '../codegen/wrapper_overrides/yaml_loader.dart';
+import '../parser/ir_merger.dart';
+import '../parser/mm_yaml_parser.dart';
 import '../parser/schema_parser.dart';
 import 'exit_codes.dart';
 
@@ -117,8 +119,37 @@ class WrapCommand extends Command<int> {
       return CliExitCodes.dataError;
     }
     final schemaSrc = schemaFile.readAsStringSync();
-    final ir = const SchemaJsonParser()
+    final baseIr = const SchemaJsonParser()
         .parseString(schemaSrc, providerVersion: '7.31.0');
+
+    // 1b. Load MM YAML overrides from <source>/mm/ and merge them into the
+    //     schema IR so that enumValues (and other MM-derived constraints) are
+    //     available to the WrapperEmitter's `deriveEnums` gate.
+    //
+    //     The mm/ directory is optional: if it doesn't exist (e.g. a
+    //     schema-only fixture), we skip merging and use the bare schema IR.
+    //     For each resource in the registry we attempt to read
+    //     `mm/<terraform_type>.yaml`; missing files are silently skipped
+    //     (not every curated resource has a corresponding MM file).
+    final mmDir = Directory(p.join(source, 'mm'));
+    final mmOverrides = <String, MmResourceOverrides>{};
+    if (mmDir.existsSync()) {
+      for (final entity in mmDir.listSync()) {
+        if (entity is! File) continue;
+        final basename = p.basename(entity.path);
+        if (!basename.endsWith('.yaml')) continue;
+        final resourceType = basename.substring(0, basename.length - 5);
+        try {
+          mmOverrides[resourceType] =
+              const MmYamlParser().parseString(entity.readAsStringSync());
+        } catch (_) {
+          // Malformed MM YAML: skip silently (schema IR is still usable).
+        }
+      }
+    }
+    final ir = mmOverrides.isEmpty
+        ? baseIr
+        : const IrMerger().merge(base: baseIr, overrides: mmOverrides);
 
     // 2. Resolve the YAML override root. In `dart test` the package_config
     //    is provided by the runner, so `Isolate.resolvePackageUri` succeeds.

--- a/packages/terradart_codegen/lib/src/cli/wrap_command.dart
+++ b/packages/terradart_codegen/lib/src/cli/wrap_command.dart
@@ -134,6 +134,9 @@ class WrapCommand extends Command<int> {
     final mmDir = Directory(p.join(source, 'mm'));
     final mmOverrides = <String, MmResourceOverrides>{};
     if (mmDir.existsSync()) {
+      // Insertion order is irrelevant: `mmOverrides` is consumed by keyed
+      // lookup in `IrMerger.merge`, so no `..sort()` is needed (unlike
+      // `yaml_loader`, whose registry order is observable).
       for (final entity in mmDir.listSync()) {
         if (entity is! File) continue;
         final basename = p.basename(entity.path);
@@ -142,8 +145,15 @@ class WrapCommand extends Command<int> {
         try {
           mmOverrides[resourceType] =
               const MmYamlParser().parseString(entity.readAsStringSync());
-        } catch (_) {
-          // Malformed MM YAML: skip silently (schema IR is still usable).
+        } catch (e) {
+          // Surface malformed MM YAML rather than silently dropping it: a
+          // dropped file would make the `deriveEnums` gate emit nothing,
+          // which is a confusing failure. Mirror the bracketed E-code
+          // convention used by the other input-error paths in this command.
+          stderr.writeln(
+            '[E405] terradart wrap: malformed MM YAML ${entity.path}: $e',
+          );
+          return CliExitCodes.dataError;
         }
       }
     }

--- a/packages/terradart_codegen/lib/src/codegen/enum_emitter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/enum_emitter.dart
@@ -23,7 +23,8 @@ String emitEnumDeclaration(EnumName name) {
     ..writeln('enum ${name.dartName} implements TerraformEnum {');
   for (var i = 0; i < name.dartMembers.length; i++) {
     final isLast = i == name.dartMembers.length - 1;
-    buf.writeln("  ${name.dartMembers[i]}('${name.rawValues[i]}')${isLast ? ';' : ','}");
+    buf.writeln(
+        "  ${name.dartMembers[i]}('${name.rawValues[i]}')${isLast ? ';' : ','}");
   }
   buf
     ..writeln()

--- a/packages/terradart_codegen/lib/src/codegen/enum_emitter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/enum_emitter.dart
@@ -13,17 +13,25 @@ import 'naming.dart';
 /// `package:terradart_core/terradart_core.dart`, which re-exports
 /// [TerraformEnum]; no separate import is required at the enum-emit site.
 String emitEnumDeclaration(EnumName name) {
-  final memberList = name.dartMembers.join(', ');
-  // Resource label is everything except the trailing PascalCase chunk; the
-  // **leaf** field name (last segment of fieldPath) is the dartdoc reference,
-  // since it's already disambiguated by the resource prefix in the enum name.
   final words = _splitPascalWords(name.dartName);
   final resource = words.length >= 2
       ? words.sublist(0, words.length - 1).join(' ')
       : name.dartName;
   final leaf = name.fieldPath.split('.').last;
-  return '/// $resource enum for `$leaf`.\n'
-      'enum ${name.dartName} implements TerraformEnum { $memberList }\n';
+  final buf = StringBuffer()
+    ..writeln('/// $resource enum for `$leaf`.')
+    ..writeln('enum ${name.dartName} implements TerraformEnum {');
+  for (var i = 0; i < name.dartMembers.length; i++) {
+    final isLast = i == name.dartMembers.length - 1;
+    buf.writeln("  ${name.dartMembers[i]}('${name.rawValues[i]}')${isLast ? ';' : ','}");
+  }
+  buf
+    ..writeln()
+    ..writeln('  const ${name.dartName}(this.terraformValue);')
+    ..writeln('  @override')
+    ..writeln('  final String terraformValue;')
+    ..writeln('}');
+  return buf.toString();
 }
 
 String writeEnumDartType(EnumName name) => name.dartName;

--- a/packages/terradart_codegen/lib/src/codegen/naming.dart
+++ b/packages/terradart_codegen/lib/src/codegen/naming.dart
@@ -33,10 +33,12 @@ String resourceFileName(String terraformType) => '$terraformType.dart';
 class EnumName {
   final String dartName;
   final List<String> dartMembers;
+  final List<String> rawValues;
   final String fieldPath;
   const EnumName({
     required this.dartName,
     required this.dartMembers,
+    required this.rawValues,
     required this.fieldPath,
   });
 }
@@ -66,6 +68,7 @@ EnumName enumName({
   return EnumName(
     dartName: '$shortResourcePascal$leafPascal',
     dartMembers: dartMembers,
+    rawValues: List<String>.from(members),
     fieldPath: fieldPath,
   );
 }

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_emitter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_emitter.dart
@@ -3,6 +3,7 @@ import '../ir/nested_block.dart';
 import '../ir/resource_def.dart';
 import 'constructor_params.dart';
 import 'dart_type_writer.dart';
+import 'enum_emitter.dart';
 import 'naming.dart';
 import 'sensitive_set_emitter.dart';
 import 'wrapper_overrides/wrapper_override.dart';
@@ -109,6 +110,24 @@ class WrapperEmitter {
       ),
     );
     buf.writeln();
+
+    // Phase A1: derive top-level `TerraformEnum` declarations from the
+    // MM-enriched IR when the override opts in via `deriveEnums: true`. Each
+    // top-level attribute carrying `enumValues` becomes a generated enum,
+    // replacing the hand-written `prelude` enum block. Nested-block enums are
+    // out of scope for A1 (top-level attributes only).
+    if (override?.deriveEnums ?? false) {
+      for (final attr in def.root.attributes) {
+        final values = attr.constraints.enumValues;
+        if (values == null || values.isEmpty) continue;
+        final en = enumName(
+          resourceType: def.terraformType,
+          fieldPath: attr.name,
+          members: values,
+        );
+        buf.writeln(emitEnumDeclaration(en));
+      }
+    }
 
     // Prelude (sealed types + helper classes the hand-written wrapper
     // ships inline). Plan 5.X: the schema-stub class is gone, so the

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/wrapper_override.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/wrapper_override.dart
@@ -194,6 +194,12 @@ final class WrapperOverride {
   /// `null` means "no prelude".
   final String? prelude;
 
+  /// Phase A1 migration gate. When `true`, the emitter derives `TerraformEnum`
+  /// declarations for this resource's enum-valued attributes from the
+  /// MM-enriched IR, and the hand-written enum block must be removed from
+  /// [prelude]. Defaults to `false` so un-migrated resources are unaffected.
+  final bool deriveEnums;
+
   /// Snake-case slot name → custom constructor / argMap snippets.
   ///
   /// Two use cases:
@@ -271,6 +277,7 @@ final class WrapperOverride {
     this.extraSensitiveFields,
     this.prelude,
     this.customSlots,
+    this.deriveEnums = false,
   });
 }
 

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_schema.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_schema.yaml
@@ -1,4 +1,5 @@
 outputDir: pubsub
+deriveEnums: true
 
 classDocComment: |-
   /// Factory wrapper for `google_pubsub_schema` (provider
@@ -73,28 +74,3 @@ extraGetters: |2
     /// `projects/{project}/schemas/{name}`). Topics' `schema_settings.schema`
     /// expects this full-path form -- pass `TfArg.ref(schema.id)`.
     TfRef<String> get id => TfRef.attribute<String>(this, 'id');
-
-prelude: |
-  // ===========================================================================
-  // Enums (sourced from schema "Possible values" prose)
-  // ===========================================================================
-
-  /// `type` -- the payload shape this schema validates. Schema default
-  /// `TYPE_UNSPECIFIED` (no validation); pick [protocolBuffer] or [avro]
-  /// to enable publisher-side validation of message payloads.
-  enum PubsubSchemaType implements TerraformEnum {
-    /// Default. No payload validation is performed. Equivalent to omitting
-    /// `type` in HCL.
-    typeUnspecified('TYPE_UNSPECIFIED'),
-
-    /// `definition` holds a Protobuf source string with a single
-    /// `message {...}` definition.
-    protocolBuffer('PROTOCOL_BUFFER'),
-
-    /// `definition` holds an Avro JSON schema string.
-    avro('AVRO');
-
-    const PubsubSchemaType(this.terraformValue);
-    @override
-    final String terraformValue;
-  }

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml_loader.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml_loader.dart
@@ -297,7 +297,7 @@ class YamlOverrideLoader {
       extraSensitiveFields:
           _readStringList(yaml, 'extraSensitiveFields', filePath),
       prelude: _readString(yaml, 'prelude', filePath),
-      deriveEnums: yaml['deriveEnums'] as bool? ?? false,
+      deriveEnums: _readBool(yaml, 'deriveEnums', filePath) ?? false,
       customSlots: _readCustomSlots(yaml, filePath),
     );
   }
@@ -506,6 +506,17 @@ class YamlOverrideLoader {
     if (v is! String) {
       throw FormatException(
         '$filePath: "$key" must be a string',
+      );
+    }
+    return v;
+  }
+
+  bool? _readBool(YamlMap yaml, String key, String filePath) {
+    final v = yaml[key];
+    if (v == null) return null;
+    if (v is! bool) {
+      throw FormatException(
+        '$filePath: "$key" must be a boolean (true or false)',
       );
     }
     return v;

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml_loader.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml_loader.dart
@@ -75,6 +75,7 @@ class YamlOverrideLoader {
     'extraImports',
     'extraSensitiveFields',
     'prelude',
+    'deriveEnums',
     'customSlots',
     // 4 Phase 4.1 axes (kind dispatch + emitter routing).
     'kind',
@@ -296,6 +297,7 @@ class YamlOverrideLoader {
       extraSensitiveFields:
           _readStringList(yaml, 'extraSensitiveFields', filePath),
       prelude: _readString(yaml, 'prelude', filePath),
+      deriveEnums: yaml['deriveEnums'] as bool? ?? false,
       customSlots: _readCustomSlots(yaml, filePath),
     );
   }

--- a/packages/terradart_codegen/test/cli/wrap_command_test.dart
+++ b/packages/terradart_codegen/test/cli/wrap_command_test.dart
@@ -386,6 +386,71 @@ void main() {
         await tmpOut.delete(recursive: true);
       }
     });
+
+    test(
+        'valid MM enum_values flow through wrap into a derived Dart enum '
+        '(happy path)', () async {
+      // Positive complement to the malformed-MM test above.
+      // Proves: valid enum_values in MM YAML → IrMerger → deriveEnums gate
+      // → derived Dart enum in wrap output.
+      //
+      // The override registry (google_pubsub_schema.yaml with deriveEnums:true)
+      // is loaded from the package, not from --source, so the gate is active.
+      // We use --only to limit output to a single file and keep the test fast.
+      final tmpSrc = await Directory.systemTemp.createTemp('phase4_mm_ok_src_');
+      final tmpOut = await Directory.systemTemp.createTemp('phase4_mm_ok_out_');
+      try {
+        // Copy the real schema.json fixture so schema parse succeeds.
+        final fixtureSchema = File(
+          p.join('test', 'fixtures', 'wrap', 'source', 'schema.json'),
+        );
+        File(p.join(tmpSrc.path, 'schema.json'))
+            .writeAsStringSync(fixtureSchema.readAsStringSync());
+
+        // Copy the real MM YAML fixture (has enum_values for PubsubSchemaType).
+        final fixtureMm = File(
+          p.join(
+            'test',
+            'fixtures',
+            'wrap',
+            'source',
+            'mm',
+            'google_pubsub_schema.yaml',
+          ),
+        );
+        final mmDir = Directory(p.join(tmpSrc.path, 'mm'));
+        mmDir.createSync(recursive: true);
+        File(p.join(mmDir.path, 'google_pubsub_schema.yaml'))
+            .writeAsStringSync(fixtureMm.readAsStringSync());
+
+        final code = await buildCliRunner().run([
+          'wrap',
+          '--provider',
+          'hashicorp/google',
+          '--source',
+          tmpSrc.path,
+          '--output',
+          tmpOut.path,
+          '--only',
+          'google_pubsub_schema',
+        ]);
+        expect(code, CliExitCodes.success);
+
+        final outFile = File(
+          p.join(tmpOut.path, 'pubsub', 'google_pubsub_schema.dart'),
+        );
+        expect(outFile.existsSync(), isTrue);
+        final contents = outFile.readAsStringSync();
+        expect(
+          contents,
+          contains('enum PubsubSchemaType implements TerraformEnum {'),
+        );
+        expect(contents, contains("typeUnspecified('TYPE_UNSPECIFIED'),"));
+      } finally {
+        await tmpSrc.delete(recursive: true);
+        await tmpOut.delete(recursive: true);
+      }
+    });
   });
 
   group('WrapCommand fixture-driven', () {

--- a/packages/terradart_codegen/test/cli/wrap_command_test.dart
+++ b/packages/terradart_codegen/test/cli/wrap_command_test.dart
@@ -344,6 +344,50 @@ void main() {
     });
   });
 
+  group('WrapCommand MM YAML', () {
+    test('malformed MM YAML exits with dataError (E405)', () async {
+      // Build a synthetic --source: a valid schema.json (copied from the
+      // real fixture so the schema parse succeeds) plus an mm/ directory
+      // holding one intentionally malformed YAML file. The wrap pipeline
+      // must surface the parse failure rather than silently dropping the
+      // file (which would make `deriveEnums` emit nothing).
+      final tmpSrc = await Directory.systemTemp.createTemp('phase4_mm_bad_');
+      final tmpOut = await Directory.systemTemp.createTemp('phase4_mm_out_');
+      try {
+        final fixtureSchema = File(
+          p.join('test', 'fixtures', 'wrap', 'source', 'schema.json'),
+        );
+        File(p.join(tmpSrc.path, 'schema.json'))
+            .writeAsStringSync(fixtureSchema.readAsStringSync());
+        final mmDir = Directory(p.join(tmpSrc.path, 'mm'));
+        mmDir.createSync(recursive: true);
+        // Unclosed YAML flow mapping → YamlException from loadYaml.
+        File(p.join(mmDir.path, 'google_pubsub_schema.yaml'))
+            .writeAsStringSync('{ : : :');
+
+        final errBuf = StringBuffer();
+        final code = await IOOverrides.runZoned(
+          () => buildCliRunner().run([
+            'wrap',
+            '--provider',
+            'hashicorp/google',
+            '--source',
+            tmpSrc.path,
+            '--output',
+            tmpOut.path,
+          ]),
+          stderr: () => _BufferSink(errBuf),
+        );
+        expect(code, CliExitCodes.dataError);
+        expect(errBuf.toString(), contains('[E405]'));
+        expect(errBuf.toString(), contains('malformed MM YAML'));
+      } finally {
+        await tmpSrc.delete(recursive: true);
+        await tmpOut.delete(recursive: true);
+      }
+    });
+  });
+
   group('WrapCommand fixture-driven', () {
     // Fixture files are stored with a `.dart.golden` suffix (matching the
     // project-wide golden naming convention under `test/golden/`) so they
@@ -396,4 +440,37 @@ void main() {
       }
     });
   });
+}
+
+/// Minimal [Stdout] stand-in that appends every `write*` call to a
+/// [StringBuffer], so in-process tests can capture what `stderr.writeln` would
+/// have printed. `IOOverrides.runZoned`'s `stderr` factory must return a
+/// [Stdout]; only the text-writing surface is exercised by the CLI, so the
+/// remainder is routed through `noSuchMethod`.
+class _BufferSink implements Stdout {
+  _BufferSink(this._buf);
+
+  final StringBuffer _buf;
+
+  @override
+  void write(Object? object) => _buf.write(object);
+
+  @override
+  void writeln([Object? object = '']) => _buf.writeln(object);
+
+  @override
+  void writeAll(Iterable<dynamic> objects, [String separator = '']) =>
+      _buf.writeAll(objects, separator);
+
+  @override
+  void writeCharCode(int charCode) => _buf.writeCharCode(charCode);
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/packages/terradart_codegen/test/codegen/derive_enums_emission_test.dart
+++ b/packages/terradart_codegen/test/codegen/derive_enums_emission_test.dart
@@ -1,0 +1,49 @@
+import 'package:terradart_codegen/src/codegen/wrapper_emitter.dart';
+import 'package:terradart_codegen/src/codegen/wrapper_overrides/wrapper_override.dart';
+import 'package:terradart_codegen/src/ir/attribute.dart';
+import 'package:terradart_codegen/src/ir/constraints.dart';
+import 'package:terradart_codegen/src/ir/nested_block.dart';
+import 'package:terradart_codegen/src/ir/resource_def.dart';
+import 'package:terradart_codegen/src/ir/type_def.dart';
+import 'package:test/test.dart';
+
+ResourceDef _schemaDef() => const ResourceDef(
+      terraformType: 'google_pubsub_schema',
+      root: BlockDef(
+        attributes: [
+          Attribute(
+            name: 'type',
+            type: StringType(),
+            constraints: Constraints(
+              optional: true,
+              enumValues: ['TYPE_UNSPECIFIED', 'PROTOCOL_BUFFER', 'AVRO'],
+            ),
+          ),
+        ],
+      ),
+    );
+
+void main() {
+  group('derived enum emission', () {
+    test('emits a TerraformEnum when deriveEnums is true', () {
+      final emitter = WrapperEmitter(overrides: {
+        'google_pubsub_schema':
+            const WrapperOverride(outputDir: 'pubsub', deriveEnums: true),
+      });
+      final src = emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
+      expect(src, contains('enum PubsubSchemaType implements TerraformEnum {'));
+      expect(src, contains("typeUnspecified('TYPE_UNSPECIFIED'),"));
+      expect(src, contains("avro('AVRO');"));
+      expect(src, contains('final String terraformValue;'));
+    });
+
+    test('does NOT emit a derived enum when deriveEnums is false', () {
+      final emitter = WrapperEmitter(overrides: {
+        'google_pubsub_schema':
+            const WrapperOverride(outputDir: 'pubsub'),
+      });
+      final src = emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
+      expect(src, isNot(contains('enum PubsubSchemaType')));
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/derive_enums_emission_test.dart
+++ b/packages/terradart_codegen/test/codegen/derive_enums_emission_test.dart
@@ -30,7 +30,8 @@ void main() {
         'google_pubsub_schema':
             const WrapperOverride(outputDir: 'pubsub', deriveEnums: true),
       });
-      final src = emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
+      final src =
+          emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
       expect(src, contains('enum PubsubSchemaType implements TerraformEnum {'));
       expect(src, contains("typeUnspecified('TYPE_UNSPECIFIED'),"));
       expect(src, contains("avro('AVRO');"));
@@ -39,10 +40,10 @@ void main() {
 
     test('does NOT emit a derived enum when deriveEnums is false', () {
       final emitter = WrapperEmitter(overrides: {
-        'google_pubsub_schema':
-            const WrapperOverride(outputDir: 'pubsub'),
+        'google_pubsub_schema': const WrapperOverride(outputDir: 'pubsub'),
       });
-      final src = emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
+      final src =
+          emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
       expect(src, isNot(contains('enum PubsubSchemaType')));
     });
   });

--- a/packages/terradart_codegen/test/codegen/enum_constraint_emits_dart_enum_test.dart
+++ b/packages/terradart_codegen/test/codegen/enum_constraint_emits_dart_enum_test.dart
@@ -3,8 +3,9 @@ import 'package:terradart_codegen/src/codegen/naming.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('emitEnumDeclaration (spec §9.2 #3)', () {
-    test('emits Dart enum with camelCase members preserving order', () {
+  group('emitEnumDeclaration', () {
+    test('emits a complete TerraformEnum with raw values and terraformValue',
+        () {
       final name = enumName(
         resourceType: 'google_pubsub_topic',
         fieldPath: 'schema_settings.encoding',
@@ -13,23 +14,33 @@ void main() {
       final src = emitEnumDeclaration(name);
       expect(src, equals('''
 /// Pubsub Topic enum for `encoding`.
-enum PubsubTopicEncoding implements TerraformEnum { encodingUnspecified, json, binary }
+enum PubsubTopicEncoding implements TerraformEnum {
+  encodingUnspecified('ENCODING_UNSPECIFIED'),
+  json('JSON'),
+  binary('BINARY');
+
+  const PubsubTopicEncoding(this.terraformValue);
+  @override
+  final String terraformValue;
+}
 '''));
     });
 
-    test('a single-member enum is still emitted', () {
+    test('a single-member enum is still emitted with its raw value', () {
       final name = enumName(
         resourceType: 'google_x',
         fieldPath: 'mode',
         members: const ['ALL'],
       );
       final src = emitEnumDeclaration(name);
-      expect(src, contains('enum XMode implements TerraformEnum { all }'));
+      expect(src, contains("all('ALL');"));
+      expect(src, contains('enum XMode implements TerraformEnum {'));
+      expect(src, contains('final String terraformValue;'));
     });
   });
 
-  group('uses-the-enum field rendering', () {
-    test('writeEnumDartType returns the enum class name', () {
+  group('writeEnumDartType', () {
+    test('returns the enum class name', () {
       final name = enumName(
         resourceType: 'google_pubsub_topic',
         fieldPath: 'schema_settings.encoding',

--- a/packages/terradart_codegen/test/codegen/enum_name_raw_values_test.dart
+++ b/packages/terradart_codegen/test/codegen/enum_name_raw_values_test.dart
@@ -1,0 +1,17 @@
+import 'package:terradart_codegen/src/codegen/naming.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EnumName.rawValues', () {
+    test('enumName carries raw SCREAMING values parallel to dartMembers', () {
+      final n = enumName(
+        resourceType: 'google_pubsub_schema',
+        fieldPath: 'type',
+        members: const ['TYPE_UNSPECIFIED', 'PROTOCOL_BUFFER', 'AVRO'],
+      );
+      expect(n.dartName, 'PubsubSchemaType');
+      expect(n.dartMembers, ['typeUnspecified', 'protocolBuffer', 'avro']);
+      expect(n.rawValues, ['TYPE_UNSPECIFIED', 'PROTOCOL_BUFFER', 'AVRO']);
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/pubsub_schema_enum_derivation_guard_test.dart
+++ b/packages/terradart_codegen/test/codegen/pubsub_schema_enum_derivation_guard_test.dart
@@ -10,10 +10,10 @@ void main() {
       ).readAsStringSync();
       expect(yaml, contains('deriveEnums: true'));
       expect(yaml, isNot(contains('enum PubsubSchemaType')));
-      expect(yaml, isNot(contains('prelude:')));
     });
 
     test('generated wrapper exposes the derived TerraformEnum', () {
+      // Relative path assumes cwd is the package dir, which `dart test` provides.
       final dart = File(
         '../terradart_google/lib/src/pubsub/google_pubsub_schema.dart',
       ).readAsStringSync();

--- a/packages/terradart_codegen/test/codegen/pubsub_schema_enum_derivation_guard_test.dart
+++ b/packages/terradart_codegen/test/codegen/pubsub_schema_enum_derivation_guard_test.dart
@@ -17,7 +17,8 @@ void main() {
       final dart = File(
         '../terradart_google/lib/src/pubsub/google_pubsub_schema.dart',
       ).readAsStringSync();
-      expect(dart, contains('enum PubsubSchemaType implements TerraformEnum {'));
+      expect(
+          dart, contains('enum PubsubSchemaType implements TerraformEnum {'));
       expect(dart, contains("typeUnspecified('TYPE_UNSPECIFIED'),"));
       expect(dart, contains('final String terraformValue;'));
     });

--- a/packages/terradart_codegen/test/codegen/pubsub_schema_enum_derivation_guard_test.dart
+++ b/packages/terradart_codegen/test/codegen/pubsub_schema_enum_derivation_guard_test.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  group('google_pubsub_schema enum derivation guard', () {
+    test('override opts into derivation and has no hand-written enum', () {
+      final yaml = File(
+        'lib/src/codegen/wrapper_overrides/yaml/google_pubsub_schema.yaml',
+      ).readAsStringSync();
+      expect(yaml, contains('deriveEnums: true'));
+      expect(yaml, isNot(contains('enum PubsubSchemaType')));
+      expect(yaml, isNot(contains('prelude:')));
+    });
+
+    test('generated wrapper exposes the derived TerraformEnum', () {
+      final dart = File(
+        '../terradart_google/lib/src/pubsub/google_pubsub_schema.dart',
+      ).readAsStringSync();
+      expect(dart, contains('enum PubsubSchemaType implements TerraformEnum {'));
+      expect(dart, contains("typeUnspecified('TYPE_UNSPECIFIED'),"));
+      expect(dart, contains('final String terraformValue;'));
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart
@@ -32,6 +32,17 @@ void main() {
         expect(override.extraImports, isNull);
         expect(override.prelude, isNull);
         expect(override.customSlots, isNull);
+        expect(override.deriveEnums, isFalse);
+      });
+
+      test('derive_enums_on -> deriveEnums true', () {
+        final loader = YamlOverrideLoader(
+          rootDir: 'test/fixtures/semantic_hints_loader/happy',
+        );
+        final result = loader.load().resources;
+        final o = result['derive_enums_on']!;
+        expect(o.deriveEnums, isTrue);
+        expect(o.outputDir, 'test_out');
       });
 
       test('class_doc_comment_only -> only classDocComment set', () {

--- a/packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart
@@ -287,6 +287,19 @@ schemaStubComment: |-
         );
       });
 
+      test('deriveEnums not a boolean -> FormatException', () {
+        final loader = YamlOverrideLoader(
+          rootDir: 'test/fixtures/semantic_hints_loader/failure/'
+              'derive_enums_not_bool',
+        );
+        expect(
+          loader.load,
+          throwsFormatExceptionWith(
+            '"deriveEnums" must be a boolean (true or false)',
+          ),
+        );
+      });
+
       test('deprecatedParams value not string -> FormatException', () {
         final loader = YamlOverrideLoader(
           rootDir: 'test/fixtures/semantic_hints_loader/failure/'

--- a/packages/terradart_codegen/test/fixtures/semantic_hints_loader/failure/derive_enums_not_bool/x.yaml
+++ b/packages/terradart_codegen/test/fixtures/semantic_hints_loader/failure/derive_enums_not_bool/x.yaml
@@ -1,0 +1,2 @@
+outputDir: x
+deriveEnums: "true"

--- a/packages/terradart_codegen/test/fixtures/semantic_hints_loader/happy/derive_enums_on.yaml
+++ b/packages/terradart_codegen/test/fixtures/semantic_hints_loader/happy/derive_enums_on.yaml
@@ -1,0 +1,2 @@
+outputDir: test_out
+deriveEnums: true

--- a/packages/terradart_google/lib/src/pubsub/google_pubsub_schema.dart
+++ b/packages/terradart_google/lib/src/pubsub/google_pubsub_schema.dart
@@ -6,23 +6,10 @@ import 'package:terradart_core/terradart_core.dart';
 /// Sensitive field paths for `google_pubsub_schema`.
 const Set<String> _googlePubsubSchemaSensitive = <String>{};
 
-// ===========================================================================
-// Enums (sourced from schema "Possible values" prose)
-// ===========================================================================
-
-/// `type` -- the payload shape this schema validates. Schema default
-/// `TYPE_UNSPECIFIED` (no validation); pick [protocolBuffer] or [avro]
-/// to enable publisher-side validation of message payloads.
+/// Pubsub Schema enum for `type`.
 enum PubsubSchemaType implements TerraformEnum {
-  /// Default. No payload validation is performed. Equivalent to omitting
-  /// `type` in HCL.
   typeUnspecified('TYPE_UNSPECIFIED'),
-
-  /// `definition` holds a Protobuf source string with a single
-  /// `message {...}` definition.
   protocolBuffer('PROTOCOL_BUFFER'),
-
-  /// `definition` holds an Avro JSON schema string.
   avro('AVRO');
 
   const PubsubSchemaType(this.terraformValue);


### PR DESCRIPTION
## Summary

Phase A1 of moving hand-written facts out of `wrapper_overrides` and into deterministic emission, so curated output converges regardless of which agent/model regenerates it. This wave makes **enum declarations** derive from the Magic-Modules-enriched IR instead of being hand-written in each override's `prelude`, proven end-to-end on one exemplar resource.

- **Machinery**: `EnumName` now carries the raw Terraform values; `emitEnumDeclaration` emits a complete `TerraformEnum` (members + `terraformValue` mapping + `const` ctor); a new per-override `deriveEnums` gate (default `false`, type-validated in the loader) controls it; `WrapperEmitter` emits derived top-level enums when the gate is on.
- **Pipeline fix**: `wrap` previously never merged MM YAML into the IR — it loaded `mm/` only to locate `schema.json`. `wrap_command` now runs `IrMerger` over `<source>/mm/*.yaml`, so MM `enumValues` actually reach the emitter. Malformed MM YAML now fails loudly with `[E405]` instead of being silently skipped.
- **Tracer bullet**: `google_pubsub_schema` is migrated — its hand-written `prelude` enum is removed and `deriveEnums: true` set. Its public API (`PubsubSchemaType` name, members, `terraformValue` values, `type` param type) is **unchanged**; the only delta is the loss of per-member doc comments (the intended convergence trade-off).

## Safety

- `wrap --check` reports **all 121 generated files match** — enabling the MM merge changes no other resource's output. By construction the only emit-time consumer of any merged constraint is the `enumValues` read inside the `deriveEnums` gate, which only `google_pubsub_schema` opts into.
- Non-breaking for users: the curated `PubsubSchemaType` enum surface is byte-identical.

## Test Plan

- [x] `tool/agent_verify.sh` exits 0 (docs consistency, `dart analyze --fatal-infos`, four-package tests, `wrap --check` 121-match, pubsub quickstart smoke)
- [x] New unit/loader/emitter/CLI tests: `EnumName.rawValues`; complete `emitEnumDeclaration`; `deriveEnums` parse + non-bool `FormatException`; gated emission (positive + negative); `wrap` malformed-MM `[E405]`; `wrap` valid-MM happy-path reads the emitted file; committed-file derivation guard
- [x] `deriveEnums: true` set on exactly one override (`google_pubsub_schema.yaml`)

## Deferred (later waves)

- Nested-block enum derivation (this wave covers top-level attributes only — documented in `wrapper_emitter`)
- Auto-derived enum **field typing** (the `dartTypeOverrides: type: PubsubSchemaType` line is intentionally kept)
- Migrating the other ~61 enum-bearing overrides (repeat the de-fatten per product)

## Note for future waves

`IrMerger` also propagates the resource `description`, and the catalog `docComment` falls back to `def.description` when no `classDocComment` is set. A future resource with (no `classDocComment`) + (null schema description) + (an MM `description`) could see a changed catalog entry once its MM file is added — currently dormant (no resource hits this; the 121-file match proves it), but worth watching when adding MM files.