### PR TITLE
refactor(google): de-fatten pubsub onto derive gates + discovery harness (Wave 0)

### DIFF
--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_subscription.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_subscription.yaml
@@ -1,20 +1,14 @@
 outputDir: pubsub
-classDocComment: |-
-  /// Factory wrapper for `google_pubsub_subscription`.
+deriveClassDoc: true
+deriveOutputGetters: true
+
+curatedDoc: |-
+  /// Pass `topic` as the full topic path via `TfArg.ref(otherTopic.id)`
+  /// (NOT `topic.nameRef`) so it resolves to
+  /// `projects/{project}/topics/{name}`.
   ///
-  /// Required identity:
-  /// - [localName]: Terraform local name.
-  /// - `name`: GCP subscription name.
-  /// - `topic`: full topic path. Pass `TfArg.ref(otherTopic.id)` (NOT
-  ///   `topic.nameRef`) so the value resolves to
-  ///   `projects/{project}/topics/{name}`.
-  ///
-  /// Example (push subscription, §1.3 narrative):
+  /// Example (push subscription):
   /// ```dart
-  /// final orders = GooglePubsubTopic(
-  ///   localName: 'orders',
-  ///   name: TfArg.literal('orders-prod'),
-  /// );
   /// final push = GooglePubsubSubscription(
   ///   localName: 'orders_push',
   ///   name: TfArg.literal('orders-push'),
@@ -45,12 +39,6 @@ paramOrder:
   - tags
   - project
 
-extraGetters: |2
-    /// Reference to `name` attribute (`google_pubsub_subscription.<id>.name`).
-    TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
-
-    /// Reference to `id` attribute (full subscription path).
-    TfRef<String> get id => TfRef.attribute<String>(this, 'id');
 dartTypeOverrides:
   ack_deadline_seconds: int
 

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_subscription_iam_member.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_subscription_iam_member.yaml
@@ -1,9 +1,10 @@
 outputDir: pubsub
-classDocComment: |-
-  /// Factory wrapper for `google_pubsub_subscription_iam_member`.
-  ///
+deriveClassDoc: true
+deriveOutputGetters: true
+
+curatedDoc: |-
   /// Pub/Sub Subscription IAM is part of the curated surface. (Cloud
-  /// Scheduler IAM is not in the curated surface — open an issue to request
+  /// Scheduler IAM is not in the curated surface -- open an issue to request
   /// curation.)
 
 paramOrder:
@@ -12,7 +13,3 @@ paramOrder:
   - member
   - condition
   - project
-
-extraGetters: |2
-    /// Reference to `etag` attribute.
-    TfRef<String> get etag => TfRef.attribute<String>(this, 'etag');

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_topic.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_topic.yaml
@@ -1,13 +1,8 @@
 outputDir: pubsub
-classDocComment: |-
-  /// Factory wrapper for `google_pubsub_topic` (provider `hashicorp/google ~> 7.0`).
-  ///
-  /// Required identity:
-  /// - [localName]: Terraform local name (the address segment after
-  ///   `google_pubsub_topic.`).
-  /// - `name`: GCP topic name. Pass `TfArg.literal('orders-prod')` or
-  ///   `TfArg.ref(otherTopic.nameRef)` to interpolate.
-  ///
+deriveClassDoc: true
+deriveOutputGetters: true
+
+curatedDoc: |-
   /// Example:
   /// ```dart
   /// final orders = GooglePubsubTopic(
@@ -16,13 +11,8 @@ classDocComment: |-
   ///   messageRetentionDuration:
   ///       TfArg.literal(const Duration(days: 7).toTfDurationString()),
   ///   lifecycle: const LifecycleOptions(preventDestroy: true),
-  /// );
+  ///   );
   /// ```
-  ///
-  /// Composition pattern: extends `Resource` for runtime
-  /// behavior. `argMap` stores `TfArg<dynamic>?` entries directly. Synth's
-  /// JSON-encoding pass walks them and calls `arg.toTfJson()` to encode at
-  /// write time.
 
 paramOrder:
   - name
@@ -35,13 +25,3 @@ paramOrder:
   - message_transforms
   - tags
   - project
-
-extraGetters: |2
-    /// Reference to `name` attribute. Use for interpolations like
-    /// `topic.nameRef` → `${google_pubsub_topic.<localName>.name}`.
-    TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
-
-    /// Reference to `id` attribute (full path
-    /// `projects/{project}/topics/{name}`). Use this when the consumer expects
-    /// the full resource path (e.g. `google_pubsub_subscription.topic`).
-    TfRef<String> get id => TfRef.attribute<String>(this, 'id');

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_topic.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_topic.yaml
@@ -11,7 +11,7 @@ curatedDoc: |-
   ///   messageRetentionDuration:
   ///       TfArg.literal(const Duration(days: 7).toTfDurationString()),
   ///   lifecycle: const LifecycleOptions(preventDestroy: true),
-  ///   );
+  /// );
   /// ```
 
 paramOrder:

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_topic_iam_member.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_pubsub_topic_iam_member.yaml
@@ -1,10 +1,11 @@
 outputDir: pubsub
-classDocComment: |-
-  /// Factory wrapper for `google_pubsub_topic_iam_member`.
-  ///
-  /// Adds a single IAM `role` → `member` binding on a topic. For
+deriveClassDoc: true
+deriveOutputGetters: true
+
+curatedDoc: |-
+  /// Adds a single IAM `role` -> `member` binding on a topic. For
   /// multi-member binding semantics, prefer `google_pubsub_topic_iam_binding`
-  /// (not yet a curated factory — open an issue to request curation).
+  /// (not yet a curated factory -- open an issue to request curation).
 
 paramOrder:
   - topic
@@ -12,7 +13,3 @@ paramOrder:
   - member
   - condition
   - project
-
-extraGetters: |2
-    /// Reference to `etag` attribute (concurrency token written by the API).
-    TfRef<String> get etag => TfRef.attribute<String>(this, 'etag');

