### PR TITLE
docs: full catalog example coverage (empty example_debt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Data & storage
 Application platform & operations
 
 - [Cloud Run v2 service (sealed `EnvVarSource`)](examples/cloud_run_quickstart/)
-- [Logging project sink → BigQuery](examples/ops_quickstart/)
+- [Logging sinks (project / folder / org) → BigQuery](examples/ops_quickstart/)
 - [Monitoring alert policy with typed `Aligner` / `Reducer`](examples/monitoring_quickstart/)
 - [Eventarc message bus + pipeline + Pub/Sub trigger](examples/eventarc_quickstart/)
 

--- a/examples/compute_lb_quickstart/README.md
+++ b/examples/compute_lb_quickstart/README.md
@@ -56,6 +56,8 @@ Thirteen Wave 6 resources are wired together in `lib/main.dart`:
 11. `google_compute_target_https_proxy`       -- terminates HTTPS
 12. `google_compute_global_address`           -- front-end VIP
 13. `google_compute_global_forwarding_rule`   -- VIP:443 -> HTTPS proxy
+14. `google_iap_web_backend_service_iam_member` + `google_iap_web_backend_service_iam_binding`
+    -- IAP accessor grant (additive member + authoritative binding demo)
 
 Wave 6 ships additional curated resources that pair with this stack but
 are out of scope for a single quickstart -- pick them up as the design

--- a/website/src/content/docs/docs/status.md
+++ b/website/src/content/docs/docs/status.md
@@ -41,6 +41,7 @@ We will label the project **beta** starting with **v0.13.0** when every **requir
 - [x] **Examples matrix** on `main` stays green (per-example synth + `terraform validate` on `tf-out/`).
 - [x] **Boundary demo**: [pubsub_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart) documents `addExport` / generated `.app.dart` and includes a subscriber stub that `dart analyze` accepts.
 - [x] **Meta docs aligned** with the current minor: CONTRIBUTING, SECURITY, issue templates, package READMEs, and root README agree on pre-alpha/beta wording, `^0.N.x` pins, and **194 curated resource factories + 1 data source** (195 catalog entries).
+- [x] **Full example coverage**: `tool/example_debt.yaml` is empty — all catalog entries appear in at least one quickstart synth (`check_docs_consistency.dart`).
 - [x] **Beta change policy** published on this page (see [Beta change policy](#beta-change-policy-applies-from-v0130)).
 
 ### Optional (does not block beta)

--- a/website/src/content/docs/docs/waves.md
+++ b/website/src/content/docs/docs/waves.md
@@ -188,6 +188,17 @@ final pool = GooglePrivatecaCaPool(
 );
 ```
 
+## Full catalog example coverage
+
+As of PR [#127](https://github.com/nozomi-koborinai/terradart/pull/127), **`tool/example_debt.yaml` is empty** — every curated factory and the `GoogleProject` data source appears in at least one quickstart synth output (machine-checked by `dart tool/check_docs_consistency.dart`).
+
+Final backfill (no new catalog entries):
+
+| Quickstart | Factories added |
+| --- | --- |
+| [compute_lb_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/compute_lb_quickstart) | `GoogleIapWebBackendServiceIamBinding` (authoritative IAP accessor list; shown alongside the additive `*_iam_member`) |
+| [ops_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/ops_quickstart) | `GoogleLoggingFolderSink`, `GoogleLoggingOrganizationSink` (`ops_folder_id` / `ops_organization_id` Terraform variables — apply needs folder/org permissions) |
+
 ## Example coverage
 
 Quickstarts extended for these waves:
@@ -205,6 +216,8 @@ Quickstarts extended for these waves:
 | `0.12.13` | [compute_lb_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/compute_lb_quickstart) | trust config + issuance config |
 | `0.12.13` | [pubsub_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart) | `GoogleProject` data source |
 | `0.12.14` | [compute_lb_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/compute_lb_quickstart) | Private CA pool → issuance config ref |
+| *(backfill)* | [compute_lb_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/compute_lb_quickstart) | IAP binding (`*_iam_binding` alongside member) |
+| *(backfill)* | [ops_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/ops_quickstart) | folder + organization logging sinks |
 
 CI runs `terraform validate` on each quickstart's synth output — see [Status — Examples matrix](/docs/status/#beta-readiness-checklist).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents PR #127 — **`tool/example_debt.yaml` is now empty** (194/194 factories + data source in quickstart synth).

### Updates

- `website/.../waves.md` — "Full catalog example coverage" section + backfill rows in example table
- `website/.../status.md` — checklist item for zero example debt
- `README.md` — ops quickstart bullet (project / folder / org sinks)
- `compute_lb_quickstart/README.md` — IAP member + binding step

No version bump (docs only).

## Verification

- `dart tool/check_docs_consistency.dart` — 194 in synth, **0** in example_debt, 25/25 validate OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b58470b-70d7-4221-bb61-733f7679c559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b58470b-70d7-4221-bb61-733f7679c559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

