### PR TITLE
docs(examples): dogfood Apis.required in gke, cloud_run, compute_lb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to terradart are documented here. The format follows [Keep a
 
 Per-package changelogs live alongside each package and are the system of record for `terradart_core`, `terradart_codegen`, `terradart_google`, and `terradart_agent` — this top-level file summarises cross-cutting milestones.
 
+## Unreleased
+
+### Changed (examples)
+
+- **`gke_quickstart`**, **`cloud_run_quickstart`**, **`compute_lb_quickstart`** — replace hand-written `GoogleProjectService` blocks with [`Apis.required`](packages/terradart_google/lib/src/project/apis.dart) (`#57` dogfood). Cloud Run quickstart now also enables `run.googleapis.com`.
+
 ## [0.12.18] - 2026-06-12
 
 Lockstep release across the workspace. **No breaking changes** vs `0.12.17`.

--- a/examples/cloud_run_quickstart/README.md
+++ b/examples/cloud_run_quickstart/README.md
@@ -32,7 +32,8 @@ terraform apply
 ## What gets created
 
 - A Secret Manager secret `api-db-password` with user-managed replication in `asia-northeast1`.
-- A Serverless VPC Access connector `run-vpc` (`10.8.0.0/28` on the `default` VPC) with `vpcaccess.googleapis.com` enabled via `google_project_service`.
+- API enablement via [`Apis.required`](../../packages/terradart_google/lib/src/project/apis.dart) (`Barrels.cloudRun`, `Barrels.serviceNetworking` → Run + VPC Access APIs).
+- A Serverless VPC Access connector `run-vpc` (`10.8.0.0/28` on the `default` VPC).
 - A Cloud Run v2 Service `api` running `gcr.io/cloudrun/hello`:
   - 1 literal env var: `LOG_LEVEL=info` via `EnvVarFromLiteral`.
   - 1 secret-backed env var: `DB_PASSWORD` via `EnvVarFromSecret(secret: 'api-db-password', version: 'latest')`.

--- a/examples/cloud_run_quickstart/lib/main.dart
+++ b/examples/cloud_run_quickstart/lib/main.dart
@@ -54,18 +54,21 @@ final class ApiServiceStack extends Stack {
       ),
     );
 
-    // ---- Wave 25: Serverless VPC Access connector -------------------------
+    // ---- API enablement + Wave 25 VPC Access connector --------------------
     //
-    // Dedicated /28 on the default VPC; the service revision below routes
-    // private-range egress through this connector.
+    // [Apis.required] covers Cloud Run + VPC Access (and compute for the
+    // default VPC). Dedicated /28 on the default VPC; the service revision
+    // below routes private-range egress through this connector.
 
-    final apiVpcAccess = add(
-      GoogleProjectService(
-        localName: 'api_vpcaccess',
-        service: TfArg.literal('vpcaccess.googleapis.com'),
-        disableOnDestroy: TfArg.literal(false),
-      ),
-    );
+    final apisByEndpoint = <String, GoogleProjectService>{};
+    for (final api in Apis.required(
+      barrels: [Barrels.cloudRun, Barrels.serviceNetworking],
+    )) {
+      final added = add(api);
+      apisByEndpoint[added.argMap['service']!.toTfJson() as String] = added;
+    }
+    final apiRun = apisByEndpoint['run.googleapis.com']!;
+    final apiVpcAccess = apisByEndpoint['vpcaccess.googleapis.com']!;
 
     final runConnector = GoogleVpcAccessConnector(
       localName: 'run_vpc',
@@ -120,6 +123,10 @@ final class ApiServiceStack extends Stack {
         maxInstanceCount: TfArg.literal(4),
         scalingMode: TfArg.literal(ScalingMode.automatic),
       ),
+      dependsOn: [
+        ResourceDependency(apiRun),
+        ResourceDependency(runConnector),
+      ],
     );
     add(apiService);
 
@@ -134,6 +141,7 @@ final class ApiServiceStack extends Stack {
             {'image': 'gcr.io/cloudrun/hello'},
           ],
         ),
+        dependsOn: [ResourceDependency(apiRun)],
       ),
     );
 
@@ -168,6 +176,7 @@ final class ApiServiceStack extends Stack {
         parallelism: TfArg.literal(1),
         taskCount: TfArg.literal(1),
       ),
+      dependsOn: [ResourceDependency(apiRun)],
     );
     add(nightlyJob);
 

