### PR TITLE
feat(codegen): derive curated output getters from the IR (Phase A3)

### DIFF
--- a/packages/terradart_codegen/lib/src/codegen/constructor_params.dart
+++ b/packages/terradart_codegen/lib/src/codegen/constructor_params.dart
@@ -28,7 +28,7 @@ import '../ir/resource_def.dart';
 ///    order (also alphabetical).
 ///
 /// **Filtering rules** (applied only when [paramOrder] is null):
-/// - Attributes are excluded if: `computed && !optional && !required`
+/// - Attributes are excluded if: [Constraints.computedOnly] holds
 ///   (computed-only — no input role) or `name == 'id'` (identity field
 ///   exposed via TfRef getter, not a constructor arg).
 /// - Nested blocks are excluded if: `name == 'timeouts'` (Terraform-internal
@@ -57,15 +57,13 @@ List<String> _naturalOrderNames(ResourceDef def) {
 
 /// Returns true when [attr] must be excluded from the constructor / catalog.
 ///
-/// Excludes computed-only attributes (`computed && !optional && !required` —
-/// no input role) and the synthetic `id` identity field (exposed via a TfRef
-/// getter, not as a constructor arg). Shared with [WrapperEmitter] (and the
-/// catalog metadata emitter) so all surfaces filter identically.
+/// Excludes computed-only attributes ([Constraints.computedOnly] — no input
+/// role) and the synthetic `id` identity field (exposed via a TfRef getter,
+/// not as a constructor arg). Shared with [WrapperEmitter] (and the catalog
+/// metadata emitter) so all surfaces filter identically.
 bool skipAttribute(Attribute attr) {
-  final c = attr.constraints;
-  final isComputedOnly = c.computed && !c.optional && !c.required;
   final isIdAttribute = attr.name == 'id';
-  return isComputedOnly || isIdAttribute;
+  return attr.constraints.computedOnly || isIdAttribute;
 }
 
 /// Returns true when [block] must be excluded from the constructor / catalog.

--- a/packages/terradart_codegen/lib/src/codegen/getter_emitter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/getter_emitter.dart
@@ -1,0 +1,61 @@
+import '../ir/resource_def.dart';
+import 'dart_type_writer.dart';
+import 'naming.dart';
+
+/// Emits derived output-attribute getters for a [ResourceDef].
+///
+/// Phase A3: output getters used to live entirely in each override's
+/// hand-written `extraGetters` axis. This emitter derives the mechanical
+/// ones from the IR so they converge across agents/models:
+///
+/// - A `name` attribute → `nameRef` (the bare `name` getter would collide
+///   with the constructor parameter; `String` matches every Terraform name).
+/// - An `id` attribute → bare `id`. Special-cased by name (parallel to
+///   `skipAttribute`'s `isIdAttribute` check), so it is exposed as a getter
+///   regardless of how its computed/optional flags would otherwise classify it.
+/// - Every **pure computed-only** attribute (`Constraints.computedOnly`)
+///   other than `id`/`name` → a camelCase getter of its rendered Dart type.
+///
+/// `optional + computed` attributes are intentionally skipped: they are
+/// settable constructor inputs, and exposing a reference getter for them is
+/// a genuine judgment call that stays in `extraGetters`.
+///
+/// The Google identity convention (`name→nameRef`, `id→id`) is encoded here.
+/// A multi-provider generalisation (e.g. AWS `arn→arnRef`) is deferred until
+/// a second provider adapter exists.
+///
+/// Output is **unformatted** Dart source (two-space indented, one blank line
+/// after each getter); the caller feeds the whole wrapper through
+/// `dart_style`. Returns an empty string when nothing is derivable.
+String emitDerivedOutputGetters(ResourceDef def) {
+  final buf = StringBuffer();
+  final attrNames = {for (final a in def.root.attributes) a.name};
+  final emitted = <String>{};
+
+  void writeGetter(String snake, String getter, String dartType) {
+    buf
+      ..writeln('  /// Reference to `$snake` attribute.')
+      ..writeln(
+        "  TfRef<$dartType> get $getter => "
+        "TfRef.attribute<$dartType>(this, '$snake');",
+      )
+      ..writeln();
+    emitted.add(snake);
+  }
+
+  if (attrNames.contains('name')) {
+    writeGetter('name', 'nameRef', 'String');
+  }
+  // `id` is special-cased by name, parallel to `skipAttribute`'s isIdAttribute
+  // check: always a getter, never a constructor arg, whatever its flags say.
+  if (attrNames.contains('id')) {
+    writeGetter('id', 'id', 'String');
+  }
+  for (final attr in def.root.attributes) {
+    if (emitted.contains(attr.name)) continue;
+    if (!attr.constraints.computedOnly) continue;
+    writeGetter(attr.name, snakeToCamel(attr.name), writeDartType(attr.type));
+  }
+
+  return buf.toString();
+}

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_emitter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_emitter.dart
@@ -4,6 +4,7 @@ import '../ir/resource_def.dart';
 import 'constructor_params.dart';
 import 'dart_type_writer.dart';
 import 'enum_emitter.dart';
+import 'getter_emitter.dart';
 import 'naming.dart';
 import 'sensitive_set_emitter.dart';
 import 'wrapper_overrides/wrapper_override.dart';
@@ -243,10 +244,24 @@ class WrapperEmitter {
       buf.writeln('  bool get supportsDeletionProtection => true;');
     }
 
+    // Phase A3: derive output-attribute getters (nameRef, id, pure
+    // computed-only) from the IR when the override opts in via
+    // `deriveOutputGetters: true`. Hand-written `extraGetters` remain for
+    // genuine exceptions (e.g. semantic renames like `member` -> `iamMember`)
+    // and are emitted after this derived block. A later `lint-override` gate
+    // (A5) will forbid hand-encoding a getter that derivation already produces.
+    if (override?.deriveOutputGetters ?? false) {
+      final derived = emitDerivedOutputGetters(def);
+      if (derived.isNotEmpty) {
+        buf.writeln();
+        buf.write(derived);
+      }
+    }
+
     // Extra getters (TfRef shortcuts, etc.) inserted from the override.
     // The override snippet already carries indent and trailing newline, so
-    // we use `write`, not `writeln`. A blank line separates them from the
-    // sensitive-fields getter.
+    // we use `write`, not `writeln`. A blank line separator is emitted before
+    // this block.
     final extraGetters = override?.extraGetters;
     if (extraGetters != null) {
       buf.writeln();

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/wrapper_override.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/wrapper_override.dart
@@ -200,6 +200,13 @@ final class WrapperOverride {
   /// [prelude]. Defaults to `false` so un-migrated resources are unaffected.
   final bool deriveEnums;
 
+  /// Phase A3 migration gate. When `true`, the emitter derives output-attribute
+  /// `TfRef` getters (`nameRef`, `id`, and pure computed-only attributes) for
+  /// this resource from the IR, and the corresponding hand-written getters must
+  /// be removed from [extraGetters] (genuine exceptions may remain). Defaults to
+  /// `false` so un-migrated resources are unaffected.
+  final bool deriveOutputGetters;
+
   /// Snake-case slot name → custom constructor / argMap snippets.
   ///
   /// Two use cases:
@@ -278,6 +285,7 @@ final class WrapperOverride {
     this.prelude,
     this.customSlots,
     this.deriveEnums = false,
+    this.deriveOutputGetters = false,
   });
 }
 

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_schema.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_schema.yaml
@@ -1,5 +1,6 @@
 outputDir: pubsub
 deriveEnums: true
+deriveOutputGetters: true
 
 classDocComment: |-
   /// Factory wrapper for `google_pubsub_schema` (provider
@@ -64,13 +65,3 @@ paramOrder:
 
 dartTypeOverrides:
   type: PubsubSchemaType
-
-extraGetters: |2
-    /// Reference to `name` attribute. Use for interpolations like
-    /// `schema.nameRef` -> `${google_pubsub_schema.<localName>.name}`.
-    TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
-
-    /// Reference to `id` attribute (full path
-    /// `projects/{project}/schemas/{name}`). Topics' `schema_settings.schema`
-    /// expects this full-path form -- pass `TfArg.ref(schema.id)`.
-    TfRef<String> get id => TfRef.attribute<String>(this, 'id');

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml_loader.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml_loader.dart
@@ -76,6 +76,7 @@ class YamlOverrideLoader {
     'extraSensitiveFields',
     'prelude',
     'deriveEnums',
+    'deriveOutputGetters',
     'customSlots',
     // 4 Phase 4.1 axes (kind dispatch + emitter routing).
     'kind',
@@ -298,6 +299,8 @@ class YamlOverrideLoader {
           _readStringList(yaml, 'extraSensitiveFields', filePath),
       prelude: _readString(yaml, 'prelude', filePath),
       deriveEnums: _readBool(yaml, 'deriveEnums', filePath) ?? false,
+      deriveOutputGetters:
+          _readBool(yaml, 'deriveOutputGetters', filePath) ?? false,
       customSlots: _readCustomSlots(yaml, filePath),
     );
   }

--- a/packages/terradart_codegen/lib/src/ir/constraints.dart
+++ b/packages/terradart_codegen/lib/src/ir/constraints.dart
@@ -47,6 +47,12 @@ final class Constraints {
 
   bool get optionalAndComputed => optional && computed;
 
+  /// Output-only attribute: the provider computes it and the user cannot set
+  /// it (`computed` with neither `optional` nor `required`). These are
+  /// excluded from the constructor and exposed as `TfRef` output getters
+  /// (Phase A3).
+  bool get computedOnly => computed && !optional && !required;
+
   Constraints copyWith({
     bool? required,
     bool? optional,

--- a/packages/terradart_codegen/test/codegen/constraints_computed_only_test.dart
+++ b/packages/terradart_codegen/test/codegen/constraints_computed_only_test.dart
@@ -1,0 +1,32 @@
+import 'package:terradart_codegen/src/ir/constraints.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Constraints.computedOnly', () {
+    test('true only when computed and neither optional nor required', () {
+      expect(const Constraints(computed: true).computedOnly, isTrue);
+    });
+
+    test('false when optional+computed (a settable input with a default)', () {
+      expect(
+        const Constraints(optional: true, computed: true).computedOnly,
+        isFalse,
+      );
+    });
+
+    test('false when required', () {
+      expect(
+        const Constraints(required: true, computed: true).computedOnly,
+        isFalse,
+      );
+    });
+
+    test('false when plain optional input', () {
+      expect(const Constraints(optional: true).computedOnly, isFalse);
+    });
+
+    test('false for the empty constraints', () {
+      expect(const Constraints().computedOnly, isFalse);
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/derive_output_getters_emission_test.dart
+++ b/packages/terradart_codegen/test/codegen/derive_output_getters_emission_test.dart
@@ -1,0 +1,83 @@
+import 'package:terradart_codegen/src/codegen/wrapper_emitter.dart';
+import 'package:terradart_codegen/src/codegen/wrapper_overrides/wrapper_override.dart';
+import 'package:terradart_codegen/src/ir/attribute.dart';
+import 'package:terradart_codegen/src/ir/constraints.dart';
+import 'package:terradart_codegen/src/ir/nested_block.dart';
+import 'package:terradart_codegen/src/ir/resource_def.dart';
+import 'package:terradart_codegen/src/ir/type_def.dart';
+import 'package:test/test.dart';
+
+ResourceDef _schemaDef() => const ResourceDef(
+      terraformType: 'google_pubsub_schema',
+      root: BlockDef(
+        attributes: [
+          Attribute(
+            name: 'name',
+            type: StringType(),
+            constraints: Constraints(required: true),
+          ),
+          Attribute(
+            name: 'id',
+            type: StringType(),
+            constraints: Constraints(optional: true, computed: true),
+          ),
+          Attribute(
+            name: 'project',
+            type: StringType(),
+            constraints: Constraints(optional: true, computed: true),
+          ),
+        ],
+      ),
+    );
+
+void main() {
+  group('derived output-getter emission', () {
+    test('emits nameRef and id when deriveOutputGetters is true', () {
+      final emitter = WrapperEmitter(overrides: {
+        'google_pubsub_schema':
+            const WrapperOverride(outputDir: 'pubsub', deriveOutputGetters: true),
+      });
+      final src = emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
+      expect(
+        src,
+        contains(
+          "TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');",
+        ),
+      );
+      expect(
+        src,
+        contains("TfRef<String> get id => TfRef.attribute<String>(this, 'id');"),
+      );
+      // `project` is optional+computed: a constructor input, not a getter.
+      expect(src, isNot(contains('get project =>')));
+    });
+
+    test('does NOT emit derived getters when deriveOutputGetters is false', () {
+      final emitter = WrapperEmitter(overrides: {
+        'google_pubsub_schema': const WrapperOverride(outputDir: 'pubsub'),
+      });
+      final src = emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
+      expect(src, isNot(contains('get nameRef')));
+      expect(src, isNot(contains('get id =>')));
+    });
+
+    test('still emits hand-written extraGetters alongside derived ones', () {
+      final emitter = WrapperEmitter(overrides: {
+        'google_pubsub_schema': const WrapperOverride(
+          outputDir: 'pubsub',
+          deriveOutputGetters: true,
+          extraGetters:
+              "  TfRef<String> get iamMember => TfRef.attribute<String>(this, 'member');\n",
+        ),
+      });
+      final src = emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
+      expect(src, contains('get nameRef'));
+      expect(src, contains('get iamMember'));
+      expect(
+        src.indexOf('get nameRef'),
+        lessThan(src.indexOf('get iamMember')),
+        reason: 'derived getters must precede hand-written extraGetters',
+      );
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/derive_output_getters_emission_test.dart
+++ b/packages/terradart_codegen/test/codegen/derive_output_getters_emission_test.dart
@@ -34,10 +34,11 @@ void main() {
   group('derived output-getter emission', () {
     test('emits nameRef and id when deriveOutputGetters is true', () {
       final emitter = WrapperEmitter(overrides: {
-        'google_pubsub_schema':
-            const WrapperOverride(outputDir: 'pubsub', deriveOutputGetters: true),
+        'google_pubsub_schema': const WrapperOverride(
+            outputDir: 'pubsub', deriveOutputGetters: true),
       });
-      final src = emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
+      final src =
+          emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
       expect(
         src,
         contains(
@@ -46,7 +47,8 @@ void main() {
       );
       expect(
         src,
-        contains("TfRef<String> get id => TfRef.attribute<String>(this, 'id');"),
+        contains(
+            "TfRef<String> get id => TfRef.attribute<String>(this, 'id');"),
       );
       // `project` is optional+computed: a constructor input, not a getter.
       expect(src, isNot(contains('get project =>')));
@@ -56,7 +58,8 @@ void main() {
       final emitter = WrapperEmitter(overrides: {
         'google_pubsub_schema': const WrapperOverride(outputDir: 'pubsub'),
       });
-      final src = emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
+      final src =
+          emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
       expect(src, isNot(contains('get nameRef')));
       expect(src, isNot(contains('get id =>')));
     });
@@ -70,7 +73,8 @@ void main() {
               "  TfRef<String> get iamMember => TfRef.attribute<String>(this, 'member');\n",
         ),
       });
-      final src = emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
+      final src =
+          emitter.emit(_schemaDef(), providerSource: 'hashicorp/google');
       expect(src, contains('get nameRef'));
       expect(src, contains('get iamMember'));
       expect(

--- a/packages/terradart_codegen/test/codegen/getter_emitter_test.dart
+++ b/packages/terradart_codegen/test/codegen/getter_emitter_test.dart
@@ -1,0 +1,123 @@
+import 'package:terradart_codegen/src/codegen/getter_emitter.dart';
+import 'package:terradart_codegen/src/ir/attribute.dart';
+import 'package:terradart_codegen/src/ir/constraints.dart';
+import 'package:terradart_codegen/src/ir/nested_block.dart';
+import 'package:terradart_codegen/src/ir/resource_def.dart';
+import 'package:terradart_codegen/src/ir/type_def.dart';
+import 'package:test/test.dart';
+
+ResourceDef _def(List<Attribute> attrs) => ResourceDef(
+      terraformType: 'google_x',
+      root: BlockDef(attributes: attrs),
+    );
+
+void main() {
+  group('emitDerivedOutputGetters', () {
+    test('emits nameRef then id for the identity attributes', () {
+      final src = emitDerivedOutputGetters(_def(const [
+        Attribute(
+          name: 'name',
+          type: StringType(),
+          constraints: Constraints(required: true),
+        ),
+        Attribute(
+          name: 'id',
+          type: StringType(),
+          constraints: Constraints(computed: true),
+        ),
+      ]));
+      expect(
+        src,
+        contains(
+          "TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');",
+        ),
+      );
+      expect(
+        src,
+        contains("TfRef<String> get id => TfRef.attribute<String>(this, 'id');"),
+      );
+      expect(src.indexOf('get nameRef'), lessThan(src.indexOf('get id')));
+    });
+
+    test('emits camelCase getters for pure computed-only attributes', () {
+      final src = emitDerivedOutputGetters(_def(const [
+        Attribute(
+          name: 'self_link',
+          type: StringType(),
+          constraints: Constraints(computed: true),
+        ),
+        Attribute(
+          name: 'generated_id',
+          type: IntType(),
+          constraints: Constraints(computed: true),
+        ),
+      ]));
+      expect(
+        src,
+        contains(
+          "TfRef<String> get selfLink => "
+          "TfRef.attribute<String>(this, 'self_link');",
+        ),
+      );
+      expect(
+        src,
+        contains(
+          "TfRef<int> get generatedId => "
+          "TfRef.attribute<int>(this, 'generated_id');",
+        ),
+      );
+      expect(src.indexOf('get selfLink'), lessThan(src.indexOf('get generatedId')));
+    });
+
+    test('emits nameRef exactly once when name is itself computed-only', () {
+      final src = emitDerivedOutputGetters(_def(const [
+        Attribute(
+          name: 'name',
+          type: StringType(),
+          constraints: Constraints(computed: true),
+        ),
+      ]));
+      expect(
+        src,
+        contains(
+          "TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');",
+        ),
+      );
+      expect('get nameRef'.allMatches(src).length, 1);
+    });
+
+    test('does NOT emit getters for optional+computed (settable) attributes',
+        () {
+      final src = emitDerivedOutputGetters(_def(const [
+        Attribute(
+          name: 'project',
+          type: StringType(),
+          constraints: Constraints(optional: true, computed: true),
+        ),
+      ]));
+      expect(src, isEmpty);
+    });
+
+    test('emits a one-line template doc comment per getter', () {
+      final src = emitDerivedOutputGetters(_def(const [
+        Attribute(
+          name: 'self_link',
+          type: StringType(),
+          constraints: Constraints(computed: true),
+        ),
+      ]));
+      expect(src, contains('/// Reference to `self_link` attribute.'));
+    });
+
+    test('returns empty source when there is nothing to derive', () {
+      final src = emitDerivedOutputGetters(_def(const [
+        Attribute(
+          name: 'description',
+          type: StringType(),
+          constraints: Constraints(optional: true),
+        ),
+      ]));
+      expect(src, isEmpty);
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/getter_emitter_test.dart
+++ b/packages/terradart_codegen/test/codegen/getter_emitter_test.dart
@@ -34,7 +34,8 @@ void main() {
       );
       expect(
         src,
-        contains("TfRef<String> get id => TfRef.attribute<String>(this, 'id');"),
+        contains(
+            "TfRef<String> get id => TfRef.attribute<String>(this, 'id');"),
       );
       expect(src.indexOf('get nameRef'), lessThan(src.indexOf('get id')));
     });
@@ -66,7 +67,8 @@ void main() {
           "TfRef.attribute<int>(this, 'generated_id');",
         ),
       );
-      expect(src.indexOf('get selfLink'), lessThan(src.indexOf('get generatedId')));
+      expect(src.indexOf('get selfLink'),
+          lessThan(src.indexOf('get generatedId')));
     });
 
     test('emits nameRef exactly once when name is itself computed-only', () {

--- a/packages/terradart_codegen/test/codegen/pubsub_schema_getter_derivation_guard_test.dart
+++ b/packages/terradart_codegen/test/codegen/pubsub_schema_getter_derivation_guard_test.dart
@@ -24,7 +24,8 @@ void main() {
       );
       expect(
         dart,
-        contains("TfRef<String> get id => TfRef.attribute<String>(this, 'id');"),
+        contains(
+            "TfRef<String> get id => TfRef.attribute<String>(this, 'id');"),
       );
       expect(dart, contains('/// Reference to `name` attribute.'));
     });

--- a/packages/terradart_codegen/test/codegen/pubsub_schema_getter_derivation_guard_test.dart
+++ b/packages/terradart_codegen/test/codegen/pubsub_schema_getter_derivation_guard_test.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  group('google_pubsub_schema output-getter derivation guard', () {
+    test('override opts into derivation and has no hand-written getters', () {
+      final yaml = File(
+        'lib/src/codegen/wrapper_overrides/yaml/google_pubsub_schema.yaml',
+      ).readAsStringSync();
+      expect(yaml, contains('deriveOutputGetters: true'));
+      expect(yaml, isNot(contains('extraGetters:')));
+    });
+
+    test('generated wrapper exposes the derived getters', () {
+      final dart = File(
+        '../terradart_google/lib/src/pubsub/google_pubsub_schema.dart',
+      ).readAsStringSync();
+      expect(
+        dart,
+        contains(
+          "TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');",
+        ),
+      );
+      expect(
+        dart,
+        contains("TfRef<String> get id => TfRef.attribute<String>(this, 'id');"),
+      );
+      expect(dart, contains('/// Reference to `name` attribute.'));
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart
@@ -33,6 +33,7 @@ void main() {
         expect(override.prelude, isNull);
         expect(override.customSlots, isNull);
         expect(override.deriveEnums, isFalse);
+        expect(override.deriveOutputGetters, isFalse);
       });
 
       test('derive_enums_on -> deriveEnums true', () {
@@ -42,6 +43,16 @@ void main() {
         final result = loader.load().resources;
         final o = result['derive_enums_on']!;
         expect(o.deriveEnums, isTrue);
+        expect(o.outputDir, 'test_out');
+      });
+
+      test('derive_getters_on -> deriveOutputGetters true', () {
+        final loader = YamlOverrideLoader(
+          rootDir: 'test/fixtures/semantic_hints_loader/happy',
+        );
+        final result = loader.load().resources;
+        final o = result['derive_getters_on']!;
+        expect(o.deriveOutputGetters, isTrue);
         expect(o.outputDir, 'test_out');
       });
 

--- a/packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart
@@ -311,6 +311,19 @@ schemaStubComment: |-
         );
       });
 
+      test('deriveOutputGetters not a boolean -> FormatException', () {
+        final loader = YamlOverrideLoader(
+          rootDir: 'test/fixtures/semantic_hints_loader/failure/'
+              'derive_getters_not_bool',
+        );
+        expect(
+          loader.load,
+          throwsFormatExceptionWith(
+            '"deriveOutputGetters" must be a boolean (true or false)',
+          ),
+        );
+      });
+
       test('deprecatedParams value not string -> FormatException', () {
         final loader = YamlOverrideLoader(
           rootDir: 'test/fixtures/semantic_hints_loader/failure/'

--- a/packages/terradart_codegen/test/fixtures/semantic_hints_loader/failure/derive_getters_not_bool/x.yaml
+++ b/packages/terradart_codegen/test/fixtures/semantic_hints_loader/failure/derive_getters_not_bool/x.yaml
@@ -1,0 +1,2 @@
+outputDir: x
+deriveOutputGetters: "true"

--- a/packages/terradart_codegen/test/fixtures/semantic_hints_loader/happy/derive_getters_on.yaml
+++ b/packages/terradart_codegen/test/fixtures/semantic_hints_loader/happy/derive_getters_on.yaml
@@ -1,0 +1,2 @@
+outputDir: test_out
+deriveOutputGetters: true

--- a/packages/terradart_google/lib/src/pubsub/google_pubsub_schema.dart
+++ b/packages/terradart_google/lib/src/pubsub/google_pubsub_schema.dart
@@ -90,12 +90,9 @@ final class GooglePubsubSchema extends Resource {
   @override
   Set<String> get sensitiveFields => _googlePubsubSchemaSensitive;
 
-  /// Reference to `name` attribute. Use for interpolations like
-  /// `schema.nameRef` -> `${google_pubsub_schema.<localName>.name}`.
+  /// Reference to `name` attribute.
   TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
 
-  /// Reference to `id` attribute (full path
-  /// `projects/{project}/schemas/{name}`). Topics' `schema_settings.schema`
-  /// expects this full-path form -- pass `TfArg.ref(schema.id)`.
+  /// Reference to `id` attribute.
   TfRef<String> get id => TfRef.attribute<String>(this, 'id');
 }


### PR DESCRIPTION
## Summary

Phase A3 of cross-agent convergent curation: output-attribute getters
(`nameRef`, `id`, pure computed-only references) now **derive
deterministically from the IR** instead of being inserted verbatim from each
override's hand-written `extraGetters`. Structural twin of Phase A1 (enum
derivation) — it shrinks the model-dependent override surface so any
agent/model regenerates identical getter output.

- `Constraints.computedOnly` (`computed && !optional && !required`) is now the
  single source of truth for the output-only predicate; `skipAttribute` routes
  through it.
- New provider-neutral `getter_emitter.dart` derives `nameRef` (from `name`),
  bare `id` (from `id`), and camelCase getters for pure computed-only
  attributes. `optional+computed` inputs stay as genuine `extraGetters`
  exceptions.
- `deriveOutputGetters` per-override gate (mirrors `deriveEnums`, incl. the
  non-boolean `FormatException` guard) enables product-by-product migration.
- Wired into `WrapperEmitter` between the built-in getters and hand-written
  `extraGetters` (which remain for genuine exceptions).
- Tracer bullet: `google_pubsub_schema` de-fattened. The regenerated golden's
  only delta is the two getters' doc comments collapsing to the one-line
  template — public getter API (names/types/targets/order) unchanged.

## Design notes

- Provider-neutral emitter (no `ProviderRules` injection) to avoid threading it
  through `wrap_command`; the Google `name->nameRef`/`id->id` convention lives
  in `getter_emitter` for now (AWS `arn->arnRef` deferred to a real second
  provider). `universalGetters`/`wrap_init` stay as the scaffold source.
- Doc trade-off accepted, deferred to A4: the `id` getter's full-path /
  `schema_settings.schema` wiring hint is lost in the template doc (same
  accepted trade-off as A1's enum-member docs); A4 (doc templating +
  curatedExamples) restores richer docs.

## Follow-ups (out of A3 scope)

- `data_source_wrapper_emitter._skipAttribute` still inlines the computed-only
  formula — route it through `Constraints.computedOnly` (pre-existing cleanup).
- `google_pubsub_topic` keeps hand-written `extraGetters` with the richer `id`
  doc — the schema/topic doc asymmetry resolves when topic gets its A3 pass.

## Test plan

- [x] `tool/agent_verify.sh` green (docs consistency, analyze, 4-package tests,
      `wrap --check` 121/121 match, quickstart smoke)
- [x] `deriveOutputGetters` happy + non-boolean failure tests (A1 symmetry)
- [x] getter_emitter unit tests (nameRef/id/computed-only, name-is-computed-only
      dedup, optional+computed skip)
- [x] WrapperEmitter integration (gate on/off, derived + extraGetters
      coexistence with ordering)
- [x] pubsub_schema regression guard
- [x] Each task passed spec + code-quality review; final holistic review: ready