### PR TITLE
chore(examples): backfill example_debt + terraform validate agent gate

### DIFF
--- a/.agents/skills/terradart-agent-verify/SKILL.md
+++ b/.agents/skills/terradart-agent-verify/SKILL.md
@@ -26,7 +26,7 @@ Policy and pitfalls live in [`AGENTS.md`](../../../AGENTS.md) at the repo root. 
 **Task progress:**
 
 - [ ] 1. From the **repository root**, run `dart pub get` if dependencies changed.
-- [ ] 2. Run `tool/agent_verify.sh` and confirm it exits 0 (`agent_verify: OK`).
+- [ ] 2. Run `tool/agent_verify.sh` and confirm it exits 0 (`agent_verify: OK`). This includes `check_example_topology` (strict quickstarts only).
 - [ ] 3. `check_docs_consistency` (step 2) already synths all quickstarts and runs `terraform validate` per example when `terraform` is on `PATH`.
 - [ ] 4. If you touched `pubsub_quickstart` or synth/export paths, run `tool/smoke_quickstart.sh`.
 - [ ] 5. Report which commands ran in the PR or task summary.

--- a/.agents/skills/terradart-agent-verify/SKILL.md
+++ b/.agents/skills/terradart-agent-verify/SKILL.md
@@ -27,7 +27,7 @@ Policy and pitfalls live in [`AGENTS.md`](../../../AGENTS.md) at the repo root. 
 
 - [ ] 1. From the **repository root**, run `dart pub get` if dependencies changed.
 - [ ] 2. Run `tool/agent_verify.sh` and confirm it exits 0 (`agent_verify: OK`).
-- [ ] 3. If you changed versions or catalog counts, also run `dart tool/check_docs_consistency.dart`.
+- [ ] 3. `check_docs_consistency` (step 2) already synths all quickstarts and runs `terraform validate` per example when `terraform` is on `PATH`.
 - [ ] 4. If you touched `pubsub_quickstart` or synth/export paths, run `tool/smoke_quickstart.sh`.
 - [ ] 5. Report which commands ran in the PR or task summary.
 
@@ -42,6 +42,6 @@ Use `--maintainer` when changing `wrap-init`, `wrap-promote`, or their tests.
 
 ## What this does not cover
 
-- Full `terraform validate` across every example (GitHub Actions enforces that on merge).
+- Parallel CI `terraform_validate` matrix fan-out (local gate validates sequentially via `example_synth_gates.dart`).
 - Live GCP `terraform apply`.
 - Publishing to pub.dev or cutting release tags (maintainer manual steps after merge).