--- a/examples/compute_lb_quickstart/lib/main.dart
+++ b/examples/compute_lb_quickstart/lib/main.dart
@@ -145,13 +145,16 @@ final class ComputeLbStack extends Stack {
     // [GoogleComputeTargetHttpsProxy.certificateMap] to `cmMap.id` at
     // apply time when migrating off Compute SSL certificates.
 
-    final apiCertificateManager = add(
-      GoogleProjectService(
-        localName: 'api_certificate_manager',
-        service: TfArg.literal('certificatemanager.googleapis.com'),
-        disableOnDestroy: TfArg.literal(false),
-      ),
-    );
+    final apisByEndpoint = <String, GoogleProjectService>{};
+    for (final api in Apis.required(
+      barrels: [Barrels.certificateManager, Barrels.privateca],
+    )) {
+      final added = add(api);
+      apisByEndpoint[added.argMap['service']!.toTfJson() as String] = added;
+    }
+    final apiCertificateManager =
+        apisByEndpoint['certificatemanager.googleapis.com']!;
+    final apiPrivateca = apisByEndpoint['privateca.googleapis.com']!;
 
     final cmDnsAuth = GoogleCertificateManagerDnsAuthorization(
       localName: 'cm_dns_auth',
@@ -162,14 +165,6 @@ final class ComputeLbStack extends Stack {
     add(cmDnsAuth);
 
     // ---- 2c. Wave 28: Private CA pool (CAS backend for issuance) ---------
-
-    final apiPrivateca = add(
-      GoogleProjectService(
-        localName: 'api_privateca',
-        service: TfArg.literal('privateca.googleapis.com'),
-        disableOnDestroy: TfArg.literal(false),
-      ),
-    );
 
     final cmCaPool = GooglePrivatecaCaPool(
       localName: 'cm_ca_pool',

--- a/examples/gke_quickstart/README.md
+++ b/examples/gke_quickstart/README.md
@@ -31,7 +31,7 @@ terraform apply
 
 ## What gets created
 
-- API enablement for `compute.googleapis.com`, `container.googleapis.com`, and `gkehub.googleapis.com`.
+- API enablement via [`Apis.required`](../../packages/terradart_google/lib/src/project/apis.dart) (`Barrels.compute`, `Barrels.container`, `Barrels.gkeBackup` → Compute, GKE, GKE Hub, GKE Backup APIs).
 - VPC `gke-vpc` and subnet `gke-subnet` in `asia-northeast1`.
 - Regional cluster `main-gke` with `remove_default_node_pool = true`.
 - Node pool `primary-pool` attached to the cluster.

--- a/examples/gke_quickstart/lib/main.dart
+++ b/examples/gke_quickstart/lib/main.dart
@@ -1,7 +1,7 @@
 /// GKE quickstart — Wave 8 + 9 + 10 end-to-end example.
 ///
 /// Provisions:
-/// - API enablement for Compute, GKE, GKE Hub, and GKE Backup;
+/// - API enablement via [Apis.required] (Compute, GKE, GKE Hub, GKE Backup);
 /// - a custom-mode VPC + regional subnet;
 /// - a regional GKE cluster (Backup for GKE agent enabled, default node
 ///   pool removed);
@@ -27,29 +27,17 @@ final class GkeQuickstartStack extends Stack {
     const region = 'asia-northeast1';
     const clusterName = 'main-gke';
 
-    final apiCompute = add(
-      GoogleProjectService(
-        localName: 'api_compute',
-        service: TfArg.literal('compute.googleapis.com'),
-        disableOnDestroy: TfArg.literal(false),
-      ),
-    );
-
-    final apiContainer = add(
-      GoogleProjectService(
-        localName: 'api_container',
-        service: TfArg.literal('container.googleapis.com'),
-        disableOnDestroy: TfArg.literal(false),
-      ),
-    );
-
-    final apiGkeHub = add(
-      GoogleProjectService(
-        localName: 'api_gkehub',
-        service: TfArg.literal('gkehub.googleapis.com'),
-        disableOnDestroy: TfArg.literal(false),
-      ),
-    );
+    final apisByEndpoint = <String, GoogleProjectService>{};
+    for (final api in Apis.required(
+      barrels: [Barrels.compute, Barrels.container, Barrels.gkeBackup],
+    )) {
+      final added = add(api);
+      apisByEndpoint[added.argMap['service']!.toTfJson() as String] = added;
+    }
+    final apiCompute = apisByEndpoint['compute.googleapis.com']!;
+    final apiContainer = apisByEndpoint['container.googleapis.com']!;
+    final apiGkeHub = apisByEndpoint['gkehub.googleapis.com']!;
+    final apiGkeBackup = apisByEndpoint['gkebackup.googleapis.com']!;
 
     final vpc = add(
       GoogleComputeNetwork(
@@ -134,14 +122,6 @@ final class GkeQuickstartStack extends Stack {
     );
 
     // ---- Wave 10: GKE Backup ------------------------------------------------
-
-    final apiGkeBackup = add(
-      GoogleProjectService(
-        localName: 'api_gkebackup',
-        service: TfArg.literal('gkebackup.googleapis.com'),
-        disableOnDestroy: TfArg.literal(false),
-      ),
-    );
 
     add(
       GoogleGkeBackupBackupChannel(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dogfoods GitHub issue #57 — replaces hand-written `GoogleProjectService` enablement with [`Apis.required`](packages/terradart_google/lib/src/project/apis.dart) in three quickstarts.

Relates to #57. **No package version bump** (example-only).

## Changes

| Quickstart | `Apis.required` barrels |
|------------|---------------------------|
| `gke_quickstart` | `compute`, `container`, `gkeBackup` |
| `cloud_run_quickstart` | `cloudRun`, `serviceNetworking` |
| `compute_lb_quickstart` | `certificateManager`, `privateca` |

**Fix:** `cloud_run_quickstart` now enables `run.googleapis.com` (was missing; only `vpcaccess` was declared before).

## Verification

- `dart tool/example_synth_gates.dart` — OK (API enablement graph)
- `tool/agent_verify.sh` — OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b58470b-70d7-4221-bb61-733f7679c559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b58470b-70d7-4221-bb61-733f7679c559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

