### PR TITLE
chore(examples): clear example_debt (IAP binding + folder/org sinks)

### DIFF
--- a/examples/compute_lb_quickstart/lib/main.dart
+++ b/examples/compute_lb_quickstart/lib/main.dart
@@ -838,7 +838,10 @@ final class ComputeLbStack extends Stack {
       ),
     );
 
-    // ---- Wave 23: IAP accessor on the global HTTPS backend ------------------
+    // ---- Wave 23: IAP on the global HTTPS backend ------------------------
+    //
+    // Member (additive) is the default pattern. Binding (authoritative per
+    // role) is shown for stacks that fully own the IAP accessor list.
 
     add(
       GoogleIapWebBackendServiceIamMember(
@@ -846,6 +849,19 @@ final class ComputeLbStack extends Stack {
         webBackendService: TfArg.ref(lbBackend.nameRef),
         role: TfArg.literal('roles/iap.httpsResourceAccessor'),
         member: TfArg.literal('allAuthenticatedUsers'),
+        dependsOn: [ResourceDependency(lbBackend)],
+      ),
+    );
+
+    add(
+      GoogleIapWebBackendServiceIamBinding(
+        localName: 'lb_iap_binding',
+        webBackendService: TfArg.ref(lbBackend.nameRef),
+        role: TfArg.literal('roles/iap.httpsResourceAccessor'),
+        members: TfArg.literal([
+          'group:platform-admins@example.com',
+        ]),
+        dependsOn: [ResourceDependency(lbBackend)],
       ),
     );
   }

--- a/examples/ops_quickstart/README.md
+++ b/examples/ops_quickstart/README.md
@@ -1,6 +1,6 @@
 # Ops quickstart
 
-End-to-end terradart example for routing Cloud Audit Logs into BigQuery via a logging sink. Provisions a BigQuery dataset (`audit_logs`) as the destination, then a `GoogleLoggingProjectSink` filtering `cloudaudit.googleapis.com` entries, with partitioned tables enabled and a single exclusion dropping high-volume DNS query logs.
+End-to-end terradart example for routing Cloud Audit Logs into BigQuery via logging sinks at project, folder, and organization scope. Provisions a BigQuery dataset (`audit_logs`) as the shared destination, a `GoogleLoggingProjectSink`, plus folder- and org-scoped sinks that read `ops_folder_id` / `ops_organization_id` Terraform variables (apply requires real folder/org permissions).
 
 ## Prerequisites
 

--- a/examples/ops_quickstart/bin/infra.dart
+++ b/examples/ops_quickstart/bin/infra.dart
@@ -1,6 +1,7 @@
 /// Synth entry. `dart run bin/infra.dart` → `tf-out/main.tf.json`.
 library;
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:terradart_example_ops_quickstart/main.dart';
@@ -13,5 +14,14 @@ Future<void> main() async {
   }
   final stack = AuditPipelineStack(projectId: projectId);
   await stack.writeTo('tf-out');
+  // Folder/org sinks need hierarchy IDs at apply time (not required for synth).
+  await File('tf-out/variables.tf.json').writeAsString(
+    const JsonEncoder.withIndent('  ').convert({
+      'variable': {
+        'ops_folder_id': {'type': 'string'},
+        'ops_organization_id': {'type': 'string'},
+      },
+    }),
+  );
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/ops_quickstart/lib/main.dart
+++ b/examples/ops_quickstart/lib/main.dart
@@ -5,7 +5,9 @@
 /// - a BigQuery dataset (`audit_logs`) as the sink destination;
 /// - a custom log bucket + filtered log view (with viewer IAM member);
 /// - a project-wide exclusion, a saved query, and a logs-based metric;
-/// - a `GoogleLoggingProjectSink` routing Cloud Audit Logs to BigQuery.
+/// - a `GoogleLoggingProjectSink` routing Cloud Audit Logs to BigQuery;
+/// - optional folder- and organization-scoped sinks (Terraform variables
+///   for `folder` / `org_id` — apply needs real hierarchy permissions).
 library;
 
 import 'package:terradart_core/terradart_core.dart';