--- a/packages/terradart_codegen/test/codegen/wrapper_emitter_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrapper_emitter_test.dart
@@ -790,8 +790,10 @@ void main() {
         // effectiveLabels / terraformLabels MUST NOT appear as constructor
         // params (computed-only, emitted as TfRef getters, not inputs).
         // Match the param-slot shapes; the getter declarations are fine.
-        expect(out, isNot(contains('TfArg<Map<String, String>>? effectiveLabels,')));
-        expect(out, isNot(contains('TfArg<Map<String, String>>? terraformLabels,')));
+        expect(out,
+            isNot(contains('TfArg<Map<String, String>>? effectiveLabels,')));
+        expect(out,
+            isNot(contains('TfArg<Map<String, String>>? terraformLabels,')));
         // `id` cannot be matched as a bare substring — it appears inside
         // `localName`, comments, etc. Match the constructor-param shape.
         expect(out, isNot(contains('TfArg<String>? id,')));

--- a/packages/terradart_codegen/test/codegen/wrapper_emitter_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrapper_emitter_test.dart
@@ -787,8 +787,11 @@ void main() {
               'constructor must be emitted; otherwise exclusion checks pass vacuously',
         );
 
-        expect(out, isNot(contains('effectiveLabels')));
-        expect(out, isNot(contains('terraformLabels')));
+        // effectiveLabels / terraformLabels MUST NOT appear as constructor
+        // params (computed-only, emitted as TfRef getters, not inputs).
+        // Match the param-slot shapes; the getter declarations are fine.
+        expect(out, isNot(contains('TfArg<Map<String, String>>? effectiveLabels,')));
+        expect(out, isNot(contains('TfArg<Map<String, String>>? terraformLabels,')));
         // `id` cannot be matched as a bare substring — it appears inside
         // `localName`, comments, etc. Match the constructor-param shape.
         expect(out, isNot(contains('TfArg<String>? id,')));

--- a/packages/terradart_codegen/test/convergence/defatten_discovery_test.dart
+++ b/packages/terradart_codegen/test/convergence/defatten_discovery_test.dart
@@ -38,9 +38,8 @@ _Setup _setup() {
     }
   }
 
-  final ir = mm.isEmpty
-      ? baseIr
-      : const IrMerger().merge(base: baseIr, overrides: mm);
+  final ir =
+      mm.isEmpty ? baseIr : const IrMerger().merge(base: baseIr, overrides: mm);
   final loaded = loadWrapperOverrides(rootDir: _overrideRoot);
   return (resources: ir.resources, loaded: loaded);
 }
@@ -217,7 +216,9 @@ void main() {
         type,
         override.outputDir,
         '${coveredEnums.length}/${hwEnums.length}',
-        curatedOnlyEnums.isEmpty ? '-' : (curatedOnlyEnums.toList()..sort()).join(';'),
+        curatedOnlyEnums.isEmpty
+            ? '-'
+            : (curatedOnlyEnums.toList()..sort()).join(';'),
         '${coveredGetters.length}/${hwGetters.length}',
         renameKeepGetters.isEmpty
             ? '-'

--- a/packages/terradart_codegen/test/convergence/defatten_discovery_test.dart
+++ b/packages/terradart_codegen/test/convergence/defatten_discovery_test.dart
@@ -1,0 +1,57 @@
+@Tags(['convergence'])
+library;
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:terradart_codegen/src/codegen/wrapper_overrides/_registry.dart';
+import 'package:terradart_codegen/src/codegen/wrapper_overrides/yaml_loader.dart';
+import 'package:terradart_codegen/src/ir/resource_def.dart';
+import 'package:terradart_codegen/src/parser/ir_merger.dart';
+import 'package:terradart_codegen/src/parser/mm_yaml_parser.dart';
+import 'package:terradart_codegen/src/parser/schema_parser.dart';
+import 'package:test/test.dart';
+
+const _overrideRoot = 'lib/src/codegen/wrapper_overrides/yaml';
+const _schemaPath = 'test/fixtures/wrap/source/schema.json';
+const _mmDir = 'test/fixtures/wrap/source/mm';
+
+typedef _Setup = ({
+  Map<String, ResourceDef> resources,
+  LoadedOverrides loaded,
+});
+
+_Setup _setup() {
+  final schemaSrc = File(_schemaPath).readAsStringSync();
+  final baseIr = const SchemaJsonParser().parseString(schemaSrc);
+
+  final mm = <String, MmResourceOverrides>{};
+  final mmDirRef = Directory(_mmDir);
+  if (mmDirRef.existsSync()) {
+    for (final file in mmDirRef.listSync().whereType<File>().where(
+          (f) => f.path.endsWith('.yaml'),
+        )) {
+      final key = p.basenameWithoutExtension(file.path);
+      mm[key] = const MmYamlParser().parseString(file.readAsStringSync());
+    }
+  }
+
+  final ir = mm.isEmpty
+      ? baseIr
+      : const IrMerger().merge(base: baseIr, overrides: mm);
+  final loaded = loadWrapperOverrides(rootDir: _overrideRoot);
+  return (resources: ir.resources, loaded: loaded);
+}
+
+void main() {
+  // -------------------------------------------------------------------------
+  // Task 1 — harness loads overrides and IR
+  // -------------------------------------------------------------------------
+  test('discovery harness loads overrides and IR', () {
+    final result = _setup();
+    expect(result.loaded.resources, isNotEmpty,
+        reason: 'loadWrapperOverrides must return at least one resource entry');
+    expect(result.resources, isNotEmpty,
+        reason: 'merged IR must contain at least one resource');
+  });
+}

--- a/packages/terradart_codegen/test/convergence/defatten_discovery_test.dart
+++ b/packages/terradart_codegen/test/convergence/defatten_discovery_test.dart
@@ -150,4 +150,98 @@ void main() {
         equals({'nameRef', 'id'}),
         reason: 'nameRef and id must be derivable for google_pubsub_topic');
   });
