### PR TITLE
fix(google): unblock terradart_google 0.12.11 pub.dev publish

### DIFF
--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -15,6 +15,10 @@ topics:
 environment:
   sdk: ^3.6.0
 
+# Gate 6 round-trip fixtures use mock PEM blocks for self-managed certificates.
+false_secrets:
+  - /test/synth/encode_round_trip_test.dart
+
 resolution: workspace
 
 dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `false_secrets` for Gate 6 mock PEM blocks in `encode_round_trip_test.dart` (self-managed certificate provisioning round-trip).

`terradart_core` and `terradart_codegen` **0.12.11** already published; `terradart_google` failed pub.dev secret scanner on the v0.12.11 tag push.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7626e6e-3191-4193-bf95-9b0aaa4ffc7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7626e6e-3191-4193-bf95-9b0aaa4ffc7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