@@ -162,13 +164,15 @@ final class AuditPipelineStack extends Stack {
       ),
     );
 
+    final projectSinkDestination = TfArg.literal(
+      'bigquery.googleapis.com/projects/$projectId/datasets/audit_logs',
+    );
+
     add(
       GoogleLoggingProjectSink(
         localName: 'audit_to_bq',
         name: TfArg.literal('audit-to-bq'),
-        destination: TfArg.literal(
-          'bigquery.googleapis.com/projects/$projectId/datasets/audit_logs',
-        ),
+        destination: projectSinkDestination,
         filter: TfArg.literal('logName:"cloudaudit.googleapis.com"'),
         uniqueWriterIdentity: TfArg.literal(true),
         bigqueryOptions: LoggingProjectSinkBigqueryOptions(
@@ -176,7 +180,43 @@ final class AuditPipelineStack extends Stack {
         ),
         dependsOn: [
           ResourceDependency(dataset),
-          ResourceDependency(apiLogging)
+          ResourceDependency(apiLogging),
+        ],
+      ),
+    );
+
+    add(
+      GoogleLoggingFolderSink(
+        localName: 'folder_audit_to_bq',
+        name: TfArg.literal('folder-audit-to-bq'),
+        folder: TfArg.variable('ops_folder_id'),
+        destination: projectSinkDestination,
+        filter: TfArg.literal('logName:"cloudaudit.googleapis.com"'),
+        includeChildren: TfArg.literal(true),
+        bigqueryOptions: LoggingFolderSinkBigqueryOptions(
+          usePartitionedTables: TfArg.literal(true),
+        ),
+        dependsOn: [
+          ResourceDependency(dataset),
+          ResourceDependency(apiLogging),
+        ],
+      ),
+    );
+
+    add(
+      GoogleLoggingOrganizationSink(
+        localName: 'org_audit_to_bq',
+        name: TfArg.literal('org-audit-to-bq'),
+        orgId: TfArg.variable('ops_organization_id'),
+        destination: projectSinkDestination,
+        filter: TfArg.literal('logName:"cloudaudit.googleapis.com"'),
+        includeChildren: TfArg.literal(true),
+        bigqueryOptions: LoggingOrganizationSinkBigqueryOptions(
+          usePartitionedTables: TfArg.literal(true),
+        ),
+        dependsOn: [
+          ResourceDependency(dataset),
+          ResourceDependency(apiLogging),
         ],
       ),
     );

--- a/tool/example_debt.yaml
+++ b/tool/example_debt.yaml
@@ -6,6 +6,3 @@
 # a factory is neither covered nor listed, and when a listed factory becomes
 # covered (remove the line) — adding a line is a reviewed decision, not a
 # default.
-GoogleIapWebBackendServiceIamBinding: pre-existing gap (Waves 1-9) — backfill candidate; curate *_iam_member only per IAM policy — binding deferred
-GoogleLoggingFolderSink: needs folder-level permissions beyond a quickstart project
-GoogleLoggingOrganizationSink: needs org-level permissions beyond a quickstart project


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clears the last **3** entries in `tool/example_debt.yaml` — **full catalog example coverage** (194 factories + 1 data source).

| Factory | Quickstart | Approach |
|---------|------------|----------|
| `GoogleIapWebBackendServiceIamBinding` | `compute_lb_quickstart` | Authoritative binding alongside existing IAP **member** (additive vs authoritative demo) |
| `GoogleLoggingFolderSink` | `ops_quickstart` | `TfArg.variable('ops_folder_id')` — apply needs real folder permissions |
| `GoogleLoggingOrganizationSink` | `ops_quickstart` | `TfArg.variable('ops_organization_id')` — apply needs org permissions |

## Notes

- **No version bump** — example/docs-only backfill per AGENTS.md PR granularity.
- `terraform validate`: 25/25 quickstarts OK; `example_debt.yaml` is now header-only.
- IAP: member remains the recommended additive pattern; binding documents the authoritative variant already in the catalog.

## Verification

- `tool/agent_verify.sh` — OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b58470b-70d7-4221-bb61-733f7679c559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b58470b-70d7-4221-bb61-733f7679c559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