+
+  // -------------------------------------------------------------------------
+  // Task 3 — all-override sweep → TSV report
+  // -------------------------------------------------------------------------
+  test('emit de-fatten discovery report', () {
+    final result = _setup();
+
+    final rows = <String>[];
+    var skipped = 0;
+
+    // TSV header
+    rows.add([
+      'type',
+      'outputDir',
+      'enumsCoveredOfTotal',
+      'curatedOnlyEnums',
+      'gettersCoveredOfTotal',
+      'renameKeepGetters',
+      'doc',
+    ].join('\t'));
+
+    for (final entry in result.loaded.all.entries) {
+      final type = entry.key;
+      final override = entry.value;
+
+      final def = result.resources[type];
+      if (def == null) {
+        // No schema fixture entry for this override — skip and count it
+        // (no silent caps; rows + skipped must reconcile to the total).
+        skipped++;
+        continue;
+      }
+
+      // Enum classification (prelude enums vs IR-derivable enums).
+      final hwEnums = handwrittenEnumNames(override.prelude);
+      final derivEnums = derivableEnumNames(def);
+      final coveredEnums = hwEnums.intersection(derivEnums);
+      final curatedOnlyEnums = hwEnums.difference(derivEnums);
+
+      // Getter classification (extraGetters vs IR-derivable getters).
+      final hwGetters = handwrittenGetterNames(override.extraGetters);
+      final derivGetters = derivableGetterNames(def);
+      final coveredGetters = hwGetters.intersection(derivGetters);
+      final renameKeepGetters = hwGetters.difference(derivGetters);
+
+      // Doc classification:
+      // - curatedDoc: classDocComment carries a fenced code block (```) or an
+      //   (case-insensitive) "example" — i.e. artisanal prose the IR cannot
+      //   derive, which must stay frozen (③).
+      // - boilerplate: classDocComment is non-null but meets neither criterion
+      //   (a candidate for A4 derivation).
+      // - none: classDocComment is null.
+      final docComment = override.classDocComment;
+      final String docClass;
+      if (docComment == null) {
+        docClass = 'none';
+      } else if (docComment.contains('```') ||
+          docComment.toLowerCase().contains('example')) {
+        docClass = 'curatedDoc';
+      } else {
+        docClass = 'boilerplate';
+      }
+
+      rows.add([
+        type,
+        override.outputDir,
+        '${coveredEnums.length}/${hwEnums.length}',
+        curatedOnlyEnums.isEmpty ? '-' : (curatedOnlyEnums.toList()..sort()).join(';'),
+        '${coveredGetters.length}/${hwGetters.length}',
+        renameKeepGetters.isEmpty
+            ? '-'
+            : (renameKeepGetters.toList()..sort()).join(';'),
+        docClass,
+      ].join('\t'));
+    }
+
+    final tsvPath = p.join(Directory.systemTemp.path, 'defatten_discovery.tsv');
+    File(tsvPath).writeAsStringSync(rows.join('\n'));
+
+    // ignore: avoid_print
+    print(
+      'DEFATTEN DISCOVERY: checked=${rows.length - 1} skipped=$skipped '
+      'report=$tsvPath',
+    );
+
+    // The data rows (rows.length - 1, excluding the header) plus the skipped
+    // overrides must reconcile exactly to the total number of loaded overrides
+    // — proof the sweep visited every override with no silent caps.
+    expect(
+      (rows.length - 1) + skipped,
+      equals(result.loaded.all.length),
+      reason: 'rows + skipped must equal total loaded overrides',
+    );
+  });
 }

--- a/packages/terradart_codegen/test/convergence/defatten_discovery_test.dart
+++ b/packages/terradart_codegen/test/convergence/defatten_discovery_test.dart
@@ -4,6 +4,8 @@ library;
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:terradart_codegen/src/codegen/getter_emitter.dart';
+import 'package:terradart_codegen/src/codegen/naming.dart';
 import 'package:terradart_codegen/src/codegen/wrapper_overrides/_registry.dart';
 import 'package:terradart_codegen/src/codegen/wrapper_overrides/yaml_loader.dart';
 import 'package:terradart_codegen/src/ir/resource_def.dart';
@@ -43,6 +45,58 @@ _Setup _setup() {
   return (resources: ir.resources, loaded: loaded);
 }
 
+// ---------------------------------------------------------------------------
+// Task 2 — symbol extraction helpers
+// ---------------------------------------------------------------------------
+
+/// Enum dart names derivable from the IR for [def].
+///
+/// CLASSIFICATION RULE (field-level, name-rendered): an enum is "derivable"
+/// iff the schema (after MM merge) carries non-empty `enumValues` for the
+/// attribute. We render the derived name through [enumName] exactly as the A1
+/// gate does and compare names. Where a hand-written enum name does NOT
+/// string-match the IR-derived name (naming drift), this helper still returns
+/// the IR-derived name; the `difference` against the hand-written set then
+/// classifies the drifted hand-written enum as curated-only — the conservative
+/// answer (it does not get auto-dropped on a name guess).
+Set<String> derivableEnumNames(ResourceDef def) => {
+      for (final a in def.root.attributes)
+        if ((a.constraints.enumValues ?? const <String>[]).isNotEmpty)
+          enumName(
+            resourceType: def.terraformType,
+            fieldPath: a.name,
+            members: a.constraints.enumValues!,
+          ).dartName,
+    };
+
+/// Getter names derivable from the IR for [def] (via [emitDerivedOutputGetters]).
+Set<String> derivableGetterNames(ResourceDef def) => RegExp(r'\bget (\w+)')
+    .allMatches(emitDerivedOutputGetters(def))
+    .map((m) => m.group(1)!)
+    .toSet();
+
+/// Enum names hand-written in the [prelude] block of an override.
+///
+/// Matches only real enum *declarations* — the identifier must be immediately
+/// followed by `implements` or `{`. A bare `\benum (\w+)` over the whole
+/// prelude string also matches the prose phrase "enum" + word inside the
+/// hand-written doc comments (e.g. "the enum below pins...", "an enum because
+/// GCP accepts...", "enum value directly"), which would pollute the
+/// curated-only report with junk tokens like `below`, `because`, `value`. By
+/// ADR-0016 every emitted/hand-written enum carries `implements TerraformEnum`,
+/// so anchoring on `implements`/`{` is a safe, lossless tightening.
+Set<String> handwrittenEnumNames(String? prelude) => prelude == null
+    ? <String>{}
+    : RegExp(r'\benum (\w+)\s*(?:implements\b|\{)')
+        .allMatches(prelude)
+        .map((m) => m.group(1)!)
+        .toSet();
+
+/// Getter names hand-written in the [extra] getters block of an override.
+Set<String> handwrittenGetterNames(String? extra) => extra == null
+    ? <String>{}
+    : RegExp(r'\bget (\w+)').allMatches(extra).map((m) => m.group(1)!).toSet();
+
 void main() {
   // -------------------------------------------------------------------------
   // Task 1 — harness loads overrides and IR
@@ -53,5 +107,47 @@ void main() {
         reason: 'loadWrapperOverrides must return at least one resource entry');
     expect(result.resources, isNotEmpty,
         reason: 'merged IR must contain at least one resource');
+  });
+
+  // -------------------------------------------------------------------------
+  // Task 2 — classification splits covered vs curated-only
+  // -------------------------------------------------------------------------
+  test('classification splits covered vs curated-only', () {
+    final result = _setup();
+
+    // --- google_bigquery_capacity_commitment ---
+    // The provider schema stores plan/renewal_plan/edition as free-form strings
+    // (no enumValues in the IR). Therefore all 3 hand-written prelude enums are
+    // curated-only; none are derivable from the schema.
+    const capacityType = 'google_bigquery_capacity_commitment';
+    final capacityDef = result.resources[capacityType];
+    expect(capacityDef, isNotNull,
+        reason: '$capacityType must exist in fixture schema');
+    final capacityOverride = result.loaded.resources[capacityType];
+    expect(capacityOverride, isNotNull,
+        reason: '$capacityType override must be loaded');
+
+    final capacityHandwritten = handwrittenEnumNames(capacityOverride!.prelude);
+    expect(capacityHandwritten, hasLength(3),
+        reason: 'expected 3 hand-written prelude enums');
+
+    final capacityDerivable = derivableEnumNames(capacityDef!);
+    final capacityCuratedOnly =
+        capacityHandwritten.difference(capacityDerivable);
+    expect(capacityCuratedOnly, equals(capacityHandwritten),
+        reason: 'all 3 capacity_commitment enums must be curated-only '
+            '(no schema enumValues for plan/renewal_plan/edition)');
+
+    // --- google_pubsub_topic ---
+    // nameRef and id are derivable from the IR (name + id attributes exist).
+    const pubsubTopicType = 'google_pubsub_topic';
+    final pubsubTopicDef = result.resources[pubsubTopicType];
+    expect(pubsubTopicDef, isNotNull,
+        reason: '$pubsubTopicType must exist in fixture schema');
+
+    final topicDerivable = derivableGetterNames(pubsubTopicDef!);
+    expect(topicDerivable.intersection({'nameRef', 'id'}),
+        equals({'nameRef', 'id'}),
+        reason: 'nameRef and id must be derivable for google_pubsub_topic');
   });
 }

