### PR TITLE
docs(agents): add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,22 @@ Inputs: a checked-in or task-provided `schema.json` (plus Magic Modules YAML whe
 - When bumping versions, check inter-package caret constraints with per-package CI in mind; workspace resolution can hide stale constraints locally.
 - Release tags and GitHub releases are created manually by the maintainer.
 
+## Cursor Cloud specific instructions
+
+Cloud VM images should have **Dart SDK stable** (≥ 3.10; workspace root requires ^3.6, `terradart_agent` requires ^3.10) and **Terraform** (≥ 1.11) on `PATH`. The update script only runs `dart pub get`; system packages are baked into the snapshot (Ubuntu: `dart` from `storage.googleapis.com/download.dartlang.org/linux/debian stable`, `terraform` from HashiCorp apt).
+
+There is no long-running dev server for core work. Primary flows:
+
+| Goal | Command (repo root) |
+|------|---------------------|
+| Agent gate (lint, tests, wrap check, smoke) | `tool/agent_verify.sh` |
+| Synth example stack | `cd examples/pubsub_quickstart && GCP_PROJECT_ID=ci-test-project-id dart run bin/infra.dart` |
+| Validate synth output | `cd examples/pubsub_quickstart/tf-out && terraform init -backend=false && terraform validate` |
+| MCP catalog server (stdio) | `cd packages/terradart_agent && dart run terradart-mcp` |
+| Docs site (optional) | `cd website && bun install && bun run dev` (needs Bun + Node ≥ 22) |
+
+`tool/agent_verify.sh` does **not** run the full `terraform_validate` example matrix; GitHub Actions enforces that on merge. Examples use `GCP_PROJECT_ID` (or `ci-test-project-id` for local smoke) — no live GCP credentials are required for synth or `terraform validate`.
+
 ## Working Rules
 
 - Prefer small, reviewable changes. Keep unrelated cleanup out of feature work.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a **Cursor Cloud specific instructions** section to `AGENTS.md` documenting:

- Required system packages (Dart stable ≥ 3.10, Terraform ≥ 1.11) baked into the VM snapshot
- Update script scope (`dart pub get` only)
- Primary dev commands: `tool/agent_verify.sh`, pubsub quickstart synth, terraform validate, MCP server, optional docs site

Verified in the cloud VM:
- `tool/agent_verify.sh` — all checks pass
- Pub/Sub quickstart synth → `terraform validate` succeeds
- MCP server tests pass
- Docs site (`bun run dev`) serves on port 4321
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11a0ddc5-6319-4849-aaee-4eb039df10c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11a0ddc5-6319-4849-aaee-4eb039df10c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