--- a/.agents/skills/terradart-backfill-examples/SKILL.md
+++ b/.agents/skills/terradart-backfill-examples/SKILL.md
@@ -23,12 +23,14 @@ Read [`CONTEXT.md`](../../../CONTEXT.md) for vocabulary. Wave policy lives in [`
 - [ ] 3. **Apply pitfall checklist** (below) before committing.
 - [ ] 4. **Sensitive / variable fields** — use `TfArg.variable('name')` in the stack and declare the variable in `bin/infra.dart` via `tf-out/variables.tf.json` (see existing `cloud_sql_quickstart`, `firebase_app_check_quickstart`, `compute_lb_quickstart`).
 - [ ] 5. **Remove covered lines** from `tool/example_debt.yaml`. Keep reasoned deferrals only (org/folder scope, IAM binding policy, etc.).
-- [ ] 6. **Verify** — from repo root:
+- [ ] 6. **Tighten topology** — wire must-reference factories into siblings; see [`terradart-tighten-example-topology`](../terradart-tighten-example-topology/SKILL.md).
+- [ ] 7. **Verify** — from repo root:
   ```bash
+  dart tool/check_example_topology.dart   # unwired SSL cert / health check / HTTP proxy
   dart tool/check_docs_consistency.dart   # synth coverage + terraform validate all quickstarts
   tool/agent_verify.sh
   ```
-- [ ] 7. No version bump or catalog count change unless you also curated new factories.
+- [ ] 8. No version bump or catalog count change unless you also curated new factories.
 
 ## Pitfall checklist (repeat mistakes)
 

--- a/.agents/skills/terradart-backfill-examples/SKILL.md
+++ b/.agents/skills/terradart-backfill-examples/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: terradart-backfill-examples
+description: Backfill example quickstarts for curated factories listed in tool/example_debt.yaml — extend stacks, sync debt, and run terraform validate locally before PR.
+metadata:
+  last_modified: 2026-06-09
+---
+# Backfill example coverage
+
+Read [`CONTEXT.md`](../../../CONTEXT.md) for vocabulary. Wave policy lives in [`AGENTS.md`](../../../AGENTS.md) and [`terradart-ship-wave`](../terradart-ship-wave/SKILL.md). This skill covers **pre-existing catalog gaps** — factories already curated but not yet in any quickstart synth output.
+
+## When to use
+
+- Shrinking `tool/example_debt.yaml` (explicit backfill PRs).
+- After a Wave lands factories in examples, but older debt remains.
+- When CI `terraform validate` fails on an example you extended.
+
+## Workflow
+
+**Task progress:**
+
+- [ ] 1. **Pick targets** from `tool/example_debt.yaml`. Prefer extending the natural quickstart (Storage → `storage_quickstart`, Compute LB → `compute_lb_quickstart`) over inventing a new example.
+- [ ] 2. **Extend `lib/main.dart`** with minimal, self-contained resources that demonstrate real constructor patterns (refs to siblings in the same stack).
+- [ ] 3. **Apply pitfall checklist** (below) before committing.
+- [ ] 4. **Sensitive / variable fields** — use `TfArg.variable('name')` in the stack and declare the variable in `bin/infra.dart` via `tf-out/variables.tf.json` (see existing `cloud_sql_quickstart`, `firebase_app_check_quickstart`, `compute_lb_quickstart`).
+- [ ] 5. **Remove covered lines** from `tool/example_debt.yaml`. Keep reasoned deferrals only (org/folder scope, IAM binding policy, etc.).
+- [ ] 6. **Verify** — from repo root:
+  ```bash
+  dart tool/check_docs_consistency.dart   # synth coverage + terraform validate all quickstarts
+  tool/agent_verify.sh
+  ```
+- [ ] 7. No version bump or catalog count change unless you also curated new factories.
+
+## Pitfall checklist (repeat mistakes)
+
+| Mistake | Correct pattern |
+|---------|-----------------|
+| Flat map keys copied from a **different** resource's docs (e.g. `bigquery_dataset: {dataset: ...}` on `listing_subscription`) | Read the **target resource's** Terraform schema nested blocks. Run `terraform validate` on the example. |
+| `destination_dataset` on Analytics Hub listing subscription | `location` + `dataset_reference` list with `dataset_id` / `project_id` — not a `dataset` URL string. |
+| Sensitive provider fields with `TfArg.literal` (including `certificate` / `private_key` on `google_compute_ssl_certificate`) | `TfArg.variable` + `variables.tf.json` in `bin/infra.dart`. Synth fails at encode time if you use literals on sensitive paths. |
+| GCS notification `topic` as bare topic name | Full path: `TfArg.ref(topic.id)` on a sibling `GooglePubsubTopic`. |
+| Eventarc / workflow destinations as nested objects when schema expects a map | Match provider schema literally; validate early. |
+| Forgetting to remove `example_debt.yaml` entry after coverage | `check_docs_consistency` fails on stale debt lines. |
+
+## Schema probe (when unsure)
+
+```bash
+cd examples/<slug>_quickstart
+GCP_PROJECT_ID=ci-test-project-id dart run bin/infra.dart
+cd tf-out && terraform init -backend=false && terraform validate
+```
+
+`tool/example_synth_gates.dart` (via `check_docs_consistency.dart`) now runs this validate step for **every** quickstart when `terraform` is on `PATH`.
+
+## What this does not cover
+
+- Curating **new** `google_*` factories — use [`terradart-add-curated-resource`](../terradart-add-curated-resource/SKILL.md).
+- Live `terraform apply` or `apply-smoke` — label-gated CI only when needed.

--- a/.agents/skills/terradart-ship-wave/SKILL.md
+++ b/.agents/skills/terradart-ship-wave/SKILL.md
@@ -23,7 +23,7 @@ If example debt must land with a Wave, limit changes to the quickstart that exer
 A Wave PR is **not done** when wrappers and `curatedDoc` land alone. It is done when:
 
 1. **Curated factories** — overrides linted, `terradart wrap` regenerated, API diff reviewed.
-2. **Runnable example** — new `examples/<name>_quickstart` **or** extend an existing example so every new/breaking factory appears in synth output. Machine-checked by `tool/check_docs_consistency.dart` (synth-based `tfType` coverage + API-enablement deps); a factory may instead get a reasoned `tool/example_debt.yaml` entry, but that is an explicit reviewed decision. Label `apply-smoke` on the PR when apply-time verification is needed.
+2. **Runnable example** — new `examples/<name>_quickstart` **or** extend an existing example so every new/breaking factory appears in synth output. Machine-checked by `tool/check_docs_consistency.dart` (synth `tfType` coverage, API-enablement deps, **`terraform validate` on every quickstart**); a factory may instead get a reasoned `tool/example_debt.yaml` entry, but that is an explicit reviewed decision. For pre-existing debt backfill, see [`terradart-backfill-examples`](../terradart-backfill-examples/SKILL.md). Label `apply-smoke` on the PR when apply-time verification is needed.
 3. **Breaking changes** — `MIGRATING.md` entry **and** example updated to the new API.
 4. **Counts & docs** — `tool/doc_expectations.dart`, `catalog_count_test.dart`, `wrap_command_test.dart`, README curated list, agent/website catalog phrases, example `pubspec.yaml` carets.
 5. **CI matrix** — add the example slug to `.github/workflows/ci.yml` `terraform_validate` matrix when introducing a new quickstart.

--- a/.agents/skills/terradart-tighten-example-topology/SKILL.md
+++ b/.agents/skills/terradart-tighten-example-topology/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: terradart-tighten-example-topology
+description: After example backfill, wire orphan factories into sibling refs (SSL certs on proxies, health checks on backends) and run topology + terraform validate gates.
+metadata:
+  last_modified: 2026-06-09
+---
+# Tighten example topology
+
+Use after [`terradart-backfill-examples`](../terradart-backfill-examples/SKILL.md) when a quickstart gained **coverage-only** resources that synth + validate but are not linked into the stack.
+
+## When to use
+
+- Reviewer or agent notices factories that "exist only to appear in synth output."
+- `dart tool/check_example_topology.dart` reports unwired **must-reference** types on a strict quickstart.
+- Before merging a large example extension (especially `compute_lb_quickstart`).
+
+## Workflow
+
+- [ ] 1. **Identify orphans** — resources with no incoming `TfArg.ref` / `dependsOn` from siblings. Natural **leaf** nodes (forwarding rules, IAM members, one-shot jobs, firewalls) do not need incoming refs.
+- [ ] 2. **Wire must-reference types** (common cases):
+
+  | Factory type | Wire into |
+  |--------------|-----------|
+  | `GoogleComputeSslCertificate` | `sslCertificates` on `GoogleComputeTargetSslProxy` / `GoogleComputeTargetHttpsProxy` |
+  | `GoogleComputeRegionSslCertificate` | `sslCertificates` on `GoogleComputeRegionTargetHttpsProxy` |
+  | `GoogleComputeRegionHealthCheck` | `healthChecks` on `GoogleComputeRegionBackendService` |
+  | `GoogleComputeTargetHttpProxy` | `target` on `GoogleComputeGlobalForwardingRule` (port 80) |
+  | `GoogleComputeRegionTargetHttpProxy` | `target` on `GoogleComputeForwardingRule` (regional ILB) |
+
+- [ ] 3. **Reorder** `add(...)` blocks so referenced resources are created before consumers; capture `final x = add(...)` when later siblings need `TfArg.ref(x.*)`.
+- [ ] 4. **Sensitive fields** — keep `TfArg.variable` + `variables.tf.json` (see backfill skill).
+- [ ] 5. **Register strict quickstarts** — add slug to `strict:` in `tool/example_topology_allowlist.yaml` when the example should enforce must-reference rules in CI.
+- [ ] 6. **Verify**:
+  ```bash
+  dart tool/check_example_topology.dart
+  dart tool/check_docs_consistency.dart
+  tool/agent_verify.sh
+  ```
+
+## Automation
+
+`tool/check_example_topology.dart` scans synth JSON for Terraform types listed under `must_be_referenced` in `tool/example_topology_allowlist.yaml`. If the resource address appears only once, the quickstart is **unwired**.
+
+- Quickstarts under `strict:` **fail** the check.
+- Others print hints only (expand `strict` as examples are tightened).
+
+This does **not** replace `terraform validate` (schema shape) or full CI matrix fan-out.
+
+## Related
+
+- [`terradart-backfill-examples`](../terradart-backfill-examples/SKILL.md) — initial coverage + debt removal
+- [`terradart-agent-verify`](../terradart-agent-verify/SKILL.md) — shared done gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ Committed maintainer skills live under [`.agents/skills/`](.agents/skills/) (Age
 | [`terradart-agent-verify`](.agents/skills/terradart-agent-verify/SKILL.md) | Finishing any agent or maintainer change |
 | [`terradart-add-curated-resource`](.agents/skills/terradart-add-curated-resource/SKILL.md) | Adding or updating a curated `google_*` factory |
 | [`terradart-ship-wave`](.agents/skills/terradart-ship-wave/SKILL.md) | Landing a Wave release (curated + example/docs + counts + CHANGELOG) |
+| [`terradart-backfill-examples`](.agents/skills/terradart-backfill-examples/SKILL.md) | Covering `tool/example_debt.yaml` gaps in existing quickstarts |
 
 Optional generic Dart skills from [dart-lang/skills](https://github.com/dart-lang/skills) (`npx skills add dart-lang/skills --skill '*' --agent universal --yes`) are not committed here. [flutter/skills](https://github.com/flutter/skills) targets Flutter apps and is not applicable to TerraDart.
 
@@ -215,7 +216,7 @@ There is no long-running dev server for core work. Primary flows:
 | MCP catalog server (stdio) | `cd packages/terradart_agent && dart run terradart-mcp` |
 | Docs site (optional) | `cd website && bun install && bun run dev` (needs Bun + Node ≥ 22) |
 
-`tool/agent_verify.sh` does **not** run the full `terraform_validate` example matrix; GitHub Actions enforces that on merge. Examples use `GCP_PROJECT_ID` (or `ci-test-project-id` for local smoke) — no live GCP credentials are required for synth or `terraform validate`.
+`dart tool/check_docs_consistency.dart` (inside `tool/agent_verify.sh`) synths every quickstart and runs `terraform validate` on each `tf-out/` when `terraform` is on `PATH`. It does **not** replace the parallel `terraform_validate` CI matrix on merge. Examples use `GCP_PROJECT_ID` (or `ci-test-project-id` for local smoke) — no live GCP credentials are required for synth or `terraform validate`.
 
 ## Working Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ Committed maintainer skills live under [`.agents/skills/`](.agents/skills/) (Age
 | [`terradart-add-curated-resource`](.agents/skills/terradart-add-curated-resource/SKILL.md) | Adding or updating a curated `google_*` factory |
 | [`terradart-ship-wave`](.agents/skills/terradart-ship-wave/SKILL.md) | Landing a Wave release (curated + example/docs + counts + CHANGELOG) |
 | [`terradart-backfill-examples`](.agents/skills/terradart-backfill-examples/SKILL.md) | Covering `tool/example_debt.yaml` gaps in existing quickstarts |
+| [`terradart-tighten-example-topology`](.agents/skills/terradart-tighten-example-topology/SKILL.md) | Wiring backfilled factories into sibling refs; `tool/check_example_topology.dart` |
 
 Optional generic Dart skills from [dart-lang/skills](https://github.com/dart-lang/skills) (`npx skills add dart-lang/skills --skill '*' --agent universal --yes`) are not committed here. [flutter/skills](https://github.com/flutter/skills) targets Flutter apps and is not applicable to TerraDart.
 

--- a/examples/bigquery_quickstart/lib/main.dart
+++ b/examples/bigquery_quickstart/lib/main.dart
@@ -245,5 +245,74 @@ final class AnalyticsStack extends Stack {
         member: TfArg.ref(ingestor.iamMember),
       ),
     );
+
+    // ---- Backfill: job, routine, capacity commitment, data transfer --------
+
+    add(
+      GoogleBigqueryJob(
+        localName: 'events_count_job',
+        jobId: TfArg.literal('events-count-backfill'),
+        location: TfArg.literal('asia-northeast1'),
+        query: BigqueryJobQuery(
+          query: TfArg.literal(
+            'SELECT COUNT(*) AS event_count FROM analytics_prod.events',
+          ),
+          useLegacySql: TfArg.literal(false),
+          destinationTable: BigqueryJobDestinationTable(
+            projectId: TfArg.literal(projectId),
+            datasetId: TfArg.ref(dataset.datasetIdRef),
+            tableId: TfArg.literal('events_daily_count'),
+          ),
+          writeDisposition: BigqueryJobWriteDisposition.writeTruncate,
+          createDisposition: BigqueryJobCreateDisposition.createIfNeeded,
+        ),
+      ),
+    );
+
+    add(
+      GoogleBigqueryRoutine(
+        localName: 'add_one',
+        datasetId: TfArg.ref(dataset.datasetIdRef),
+        routineId: TfArg.literal('add_one'),
+        routineType: TfArg.literal(BigqueryRoutineType.scalarFunction),
+        definitionBody: TfArg.literal('x + 1'),
+        language: TfArg.literal(BigqueryRoutineLanguage.sql),
+        arguments: [
+          BigqueryRoutineArgument(
+            name: TfArg.literal('x'),
+            dataType: TfArg.literal('{"typeKind":"INT64"}'),
+          ),
+        ],
+        returnType: TfArg.literal('{"typeKind":"INT64"}'),
+      ),
+    );
+
+    add(
+      GoogleBigqueryCapacityCommitment(
+        localName: 'analytics_trial',
+        capacityCommitmentId: TfArg.literal('analytics-trial'),
+        location: TfArg.literal('asia-northeast1'),
+        slotCount: TfArg.literal(50),
+        plan: TfArg.literal(BigqueryCapacityCommitmentPlan.trial),
+        renewalPlan: TfArg.literal(BigqueryCapacityCommitmentRenewalPlan.none),
+      ),
+    );
+
+    add(
+      GoogleBigqueryDataTransferConfig(
+        localName: 'daily_events_rollup',
+        displayName: TfArg.literal('Daily events rollup'),
+        dataSourceId: TfArg.literal('scheduled_query'),
+        destinationDatasetId: TfArg.ref(dataset.datasetIdRef),
+        location: TfArg.literal('asia-northeast1'),
+        schedule: TfArg.literal('every 24 hours'),
+        params: TfArg.literal({
+          'query':
+              'SELECT event_id, ts FROM `analytics_prod.events` LIMIT 1000',
+          'destination_table_name_template': 'events_rollup',
+          'write_disposition': 'WRITE_TRUNCATE',
+        }),
+      ),
+    );
   }
 }

--- a/examples/cloud_functions_quickstart/lib/main.dart
+++ b/examples/cloud_functions_quickstart/lib/main.dart
@@ -51,7 +51,7 @@ final class HttpFunctionStack extends Stack {
     );
     add(runtimeSa);
 
-    add(
+    final helloHttp = add(
       GoogleCloudfunctions2Function(
         localName: 'hello_http',
         name: TfArg.literal('hello-http'),
@@ -78,6 +78,16 @@ final class HttpFunctionStack extends Stack {
           serviceAccountEmail: TfArg.ref(runtimeSa.email),
           environmentVariables: TfArg.literal({'LOG_LEVEL': 'info'}),
         ),
+      ),
+    );
+
+    add(
+      GoogleCloudfunctions2FunctionIamMember(
+        localName: 'hello_http_invoker',
+        cloudFunction: TfArg.ref(helloHttp.nameRef),
+        location: TfArg.literal('asia-northeast1'),
+        role: TfArg.literal('roles/cloudfunctions.invoker'),
+        member: TfArg.literal('allAuthenticatedUsers'),
       ),
     );
   }

--- a/examples/compute_lb_quickstart/bin/infra.dart
+++ b/examples/compute_lb_quickstart/bin/infra.dart
@@ -1,6 +1,7 @@
 /// Synth entry. `dart run bin/infra.dart` -> `tf-out/main.tf.json`.
 library;
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:terradart_example_compute_lb_quickstart/main.dart';
@@ -13,5 +14,14 @@ Future<void> main() async {
   }
   final stack = ComputeLbStack(projectId: projectId);
   await stack.writeTo('tf-out');
+  // `private_key` on self-managed SSL cert uses TfArg.variable.
+  await File('tf-out/variables.tf.json').writeAsString(
+    const JsonEncoder.withIndent('  ').convert({
+      'variable': {
+        'lb_self_managed_certificate': {'type': 'string', 'sensitive': true},
+        'lb_self_managed_private_key': {'type': 'string', 'sensitive': true},
+      },
+    }),
+  );
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/compute_lb_quickstart/bin/infra.dart
+++ b/examples/compute_lb_quickstart/bin/infra.dart
@@ -20,6 +20,8 @@ Future<void> main() async {
       'variable': {
         'lb_self_managed_certificate': {'type': 'string', 'sensitive': true},
         'lb_self_managed_private_key': {'type': 'string', 'sensitive': true},
+        'lb_regional_certificate': {'type': 'string', 'sensitive': true},
+        'lb_regional_private_key': {'type': 'string', 'sensitive': true},
       },
     }),
   );

--- a/examples/compute_lb_quickstart/lib/main.dart
+++ b/examples/compute_lb_quickstart/lib/main.dart
@@ -125,6 +125,15 @@ final class ComputeLbStack extends Stack {
       ),
     );
 
+    final selfManagedCert = add(
+      GoogleComputeSslCertificate(
+        localName: 'self_managed_cert',
+        name: TfArg.literal('app-self-managed-cert'),
+        certificate: TfArg.variable('lb_self_managed_certificate'),
+        privateKey: TfArg.variable('lb_self_managed_private_key'),
+      ),
+    );
+
     // ---- 3a. Health check ------------------------------------------------
     //
     // An HTTPS probe on `/healthz` that the backend service consults to
@@ -304,7 +313,9 @@ final class ComputeLbStack extends Stack {
         localName: 'lb_ssl_proxy',
         name: TfArg.literal('app-lb-ssl-proxy'),
         backendService: TfArg.ref(lbBackend.selfLink),
-        sslCertificates: TfArg.literal([lbCert.selfLink.interpolation]),
+        sslCertificates:
+            TfArg.literal([selfManagedCert.selfLink.interpolation]),
+        dependsOn: [ResourceDependency(selfManagedCert)],
       ),
     );
 
@@ -344,6 +355,19 @@ final class ComputeLbStack extends Stack {
       ),
     );
 
+    final regionalHealthCheck = add(
+      GoogleComputeRegionHealthCheck(
+        localName: 'regional_hc',
+        name: TfArg.literal('app-regional-hc'),
+        region: TfArg.literal(region),
+        httpsHealthCheck: ComputeRegionHealthCheckRegionHealthCheckHttpsConfig(
+          port: TfArg.literal(443),
+          requestPath: TfArg.literal('/healthz'),
+          portSpecification: RegionHealthCheckPortSpecification.useFixedPort,
+        ),
+      ),
+    );
+
     final regionalBackend = add(
       GoogleComputeRegionBackendService(
         localName: 'regional_backend',
@@ -352,12 +376,15 @@ final class ComputeLbStack extends Stack {
         protocol: TfArg.literal(RegionBackendServiceProtocol.tcp),
         loadBalancingScheme:
             TfArg.literal(RegionBackendServiceLoadBalancingScheme.internal),
+        healthChecks:
+            TfArg.literal([regionalHealthCheck.selfLink.interpolation]),
         backends: [
           ComputeRegionBackendServiceRegionBackendServiceBackend(
             group: TfArg.ref(lbNeg.selfLink),
             balancingMode: RegionBackendServiceBalancingMode.connection,
           ),
         ],
+        dependsOn: [ResourceDependency(regionalHealthCheck)],
       ),
     );
 
@@ -383,13 +410,23 @@ final class ComputeLbStack extends Stack {
       ),
     );
 
-    add(
+    final regionalSslPolicy = add(
       GoogleComputeRegionSslPolicy(
         localName: 'regional_ssl_policy',
         name: TfArg.literal('app-regional-ssl-policy'),
         region: TfArg.literal(region),
         profile: TfArg.literal('MODERN'),
         minTlsVersion: TfArg.literal('TLS_1_2'),
+      ),
+    );
+
+    final regionalSslCert = add(
+      GoogleComputeRegionSslCertificate(
+        localName: 'regional_cert',
+        name: TfArg.literal('app-regional-cert'),
+        region: TfArg.literal(region),
+        certificate: TfArg.variable('lb_regional_certificate'),
+        privateKey: TfArg.variable('lb_regional_private_key'),
       ),
     );
 
@@ -527,7 +564,7 @@ final class ComputeLbStack extends Stack {
       ),
     );
 
-    add(
+    final httpProxy = add(
       GoogleComputeTargetHttpProxy(
         localName: 'http_proxy',
         name: TfArg.literal('app-http-proxy'),
@@ -536,11 +573,16 @@ final class ComputeLbStack extends Stack {
     );
 
     add(
-      GoogleComputeSslCertificate(
-        localName: 'self_managed_cert',
-        name: TfArg.literal('app-self-managed-cert'),
-        certificate: TfArg.variable('lb_self_managed_certificate'),
-        privateKey: TfArg.variable('lb_self_managed_private_key'),
+      GoogleComputeGlobalForwardingRule(
+        localName: 'lb_http_forwarding_rule',
+        name: TfArg.literal('app-lb-http-forwarding-rule'),
+        ipAddress: TfArg.ref(lbVip.addressRef),
+        ipProtocol: TfArg.literal(GlobalForwardingRuleIpProtocol.tcp),
+        portRange: TfArg.literal('80'),
+        loadBalancingScheme: TfArg.literal(
+          GlobalForwardingRuleLoadBalancingScheme.externalManaged,
+        ),
+        target: TfArg.ref(httpProxy.selfLink),
       ),
     );
 
@@ -554,19 +596,6 @@ final class ComputeLbStack extends Stack {
       ),
     );
 
-    add(
-      GoogleComputeRegionHealthCheck(
-        localName: 'regional_hc',
-        name: TfArg.literal('app-regional-hc'),
-        region: TfArg.literal(region),
-        httpsHealthCheck: ComputeRegionHealthCheckRegionHealthCheckHttpsConfig(
-          port: TfArg.literal(443),
-          requestPath: TfArg.literal('/healthz'),
-          portSpecification: RegionHealthCheckPortSpecification.useFixedPort,
-        ),
-      ),
-    );
-
     final regionUrlMap = add(
       GoogleComputeRegionUrlMap(
         localName: 'regional_url_map',
@@ -576,7 +605,7 @@ final class ComputeLbStack extends Stack {
       ),
     );
 
-    add(
+    final regionHttpProxy = add(
       GoogleComputeRegionTargetHttpProxy(
         localName: 'regional_http_proxy',
         name: TfArg.literal('app-regional-http-proxy'),
@@ -591,12 +620,13 @@ final class ComputeLbStack extends Stack {
         name: TfArg.literal('app-regional-https-proxy'),
         region: TfArg.literal(region),
         urlMap: TfArg.ref(regionUrlMap.selfLink),
-        sslCertificates: TfArg.literal([
-          'projects/$projectId/regions/$region/sslCertificates/regional-placeholder',
-        ]),
-        sslPolicy: TfArg.literal(
-          'projects/$projectId/regions/$region/sslPolicies/app-regional-ssl-policy',
-        ),
+        sslCertificates:
+            TfArg.literal([regionalSslCert.selfLink.interpolation]),
+        sslPolicy: TfArg.ref(regionalSslPolicy.selfLink),
+        dependsOn: [
+          ResourceDependency(regionalSslCert),
+          ResourceDependency(regionalSslPolicy),
+        ],
       ),
     );
 
@@ -645,6 +675,23 @@ final class ComputeLbStack extends Stack {
         ipAddress: TfArg.ref(ilbAddress.selfLink),
         ipProtocol: TfArg.literal(ForwardingRuleIpProtocol.tcp),
         portRange: TfArg.literal('443'),
+        loadBalancingScheme: TfArg.literal(
+          ForwardingRuleLoadBalancingScheme.internalManaged,
+        ),
+      ),
+    );
+
+    add(
+      GoogleComputeForwardingRule(
+        localName: 'ilb_http',
+        name: TfArg.literal('app-ilb-http'),
+        region: TfArg.literal(region),
+        target: TfArg.ref(regionHttpProxy.selfLink),
+        network: TfArg.ref(lbVpc.selfLink),
+        subnetwork: TfArg.ref(lbSubnet.selfLink),
+        ipAddress: TfArg.ref(ilbAddress.selfLink),
+        ipProtocol: TfArg.literal(ForwardingRuleIpProtocol.tcp),
+        portRange: TfArg.literal('80'),
         loadBalancingScheme: TfArg.literal(
           ForwardingRuleLoadBalancingScheme.internalManaged,
         ),

--- a/examples/compute_lb_quickstart/lib/main.dart
+++ b/examples/compute_lb_quickstart/lib/main.dart
@@ -446,5 +446,209 @@ final class ComputeLbStack extends Stack {
         port: TfArg.literal(443),
       ),
     );
+
+    // ---- Backfill: fleet, firewall, HTTP path, backend bucket, regional ILB ---
+
+    add(
+      GoogleComputeFirewall(
+        localName: 'allow_lb_health',
+        name: TfArg.literal('app-allow-lb-health'),
+        network: TfArg.ref(lbVpc.selfLink),
+        direction: TfArg.literal(FirewallDirection.ingress),
+        allow: [
+          ComputeFirewallFirewallAllowRule(
+            protocol: TfArg.literal('tcp'),
+            ports: ['443'],
+          ),
+        ],
+        sourceRanges: TfArg.literal(['130.211.0.0/22', '35.191.0.0/16']),
+      ),
+    );
+
+    final webTemplate = add(
+      GoogleComputeInstanceTemplate(
+        localName: 'web_template',
+        namePrefix: TfArg.literal('app-web-'),
+        machineType: TfArg.literal('e2-small'),
+        disk: [
+          ComputeInstanceTemplateInstanceTemplateDisk(
+            boot: TfArg.literal(true),
+            sourceImage: TfArg.literal('debian-cloud/debian-12'),
+            autoDelete: TfArg.literal(true),
+          ),
+        ],
+        networkInterface: [
+          ComputeInstanceTemplateInstanceTemplateNetworkInterface(
+            network: TfArg.ref(lbVpc.selfLink),
+            subnetwork: TfArg.ref(lbSubnet.selfLink),
+          ),
+        ],
+      ),
+    );
+
+    final webMig = add(
+      GoogleComputeInstanceGroupManager(
+        localName: 'web_mig',
+        name: TfArg.literal('app-web-mig'),
+        zone: TfArg.literal(zone),
+        baseInstanceName: TfArg.literal('app-web'),
+        targetSize: TfArg.literal(1),
+        versions: [
+          ComputeInstanceGroupManagerInstanceGroupManagerVersion(
+            name: TfArg.literal('default'),
+            instanceTemplate: TfArg.ref(webTemplate.selfLink),
+          ),
+        ],
+      ),
+    );
+
+    add(
+      GoogleComputeAutoscaler(
+        localName: 'web_autoscaler',
+        name: TfArg.literal('app-web-autoscaler'),
+        zone: TfArg.literal(zone),
+        target: TfArg.ref(webMig.selfLink),
+        autoscalingPolicy: ComputeAutoscalerAutoscalerAutoscalingPolicy(
+          minReplicas: TfArg.literal(1),
+          maxReplicas: TfArg.literal(3),
+          cpuUtilization: ComputeAutoscalerAutoscalerCpuUtilization(
+            target: TfArg.literal(0.7),
+          ),
+        ),
+      ),
+    );
+
+    add(
+      GoogleComputeBackendBucket(
+        localName: 'static_assets',
+        name: TfArg.literal('app-static-assets'),
+        bucketName: TfArg.literal('my-app-static-assets'),
+        enableCdn: TfArg.literal(true),
+      ),
+    );
+
+    add(
+      GoogleComputeTargetHttpProxy(
+        localName: 'http_proxy',
+        name: TfArg.literal('app-http-proxy'),
+        urlMap: TfArg.ref(lbUrlMap.selfLink),
+      ),
+    );
+
+    add(
+      GoogleComputeSslCertificate(
+        localName: 'self_managed_cert',
+        name: TfArg.literal('app-self-managed-cert'),
+        certificate: TfArg.variable('lb_self_managed_certificate'),
+        privateKey: TfArg.variable('lb_self_managed_private_key'),
+      ),
+    );
+
+    final ilbAddress = add(
+      GoogleComputeAddress(
+        localName: 'ilb_vip',
+        name: TfArg.literal('app-ilb-vip'),
+        region: TfArg.literal(region),
+        subnetwork: TfArg.ref(lbSubnet.selfLink),
+        addressType: TfArg.literal(AddressType.internal),
+      ),
+    );
+
+    add(
+      GoogleComputeRegionHealthCheck(
+        localName: 'regional_hc',
+        name: TfArg.literal('app-regional-hc'),
+        region: TfArg.literal(region),
+        httpsHealthCheck: ComputeRegionHealthCheckRegionHealthCheckHttpsConfig(
+          port: TfArg.literal(443),
+          requestPath: TfArg.literal('/healthz'),
+          portSpecification: RegionHealthCheckPortSpecification.useFixedPort,
+        ),
+      ),
+    );
+
+    final regionUrlMap = add(
+      GoogleComputeRegionUrlMap(
+        localName: 'regional_url_map',
+        name: TfArg.literal('app-regional-url-map'),
+        region: TfArg.literal(region),
+        defaultService: TfArg.ref(regionalBackend.selfLink),
+      ),
+    );
+
+    add(
+      GoogleComputeRegionTargetHttpProxy(
+        localName: 'regional_http_proxy',
+        name: TfArg.literal('app-regional-http-proxy'),
+        region: TfArg.literal(region),
+        urlMap: TfArg.ref(regionUrlMap.selfLink),
+      ),
+    );
+
+    final regionHttpsProxy = add(
+      GoogleComputeRegionTargetHttpsProxy(
+        localName: 'regional_https_proxy',
+        name: TfArg.literal('app-regional-https-proxy'),
+        region: TfArg.literal(region),
+        urlMap: TfArg.ref(regionUrlMap.selfLink),
+        sslCertificates: TfArg.literal([
+          'projects/$projectId/regions/$region/sslCertificates/regional-placeholder',
+        ]),
+        sslPolicy: TfArg.literal(
+          'projects/$projectId/regions/$region/sslPolicies/app-regional-ssl-policy',
+        ),
+      ),
+    );
+
+    final regionalMig = add(
+      GoogleComputeRegionInstanceGroupManager(
+        localName: 'regional_web_mig',
+        name: TfArg.literal('app-regional-web-mig'),
+        region: TfArg.literal(region),
+        baseInstanceName: TfArg.literal('app-regional-web'),
+        targetSize: TfArg.literal(2),
+        distributionPolicyZones: TfArg.literal([zone]),
+        versions: [
+          ComputeRegionInstanceGroupManagerRegionInstanceGroupManagerVersion(
+            name: TfArg.literal('default'),
+            instanceTemplate: TfArg.ref(webTemplate.selfLink),
+          ),
+        ],
+      ),
+    );
+
+    add(
+      GoogleComputeRegionAutoscaler(
+        localName: 'regional_web_autoscaler',
+        name: TfArg.literal('app-regional-web-autoscaler'),
+        region: TfArg.literal(region),
+        target: TfArg.ref(regionalMig.selfLink),
+        autoscalingPolicy:
+            ComputeRegionAutoscalerRegionAutoscalerAutoscalingPolicy(
+          minReplicas: TfArg.literal(2),
+          maxReplicas: TfArg.literal(6),
+          cpuUtilization: ComputeRegionAutoscalerRegionAutoscalerCpuUtilization(
+            target: TfArg.literal(0.65),
+          ),
+        ),
+      ),
+    );
+
+    add(
+      GoogleComputeForwardingRule(
+        localName: 'ilb_https',
+        name: TfArg.literal('app-ilb-https'),
+        region: TfArg.literal(region),
+        target: TfArg.ref(regionHttpsProxy.selfLink),
+        network: TfArg.ref(lbVpc.selfLink),
+        subnetwork: TfArg.ref(lbSubnet.selfLink),
+        ipAddress: TfArg.ref(ilbAddress.selfLink),
+        ipProtocol: TfArg.literal(ForwardingRuleIpProtocol.tcp),
+        portRange: TfArg.literal('443'),
+        loadBalancingScheme: TfArg.literal(
+          ForwardingRuleLoadBalancingScheme.internalManaged,
+        ),
+      ),
+    );
   }
 }

--- a/examples/firebase_app_check_quickstart/bin/infra.dart
+++ b/examples/firebase_app_check_quickstart/bin/infra.dart
@@ -19,6 +19,8 @@ Future<void> main() async {
     const JsonEncoder.withIndent('  ').convert({
       'variable': {
         'recaptcha_v3_site_secret': {'type': 'string', 'sensitive': true},
+        'app_check_debug_token': {'type': 'string', 'sensitive': true},
+        'device_check_private_key': {'type': 'string', 'sensitive': true},
       },
     }),
   );

--- a/examples/firebase_app_check_quickstart/lib/main.dart
+++ b/examples/firebase_app_check_quickstart/lib/main.dart
@@ -53,5 +53,50 @@ final class AppCheckStack extends Stack {
         enforcementMode: TfArg.literal(AppCheckEnforcementMode.enforced),
       ),
     );
+
+    // ---- Backfill: per-platform providers + debug token + resource policy ----
+
+    add(
+      GoogleFirebaseAppCheckAppAttestConfig(
+        localName: 'ios_app_attest',
+        appId: TfArg.literal('1:1234567890:ios:abcdef'),
+      ),
+    );
+
+    add(
+      GoogleFirebaseAppCheckDeviceCheckConfig(
+        localName: 'ios_device_check',
+        appId: TfArg.literal('1:1234567890:ios:legacy'),
+        keyId: TfArg.literal('ABCDEFGHIJ'),
+        privateKey: TfArg.variable('device_check_private_key'),
+      ),
+    );
+
+    add(
+      GoogleFirebaseAppCheckPlayIntegrityConfig(
+        localName: 'android_play_integrity',
+        appId: TfArg.literal('1:1234567890:android:abcdef'),
+      ),
+    );
+
+    add(
+      GoogleFirebaseAppCheckDebugToken(
+        localName: 'ci_debug_token',
+        appId: TfArg.literal('1:1234567890:web:abcdef'),
+        displayName: TfArg.literal('CI debug token'),
+        token: TfArg.variable('app_check_debug_token'),
+      ),
+    );
+
+    add(
+      GoogleFirebaseAppCheckResourcePolicy(
+        localName: 'ios_oauth_policy',
+        serviceId: TfArg.literal('oauth2.googleapis.com'),
+        targetResource: TfArg.literal(
+          '//oauth2.googleapis.com/projects/123456789/oauthClients/example-client',
+        ),
+        enforcementMode: TfArg.literal(AppCheckEnforcementMode.unenforced),
+      ),
+    );
   }
 }

--- a/examples/firebase_app_hosting_quickstart/lib/main.dart
+++ b/examples/firebase_app_hosting_quickstart/lib/main.dart
@@ -59,5 +59,47 @@ final class AppHostingStack extends Stack {
         domainId: TfArg.literal('apphosting.example.com'),
       ),
     );
+
+    // ---- Backfill: default domain, build, traffic ---------------------------
+
+    add(
+      GoogleFirebaseAppHostingDefaultDomain(
+        localName: 'default_domain',
+        backend: TfArg.ref(backend.backendIdRef),
+        location: TfArg.literal('us-central1'),
+        domainId: TfArg.literal(
+          'quickstart-backend--$projectId.us-central1.hosted.app',
+        ),
+      ),
+    );
+
+    final releaseBuild = add(
+      GoogleFirebaseAppHostingBuild(
+        localName: 'release_build',
+        backend: TfArg.ref(backend.backendIdRef),
+        location: TfArg.literal('us-central1'),
+        buildId: TfArg.literal('release-1'),
+        source: FirebaseAppHostingBuildAppHostingBuildSourceCodebase(
+          branch: TfArg.literal('main'),
+        ),
+        displayName: TfArg.literal('Initial release build'),
+      ),
+    );
+
+    add(
+      GoogleFirebaseAppHostingTraffic(
+        localName: 'live_traffic',
+        backend: TfArg.ref(backend.backendIdRef),
+        location: TfArg.literal('us-central1'),
+        target: FirebaseAppHostingTrafficAppHostingTrafficTarget(
+          splits: [
+            FirebaseAppHostingTrafficAppHostingTrafficSplit(
+              build: TfArg.ref(releaseBuild.buildIdRef),
+              percent: TfArg.literal(100),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/examples/firestore_quickstart/lib/main.dart
+++ b/examples/firestore_quickstart/lib/main.dart
@@ -54,5 +54,34 @@ final class MessagesStack extends Stack {
         ],
       ),
     );
+
+    // ---- Backfill: field overrides, backup schedule, user creds -------------
+
+    add(
+      GoogleFirestoreField(
+        localName: 'expires_at_ttl',
+        collection: TfArg.literal('messages'),
+        field: TfArg.literal('expires_at'),
+        database: TfArg.ref(db.nameRef),
+        ttlConfig: const FirestoreFieldTtlConfig(),
+      ),
+    );
+
+    add(
+      GoogleFirestoreBackupSchedule(
+        localName: 'daily_backup',
+        database: TfArg.ref(db.nameRef),
+        retention: TfArg.literal('604800s'),
+        recurrence: const FirestoreBackupScheduleDailyRecurrence(),
+      ),
+    );
+
+    add(
+      GoogleFirestoreUserCreds(
+        localName: 'analytics_reader',
+        database: TfArg.ref(db.nameRef),
+        name: TfArg.literal('analytics-reader'),
+      ),
+    );
   }
 }

--- a/examples/storage_quickstart/lib/main.dart
+++ b/examples/storage_quickstart/lib/main.dart
@@ -18,6 +18,7 @@ library;
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/provider.dart';
+import 'package:terradart_google/pubsub.dart';
 import 'package:terradart_google/storage.dart';
 
 final class AssetsStack extends Stack {
@@ -97,6 +98,31 @@ final class AssetsStack extends Stack {
         localName: 'config_folder',
         bucket: TfArg.ref(assets.nameRef),
         name: TfArg.literal('config/'),
+      ),
+    );
+
+    // ---- Backfill: GCS -> Pub/Sub object notifications ----------------------
+
+    final objectEventsTopic = add(
+      GooglePubsubTopic(
+        localName: 'object_events',
+        name: TfArg.literal('gcs-object-events'),
+      ),
+    );
+
+    add(
+      GoogleStorageNotification(
+        localName: 'assets_object_events',
+        bucket: TfArg.ref(assets.nameRef),
+        topic: TfArg.ref(objectEventsTopic.id),
+        payloadFormat:
+            TfArg.literal(StorageNotificationPayloadFormat.jsonApiV1),
+        eventTypes: const [
+          StorageNotificationEventType.objectFinalize,
+          StorageNotificationEventType.objectDelete,
+        ],
+        objectNamePrefix: TfArg.literal('config/'),
+        dependsOn: [ResourceDependency(objectEventsTopic)],
       ),
     );
   }

--- a/tool/agent_verify.sh
+++ b/tool/agent_verify.sh
@@ -36,6 +36,9 @@ dart pub get
 echo ">> check_docs_consistency"
 dart tool/check_docs_consistency.dart
 
+echo ">> check_example_topology"
+dart tool/check_example_topology.dart
+
 echo ">> dart analyze"
 dart analyze packages/ --fatal-infos --fatal-warnings
 

--- a/tool/check_example_topology.dart
+++ b/tool/check_example_topology.dart
@@ -1,0 +1,159 @@
+// check_example_topology.dart — detect unwired "must reference" example resources.
+//
+// Flags factory types that should be linked into a sibling (SSL cert on a
+// proxy, health check on a backend) but appear only once in synth JSON.
+//
+// Run from repo root: dart tool/check_example_topology.dart
+// ignore_for_file: avoid_print
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:yaml/yaml.dart';
+
+Future<void> main() async {
+  final errors = <String>[];
+  final config = _loadConfig(errors);
+  if (errors.isNotEmpty) {
+    _fail(errors);
+  }
+
+  final strict = config.strict;
+  final mustBeReferenced = config.mustBeReferenced;
+
+  final quickstarts = Directory('examples')
+      .listSync()
+      .whereType<Directory>()
+      .map((d) => d.path.split(Platform.pathSeparator).last)
+      .where((name) => name.endsWith('_quickstart'))
+      .toList()
+    ..sort();
+
+  var strictViolations = 0;
+
+  for (final slug in quickstarts) {
+    final json = await _synthExample(slug, errors);
+    if (json == null) continue;
+    final unwired = _unwiredMustReference(json, mustBeReferenced);
+    if (unwired.isEmpty) continue;
+
+    if (strict.contains(slug)) {
+      strictViolations += unwired.length;
+      for (final entry in unwired.entries) {
+        errors.add(
+          'examples/$slug: ${entry.key} is not referenced by any sibling '
+          '(expected incoming ref for ${entry.value})',
+        );
+      }
+    } else {
+      print(
+        'examples/$slug: ${unwired.length} unwired must-reference resource(s) '
+        '(non-strict):',
+      );
+      for (final address in unwired.keys.toList()..sort()) {
+        print('  - $address');
+      }
+    }
+  }
+
+  if (errors.isNotEmpty) {
+    _fail(errors);
+  }
+  print(
+    'check_example_topology: OK (${strict.length} strict quickstart(s), '
+    '$strictViolations violation(s) in strict set)',
+  );
+}
+
+({Set<String> strict, Set<String> mustBeReferenced}) _loadConfig(
+  List<String> errors,
+) {
+  final file = File('tool/example_topology_allowlist.yaml');
+  if (!file.existsSync()) {
+    errors.add('Missing ${file.path}');
+    return (strict: {}, mustBeReferenced: {});
+  }
+  final doc = loadYaml(file.readAsStringSync());
+  if (doc is! YamlMap) {
+    errors.add('tool/example_topology_allowlist.yaml: expected a map');
+    return (strict: {}, mustBeReferenced: {});
+  }
+
+  Set<String> readList(String key) {
+    final value = doc[key];
+    if (value == null) return {};
+    if (value is! YamlList) {
+      errors.add('tool/example_topology_allowlist.yaml: $key must be a list');
+      return {};
+    }
+    return value.map((e) => e.toString()).toSet();
+  }
+
+  return (
+    strict: readList('strict'),
+    mustBeReferenced: readList('must_be_referenced'),
+  );
+}
+
+Future<Map<String, dynamic>?> _synthExample(
+  String slug,
+  List<String> errors,
+) async {
+  final infra = File('examples/$slug/bin/infra.dart');
+  if (!infra.existsSync()) return null;
+  final result = await Process.run(
+    'dart',
+    ['run', 'bin/infra.dart'],
+    workingDirectory: 'examples/$slug',
+    environment: {
+      'GCP_PROJECT_ID': 'ci-test-project-id',
+      'DB_PASSWORD':
+          Platform.environment['DB_PASSWORD'] ?? 'ci-synth-placeholder',
+    },
+  );
+  if (result.exitCode != 0) {
+    errors.add(
+      'examples/$slug: synth failed (exit ${result.exitCode})\n${result.stderr}',
+    );
+    return null;
+  }
+  final out = File('examples/$slug/tf-out/main.tf.json');
+  if (!out.existsSync()) {
+    errors.add('examples/$slug: missing tf-out/main.tf.json after synth');
+    return null;
+  }
+  return jsonDecode(out.readAsStringSync()) as Map<String, dynamic>;
+}
+
+Map<String, String> _unwiredMustReference(
+  Map<String, dynamic> root,
+  Set<String> mustBeReferenced,
+) {
+  if (mustBeReferenced.isEmpty) return const {};
+  final resources = root['resource'];
+  if (resources is! Map) return const {};
+  final fullJson = jsonEncode(root);
+  final unwired = <String, String>{};
+  for (final typeEntry in resources.entries) {
+    final tfType = typeEntry.key.toString();
+    if (!mustBeReferenced.contains(tfType)) continue;
+    final instances = typeEntry.value;
+    if (instances is! Map) continue;
+    for (final localName in instances.keys) {
+      final address = '$tfType.$localName';
+      final refNeedle = '\${$address.';
+      if (!fullJson.contains(refNeedle)) {
+        unwired[address] = tfType;
+      }
+    }
+  }
+  return unwired;
+}
+
+void _fail(List<String> errors) {
+  stderr.writeln('check_example_topology: FAILED');
+  for (final e in errors) {
+    stderr.writeln('  - $e');
+  }
+  exit(1);
+}

--- a/tool/example_debt.yaml
+++ b/tool/example_debt.yaml
@@ -6,39 +6,8 @@
 # a factory is neither covered nor listed, and when a listed factory becomes
 # covered (remove the line) — adding a line is a reviewed decision, not a
 # default.
-GoogleBigqueryCapacityCommitment: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleBigqueryDataTransferConfig: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleBigqueryJob: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleBigqueryRoutine: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleCloudfunctions2FunctionIamMember: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeAutoscaler: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeBackendBucket: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeFirewall: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeForwardingRule: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeInstanceGroupManager: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeInstanceTemplate: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeRegionAutoscaler: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeRegionHealthCheck: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeRegionInstanceGroupManager: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeRegionTargetHttpProxy: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeRegionTargetHttpsProxy: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeRegionUrlMap: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeSslCertificate: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleComputeTargetHttpProxy: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleFirebaseAppCheckAppAttestConfig: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleFirebaseAppCheckDebugToken: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleFirebaseAppCheckDeviceCheckConfig: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleFirebaseAppCheckPlayIntegrityConfig: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleFirebaseAppCheckResourcePolicy: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleFirebaseAppHostingBuild: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleFirebaseAppHostingDefaultDomain: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleFirebaseAppHostingTraffic: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleFirestoreBackupSchedule: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleFirestoreField: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleFirestoreUserCreds: pre-existing gap (Waves 1-9) — backfill candidate
-GoogleIapWebBackendServiceIamBinding: pre-existing gap (Waves 1-9) — backfill candidate
+GoogleIapWebBackendServiceIamBinding: pre-existing gap (Waves 1-9) — backfill candidate; curate *_iam_member only per IAM policy — binding deferred
 GoogleLoggingFolderSink: needs folder-level permissions beyond a quickstart project
 GoogleLoggingOrganizationSink: needs org-level permissions beyond a quickstart project
-GoogleComputeRegionSslCertificate: regional ILB follow-up; compute_lb uses global managed cert
+GoogleComputeRegionSslCertificate: regional ILB follow-up; compute_lb uses placeholder regional cert self-link for validate-only ILB chain
 GoogleProject: creating projects needs org/billing scope beyond a quickstart project
-GoogleStorageNotification: pre-existing gap (Waves 1-9) — backfill candidate

--- a/tool/example_debt.yaml
+++ b/tool/example_debt.yaml
@@ -9,5 +9,4 @@
 GoogleIapWebBackendServiceIamBinding: pre-existing gap (Waves 1-9) — backfill candidate; curate *_iam_member only per IAM policy — binding deferred
 GoogleLoggingFolderSink: needs folder-level permissions beyond a quickstart project
 GoogleLoggingOrganizationSink: needs org-level permissions beyond a quickstart project
-GoogleComputeRegionSslCertificate: regional ILB follow-up; compute_lb uses placeholder regional cert self-link for validate-only ILB chain
 GoogleProject: creating projects needs org/billing scope beyond a quickstart project

--- a/tool/example_synth_gates.dart
+++ b/tool/example_synth_gates.dart
@@ -45,10 +45,65 @@ Future<void> runExampleSynthGates(List<String> errors) async {
   for (final entry in synthByExample.entries) {
     checkApiEnablement(entry.key, entry.value, errors);
   }
+  await _checkTerraformValidate(errors, quickstarts);
 
   print(
     'example synth: ${quickstarts.length} quickstarts, '
     '${allTfTypes.length} distinct tfTypes in synth output',
+  );
+}
+
+/// Runs `terraform init` + `terraform validate` on each quickstart's synth
+/// output. Catches nested-block shape mistakes that synth-only coverage
+/// misses (e.g. wrong keys inside `destination_dataset`).
+Future<void> _checkTerraformValidate(
+  List<String> errors,
+  List<String> quickstarts,
+) async {
+  final which = await Process.run('which', ['terraform']);
+  if (which.exitCode != 0) {
+    print('example terraform validate: skipped (terraform not on PATH)');
+    return;
+  }
+
+  var validated = 0;
+  for (final slug in quickstarts) {
+    final tfOut = Directory('examples/$slug/tf-out');
+    final mainTf = File('${tfOut.path}/main.tf.json');
+    if (!mainTf.existsSync()) {
+      errors.add(
+        'examples/$slug: missing tf-out/main.tf.json before terraform validate',
+      );
+      continue;
+    }
+    final init = await Process.run(
+      'terraform',
+      ['init', '-backend=false', '-input=false', '-reconfigure'],
+      workingDirectory: tfOut.path,
+    );
+    if (init.exitCode != 0) {
+      errors.add(
+        'examples/$slug: terraform init failed (exit ${init.exitCode})\n'
+        '${init.stderr}',
+      );
+      continue;
+    }
+    final validate = await Process.run(
+      'terraform',
+      ['validate'],
+      workingDirectory: tfOut.path,
+    );
+    if (validate.exitCode != 0) {
+      errors.add(
+        'examples/$slug: terraform validate failed (exit ${validate.exitCode})\n'
+        '${validate.stderr}',
+      );
+      continue;
+    }
+    validated++;
+  }
+  print(
+    'example terraform validate: $validated/${quickstarts.length} quickstarts OK',
   );
 }
 

--- a/tool/example_topology_allowlist.yaml
+++ b/tool/example_topology_allowlist.yaml
@@ -1,0 +1,15 @@
+# Rules for tool/check_example_topology.dart.
+#
+# `must_be_referenced`: when a quickstart synths one of these Terraform types,
+# its address must appear at least twice in main.tf.json (referenced by a
+# sibling). Natural leaf types (forwarding rules, IAM members, one-shot jobs)
+# are intentionally omitted.
+strict:
+  - compute_lb_quickstart
+
+must_be_referenced:
+  - google_compute_ssl_certificate
+  - google_compute_region_ssl_certificate
+  - google_compute_region_health_check
+  - google_compute_target_http_proxy
+  - google_compute_region_target_http_proxy


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Backfills **31 pre-existing curated factories** (example_debt **36 → 4** after topology pass).

### Agent harness (repeat-mistake prevention)

| Layer | What it catches |
|-------|-----------------|
| `example_synth_gates` | synth coverage, API deps, **terraform validate all quickstarts** |
| `check_example_topology` | unwired SSL certs / health checks / HTTP proxies on **strict** quickstarts |
| `terradart-backfill-examples` skill | nested blocks, sensitive `TfArg.variable`, debt sync |
| `terradart-tighten-example-topology` skill | post-backfill wiring checklist |

### compute_lb topology pass (latest commit)

- `GoogleComputeSslCertificate` → `TargetSslProxy.sslCertificates`
- `GoogleComputeRegionSslCertificate` → `RegionTargetHttpsProxy` (debt removed)
- `GoogleComputeRegionHealthCheck` → `RegionBackendService.healthChecks`
- `GoogleComputeTargetHttpProxy` / `RegionTargetHttpProxy` → forwarding rules :80

## Verification

- `dart tool/check_example_topology.dart` — OK
- `dart tool/check_docs_consistency.dart` — OK (25/25 terraform validate)
- `tool/agent_verify.sh` — OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7626e6e-3191-4193-bf95-9b0aaa4ffc7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7626e6e-3191-4193-bf95-9b0aaa4ffc7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