--- a/packages/terradart_codegen/test/fixtures/wrap/expected_output/pubsub/google_pubsub_subscription.dart.golden
+++ b/packages/terradart_codegen/test/fixtures/wrap/expected_output/pubsub/google_pubsub_subscription.dart.golden
@@ -187,19 +187,12 @@ class PubsubSubscriptionExpirationPolicy {
 
 /// Factory wrapper for `google_pubsub_subscription`.
 ///
-/// Required identity:
-/// - [localName]: Terraform local name.
-/// - `name`: GCP subscription name.
-/// - `topic`: full topic path. Pass `TfArg.ref(otherTopic.id)` (NOT
-///   `topic.nameRef`) so the value resolves to
-///   `projects/{project}/topics/{name}`.
+/// Pass `topic` as the full topic path via `TfArg.ref(otherTopic.id)`
+/// (NOT `topic.nameRef`) so it resolves to
+/// `projects/{project}/topics/{name}`.
 ///
-/// Example (push subscription, §1.3 narrative):
+/// Example (push subscription):
 /// ```dart
-/// final orders = GooglePubsubTopic(
-///   localName: 'orders',
-///   name: TfArg.literal('orders-prod'),
-/// );
 /// final push = GooglePubsubSubscription(
 ///   localName: 'orders_push',
 ///   name: TfArg.literal('orders-push'),
@@ -273,9 +266,17 @@ final class GooglePubsubSubscription extends Resource {
   @override
   Set<String> get sensitiveFields => _googlePubsubSubscriptionSensitive;
 
-  /// Reference to `name` attribute (`google_pubsub_subscription.<id>.name`).
+  /// Reference to `name` attribute.
   TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
 
-  /// Reference to `id` attribute (full subscription path).
+  /// Reference to `id` attribute.
   TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+  /// Reference to `effective_labels` attribute.
+  TfRef<Map<String, String>> get effectiveLabels =>
+      TfRef.attribute<Map<String, String>>(this, 'effective_labels');
+
+  /// Reference to `terraform_labels` attribute.
+  TfRef<Map<String, String>> get terraformLabels =>
+      TfRef.attribute<Map<String, String>>(this, 'terraform_labels');
 }

--- a/packages/terradart_codegen/test/fixtures/wrap/expected_output/pubsub/google_pubsub_subscription_iam_member.dart.golden
+++ b/packages/terradart_codegen/test/fixtures/wrap/expected_output/pubsub/google_pubsub_subscription_iam_member.dart.golden
@@ -9,7 +9,7 @@ const Set<String> _googlePubsubSubscriptionIamMemberSensitive = <String>{};
 /// Factory wrapper for `google_pubsub_subscription_iam_member`.
 ///
 /// Pub/Sub Subscription IAM is part of the curated surface. (Cloud
-/// Scheduler IAM is not in the curated surface — open an issue to request
+/// Scheduler IAM is not in the curated surface -- open an issue to request
 /// curation.)
 final class GooglePubsubSubscriptionIamMember extends Resource {
   static const String tfType = 'google_pubsub_subscription_iam_member';
@@ -37,6 +37,9 @@ final class GooglePubsubSubscriptionIamMember extends Resource {
   @override
   Set<String> get sensitiveFields =>
       _googlePubsubSubscriptionIamMemberSensitive;
+
+  /// Reference to `id` attribute.
+  TfRef<String> get id => TfRef.attribute<String>(this, 'id');
 
   /// Reference to `etag` attribute.
   TfRef<String> get etag => TfRef.attribute<String>(this, 'etag');

--- a/packages/terradart_codegen/test/fixtures/wrap/expected_output/pubsub/google_pubsub_topic.dart.golden
+++ b/packages/terradart_codegen/test/fixtures/wrap/expected_output/pubsub/google_pubsub_topic.dart.golden
@@ -6,13 +6,7 @@ import 'package:terradart_core/terradart_core.dart';
 /// Sensitive field paths for `google_pubsub_topic`.
 const Set<String> _googlePubsubTopicSensitive = <String>{};
 
-/// Factory wrapper for `google_pubsub_topic` (provider `hashicorp/google ~> 7.0`).
-///
-/// Required identity:
-/// - [localName]: Terraform local name (the address segment after
-///   `google_pubsub_topic.`).
-/// - `name`: GCP topic name. Pass `TfArg.literal('orders-prod')` or
-///   `TfArg.ref(otherTopic.nameRef)` to interpolate.
+/// Factory wrapper for `google_pubsub_topic`.
 ///
 /// Example:
 /// ```dart
@@ -24,11 +18,6 @@ const Set<String> _googlePubsubTopicSensitive = <String>{};
 ///   lifecycle: const LifecycleOptions(preventDestroy: true),
 /// );
 /// ```
-///
-/// Composition pattern: extends `Resource` for runtime
-/// behavior. `argMap` stores `TfArg<dynamic>?` entries directly. Synth's
-/// JSON-encoding pass walks them and calls `arg.toTfJson()` to encode at
-/// write time.
 final class GooglePubsubTopic extends Resource {
   static const String tfType = 'google_pubsub_topic';
 
@@ -69,12 +58,17 @@ final class GooglePubsubTopic extends Resource {
   @override
   Set<String> get sensitiveFields => _googlePubsubTopicSensitive;
 
-  /// Reference to `name` attribute. Use for interpolations like
-  /// `topic.nameRef` → `${google_pubsub_topic.<localName>.name}`.
+  /// Reference to `name` attribute.
   TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
 
-  /// Reference to `id` attribute (full path
-  /// `projects/{project}/topics/{name}`). Use this when the consumer expects
-  /// the full resource path (e.g. `google_pubsub_subscription.topic`).
+  /// Reference to `id` attribute.
   TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+  /// Reference to `effective_labels` attribute.
+  TfRef<Map<String, String>> get effectiveLabels =>
+      TfRef.attribute<Map<String, String>>(this, 'effective_labels');
+
+  /// Reference to `terraform_labels` attribute.
+  TfRef<Map<String, String>> get terraformLabels =>
+      TfRef.attribute<Map<String, String>>(this, 'terraform_labels');
 }

--- a/packages/terradart_codegen/test/fixtures/wrap/expected_output/pubsub/google_pubsub_topic_iam_member.dart.golden
+++ b/packages/terradart_codegen/test/fixtures/wrap/expected_output/pubsub/google_pubsub_topic_iam_member.dart.golden
@@ -8,9 +8,9 @@ const Set<String> _googlePubsubTopicIamMemberSensitive = <String>{};
 
 /// Factory wrapper for `google_pubsub_topic_iam_member`.
 ///
-/// Adds a single IAM `role` → `member` binding on a topic. For
+/// Adds a single IAM `role` -> `member` binding on a topic. For
 /// multi-member binding semantics, prefer `google_pubsub_topic_iam_binding`
-/// (not yet a curated factory — open an issue to request curation).
+/// (not yet a curated factory -- open an issue to request curation).
 final class GooglePubsubTopicIamMember extends Resource {
   static const String tfType = 'google_pubsub_topic_iam_member';
 
@@ -37,6 +37,9 @@ final class GooglePubsubTopicIamMember extends Resource {
   @override
   Set<String> get sensitiveFields => _googlePubsubTopicIamMemberSensitive;
 
-  /// Reference to `etag` attribute (concurrency token written by the API).
+  /// Reference to `id` attribute.
+  TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+  /// Reference to `etag` attribute.
   TfRef<String> get etag => TfRef.attribute<String>(this, 'etag');
 }

--- a/packages/terradart_codegen/test/golden/google_pubsub_subscription.factory.expected.dart.golden
+++ b/packages/terradart_codegen/test/golden/google_pubsub_subscription.factory.expected.dart.golden
@@ -184,19 +184,12 @@ class PubsubSubscriptionExpirationPolicy {
 
 /// Factory wrapper for `google_pubsub_subscription`.
 ///
-/// Required identity:
-/// - [localName]: Terraform local name.
-/// - `name`: GCP subscription name.
-/// - `topic`: full topic path. Pass `TfArg.ref(otherTopic.id)` (NOT
-///   `topic.nameRef`) so the value resolves to
-///   `projects/{project}/topics/{name}`.
+/// Pass `topic` as the full topic path via `TfArg.ref(otherTopic.id)`
+/// (NOT `topic.nameRef`) so it resolves to
+/// `projects/{project}/topics/{name}`.
 ///
-/// Example (push subscription, §1.3 narrative):
+/// Example (push subscription):
 /// ```dart
-/// final orders = GooglePubsubTopic(
-///   localName: 'orders',
-///   name: TfArg.literal('orders-prod'),
-/// );
 /// final push = GooglePubsubSubscription(
 ///   localName: 'orders_push',
 ///   name: TfArg.literal('orders-push'),
@@ -270,9 +263,17 @@ final class GooglePubsubSubscription extends Resource {
   @override
   Set<String> get sensitiveFields => _googlePubsubSubscriptionSensitive;
 
-  /// Reference to `name` attribute (`google_pubsub_subscription.<id>.name`).
+  /// Reference to `name` attribute.
   TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
 
-  /// Reference to `id` attribute (full subscription path).
+  /// Reference to `id` attribute.
   TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+  /// Reference to `effective_labels` attribute.
+  TfRef<Map<String, String>> get effectiveLabels =>
+      TfRef.attribute<Map<String, String>>(this, 'effective_labels');
+
+  /// Reference to `terraform_labels` attribute.
+  TfRef<Map<String, String>> get terraformLabels =>
+      TfRef.attribute<Map<String, String>>(this, 'terraform_labels');
 }

--- a/packages/terradart_codegen/test/golden/google_pubsub_subscription_iam_member.factory.expected.dart.golden
+++ b/packages/terradart_codegen/test/golden/google_pubsub_subscription_iam_member.factory.expected.dart.golden
@@ -6,7 +6,7 @@ const Set<String> _googlePubsubSubscriptionIamMemberSensitive = <String>{};
 /// Factory wrapper for `google_pubsub_subscription_iam_member`.
 ///
 /// Pub/Sub Subscription IAM is part of the curated surface. (Cloud
-/// Scheduler IAM is not in the curated surface — open an issue to request
+/// Scheduler IAM is not in the curated surface -- open an issue to request
 /// curation.)
 final class GooglePubsubSubscriptionIamMember extends Resource {
   static const String tfType = 'google_pubsub_subscription_iam_member';
@@ -34,6 +34,9 @@ final class GooglePubsubSubscriptionIamMember extends Resource {
   @override
   Set<String> get sensitiveFields =>
       _googlePubsubSubscriptionIamMemberSensitive;
+
+  /// Reference to `id` attribute.
+  TfRef<String> get id => TfRef.attribute<String>(this, 'id');
 
   /// Reference to `etag` attribute.
   TfRef<String> get etag => TfRef.attribute<String>(this, 'etag');

--- a/packages/terradart_codegen/test/golden/google_pubsub_topic.factory.expected.dart.golden
+++ b/packages/terradart_codegen/test/golden/google_pubsub_topic.factory.expected.dart.golden
@@ -3,13 +3,7 @@ import 'package:terradart_core/terradart_core.dart';
 /// Sensitive field paths for `google_pubsub_topic`.
 const Set<String> _googlePubsubTopicSensitive = <String>{};
 
-/// Factory wrapper for `google_pubsub_topic` (provider `hashicorp/google ~> 7.0`).
-///
-/// Required identity:
-/// - [localName]: Terraform local name (the address segment after
-///   `google_pubsub_topic.`).
-/// - `name`: GCP topic name. Pass `TfArg.literal('orders-prod')` or
-///   `TfArg.ref(otherTopic.nameRef)` to interpolate.
+/// Factory wrapper for `google_pubsub_topic`.
 ///
 /// Example:
 /// ```dart
@@ -21,11 +15,6 @@ const Set<String> _googlePubsubTopicSensitive = <String>{};
 ///   lifecycle: const LifecycleOptions(preventDestroy: true),
 /// );
 /// ```
-///
-/// Composition pattern: extends `Resource` for runtime
-/// behavior. `argMap` stores `TfArg<dynamic>?` entries directly. Synth's
-/// JSON-encoding pass walks them and calls `arg.toTfJson()` to encode at
-/// write time.
 final class GooglePubsubTopic extends Resource {
   static const String tfType = 'google_pubsub_topic';
 
@@ -66,12 +55,17 @@ final class GooglePubsubTopic extends Resource {
   @override
   Set<String> get sensitiveFields => _googlePubsubTopicSensitive;
 
-  /// Reference to `name` attribute. Use for interpolations like
-  /// `topic.nameRef` → `${google_pubsub_topic.<localName>.name}`.
+  /// Reference to `name` attribute.
   TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
 
-  /// Reference to `id` attribute (full path
-  /// `projects/{project}/topics/{name}`). Use this when the consumer expects
-  /// the full resource path (e.g. `google_pubsub_subscription.topic`).
+  /// Reference to `id` attribute.
   TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+  /// Reference to `effective_labels` attribute.
+  TfRef<Map<String, String>> get effectiveLabels =>
+      TfRef.attribute<Map<String, String>>(this, 'effective_labels');
+
+  /// Reference to `terraform_labels` attribute.
+  TfRef<Map<String, String>> get terraformLabels =>
+      TfRef.attribute<Map<String, String>>(this, 'terraform_labels');
 }

--- a/packages/terradart_codegen/test/golden/google_pubsub_topic_iam_member.factory.expected.dart.golden
+++ b/packages/terradart_codegen/test/golden/google_pubsub_topic_iam_member.factory.expected.dart.golden
@@ -5,9 +5,9 @@ const Set<String> _googlePubsubTopicIamMemberSensitive = <String>{};
 
 /// Factory wrapper for `google_pubsub_topic_iam_member`.
 ///
-/// Adds a single IAM `role` → `member` binding on a topic. For
+/// Adds a single IAM `role` -> `member` binding on a topic. For
 /// multi-member binding semantics, prefer `google_pubsub_topic_iam_binding`
-/// (not yet a curated factory — open an issue to request curation).
+/// (not yet a curated factory -- open an issue to request curation).
 final class GooglePubsubTopicIamMember extends Resource {
   static const String tfType = 'google_pubsub_topic_iam_member';
 
@@ -34,6 +34,9 @@ final class GooglePubsubTopicIamMember extends Resource {
   @override
   Set<String> get sensitiveFields => _googlePubsubTopicIamMemberSensitive;
 
-  /// Reference to `etag` attribute (concurrency token written by the API).
+  /// Reference to `id` attribute.
+  TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+  /// Reference to `etag` attribute.
   TfRef<String> get etag => TfRef.attribute<String>(this, 'etag');
 }

--- a/packages/terradart_google/lib/src/_catalog.g.dart
+++ b/packages/terradart_google/lib/src/_catalog.g.dart
@@ -3351,7 +3351,7 @@ const List<CatalogEntry> terradartCatalog = <CatalogEntry>[
     ],
     sensitiveFields: <String>[],
     docComment:
-        'Factory wrapper for `google_pubsub_subscription`.\n\nRequired identity:\n- [localName]: Terraform local name.\n- `name`: GCP subscription name.\n- `topic`: full topic path. Pass `TfArg.ref(otherTopic.id)` (NOT\n  `topic.nameRef`) so the value resolves to\n  `projects/{project}/topics/{name}`.\n\nExample (push subscription, §1.3 narrative):\n```dart\nfinal orders = GooglePubsubTopic(\n  localName: \'orders\',\n  name: TfArg.literal(\'orders-prod\'),\n);\nfinal push = GooglePubsubSubscription(\n  localName: \'orders_push\',\n  name: TfArg.literal(\'orders-push\'),\n  topic: TfArg.ref(orders.id),\n  pushConfig: const PubsubSubscriptionPushConfig(\n    pushEndpoint: TfArgLiteral(\'https://app.example.com/push\'),\n  ),\n);\n```',
+        'Factory wrapper for `google_pubsub_subscription`.\n\nPass `topic` as the full topic path via `TfArg.ref(otherTopic.id)`\n(NOT `topic.nameRef`) so it resolves to\n`projects/{project}/topics/{name}`.\n\nExample (push subscription):\n```dart\nfinal push = GooglePubsubSubscription(\n  localName: \'orders_push\',\n  name: TfArg.literal(\'orders-push\'),\n  topic: TfArg.ref(orders.id),\n  pushConfig: const PubsubSubscriptionPushConfig(\n    pushEndpoint: TfArgLiteral(\'https://app.example.com/push\'),\n  ),\n);\n```',
   ),
   CatalogEntry(
     tfType: 'google_pubsub_subscription_iam_member',
@@ -3370,15 +3370,14 @@ const List<CatalogEntry> terradartCatalog = <CatalogEntry>[
     nestedTypes: <String>[],
     sensitiveFields: <String>[],
     docComment:
-        'Factory wrapper for `google_pubsub_subscription_iam_member`.\n\nPub/Sub Subscription IAM is part of the curated surface. (Cloud\nScheduler IAM is not in the curated surface — open an issue to request\ncuration.)',
+        'Factory wrapper for `google_pubsub_subscription_iam_member`.\n\nPub/Sub Subscription IAM is part of the curated surface. (Cloud\nScheduler IAM is not in the curated surface -- open an issue to request\ncuration.)',
   ),
   CatalogEntry(
     tfType: 'google_pubsub_topic',
     className: 'GooglePubsubTopic',
     barrel: 'pubsub',
     kind: CatalogKind.resource,
-    summary:
-        'Factory wrapper for `google_pubsub_topic` (provider `hashicorp/google ~> 7.0`).',
+    summary: 'Factory wrapper for `google_pubsub_topic`.',
     constructorParams: <String>[
       'localName',
       'name',
@@ -3395,7 +3394,7 @@ const List<CatalogEntry> terradartCatalog = <CatalogEntry>[
     nestedTypes: <String>[],
     sensitiveFields: <String>[],
     docComment:
-        'Factory wrapper for `google_pubsub_topic` (provider `hashicorp/google ~> 7.0`).\n\nRequired identity:\n- [localName]: Terraform local name (the address segment after\n  `google_pubsub_topic.`).\n- `name`: GCP topic name. Pass `TfArg.literal(\'orders-prod\')` or\n  `TfArg.ref(otherTopic.nameRef)` to interpolate.\n\nExample:\n```dart\nfinal orders = GooglePubsubTopic(\n  localName: \'orders\',\n  name: TfArg.literal(\'orders-prod\'),\n  messageRetentionDuration:\n      TfArg.literal(const Duration(days: 7).toTfDurationString()),\n  lifecycle: const LifecycleOptions(preventDestroy: true),\n);\n```\n\nComposition pattern: extends `Resource` for runtime\nbehavior. `argMap` stores `TfArg<dynamic>?` entries directly. Synth\'s\nJSON-encoding pass walks them and calls `arg.toTfJson()` to encode at\nwrite time.',
+        'Factory wrapper for `google_pubsub_topic`.\n\nExample:\n```dart\nfinal orders = GooglePubsubTopic(\n  localName: \'orders\',\n  name: TfArg.literal(\'orders-prod\'),\n  messageRetentionDuration:\n      TfArg.literal(const Duration(days: 7).toTfDurationString()),\n  lifecycle: const LifecycleOptions(preventDestroy: true),\n);\n```',
   ),
   CatalogEntry(
     tfType: 'google_pubsub_topic_iam_member',
@@ -3414,7 +3413,7 @@ const List<CatalogEntry> terradartCatalog = <CatalogEntry>[
     nestedTypes: <String>[],
     sensitiveFields: <String>[],
     docComment:
-        'Factory wrapper for `google_pubsub_topic_iam_member`.\n\nAdds a single IAM `role` → `member` binding on a topic. For\nmulti-member binding semantics, prefer `google_pubsub_topic_iam_binding`\n(not yet a curated factory — open an issue to request curation).',
+        'Factory wrapper for `google_pubsub_topic_iam_member`.\n\nAdds a single IAM `role` -> `member` binding on a topic. For\nmulti-member binding semantics, prefer `google_pubsub_topic_iam_binding`\n(not yet a curated factory -- open an issue to request curation).',
   ),
   CatalogEntry(
     tfType: 'google_secret_manager_secret',

--- a/packages/terradart_google/lib/src/pubsub/google_pubsub_subscription.dart
+++ b/packages/terradart_google/lib/src/pubsub/google_pubsub_subscription.dart
@@ -187,19 +187,12 @@ class PubsubSubscriptionExpirationPolicy {
 
 /// Factory wrapper for `google_pubsub_subscription`.
 ///
-/// Required identity:
-/// - [localName]: Terraform local name.
-/// - `name`: GCP subscription name.
-/// - `topic`: full topic path. Pass `TfArg.ref(otherTopic.id)` (NOT
-///   `topic.nameRef`) so the value resolves to
-///   `projects/{project}/topics/{name}`.
+/// Pass `topic` as the full topic path via `TfArg.ref(otherTopic.id)`
+/// (NOT `topic.nameRef`) so it resolves to
+/// `projects/{project}/topics/{name}`.
 ///
-/// Example (push subscription, §1.3 narrative):
+/// Example (push subscription):
 /// ```dart
-/// final orders = GooglePubsubTopic(
-///   localName: 'orders',
-///   name: TfArg.literal('orders-prod'),
-/// );
 /// final push = GooglePubsubSubscription(
 ///   localName: 'orders_push',
 ///   name: TfArg.literal('orders-push'),
@@ -273,9 +266,17 @@ final class GooglePubsubSubscription extends Resource {
   @override
   Set<String> get sensitiveFields => _googlePubsubSubscriptionSensitive;
 
-  /// Reference to `name` attribute (`google_pubsub_subscription.<id>.name`).
+  /// Reference to `name` attribute.
   TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
 
-  /// Reference to `id` attribute (full subscription path).
+  /// Reference to `id` attribute.
   TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+  /// Reference to `effective_labels` attribute.
+  TfRef<Map<String, String>> get effectiveLabels =>
+      TfRef.attribute<Map<String, String>>(this, 'effective_labels');
+
+  /// Reference to `terraform_labels` attribute.
+  TfRef<Map<String, String>> get terraformLabels =>
+      TfRef.attribute<Map<String, String>>(this, 'terraform_labels');
 }

--- a/packages/terradart_google/lib/src/pubsub/google_pubsub_subscription_iam_member.dart
+++ b/packages/terradart_google/lib/src/pubsub/google_pubsub_subscription_iam_member.dart
@@ -9,7 +9,7 @@ const Set<String> _googlePubsubSubscriptionIamMemberSensitive = <String>{};
 /// Factory wrapper for `google_pubsub_subscription_iam_member`.
 ///
 /// Pub/Sub Subscription IAM is part of the curated surface. (Cloud
-/// Scheduler IAM is not in the curated surface — open an issue to request
+/// Scheduler IAM is not in the curated surface -- open an issue to request
 /// curation.)
 final class GooglePubsubSubscriptionIamMember extends Resource {
   static const String tfType = 'google_pubsub_subscription_iam_member';
@@ -37,6 +37,9 @@ final class GooglePubsubSubscriptionIamMember extends Resource {
   @override
   Set<String> get sensitiveFields =>
       _googlePubsubSubscriptionIamMemberSensitive;
+
+  /// Reference to `id` attribute.
+  TfRef<String> get id => TfRef.attribute<String>(this, 'id');
 
   /// Reference to `etag` attribute.
   TfRef<String> get etag => TfRef.attribute<String>(this, 'etag');

--- a/packages/terradart_google/lib/src/pubsub/google_pubsub_topic.dart
+++ b/packages/terradart_google/lib/src/pubsub/google_pubsub_topic.dart
@@ -16,7 +16,7 @@ const Set<String> _googlePubsubTopicSensitive = <String>{};
 ///   messageRetentionDuration:
 ///       TfArg.literal(const Duration(days: 7).toTfDurationString()),
 ///   lifecycle: const LifecycleOptions(preventDestroy: true),
-///   );
+/// );
 /// ```
 final class GooglePubsubTopic extends Resource {
   static const String tfType = 'google_pubsub_topic';

--- a/packages/terradart_google/lib/src/pubsub/google_pubsub_topic.dart
+++ b/packages/terradart_google/lib/src/pubsub/google_pubsub_topic.dart
@@ -6,13 +6,7 @@ import 'package:terradart_core/terradart_core.dart';
 /// Sensitive field paths for `google_pubsub_topic`.
 const Set<String> _googlePubsubTopicSensitive = <String>{};
 
-/// Factory wrapper for `google_pubsub_topic` (provider `hashicorp/google ~> 7.0`).
-///
-/// Required identity:
-/// - [localName]: Terraform local name (the address segment after
-///   `google_pubsub_topic.`).
-/// - `name`: GCP topic name. Pass `TfArg.literal('orders-prod')` or
-///   `TfArg.ref(otherTopic.nameRef)` to interpolate.
+/// Factory wrapper for `google_pubsub_topic`.
 ///
 /// Example:
 /// ```dart
@@ -22,13 +16,8 @@ const Set<String> _googlePubsubTopicSensitive = <String>{};
 ///   messageRetentionDuration:
 ///       TfArg.literal(const Duration(days: 7).toTfDurationString()),
 ///   lifecycle: const LifecycleOptions(preventDestroy: true),
-/// );
+///   );
 /// ```
-///
-/// Composition pattern: extends `Resource` for runtime
-/// behavior. `argMap` stores `TfArg<dynamic>?` entries directly. Synth's
-/// JSON-encoding pass walks them and calls `arg.toTfJson()` to encode at
-/// write time.
 final class GooglePubsubTopic extends Resource {
   static const String tfType = 'google_pubsub_topic';
 
@@ -69,12 +58,17 @@ final class GooglePubsubTopic extends Resource {
   @override
   Set<String> get sensitiveFields => _googlePubsubTopicSensitive;
 
-  /// Reference to `name` attribute. Use for interpolations like
-  /// `topic.nameRef` → `${google_pubsub_topic.<localName>.name}`.
+  /// Reference to `name` attribute.
   TfRef<String> get nameRef => TfRef.attribute<String>(this, 'name');
 
-  /// Reference to `id` attribute (full path
-  /// `projects/{project}/topics/{name}`). Use this when the consumer expects
-  /// the full resource path (e.g. `google_pubsub_subscription.topic`).
+  /// Reference to `id` attribute.
   TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+  /// Reference to `effective_labels` attribute.
+  TfRef<Map<String, String>> get effectiveLabels =>
+      TfRef.attribute<Map<String, String>>(this, 'effective_labels');
+
+  /// Reference to `terraform_labels` attribute.
+  TfRef<Map<String, String>> get terraformLabels =>
+      TfRef.attribute<Map<String, String>>(this, 'terraform_labels');
 }

--- a/packages/terradart_google/lib/src/pubsub/google_pubsub_topic_iam_member.dart
+++ b/packages/terradart_google/lib/src/pubsub/google_pubsub_topic_iam_member.dart
@@ -8,9 +8,9 @@ const Set<String> _googlePubsubTopicIamMemberSensitive = <String>{};
 
 /// Factory wrapper for `google_pubsub_topic_iam_member`.
 ///
-/// Adds a single IAM `role` → `member` binding on a topic. For
+/// Adds a single IAM `role` -> `member` binding on a topic. For
 /// multi-member binding semantics, prefer `google_pubsub_topic_iam_binding`
-/// (not yet a curated factory — open an issue to request curation).
+/// (not yet a curated factory -- open an issue to request curation).
 final class GooglePubsubTopicIamMember extends Resource {
   static const String tfType = 'google_pubsub_topic_iam_member';
 
@@ -37,6 +37,9 @@ final class GooglePubsubTopicIamMember extends Resource {
   @override
   Set<String> get sensitiveFields => _googlePubsubTopicIamMemberSensitive;
 
-  /// Reference to `etag` attribute (concurrency token written by the API).
+  /// Reference to `id` attribute.
+  TfRef<String> get id => TfRef.attribute<String>(this, 'id');
+
+  /// Reference to `etag` attribute.
   TfRef<String> get etag => TfRef.attribute<String>(this, 'etag');
 }


### PR DESCRIPTION
## Summary
Wave 0 of the convergent-curation de-fatten migration -- a read-only discovery measurement plus the pubsub tracer that validates the loop before the mass waves.

- **Discovery harness** (`defatten_discovery_test.dart`): sweeps all 120 overrides, measuring which hand-written enum/getter symbols a derive gate reproduces vs which stay curated-only.
- **Pubsub tracer** (4 overrides): migrated onto `deriveClassDoc` + `deriveOutputGetters` + `curatedDoc`; prelude helper classes + customSlots kept frozen.
- **Golden refresh**: Level A goldens + wrap fixture + `_catalog.g.dart` updated to the de-fatten output (no public-symbol regression; `id`/`effectiveLabels`/`terraformLabels` are intentional additive getters).

### Key discovery finding
- **Enums**: 232 hand-written, only **5 derivable** (the GA schema stores enum-shaped fields as free-form strings) -> 227 stay frozen in `prelude`. Enum derivation only grows via upstream magic-modules `enum_values` (schema-bump sync), never hand-authored.
- **Getters**: **399/450 derivable** -- the real de-fatten payload.
- **Docs**: 96 curatedDoc, 23 boilerplate, 1 already migrated.

## Test Plan
- [x] `tool/agent_verify.sh` green (all tests pass; wrap --check 121 files match; lint-override 120 clean; smoke OK)
- [x] No public-symbol regression (8 helper classes + getters retained on pubsub_subscription)
- [x] Cross-model spot-check (non-Claude agent re-runs the AGENTS.md recipe) -- deferred