### PR TITLE
[SUPERSEDED] docs(website): Waves 23–24 and 0.12.10 migration guide

### DIFF
--- a/tool/check_docs_consistency.dart
+++ b/tool/check_docs_consistency.dart
@@ -35,6 +35,18 @@ Future<void> main() async {
   );
   _checkPhrase(
     errors,
+    'website/src/content/docs/docs/status.md',
+    '$curatedFactoryCount curated resource factories + 1 data source',
+    '($catalogEntryCount catalog entries)',
+  );
+  _checkPhrase(
+    errors,
+    'website/src/content/docs/docs/waves.md',
+    '$curatedFactoryCount curated resource factories + 1 data source',
+    '($catalogEntryCount catalog entries)',
+  );
+  _checkPhrase(
+    errors,
     'website/src/content/docs/docs/agent/index.md',
     agentCatalogEntriesPhrase,
     agentResourceFactoriesPhrase,

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -43,6 +43,8 @@ export default defineConfig({
             "docs/getting-started",
             "docs/why-terradart",
             "docs/architecture",
+            "docs/waves",
+            "docs/migrating",
             "docs/status",
           ],
         },

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -97,5 +97,7 @@ Rename `orders-prod` in the Stack without updating the subscriber and `dart anal
 
 - [Why TerraDart](/docs/why-terradart/) — motivation and comparisons
 - [Architecture](/docs/architecture/) — `synth()`, `writeTo()`, curated coverage
+- [Waves 23–24](/docs/waves/) — latest curated factories (v0.12.10)
+- [Migrating](/docs/migrating/) — read before bumping from `0.12.9`
 - [Status & versioning](/docs/status/) — pre-alpha vs beta vs 1.0
 - [Examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and [cookbook](https://github.com/nozomi-koborinai/terradart-cookbook) for fuller stacks

--- a/website/src/content/docs/docs/index.md
+++ b/website/src/content/docs/docs/index.md
@@ -12,6 +12,8 @@ Guides track the **0.12.x** line on pub.dev. The repo [README](https://github.co
 - [Getting Started](/docs/getting-started/) — install, first `*.tf.json`, boundary export
 - [Why TerraDart](/docs/why-terradart/) — motivation, comparison, and curated coverage
 - [Architecture](/docs/architecture/) — generate `*.tf.json`, `synth()` / `writeTo()`, AppExport
+- [Waves 23–24](/docs/waves/) — ten factories added in v0.12.10 and example pointers
+- [Migrating](/docs/migrating/) — upgrade from 0.12.9 (enum / nested-helper breaking changes)
 - [Status & versioning](/docs/status/) — pre-alpha, beta readiness (from v0.13.0), 1.0
 
 ## For AI assistants

--- a/website/src/content/docs/docs/migrating.md
+++ b/website/src/content/docs/docs/migrating.md
@@ -1,0 +1,107 @@
+---
+title: Migrating
+description: Upgrade notes for terradart_google — enum and nested-helper breaking changes in v0.12.10.
+---
+
+Read this page before bumping **`terradart_google` from `0.12.9` to `0.12.10`** (or any `^0.12.10` caret that resolves to `0.12.10+`). Patch releases within `0.12.10` are additive only; the breaking surface below landed in **`0.12.10`**.
+
+The canonical, full migration history lives in the repo: [MIGRATING.md on GitHub](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md). This page mirrors the **`0.12.9 → 0.12.10`** section for terradart.dev readers.
+
+## Lockstep bumps
+
+Bump all workspace packages together:
+
+```yaml
+dependencies:
+  terradart_core: ^0.12.10
+  terradart_google: ^0.12.10
+```
+
+Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest `0.12.x` patch.
+
+## What changed in 0.12.10
+
+`terradart_google` now uses **typed enums** and **nested helper classes** wherever the Terraform provider schema exposes a finite set of string values or a structured nested block. Fields that used to accept `TfArg<String>` or `TfArg<Map<String, dynamic>>?` may now require enum constants or helper `encode()` types.
+
+`dart analyze` surfaces most mismatches immediately — string literals that compiled on `0.12.9` no longer type-check.
+
+### Top-level enum fields
+
+| Factory | Field | Enum |
+| --- | --- | --- |
+| `GoogleBigqueryDatapolicyDataPolicy` | `dataPolicyType` | `BigqueryDatapolicyDataPolicyType` |
+| `GoogleBigqueryReservationAssignment` | `jobType` | `BigqueryReservationAssignmentJobType` |
+| `GoogleComputeServiceAttachment` | `connectionPreference` | `ServiceAttachmentConnectionPreference` |
+| `GoogleComputeRegionSecurityPolicy` | `type` | `RegionSecurityPolicyType` |
+| `GoogleComputeRegionSslPolicy` | `profile` / `minTlsVersion` | `RegionSslPolicyProfile` / `RegionSslPolicyMinTlsVersion` |
+| `GoogleComputeTargetTcpProxy` | `proxyHeader` | `TargetTcpProxyProxyHeader` |
+| `GoogleComputeTargetSslProxy` | `proxyHeader` | `TargetSslProxyProxyHeader` |
+| `GoogleComputeRegionTargetTcpProxy` | `proxyHeader` | `RegionTargetTcpProxyProxyHeader` |
+| `GoogleCloudTasksQueue` | `desiredState` | `CloudTasksQueueDesiredState` |
+| `GoogleLoggingSavedQuery` | `visibility` | `LoggingSavedQueryVisibility` |
+| `GoogleMonitoringSlo` | `calendarPeriod` | `MonitoringSloCalendarPeriod` |
+| `GoogleStorageHmacKey` | `state` | `StorageHmacKeyState` |
+| `GoogleKmsCryptoKeyVersion` | `state` | `KmsCryptoKeyVersionState` |
+| `GoogleSecretManagerSecretVersion` | `deletionPolicy` | `SecretManagerSecretVersionDeletionPolicy` |
+| `GoogleComputeInstanceGroupManager` | `listManagedInstancesResults` | `InstanceGroupManagerListManagedInstancesResults` |
+| `GoogleComputeRegionInstanceGroupManager` | `listManagedInstancesResults` | `RegionInstanceGroupManagerListManagedInstancesResults` |
+| `GoogleSqlUser` | `deletionPolicy` | `SqlUserDeletionPolicy` |
+
+Optional Analytics Hub `discoveryType` fields use `BigqueryAnalyticsHubDataExchangeDiscoveryType` / `BigqueryAnalyticsHubListingDiscoveryType`.
+
+Factories introduced in `0.12.10` (for example `GoogleDnsRecordSet.type`, `GoogleCloudRunV2WorkerPool.launchStage`) ship as enums from day one — there is no prior `String` API to migrate.
+
+### Nested helper blocks
+
+| Factory | Slot | Helper / enum |
+| --- | --- | --- |
+| `GoogleComputeRouter` | `bgp` | `ComputeRouterBgp` / `ComputeRouterBgpAdvertiseMode` |
+| `GoogleComputeSecurityPolicyRule` | `match` / `rateLimitOptions` | `ComputeSecurityPolicyRule*` types |
+| `GoogleComputeRegionSecurityPolicyRule` | `match` / `rateLimitOptions` | `ComputeRegionSecurityPolicyRule*` types |
+| `GoogleEventarcMessageBus` / `GoogleEventarcGoogleApiSource` / `GoogleEventarcPipeline` | `loggingConfig` | `EventarcMessageBusLoggingConfig` / `EventarcMessageBusLogSeverity` |
+| `GoogleComputeInstance` / `GoogleComputeInstanceTemplate` | `networkPerformanceConfig` | `ComputeInstanceNetworkPerformanceConfigTotalEgressBandwidthTier` |
+| `GoogleComputeBackendService` | `localityLbPolicies` | `LocalityLbPolicy` |
+| `GoogleComputeRegionSecurityPolicy` | `rules` / `advancedOptionsConfig` / … | `ComputeRegionSecurityPolicy*` helpers |
+| `GoogleComputeUrlMap` / `GoogleComputeRegionUrlMap` | route actions / cache policy | `*UrlMapRouteAction` / `*UrlMapCacheMode` |
+| `GoogleDnsPolicy` | `alternativeNameServerConfig` | `DnsPolicyAlternativeNameServerConfig` |
+| `GoogleDnsRecordSet` | `routingPolicy` | `DnsRecordSetRoutingPolicy*` |
+| `GoogleDnsResponsePolicyRule` | `localData` | `DnsResponsePolicyRuleLocalData` |
+| `GooglePubsubTopic` | `schemaSettings` / `ingestionDataSourceSettings` | `PubsubTopic*` helpers |
+| `GoogleGkeHubFleet` | `defaultClusterConfig` | `GkeHubFleetDefaultClusterConfig` |
+| `GoogleGkeBackupBackupPlan` / `GoogleGkeBackupRestorePlan` | schedule / restore config | `GkeBackup*` helpers |
+| `GoogleCloudRunV2WorkerPool` | template / scaling | `CloudRunV2WorkerPool*` helpers |
+| `GoogleBigqueryDatapolicyDataPolicy` | `dataMaskingPolicy` | `BigqueryDatapolicyDataPolicyDataMaskingPolicy` |
+| `GoogleArtifactRegistryRepository` | remote APT/YUM bases | `ArtifactRegistryAptRepositoryBase` / `ArtifactRegistryYumRepositoryBase` |
+
+### Before and after
+
+```dart
+// 0.12.9
+dataPolicyType: TfArg.literal('DATA_MASKING_POLICY'),
+connectionPreference: TfArg.literal('ACCEPT_AUTOMATIC'),
+
+// 0.12.10
+dataPolicyType: TfArg.literal(BigqueryDatapolicyDataPolicyType.dataMaskingPolicy),
+connectionPreference:
+    TfArg.literal(ServiceAttachmentConnectionPreference.acceptAutomatic),
+```
+
+For nested blocks, replace raw maps with helper constructors and call `.encode()` only when you hand-roll arg maps — curated factories accept the helper types directly on constructor parameters.
+
+### `GoogleComputeRegionSecurityPolicy` rules
+
+`GoogleComputeRegionSecurityPolicy` now expects embedded `rules` on the policy resource. Standalone `GoogleComputeRegionSecurityPolicyRule` remains for additional rules added after the policy exists.
+
+## Additive factories (no migration)
+
+Waves 23–24 shipped **ten new curated factories** in `0.12.10`. They are additive — only adopt them when you need the capability. See [Waves 23–24](/docs/waves/) for the factory list and runnable examples.
+
+## Older releases
+
+Earlier breaking changes (WIF provider sealed `trustSource`, `terradart codegen` removal, Stack class modifiers, and more) are documented in [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md).
+
+## Next steps
+
+- [Waves 23–24](/docs/waves/) — new factories and example stacks
+- [Status & versioning](/docs/status/) — pre-alpha expectations and beta policy
+- [Examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) — updated quickstarts exercising the new APIs

--- a/website/src/content/docs/docs/status.md
+++ b/website/src/content/docs/docs/status.md
@@ -40,12 +40,12 @@ We will label the project **beta** starting with **v0.13.0** when every **requir
 - [x] **`tool/smoke_quickstart.sh`** runs in CI and passes (`pubsub_quickstart`: pub get → synth → analyze including export consumer stub).
 - [x] **Examples matrix** on `main` stays green (per-example synth + `terraform validate` on `tf-out/`).
 - [x] **Boundary demo**: [pubsub_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart) documents `addExport` / generated `.app.dart` and includes a subscriber stub that `dart analyze` accepts.
-- [x] **Meta docs aligned** with the current minor: CONTRIBUTING, SECURITY, issue templates, package READMEs, and root README agree on pre-alpha/beta wording, `^0.N.x` pins, and **147 curated factories + 1 data source**.
+- [x] **Meta docs aligned** with the current minor: CONTRIBUTING, SECURITY, issue templates, package READMEs, and root README agree on pre-alpha/beta wording, `^0.N.x` pins, and **186 curated resource factories + 1 data source** (187 catalog entries).
 - [x] **Beta change policy** published on this page (see [Beta change policy](#beta-change-policy-applies-from-v0130)).
 
 ### Optional (does not block beta)
 
-- [ ] **`MIGRATING.md` covers the last two minors** (e.g. 0.11→0.12 and 0.12→0.13). *Each new minor must add a section; two-minor depth is a quality bar.*
+- [x] **`MIGRATING.md` / site migration guide** — [Migrating](/docs/migrating/) mirrors the `0.12.9 → 0.12.10` breaking changes; [MIGRATING.md on GitHub](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) remains canonical for older releases. *Two-minor depth across minors is still a beta quality bar when `0.13.0` ships.*
 - [ ] **External quickstart**: someone outside the core team completes the README path once; feedback captured in an issue or discussion.
 - [ ] **Real apply dogfood** via [terradart-cookbook](https://github.com/nozomi-koborinai/terradart-cookbook): at least one non-trivial recipe documents a successful `terraform apply`.
 - [ ] **`terradart-mcp`**: [Agent install](/docs/agent/install/) verified on a clean machine (Homebrew or release binary + four tools).

--- a/website/src/content/docs/docs/waves.md
+++ b/website/src/content/docs/docs/waves.md
@@ -1,0 +1,81 @@
+---
+title: Waves 23–24 (v0.12.10)
+description: Ten curated google_* factories shipped in Waves 23–24 with example stack pointers.
+---
+
+**v0.12.10** added ten curated resource factories across DNS, Eventarc, Cloud Run, IAP, Compute, and BigQuery. All are **additive** — no breaking changes for code that does not import these types.
+
+Catalog after `0.12.10`: **186 curated resource factories + 1 data source** (187 catalog entries). See [status](/docs/status/) for versioning policy.
+
+If you are upgrading from `0.12.9`, read [Migrating](/docs/migrating/) first — the same release also enum-ized many **existing** factories.
+
+## Wave 23
+
+| Terraform type | Dart factory | Barrel | Example |
+| --- | --- | --- | --- |
+| `google_dns_record_set` | `GoogleDnsRecordSet` | `dns` | [dns_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/dns_quickstart) |
+| `google_dns_policy` | `GoogleDnsPolicy` | `dns` | [dns_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/dns_quickstart) |
+| `google_eventarc_google_channel_config` | `GoogleEventarcGoogleChannelConfig` | `eventarc` | [eventarc_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/eventarc_quickstart) |
+| `google_cloud_run_v2_worker_pool` | `GoogleCloudRunV2WorkerPool` | `cloud_run` | [cloud_run_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/cloud_run_quickstart) |
+| `google_iap_web_backend_service_iam_member` | `GoogleIapWebBackendServiceIamMember` | `iap` | [compute_lb_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/compute_lb_quickstart) |
+
+### Wave 23 highlights
+
+- **DNS** — `GoogleDnsRecordSet` supports routing-policy helpers and typed record enums; `GoogleDnsPolicy` covers inbound forwarding and DNSSEC-related project policy.
+- **Eventarc** — `GoogleEventarcGoogleChannelConfig` configures the Google-owned channel used by Eventarc triggers.
+- **Cloud Run** — `GoogleCloudRunV2WorkerPool` is the long-running worker pool resource (distinct from Services and Jobs).
+- **IAP** — `GoogleIapWebBackendServiceIamMember` grants Identity-Aware Proxy access on an HTTPS load-balancer backend.
+
+## Wave 24
+
+| Terraform type | Dart factory | Barrel | Example |
+| --- | --- | --- | --- |
+| `google_dns_response_policy` | `GoogleDnsResponsePolicy` | `dns` | [dns_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/dns_quickstart) |
+| `google_dns_response_policy_rule` | `GoogleDnsResponsePolicyRule` | `dns` | [dns_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/dns_quickstart) |
+| `google_cloud_run_v2_worker_pool_iam_member` | `GoogleCloudRunV2WorkerPoolIamMember` | `cloud_run` | [cloud_run_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/cloud_run_quickstart) |
+| `google_compute_router` | `GoogleComputeRouter` | `compute` | [compute_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/compute_quickstart) |
+| `google_bigquery_datapolicy_data_policy_iam_member` | `GoogleBigqueryDatapolicyDataPolicyIamMember` | `bigquery` | [bigquery_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/bigquery_quickstart) |
+
+### Wave 24 highlights
+
+- **DNS** — response policies and rules for private or hybrid DNS override scenarios (paired with managed zones from earlier waves).
+- **Cloud Run** — IAM member adjunct for worker pools (`roles/run.invoker` pattern).
+- **Compute** — `GoogleComputeRouter` with typed `ComputeRouterBgp` / `ComputeRouterBgpAdvertiseMode` for Cloud Router BGP sessions.
+- **BigQuery** — IAM member on data policies (column-level policy enforcement).
+
+## Example coverage
+
+These quickstarts were extended in the `0.12.10` release to synth every new factory:
+
+- [dns_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/dns_quickstart) — policy, record set, response policy + rule
+- [eventarc_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/eventarc_quickstart) — channel config
+- [cloud_run_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/cloud_run_quickstart) — worker pool + IAM
+- [compute_lb_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/compute_lb_quickstart) — IAP member
+- [compute_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/compute_quickstart) — Cloud Router
+- [bigquery_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/bigquery_quickstart) — datapolicy IAM member
+
+CI runs `terraform validate` on each quickstart's synth output — see [Status — Examples matrix](/docs/status/#beta-readiness-checklist).
+
+## Using factories in a Stack
+
+Import from the service barrel (not `terradart_google.dart` re-exports alone — barrel imports keep analyzer scope smaller):
+
+```dart
+import 'package:terradart_google/dns.dart';
+import 'package:terradart_google/compute.dart';
+
+final router = GoogleComputeRouter(
+  localName: 'edge',
+  name: TfArg.literal('edge-router'),
+  network: TfArg.ref(vpc.selfLink),
+  bgp: ComputeRouterBgp(asn: TfArg.literal(64514)),
+);
+```
+
+Agents can look up constructor shapes via [terradart-mcp](/docs/agent/) (`get_resource_schema`, `list_resources`).
+
+## Next steps
+
+- [Migrating](/docs/migrating/) — enum / nested-helper breaking changes in `0.12.10`
+- [Getting Started](/docs/getting-started/) — first Stack if you are new to TerraDart
+- [CHANGELOG](https://github.com/nozomi-koborinai/terradart/blob/main/CHANGELOG.md) — full release notes

--- a/website/src/content/docs/docs/why-terradart.mdx
+++ b/website/src/content/docs/docs/why-terradart.mdx
@@ -96,7 +96,7 @@ HCL has provider schema types; CDKTF bindings are typed in TypeScript and other 
 
 ## Curated provider coverage
 
-[`terradart_google`](https://pub.dev/packages/terradart_google) does not wrap every resource in the upstream HashiCorp `google` provider. It ships **typed factories for a growing, battle-tested subset** — see [status](/docs/status/) and [Architecture — Provider integration](/docs/architecture/#provider-integration). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart-cookbook) (both expanding).
+[`terradart_google`](https://pub.dev/packages/terradart_google) does not wrap every resource in the upstream HashiCorp `google` provider. It ships **typed factories for a growing, battle-tested subset** — **186 curated resource factories + 1 data source** (187 catalog entries) as of v0.12.10. Recent additions are documented in [Waves 23–24](/docs/waves/); see also [status](/docs/status/) and [Architecture — Provider integration](/docs/architecture/#provider-integration). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart-cookbook) (both expanding). Upgrading from `0.12.9`? Read [Migrating](/docs/migrating/) first.
 
 ## Non-goals
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> **Superseded by [#121](https://github.com/nozomi-koborinai/terradart/pull/121)** — please close this PR without merging.

#121 includes everything here plus Waves 25–26 documentation and updated v0.12.11 catalog counts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7626e6e-3191-4193-bf95-9b0aaa4ffc7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7626e6e-3191-4193-bf95-9b0aaa4ffc7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

