### PR TITLE
feat(codegen): teach OutputDirResolver product folding and assert outputDir convergence

### DIFF
--- a/packages/terradart_codegen/dart_test.yaml
+++ b/packages/terradart_codegen/dart_test.yaml
@@ -21,5 +21,8 @@ tags:
   # default loop -- declared here only to silence the
   # "tag wasn't specified" warning.
   integration:
+  # `convergence` tags the wrap-init anchor test. Declared (no skip) so it runs
+  # in the default loop and the "tag wasn't specified" warning is silenced.
+  convergence:
   e2e:
     skip: "e2e tests are opt-in; run with `dart test -t e2e --run-skipped`"

--- a/packages/terradart_codegen/lib/src/codegen/providers/google_provider_rules.dart
+++ b/packages/terradart_codegen/lib/src/codegen/providers/google_provider_rules.dart
@@ -44,5 +44,20 @@ final class GoogleProviderRules extends ProviderRules {
 
     // Phase 4.5 pilot — additional MM-product alias.
     'cloudrunv2': 'cloud_run',
+
+    // Phase D — product folding: terraform-type prefix -> product directory.
+    // Closes the convergence outputDir gap via resolver Step 2 (longest-prefix)
+    // / Step 3 (segment-1). Keys verified against the tracer.
+    'artifact_registry': 'artifact_registry',
+    'cloud_run': 'cloud_run',
+    'cloudbuild': 'cloud_build',
+    'cloudbuildv2': 'cloud_build',
+    'cloudfunctions2': 'cloud_functions',
+    'firebase_app_check': 'firebase_app_check',
+    'firebase_app_hosting': 'firebase_app_hosting',
+    'firebase_data_connect': 'firebase_data_connect',
+    'firebase_remote_config': 'firebase_remote_config',
+    'project_iam': 'iam',
+    'service_networking': 'service_networking',
   };
 }

--- a/packages/terradart_codegen/test/convergence/wrap_init_convergence_test.dart
+++ b/packages/terradart_codegen/test/convergence/wrap_init_convergence_test.dart
@@ -109,24 +109,24 @@ void main() {
       // ignore: avoid_print
       print('  MISMATCH $m');
     }
-    // Tracer never fails — it only measures. The asserting test below guards the
-    // axes that are convergent today (kind + schemaStubBodyMode); outputDir is a
-    // known resolver gap tracked separately (see test below + spec Phase D).
+    // Tracer never fails — it only measures. The asserting test below now guards
+    // all three axes (kind + outputDir + schemaStubBodyMode). The one residual
+    // tracer mismatch is google_project's raw kind spelling (committed
+    // `dataSource` vs wrap-init emit `data_source`); the assertion normalizes it
+    // via `_committedKind`, so it is not a real drift.
     expect(true, isTrue);
   });
 
-  // Phase D assertion. Scope: kind + schemaStubBodyMode only.
+  // Phase D assertion. Scope: kind + outputDir + schemaStubBodyMode.
   //
-  // outputDir is intentionally EXCLUDED: the tracer measured 29 overrides whose
-  // committed outputDir folds a resource into its product directory (e.g.
-  // `cloud_run`, `firebase_app_check`, `artifact_registry`) while the current
-  // `OutputDirResolver` derives the bare first segment (`cloud`, `firebase`,
-  // `artifact`). That is a resolver gap to close before outputDir can join this
-  // assertion — not a per-override drift to "fix" by rewriting 29 hand-curated
-  // values. Tracked as a follow-up (spec Phase D). kind + schemaStubBodyMode are
-  // fully convergent across all committed overrides today.
+  // outputDir joins the anchor here: OutputDirResolver folds each resource into
+  // its product directory (e.g. `cloud_run`, `firebase_app_check`,
+  // `artifact_registry`) via the GoogleProviderRules alias map, matching the
+  // committed outputDir of every override. A regression in the resolver or the
+  // alias map (or a new product whose prefix is missing) trips this assertion
+  // even though `wrap --check` stays green (it reads the override as truth).
   test(
-      'committed overrides match the wrap-init anchor (kind + schemaStubBodyMode)',
+      'committed overrides match the wrap-init anchor (kind + outputDir + schemaStubBodyMode)',
       () {
     final offenders = <String>[];
     var skipped = 0;
@@ -161,6 +161,10 @@ void main() {
         diffs.add('kind: committed=${_committedKind(committed.kind)} '
             'derived=${_derivedKind(draft)}');
       }
+      if (committed.outputDir != _derivedOutputDir(draft)) {
+        diffs.add('outputDir: committed=${committed.outputDir} '
+            'derived=${_derivedOutputDir(draft)}');
+      }
       if (committed.schemaStubBodyMode.name != _derivedStub(draft)) {
         diffs.add(
             'schemaStubBodyMode: committed=${committed.schemaStubBodyMode.name} '
@@ -170,7 +174,8 @@ void main() {
     }
 
     // ignore: avoid_print
-    print('CONVERGENCE (kind+stub): skipped=$skipped (no schema fixture)');
+    print('CONVERGENCE (kind+outputDir+stub): skipped=$skipped '
+        '(no schema fixture)');
     expect(
       offenders,
       isEmpty,


### PR DESCRIPTION
## Summary

Closes the convergence outputDir gap surfaced by the Phase D tracer (PR #93). OutputDirResolver now folds each curated resource into its product directory, and the convergence test asserts the outputDir axis alongside kind and schemaStubBodyMode.

## Changes

- **OutputDirResolver alias map** (`google_provider_rules.dart`): add 11 terraform-prefix entries (`cloud_run`, `artifact_registry`, `cloudbuild`/`cloudbuildv2` to `cloud_build`, `cloudfunctions2` to `cloud_functions`, `firebase_app_check` / `firebase_app_hosting` / `firebase_data_connect` / `firebase_remote_config`, `project_iam` to `iam`, `service_networking`). The resolver's longest-prefix logic is unchanged — data only.
- **Convergence assertion** (`wrap_init_convergence_test.dart`): the wrap-init anchor test now guards kind + outputDir + schemaStubBodyMode (previously kind + schemaStubBodyMode). The 29 product-folding overrides now converge; the lone residual tracer mismatch is `google_project`'s raw `dataSource` vs `data_source` kind spelling, which the assertion normalizes via `_committedKind`.
- **dart_test.yaml**: declare the `convergence` tag (no skip) to silence the "tag wasn't specified" warning.

## Why this is safe

`OutputDirResolver` is used only by the wrap-init scaffolder, not the wrap regeneration path (which reads each override's committed `outputDir`). So `wrap --check` is unaffected — the generated surface does not change.

## Test plan

`tool/agent_verify.sh` is green:
- `wrap --check`: all 121 files match (generated output unchanged)
- convergence: `mismatches=1` (kind spelling only; outputDir now 0)
- all four package test suites pass
- analyze / lint-override / smoke clean
