### PR TITLE
chore: release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,44 +4,33 @@ All notable changes to terradart are documented here. The format follows [Keep a
 
 Per-package changelogs live alongside each package and are the system of record for `terradart_core`, `terradart_codegen`, `terradart_google`, and `terradart_agent` — this top-level file summarises cross-cutting milestones.
 
-## [Unreleased]
+## [0.13.0] - 2026-06-14
 
-**Breaking** — design pass for AI-autonomous maintenance (see [MIGRATING.md](MIGRATING.md)):
-
-- **`terradart_google`** — `Apis.enable(stack, barrels: ...)` replaces the `ApisEnablement` / `ApiEnablement` two-layer API; `TimeProvider` / `TimeSleep` move in from core under the new `time` barrel; `GoogleProvider.providerAlias` removed.
-- **`terradart_core`** — provider-aliasing dead surface removed (`StackProvider.providerAlias`, `ProviderBinding`, `Resource.provider`); `Stack.synth()` now fails fast when a resource's provider is not registered.
-- New machine gates: barrel-completeness test for generated wrappers and a `deletion_protection` parity invariant (both immediately caught live instances in Waves 33–35 output).
-
-**Maintenance hardening** — turning recurring Cursor-agent correction classes into pre-merge gates (mined from the `cursor/*` Wave PR history, where the repair loop ran entirely through fixup commits with no human review comments):
-
-- **API-enablement ratchet** — the example synth gate (which already ran via `check_docs_consistency`) now fails when an example enables some APIs but not every API its resources need, not just when an enabled API lacks a dependency edge. This is the exact Wave 32 secretmanager class. `tool/example_api_debt.yaml` is the audited escape hatch.
-- **MM upstream fingerprint gate** — flags `upstream: null` manifest entries that look Magic-Modules-generated; 29 mislabeled entries (+6 broken paths) corrected, re-activating enum-drift checks across certificatemanager / privateca / alloydb / memcache / spanner / filestore / logging and more.
-- **Catalog counts derived from `_catalog.g.dart`** — kills the parallel-wave count race that forced a reconcile cycle in each of #136/#137/#138.
-- **Pre-merge `pub publish --dry-run`** — catches fixture secret-scanner trips before they break publish (previously fixed reactively in 0.12.5 and 0.12.11).
-- **`dart analyze tool/`** — the gate scripts themselves are now analyzed (two latent errors fixed).
-
-**MM fixture sync** — fetched the 73 now-correct MM fixtures, activating the enum-drift checks that were vacuous without them (zero drift across the frozen prelude enums). Surfacing the real fixtures exposed two design issues, fixed as breaking changes:
-
-- **`terradart_google`** — `google_certificate_manager_certificate_map_entry`: `hostname` / `matcher` collapse into a required sealed `match` (the provider's `exactly_one_of`); `google_logging_saved_query`: `LoggingSavedQueryVisibility.privateVisibility` → `.private` (the derived enum is now canonical; the hand-written duplicate that shadowed it is removed).
-- **`terradart_codegen`** — `canonicalExactlyOneOfGroups` no longer mis-collapses a nested-block member like `subnet.0.name` into a bogus sibling group; `google_dns_record_set` corrected to `upstream: null` (no `mmv1` source exists).
-
-## [0.12.20] - 2026-06-12
-
-Lockstep release across the workspace. **No breaking changes** for reachable API (the previously unreachable `RedisInstanceWeeklyMaintenanceWindow` gains a required `startTime`).
+Lockstep release folding in the unreleased 0.12.20 (Waves 33–35) plus the
+AI-autonomous-maintenance design pass and harness hardening. **Breaking** —
+see [MIGRATING.md](MIGRATING.md).
 
 ### Added
 
-- **`terradart_google`** — Wave 33 AlloyDB (3): `google_alloydb_cluster`, `google_alloydb_instance`, `google_alloydb_user`; new `alloydb` barrel.
-- Extended **`cloud_sql_quickstart`** — AlloyDB cluster + primary instance + app user on the existing PSA VPC chain.
-- **`terradart_core`** — `TimeSleep.id` — typed ref to the completed-wait timestamp.
+- **`terradart_google`** — Waves 33–35: AlloyDB (cluster / instance / user / backup), Cloud Filestore (instance / backup / snapshot), Memorystore for Memcached, Spanner (instance / database); new `alloydb` / `filestore` / `memcache` / `spanner` barrels.
 
-### Fixed
+### Breaking — design pass for AI-autonomous maintenance
 
-- **`terradart_google`** — `GoogleRedisInstance` `maintenancePolicy` / `persistenceConfig` were declared but never wired into the constructor (customSlots missing from `paramOrder`); blocks are now reachable, schema-complete (`start_time`, `persistence_mode`), and fully exported from the `redis` barrel. `ApiEnablement.registerOn` now fail-fasts on a missing `TimeProvider`, keys the propagation `TimeSleep` to the service set via `triggers`, and derives the sleep name from `localNamePrefix`.
-- **`terradart_codegen`** — `lint-override` gains dead-customSlots rules so a spec can no longer ship constructor params that the emitter silently drops; `google_compute_url_map` / `google_compute_region_url_map` regain their dropped `defaultRouteAction` param.
-- **`cloud_run_quickstart`** — enables the Secret Manager API it depends on and consumes the Redis cache via a typed `host` ref (`REDIS_HOST`).
+- **`terradart_google`** — `Apis.enable(stack, barrels: ...)` replaces the `ApisEnablement` / `ApiEnablement` two-layer API; `TimeProvider` / `TimeSleep` move in from core under the new `time` barrel; `GoogleProvider.providerAlias` removed.
+- **`terradart_core`** — provider-aliasing dead surface removed (`StackProvider.providerAlias`, `ProviderBinding`, `Resource.provider`); `Stack.synth()` now fails fast when a resource's provider is not registered.
+- **`terradart_google`** — `google_certificate_manager_certificate_map_entry` (`hostname` / `matcher` → required sealed `match`) and `google_logging_saved_query` (`LoggingSavedQueryVisibility.privateVisibility` → `.private`), surfaced by the MM fixture sync.
 
-Catalog: **202 curated resource factories + 1 data source** (203 entries; 32 service barrels).
+### Maintenance hardening — recurring Cursor-agent correction classes as pre-merge gates
+
+Mined from the `cursor/*` Wave PR history (the repair loop ran entirely through fixup commits with no human review comments):
+
+- **API-enablement ratchet** — the example synth gate now fails when an example enables some APIs but not every API its resources need (the Wave 32 secretmanager class). `tool/example_api_debt.yaml` is the audited escape hatch.
+- **MM upstream fingerprint gate** + a 29-entry (+6 broken-path) manifest correction, re-activating enum-drift checks; the **73-fixture sync** then ran them with zero drift.
+- **Barrel-completeness test**, **`deletion_protection` parity invariant**, **dead-customSlots `lint-override` rules**.
+- **Catalog counts derived from `_catalog.g.dart`** — kills the parallel-wave count race (#136/#137/#138).
+- **Pre-merge `pub publish --dry-run`** and **`dart analyze tool/`**.
+
+Catalog: **209 curated resource factories + 1 data source** (210 entries; 35 service barrels).
 
 ## [0.12.19] - 2026-06-12
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing to terradart
 
-Thanks for taking time to look at this. terradart is a **pre-alpha** single-maintainer project (0.12.x today; [beta planned at v0.13.0](https://terradart.dev/docs/status/#beta-readiness-checklist)). Contributions are welcome on a best-effort basis.
+Thanks for taking time to look at this. terradart is a **pre-alpha** single-maintainer project (0.13.x today; [beta planned at v0.13.0](https://terradart.dev/docs/status/#beta-readiness-checklist)). Contributions are welcome on a best-effort basis.
 
 ## What kind of contribution?
 
 terradart ships one consumer surface:
 
-- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**209 curated resource factories + 1 data source** as of 0.12.x). Bug fixes, tests, and doc improvements welcome. New resources land via `terradart wrap` overrides — open an issue first to discuss scope.
+- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**209 curated resource factories + 1 data source** as of 0.13.x). Bug fixes, tests, and doc improvements welcome. New resources land via `terradart wrap` overrides — open an issue first to discuss scope.
 
-Within a **minor** line (`^0.12.x`), we aim to avoid breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (stricter from v0.13.0 beta — see [status](https://terradart.dev/docs/status/)).
+Within a **minor** line (`^0.13.x`), we aim to avoid breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (stricter from v0.13.0 beta — see [status](https://terradart.dev/docs/status/)).
 
 Bug reports / questions / feature requests: pick a template when [opening an issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 >
 > Google Cloud infrastructure as real Dart code — typed, refactor-safe, drop-in for `terraform apply`.
 
-**Pre-alpha** — no SemVer guarantees until v1.0.0. Pin `^0.12.x`, read [`MIGRATING.md`](MIGRATING.md) before bumping, and see [status on terradart.dev](https://terradart.dev/docs/status/).
+**Pre-alpha** — no SemVer guarantees until v1.0.0. Pin `^0.13.x`, read [`MIGRATING.md`](MIGRATING.md) before bumping, and see [status on terradart.dev](https://terradart.dev/docs/status/).
 
 <!-- identity -->
 [![pub: terradart_core](https://img.shields.io/pub/v/terradart_core.svg?label=pub%3A%20core)](https://pub.dev/packages/terradart_core)
@@ -202,8 +202,8 @@ GoogleCloudRunV2Service(
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.12.x
-  terradart_google: ^0.12.x
+  terradart_core: ^0.13.x
+  terradart_google: ^0.13.x
 ```
 
 ```bash
@@ -278,7 +278,7 @@ Application platform & operations
 
 ## Status
 
-**Pre-alpha**, pre-1.0 (0.12.x). No SemVer guarantees until v1.0.0; pin `^0.12.x` and read [`MIGRATING.md`](MIGRATING.md) before every minor bump. Beta is planned from **v0.13.0** once [readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met. Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
+**Pre-alpha**, pre-1.0 (0.13.x). No SemVer guarantees until v1.0.0; pin `^0.13.x` and read [`MIGRATING.md`](MIGRATING.md) before every minor bump. Beta is planned from **v0.13.0** once [readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met. Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
 
 ## Schema-bump automation (Plan 5.E)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,12 +31,12 @@ What does **not** count:
 
 ## Supported versions
 
-Pin dependencies with `^0.12.x` on [pub.dev](https://pub.dev/packages/terradart_core) today.
+Pin dependencies with `^0.13.x` on [pub.dev](https://pub.dev/packages/terradart_core) today.
 
 | Version | Status | Security fixes |
 |---|---|---|
-| **0.12.x** (pre-alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
-| **0.11.x and older** | Unsupported | Upgrade to 0.12.x; see [MIGRATING.md](MIGRATING.md) |
+| **0.13.x** (pre-alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
+| **0.11.x and older** | Unsupported | Upgrade to 0.13.x; see [MIGRATING.md](MIGRATING.md) |
 | **0.13.x** (beta, planned) | Best-effort with clearer minor-boundary policy | See [status on terradart.dev](https://terradart.dev/docs/status/) |
 
 ## Disclosure policy

--- a/examples/bigquery_quickstart/pubspec.yaml
+++ b/examples/bigquery_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_build_quickstart/pubspec.yaml
+++ b/examples/cloud_build_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_functions_quickstart/pubspec.yaml
+++ b/examples/cloud_functions_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_quickstart/pubspec.yaml
+++ b/examples/cloud_run_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_scheduler_quickstart/pubspec.yaml
+++ b/examples/cloud_scheduler_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_sql_quickstart/pubspec.yaml
+++ b/examples/cloud_sql_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_tasks_quickstart/pubspec.yaml
+++ b/examples/cloud_tasks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_lb_quickstart/pubspec.yaml
+++ b/examples/compute_lb_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_quickstart/pubspec.yaml
+++ b/examples/compute_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dns_quickstart/pubspec.yaml
+++ b/examples/dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/eventarc_quickstart/pubspec.yaml
+++ b/examples/eventarc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_check_quickstart/pubspec.yaml
+++ b/examples/firebase_app_check_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_hosting_quickstart/pubspec.yaml
+++ b/examples/firebase_app_hosting_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_data_connect_quickstart/pubspec.yaml
+++ b/examples/firebase_data_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_remote_config_quickstart/pubspec.yaml
+++ b/examples/firebase_remote_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_document_quickstart/pubspec.yaml
+++ b/examples/firestore_document_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_quickstart/pubspec.yaml
+++ b/examples/firestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_quickstart/pubspec.yaml
+++ b/examples/gke_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iam_quickstart/pubspec.yaml
+++ b/examples/iam_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_quickstart/pubspec.yaml
+++ b/examples/kms_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/monitoring_quickstart/pubspec.yaml
+++ b/examples/monitoring_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ops_quickstart/pubspec.yaml
+++ b/examples/ops_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/pubsub_quickstart/pubspec.yaml
+++ b/examples/pubsub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/secret_manager_quickstart/pubspec.yaml
+++ b/examples/secret_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_quickstart/pubspec.yaml
+++ b/examples/storage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/terradart_agent/CHANGELOG.md
+++ b/packages/terradart_agent/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.12.20
+## 0.13.0 - 2026-06-14
 
-Lockstep version bump for `terradart_google` v0.12.20. MCP catalog grows by three AlloyDB factories (203 entries; 32 service barrels).
+Lockstep version bump for `terradart_google` v0.13.0. MCP catalog: **210 entries** (35 service barrels). `TimeProvider` / `TimeSleep` now come from `package:terradart_google/time.dart` (moved out of `terradart_core`).
 
 ## 0.12.19
 

--- a/packages/terradart_agent/lib/src/version.dart
+++ b/packages/terradart_agent/lib/src/version.dart
@@ -1,4 +1,4 @@
 /// The terradart-mcp binary version, kept in lockstep with pubspec.yaml's
 /// `version:` field by `tool/bump_version.sh`. The lockstep is guarded by
 /// test/version_test.dart so the two can never silently drift.
-const String packageVersion = '0.12.20';
+const String packageVersion = '0.13.0';

--- a/packages/terradart_agent/pubspec.yaml
+++ b/packages/terradart_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_agent
 description: terradart-mcp — MCP server exposing the curated GCP factory catalog of TerraDart.
-version: 0.12.20
+version: 0.13.0
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -16,8 +16,8 @@ executables:
   terradart-mcp: terradart_mcp
 
 dependencies:
-  terradart_core: ^0.12.20
-  terradart_google: ^0.12.20
+  terradart_core: ^0.13.0
+  terradart_google: ^0.13.0
   genkit: ^0.13.2
   genkit_mcp: ^0.1.7
   schemantic: ^0.1.3

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.13.0 - 2026-06-14
 
 **BREAKING** — removes the `terradart codegen` CLI subcommand, `runCodegen`, `CodegenResult`, and `FileEmitter`. Maintainer generation is `terradart wrap` only. See [MIGRATING.md](../../MIGRATING.md).
 
@@ -24,9 +24,7 @@ Maintainer:
 - **Changed** — catalog counts in `tool/doc_expectations.dart` are now DERIVED from `_catalog.g.dart` instead of hand-bumped constants, removing the parallel-wave count race that forced reconcile cycles in #136/#137/#138. `catalog_count_test` no longer pins a literal total; only human-readable prose still needs syncing (and `check_docs_consistency` enforces it).
 - **Added** — pre-merge `pub publish --dry-run` CI job for `terradart_core` / `terradart_codegen` / `terradart_google`, catching fixture secret-scanner trips before they break publish (the reactive 0.12.5 and 0.12.11 false-secret fixes).
 
-## 0.12.20
-
-Wave 33 overrides: `google_alloydb_cluster` (network/backup/maintenance helpers), `google_alloydb_instance`, `google_alloydb_user`.
+- **Added** — Wave 33–35 wrapper overrides: AlloyDB (`google_alloydb_cluster` / `_instance` / `_user` / `_backup`), Cloud Filestore (`google_filestore_instance` / `_backup` / `_snapshot`), `google_memcache_instance`, Spanner (`google_spanner_instance` / `_database`); new `alloydb` / `filestore` / `memcache` / `spanner` MM manifest entries.
 
 ## 0.12.19
 

--- a/packages/terradart_codegen/README.md
+++ b/packages/terradart_codegen/README.md
@@ -15,7 +15,7 @@ End users depend on [`terradart_google`](https://pub.dev/packages/terradart_goog
 Activate on the same minor line as your workspace when working on the repo:
 
 ```bash
-dart pub global activate terradart_codegen ^0.12.x
+dart pub global activate terradart_codegen ^0.13.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_codegen) for the latest patch.

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart maintainer tooling — parses Terraform provider schema JSON and Magic Modules YAML and emits curated factory wrappers via terradart wrap. Ships the terradart CLI.
-version: 0.12.20
+version: 0.13.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -33,7 +33,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.12.20
+  terradart_core: ^0.13.0
 
 dev_dependencies:
   http: ^1.0.0

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,24 +1,14 @@
 # Changelog
 
-## Unreleased
+## 0.13.0 - 2026-06-14
+
+Lockstep release. **Breaking** — see [MIGRATING.md](../../MIGRATING.md).
 
 ### Breaking
 
-- `TimeProvider` / `TimeSleep` moved to `terradart_google` (`package:terradart_google/time.dart`) — core is provider-neutral again. See [MIGRATING.md](../../MIGRATING.md).
-- Removed the unimplemented provider-aliasing surface: `StackProvider.providerAlias`, `ProviderBinding`, and `Resource.provider`. None of it ever reached the synthesized JSON; aliasing returns as an end-to-end feature when multi-provider stacks land.
-- `Stack.synth()` validates provider coverage: every registered resource / data source type prefix (segment before the first `_`) must match a registered provider's `providerName`, otherwise synth throws `StateError`. Previously Terraform silently fell back to an unpinned implied provider.
-
-## 0.12.20
-
-### Added
-
-- `TimeSleep.id` — typed ref to the completed-wait timestamp, matching the curated-wrapper getter convention.
-
-### Fixed
-
-- `TimeSleep` docs: removed a dartdoc reference to a symbol outside this package; duration guidance now points at `TfArg.duration`, and `triggers` semantics are documented.
-
-Lockstep version bump for `terradart_google` v0.12.20 (Wave 33 AlloyDB).
+- `TimeProvider` / `TimeSleep` moved to `terradart_google` (`package:terradart_google/time.dart`) — core is provider-neutral again.
+- Removed the unimplemented provider-aliasing surface: `StackProvider.providerAlias`, `ProviderBinding`, and `Resource.provider`. None of it ever reached the synthesized JSON; aliasing returns when multi-provider stacks land.
+- `Stack.synth()` validates provider coverage: a registered resource / data source whose type prefix (segment before the first `_`) has no matching provider `providerName` now throws `StateError` instead of silently falling back to an unpinned implied provider.
 
 ## 0.12.19
 

--- a/packages/terradart_core/README.md
+++ b/packages/terradart_core/README.md
@@ -36,7 +36,7 @@ enum RoutingMode implements TerraformEnum {
 
 ```yaml
 dependencies:
-  terradart_core: ^0.12.x
+  terradart_core: ^0.13.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch. Read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before minor bumps.

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.12.20
+version: 0.13.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,48 +1,43 @@
 # Changelog
 
-## Unreleased
+## 0.13.0 - 2026-06-14
+
+Lockstep release. Folds in the unreleased 0.12.20 (Waves 33–35) plus the
+AI-autonomous-maintenance design pass and harness work. **Breaking** — see
+[MIGRATING.md](../../MIGRATING.md).
 
 ### Breaking
 
-- `Apis.enable(stack, barrels: ...)` replaces `ApisEnablement.enable(...).registerOn(stack)` and the `ApiEnablement` bundle — one call registers the services plus the propagation `TimeSleep` and returns the dependency list. See [MIGRATING.md](../../MIGRATING.md).
+- `Apis.enable(stack, barrels: ...)` replaces `ApisEnablement.enable(...).registerOn(stack)` and the `ApiEnablement` bundle — one call registers the services plus the propagation `TimeSleep` and returns the dependency list.
 - `TimeProvider` / `TimeSleep` moved here from `terradart_core` — import `package:terradart_google/time.dart`.
 - `GoogleProvider.providerAlias` removed (a silent no-op: synth never emitted the alias).
-- `google_certificate_manager_certificate_map_entry` — `hostname` / `matcher` replaced by a required sealed `match` (`CertificateManagerCertificateMapEntryMatch.hostname(...)` / `.matcher(...)`), enforcing the provider's `exactly_one_of` at compile time.
-- `google_logging_saved_query` — `LoggingSavedQueryVisibility.privateVisibility` renamed to `.private` (now derived from Magic Modules; the hand-written prelude enum that shadowed it is removed).
-
-### Fixed
-
-- `secret_manager` barrel exports the sealed replication variants (`SecretManagerSecretAutoReplication` / `SecretManagerSecretUserManagedReplication`) that the catalog already advertised.
-- `google_alloydb_cluster` / `google_memcache_instance` — `deletionProtection` input wired (the schema capability was advertised with no setter; caught by the new parity gate).
-- `google_vpc_access_connector` / `google_storage_hmac_key` / `google_storage_managed_folder` — class docs now carry the upstream Magic Modules descriptions (their MM fixtures were synced for the first time).
-
-### Added (maintainer)
-
-- Barrel completeness gate: every public type of a generated wrapper must appear in its barrel's `show` clause (`per_service_barrel_test`).
-
-## 0.12.20 - 2026-06-12
+- `google_certificate_manager_certificate_map_entry` — `hostname` / `matcher` replaced by a required sealed `match` (`CertificateManagerCertificateMapEntryMatch.hostname(...)` / `.matcher(...)`).
+- `google_logging_saved_query` — `LoggingSavedQueryVisibility.privateVisibility` renamed to `.private` (now derived from Magic Modules).
 
 ### Added
 
-- Wave 33 AlloyDB (3): `google_alloydb_cluster` (network + initial user helpers), `google_alloydb_instance` (machine config), `google_alloydb_user`.
-- New `alloydb` barrel; `Barrels.alloydb` → `alloydb.googleapis.com`.
-- Extended `cloud_sql_quickstart` — AlloyDB on the same PSA chain as private Cloud SQL.
-- `GoogleRedisInstance` — `authEnabled`, `transitEncryptionMode`, `replicaCount`, `readReplicasMode` inputs plus `RedisInstanceTransitEncryptionMode`, `RedisInstanceReadReplicasMode`, `RedisInstancePersistenceMode`, `RedisInstanceMaintenanceStartTime`, backing the previously input-less `authString` / `serverCaCerts` / `readEndpoint` / `readEndpointPort` getters.
-- `GoogleRedisInstance` — `deletionProtection` input, matching every other `supportsDeletionProtection` wrapper (the capability was advertised with no way to set the flag).
-- `GoogleComputeUrlMap` / `GoogleComputeRegionUrlMap` — `defaultRouteAction` parameter (the customSlot existed in both specs but was dropped from both constructors).
+- Wave 33 AlloyDB: `google_alloydb_cluster` / `google_alloydb_instance` / `google_alloydb_user`; new `alloydb` barrel.
+- Wave 34 Cloud Filestore: `google_filestore_instance` / `google_filestore_backup` / `google_filestore_snapshot`; new `filestore` barrel.
+- Wave 35: `google_alloydb_backup`; Memorystore for Memcached `google_memcache_instance` (new `memcache` barrel); Spanner `google_spanner_instance` / `google_spanner_database` (new `spanner` barrel).
+- `GoogleRedisInstance` — `authEnabled`, `transitEncryptionMode`, `replicaCount`, `readReplicasMode` (+ `RedisInstanceTransitEncryptionMode` / `RedisInstanceReadReplicasMode` / `RedisInstancePersistenceMode` / `RedisInstanceMaintenanceStartTime`), `deletionProtection`, and reachable `maintenancePolicy` / `persistenceConfig`.
+- `GoogleComputeUrlMap` / `GoogleComputeRegionUrlMap` — `defaultRouteAction` parameter.
+- `TimeSleep.id` — typed ref to the completed-wait timestamp.
+- Extended quickstarts: `cloud_sql_quickstart` (AlloyDB), `cloud_run_quickstart` (Redis cache + `Apis.enable` propagation).
 
 ### Fixed
 
-- `GoogleRedisInstance` — the Wave 32 `maintenancePolicy` / `persistenceConfig` customSlots were silently dropped (missing from `paramOrder`), so neither block could ever be configured; both now reach the constructor. `RedisInstanceWeeklyMaintenanceWindow` requires `startTime` (`start_time` is `min_items = 1` in the provider schema) and `RedisInstancePersistenceConfig` gains `persistenceMode` / `rdbSnapshotStartTime` so RDB persistence can actually be turned on.
-- `redis` barrel — exports every nested helper type (previously 3 of 7; the catalog `nestedTypes` advertised symbols the barrel hid from importers).
-- `ApiEnablement.registerOn` — validates before mutating the stack: throws `StateError` when the stack has no `time` provider (previously synthesized `time_sleep` with an unpinned implied `hashicorp/time`) and `ArgumentError` for positive sub-second delays; non-positive delays skip the sleep (now documented).
-- `ApiEnablement.registerOn` — the propagation `TimeSleep` carries a `triggers` map keyed to the service set, so APIs enabled in later applies get the same propagation wait instead of racing `SERVICE_DISABLED`.
-- `ApisEnablement.enable` — `propagationLocalName` defaults to `'<localNamePrefix>_propagation'`, so two enablement groups with distinct prefixes no longer collide on `time_sleep.api_propagation`.
-- `cloud_run_quickstart` — enables `secretmanager.googleapis.com` via `Barrels.secretManager` (the README already claimed credentials-only setup) and wires `REDIS_HOST` into the service env from the cache's typed `host` ref.
-- `ApiEnablement.registerOn` — an empty `services` list registers nothing and returns no deps (previously a barrel set contributing no APIs still gated all dependents behind a 60s no-op `time_sleep`).
+- `GoogleRedisInstance` — the Wave 32 `maintenancePolicy` / `persistenceConfig` customSlots were silently dropped (missing from `paramOrder`); both now reach the constructor, are schema-complete (`start_time`, `persistence_mode`), and fully exported from the `redis` barrel.
+- `secret_manager` barrel exports the sealed replication variants (`SecretManagerSecretAutoReplication` / `SecretManagerSecretUserManagedReplication`) the catalog already advertised.
+- `google_alloydb_cluster` / `google_memcache_instance` — `deletionProtection` input wired (caught by the new parity gate).
+- `google_vpc_access_connector` / `google_storage_hmac_key` / `google_storage_managed_folder` — class docs now carry the upstream Magic Modules descriptions (their MM fixtures were synced for the first time).
+- `cloud_run_quickstart` — enables `secretmanager.googleapis.com` via `Barrels.secretManager` and wires `REDIS_HOST` into the service env from the cache's typed `host` ref.
 - pubspec description no longer hardcodes a resource count (was stale at 118).
 
-Catalog: **202 curated resource factories + 1 data source** (203 entries; 32 service barrels).
+### Added (maintainer)
+
+- New machine gates: barrel completeness (`per_service_barrel_test`), `deletion_protection` parity invariant, dead-customSlots `lint-override` rules, MM upstream fingerprint gate, the example API-enablement ratchet, pre-merge `pub publish --dry-run`, and `dart analyze tool/`. MM fixtures synced (73; zero enum drift). Catalog counts derived from `_catalog.g.dart`.
+
+Catalog: **209 curated resource factories + 1 data source** (210 entries; 35 service barrels).
 
 ## 0.12.19 - 2026-06-12
 

--- a/packages/terradart_google/README.md
+++ b/packages/terradart_google/README.md
@@ -16,8 +16,8 @@ Runtime primitives (`Stack`, `TfArg`, `writeTo`) live in [`terradart_core`](http
 
 ```yaml
 dependencies:
-  terradart_core: ^0.12.x
-  terradart_google: ^0.12.x
+  terradart_core: ^0.13.x
+  terradart_google: ^0.13.x
 ```
 
 ## Usage example

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: Curated factory wrappers for Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.
-version: 0.12.20
+version: 0.13.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -22,11 +22,11 @@ false_secrets:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.12.20
+  terradart_core: ^0.13.0
   meta: ^1.15.0
 
 dev_dependencies:
-  terradart_codegen: ^0.12.20
+  terradart_codegen: ^0.13.0
   path: ^1.9.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -3,7 +3,7 @@ title: Getting Started
 description: Install TerraDart and generate your first *.tf.json from a Stack.
 ---
 
-This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.12.x** line. TerraDart is **pre-alpha** until [beta gates](/docs/status/#beta-readiness-checklist) are complete (planned label: **v0.13.0**).
+This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.13.x** line. TerraDart is **pre-alpha** until [beta gates](/docs/status/#beta-readiness-checklist) are complete (planned label: **v0.13.0**).
 
 ## Prerequisites
 
@@ -16,8 +16,8 @@ This guide matches the [README quickstart](https://github.com/nozomi-koborinai/t
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.12.x
-  terradart_google: ^0.12.x
+  terradart_core: ^0.13.x
+  terradart_google: ^0.13.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch, then run:


### PR DESCRIPTION
## What

Lockstep version bump **0.12.20 → 0.13.0** across the workspace, cutting the first release since `v0.12.19`.

## Why a minor (0.13.0), not a patch

`v0.12.20` was bumped in pubspec by Wave 33 but never tagged. Since then, **breaking changes accreted into that same 0.12.20**: the `Apis.enable` collapse, the `TimeProvider`/`TimeSleep` move to `terradart_google`, the provider-aliasing removal, `Stack.synth()` provider validation, and the `cert_map_entry` / `saved_query` reshapes. Per pre-1.0 convention (`0.minor.patch`, minor = breaking boundary), these belong in **0.13.0**. Tagging `v0.12.20` now would have shipped breaking changes as a patch.

## What's in 0.13.0

Everything unreleased since `v0.12.19`:
- **Waves 33–35** — AlloyDB (cluster/instance/user/backup), Cloud Filestore (instance/backup/snapshot), Memorystore for Memcached, Spanner (instance/database); new `alloydb` / `filestore` / `memcache` / `spanner` barrels.
- **AI-autonomous-maintenance pass** (#139/#140/#141) — `Apis.enable`, time barrel, provider-coverage validation, the pre-merge harness gates, the MM fixture sync, and the two sealed/enum reshapes.

## Bump details

- `tool/bump_version.sh 0.13.0` — package versions, inter-package carets, `terradart_agent` `version.dart`, 25 example carets, README + getting-started caret samples.
- Caret notes `0.12.x → 0.13.x` in README / CONTRIBUTING / SECURITY / per-package READMEs / getting-started (the `^0.N.x` form the bump script doesn't touch).
- CHANGELOG (root + 4 packages) consolidated into a single `0.13.0` section, dated 2026-06-14. **Backfilled the Wave 34 / Wave 35 entries that #137/#138 never recorded** in any changelog.
- Catalog phrases refreshed to **209 curated resource factories + 1 data source** (210 entries; 35 service barrels).

## After merge (maintainer)

Tag `v0.13.0` and write the GitHub release notes by hand, as usual. The publish workflow (OIDC) then pushes `terradart_core` → `terradart_codegen` → `terradart_google` to pub.dev.

## Verification

`tool/agent_verify.sh --format` exit 0 (incl. `version_test` lockstep, `check_docs_consistency` caret + catalog at 0.13.x / 210). `pub publish --dry-run` is clean on a clean checkout (local runs only warn about the uncommitted bump itself).
