### PR TITLE
fix(ci): harden schema-bump curation backlog append (#35)

### DIFF
--- a/.github/workflows/schema-bump.yml
+++ b/.github/workflows/schema-bump.yml
@@ -197,13 +197,11 @@ jobs:
           fi
           today=$(date -u +%Y-%m-%d)
           v7_latest=$(jq -r '.v7_latest' /tmp/state.json)
-          jq -r '.added_resources[]' /tmp/schema_diff.json | while read -r r; do
-            # Append: shell mutation, idempotent for this run only.
-            printf '  - resource: %s\n    detected_at: %s\n    provider_version: %s\n' \
-              "$r" "$today" "$v7_latest" >> tool/curation_backlog.yaml
-          done
-          # Validate post-append.
-          python3 -c "import yaml; yaml.safe_load(open('tool/curation_backlog.yaml'))"
+          dart tool/append_curation_backlog.dart \
+            --backlog=tool/curation_backlog.yaml \
+            --diff=/tmp/schema_diff.json \
+            --detected-at="$today" \
+            --provider-version="$v7_latest"
 
       - name: Skip if nothing changed
         id: skip_check
@@ -228,7 +226,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$branch"
-          git add -A
+          git add \
+            tool/curation_backlog.yaml \
+            packages/terradart_codegen/test/fixtures/wrap/source/schema.json \
+            packages/terradart_codegen/test/fixtures/wrap/source/mm \
+            packages/terradart_google/lib/src/_provider_meta.dart \
+            packages/terradart_google/lib/src
           git commit -m "chore(schema): weekly bump $today"
           git push -u origin "$branch"
           gh pr create \

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ RESUME.md
 
 # sed -i.bak residue (tool/prepare_publish.sh generates these during swap).
 *.bak
+# schema-bump workflow drift report (PR body only; not committed)
+.schema-bump/

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -11,6 +11,13 @@ Maintainer:
 - **Added** — `tool/example_synth_gates.dart` (synth-based example coverage + API-enablement dependency checker, #108).
 - **Added** — label-gated `apply-smoke` GitHub workflow + `tool/apply_smoke.sh` (#109).
 
+## Unreleased
+
+Maintainer:
+
+- **Added** — `tool/append_curation_backlog.dart` for idempotent schema-bump backlog updates (#35).
+- **Fixed** — schema-bump workflow no longer appends invalid YAML outside `entries:`; excludes `.schema-bump/` from commits.
+
 ## 0.12.17
 
 No codegen changes. Lockstep version bump for `terradart_google` v0.12.17 (`Apis.required` helper).

--- a/packages/terradart_codegen/test/tool/append_curation_backlog_test.dart
+++ b/packages/terradart_codegen/test/tool/append_curation_backlog_test.dart
@@ -1,0 +1,53 @@
+import 'package:test/test.dart';
+
+import '../../../../tool/append_curation_backlog.dart';
+
+void main() {
+  group('appendCurationEntries', () {
+    test('appends under entries schema and dedupes by resource', () {
+      final result = appendCurationEntries(
+        existing: const [
+          {
+            'resource': 'google_foo',
+            'detected_at': '2026-01-01',
+            'provider_version': '7.0.0',
+          },
+        ],
+        resources: ['google_foo', 'google_bar'],
+        detectedAt: '2026-06-12',
+        providerVersion: '7.2.0',
+      );
+      expect(result, hasLength(2));
+      expect(result.map((e) => e['resource']).toList(),
+          ['google_bar', 'google_foo']);
+      expect(result.first['provider_version'], '7.2.0');
+    });
+  });
+
+  group('formatBacklogYaml', () {
+    test('round-trips empty entries', () {
+      const header = '# header';
+      final yaml = formatBacklogYaml(header: header, entries: const []);
+      expect(readBacklogEntries(yaml), isEmpty);
+      expect(yaml, contains('entries:\n  []'));
+    });
+
+    test('preserves header and writes entries list', () {
+      const header = '# tool/curation_backlog.yaml';
+      final yaml = formatBacklogYaml(
+        header: header,
+        entries: const [
+          {
+            'resource': 'google_new',
+            'detected_at': '2026-06-12',
+            'provider_version': '7.2.0',
+          },
+        ],
+      );
+      expect(yaml.startsWith('# tool/curation_backlog.yaml'), isTrue);
+      final entries = readBacklogEntries(yaml);
+      expect(entries, hasLength(1));
+      expect(entries.single['resource'], 'google_new');
+    });
+  });
+}

--- a/tool/append_curation_backlog.dart
+++ b/tool/append_curation_backlog.dart
@@ -1,0 +1,182 @@
+// append_curation_backlog.dart — idempotent append under `entries:` in
+// tool/curation_backlog.yaml (schema-bump workflow).
+//
+// Usage:
+//   dart tool/append_curation_backlog.dart \
+//     --backlog=tool/curation_backlog.yaml \
+//     --diff=/tmp/schema_diff.json \
+//     --detected-at=2026-06-12 \
+//     --provider-version=7.2.0
+//
+// ignore_for_file: avoid_print
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:yaml/yaml.dart';
+
+const _exitUsage = 64;
+const _exitIo = 65;
+
+Future<void> main(List<String> args) async {
+  final parsed = _parseArgs(args);
+  if (parsed == null) {
+    stderr.writeln(
+      'Usage: dart tool/append_curation_backlog.dart '
+      '--backlog=<path> --diff=<schema_diff.json> '
+      '--detected-at=YYYY-MM-DD --provider-version=X.Y.Z',
+    );
+    exit(_exitUsage);
+  }
+
+  final diffFile = File(parsed.diffPath);
+  if (!diffFile.existsSync()) {
+    stderr.writeln('Diff file not found: ${parsed.diffPath}');
+    exit(_exitIo);
+  }
+  final diff = jsonDecode(diffFile.readAsStringSync()) as Map<String, dynamic>;
+  final added = (diff['added_resources'] as List<dynamic>? ?? const [])
+      .cast<String>();
+
+  if (added.isEmpty) {
+    print('No added_resources; backlog unchanged.');
+    exit(0);
+  }
+
+  final backlogFile = File(parsed.backlogPath);
+  if (!backlogFile.existsSync()) {
+    stderr.writeln('Backlog file not found: ${parsed.backlogPath}');
+    exit(_exitIo);
+  }
+
+  final header = _readHeader(backlogFile.readAsStringSync());
+  final entries = readBacklogEntries(backlogFile.readAsStringSync());
+  final appended = appendCurationEntries(
+    existing: entries,
+    resources: added,
+    detectedAt: parsed.detectedAt,
+    providerVersion: parsed.providerVersion,
+  );
+
+  backlogFile.writeAsStringSync(formatBacklogYaml(header: header, entries: appended));
+  print(
+    'curation_backlog: ${appended.length} entries '
+    '(${added.length} candidate resource(s) from diff)',
+  );
+}
+
+class _Args {
+  _Args({
+    required this.backlogPath,
+    required this.diffPath,
+    required this.detectedAt,
+    required this.providerVersion,
+  });
+
+  final String backlogPath;
+  final String diffPath;
+  final String detectedAt;
+  final String providerVersion;
+}
+
+_Args? _parseArgs(List<String> args) {
+  String? backlog;
+  String? diff;
+  String? detectedAt;
+  String? providerVersion;
+  for (final a in args) {
+    if (a.startsWith('--backlog=')) {
+      backlog = a.substring('--backlog='.length);
+    } else if (a.startsWith('--diff=')) {
+      diff = a.substring('--diff='.length);
+    } else if (a.startsWith('--detected-at=')) {
+      detectedAt = a.substring('--detected-at='.length);
+    } else if (a.startsWith('--provider-version=')) {
+      providerVersion = a.substring('--provider-version='.length);
+    }
+  }
+  if (backlog == null ||
+      diff == null ||
+      detectedAt == null ||
+      providerVersion == null) {
+    return null;
+  }
+  return _Args(
+    backlogPath: backlog,
+    diffPath: diff,
+    detectedAt: detectedAt,
+    providerVersion: providerVersion,
+  );
+}
+
+/// Parses `entries:` from [yamlSource]. Returns an empty list when absent.
+List<Map<String, String>> readBacklogEntries(String yamlSource) {
+  final doc = loadYaml(yamlSource);
+  if (doc is! YamlMap) return [];
+  final raw = doc['entries'];
+  if (raw is! YamlList) return [];
+  return [
+    for (final item in raw)
+      if (item is YamlMap)
+        {
+          for (final key in item.keys)
+            key.toString(): item[key].toString(),
+        },
+  ];
+}
+
+/// Appends [resources] not already present (by `resource` key).
+List<Map<String, String>> appendCurationEntries({
+  required List<Map<String, String>> existing,
+  required List<String> resources,
+  required String detectedAt,
+  required String providerVersion,
+}) {
+  final seen = existing.map((e) => e['resource']).whereType<String>().toSet();
+  final out = [...existing];
+  for (final resource in resources) {
+    if (seen.contains(resource)) continue;
+    out.add({
+      'resource': resource,
+      'detected_at': detectedAt,
+      'provider_version': providerVersion,
+    });
+    seen.add(resource);
+  }
+  out.sort((a, b) => (a['resource'] ?? '').compareTo(b['resource'] ?? ''));
+  return out;
+}
+
+String _readHeader(String yamlSource) {
+  final lines = yamlSource.split('\n');
+  final headerLines = <String>[];
+  for (final line in lines) {
+    if (line.startsWith('entries:')) break;
+    headerLines.add(line);
+  }
+  return headerLines.join('\n').trimRight();
+}
+
+/// Writes the backlog file: comment [header] + `entries:` list.
+String formatBacklogYaml({
+  required String header,
+  required List<Map<String, String>> entries,
+}) {
+  final buf = StringBuffer()
+    ..writeln(header)
+    ..writeln()
+    ..writeln('entries:');
+  for (final entry in entries) {
+    buf.writeln('  - resource: ${entry['resource']}');
+    buf.writeln('    detected_at: ${entry['detected_at']}');
+    buf.writeln('    provider_version: ${entry['provider_version']}');
+    final note = entry['note'];
+    if (note != null && note.isNotEmpty) {
+      buf.writeln('    note: $note');
+    }
+  }
+  if (entries.isEmpty) {
+    buf.writeln('  []');
+  }
+  return buf.toString().endsWith('\n') ? buf.toString() : '${buf.toString()}\n';
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens Plan 5.E schema-bump automation (issue #35). Core automation already shipped in PR #42; this PR fixes the broken curation backlog append and tightens commit scope.

Closes #35.

## Changes

- `tool/append_curation_backlog.dart` — idempotent append under `entries:` with dedup
- `schema-bump.yml` — Dart helper + explicit `git add` paths
- `.gitignore` — `.schema-bump/`

## Verification

- `tool/agent_verify.sh` — OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b58470b-70d7-4221-bb61-733f7679c559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b58470b-70d7-4221-bb61-733f7679c559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

