### PR TITLE
ci: real-apply coverage — PR change-gate + nightly sweep

### DIFF
--- a/.github/workflows/apply-smoke-nightly.yml
+++ b/.github/workflows/apply-smoke-nightly.yml
@@ -1,0 +1,60 @@
+name: Apply smoke nightly
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: apply-smoke
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  sweep:
+    name: nightly apply sweep (terradart-validate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.11.0"
+      - name: Authenticate to Google Cloud (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - run: dart pub get
+      - name: Apply-smoke all quickstarts
+        id: sweep
+        env:
+          GCP_VALIDATE_PROJECT_ID: ${{ secrets.GCP_VALIDATE_PROJECT_ID }}
+        run: |
+          chmod +x tool/apply_smoke.sh
+          set -o pipefail
+          tool/apply_smoke.sh --all 2>&1 | tee /tmp/sweep.log
+      - name: Open or update failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          summary="$(grep -E 'FAILED:' /tmp/sweep.log | tail -1 || echo 'see run log')"
+          title="nightly apply-smoke failures"
+          body="$(printf 'Nightly apply sweep failed on %s.\n\n%s\n\nRun: %s' \
+            "$(date -u +%Y-%m-%d)" "$summary" "$RUN_URL")"
+          existing="$(gh issue list --repo "$REPO" --state open \
+            --search "$title in:title" --json number --jq '.[0].number')"
+          if [[ -n "$existing" ]]; then
+            gh issue comment "$existing" --repo "$REPO" --body "$body"
+          else
+            gh issue create --repo "$REPO" --title "$title" --body "$body"
+          fi

--- a/.github/workflows/docs-consistency.yml
+++ b/.github/workflows/docs-consistency.yml
@@ -27,6 +27,10 @@ jobs:
         # Guards the coverage / API-enablement-ratchet logic itself; the gate
         # runs over the real examples inside check_docs_consistency below.
         run: dart --enable-asserts tool/example_synth_gates_test.dart
+      - name: apply_smoke selection test (no GCP)
+        run: |
+          chmod +x tool/apply_smoke_test.sh
+          tool/apply_smoke_test.sh
       - name: Docs caret + catalog count
         run: dart tool/check_docs_consistency.dart
       - name: Pub/Sub quickstart smoke

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,7 @@ Inputs: a checked-in or task-provided `schema.json` (plus Magic Modules YAML whe
 7. **Export the full public surface from the per-service barrel.** `lib/<service>.dart` must `show` every public type the generated wrapper declares — the catalog advertises all of them to MCP agents (enforced by the barrel-completeness group in `per_service_barrel_test`).
 8. **Wire API enablement in examples through `Apis.enable`** (`package:terradart_google/project.dart`; the propagation `TimeSleep` needs `const TimeProvider()` from `package:terradart_google/time.dart` on the stack). Synth fails fast when any resource's provider is missing from `Stack.providers`.
 9. **Test:** targeted tests first, then `tool/agent_verify.sh` (add `--maintainer` when touching wrap-init / wrap-promote).
+10. **For real-apply coverage, add the `apply-smoke` label to the PR** when it adds or changes a curated resource or an example. The label runs `apply-smoke.yml`, which applies the changed examples to `terradart-validate` and blocks merge on failure. Every example is also applied nightly by `apply-smoke-nightly.yml` (`tool/apply_smoke.sh --all`), which opens a dedup'd issue on failure — so a resource that only `validate`s but cannot `apply` is caught within a day even without the label. `terraform validate` (synth gate) does **not** prove a resource applies.
 
 ### Handle Provider Schema Or MM YAML Drift
 
@@ -220,6 +221,8 @@ There is no long-running dev server for core work. Primary flows:
 |------|---------------------|
 | Agent gate (lint, tests, wrap check, smoke) | `tool/agent_verify.sh` |
 | Suspected mislabeled `upstream: null` | `dart tool/check_mm_upstream_fingerprint.dart` |
+| Apply-smoke selection (no GCP) | `tool/apply_smoke.sh --all --dry-run` |
+| Apply one example for real | `GCP_PROJECT_ID=terradart-validate tool/apply_smoke.sh --example <slug>` |
 | Example coverage + API-enablement ratchet | `dart tool/check_docs_consistency.dart` (runs the synth gate) |
 | Publish readiness (per package) | `cd packages/<pkg> && dart pub publish --dry-run` |
 | Synth example stack | `cd examples/pubsub_quickstart && GCP_PROJECT_ID=ci-test-project-id dart run bin/infra.dart` |

--- a/tool/agent_verify.sh
+++ b/tool/agent_verify.sh
@@ -86,6 +86,10 @@ dart tool/check_override_enum_gaps.dart --strict-nested
 echo ">> check_mm_upstream_fingerprint"
 dart tool/check_mm_upstream_fingerprint.dart
 
+echo ">> apply_smoke_test (selection, no GCP)"
+chmod +x tool/apply_smoke_test.sh
+tool/apply_smoke_test.sh
+
 echo ">> smoke_quickstart"
 chmod +x tool/smoke_quickstart.sh
 tool/smoke_quickstart.sh

--- a/tool/apply_smoke.sh
+++ b/tool/apply_smoke.sh
@@ -1,25 +1,35 @@
 #!/usr/bin/env bash
-# Apply-smoke changed example quickstarts against a live GCP project (terradart-validate).
+# Apply-smoke example quickstarts against a live GCP project (terradart-validate).
 #
-# Usage (repo root):
-#   GCP_PROJECT_ID=terradart-validate tool/apply_smoke.sh
-#   tool/apply_smoke.sh --example gke_quickstart
+# Modes:
+#   (default)         apply the examples changed vs GITHUB_BASE_SHA/origin/main
+#   --all             apply every examples/*_quickstart (nightly sweep)
+#   --example <slug>  apply exactly one
+#   --dry-run         print the selected slugs and exit (no terraform, no GCP)
 #
-# Requires: terraform on PATH, WIF auth (GitHub Actions) or application default credentials.
-set -euo pipefail
+# Behaviour:
+#   - Each example: synth -> terraform init -> apply -> destroy. destroy ALWAYS
+#     runs (trap), even when apply fails, so a failed run still tears down.
+#   - --all keeps going past a failing example and exits non-zero at the end
+#     with a summary; default/--example fail fast (small changed set).
+#
+# Requires (non-dry-run): terraform on PATH, WIF auth (CI) or ADC, and
+# GCP_PROJECT_ID or GCP_VALIDATE_PROJECT_ID.
+set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
+MODE="changed"
 EXPLICIT_EXAMPLE=""
+DRY_RUN=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --example)
-      EXPLICIT_EXAMPLE="$2"
-      shift 2
-      ;;
+    --all) MODE="all"; shift ;;
+    --example) MODE="example"; EXPLICIT_EXAMPLE="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
     -h | --help)
-      sed -n '2,8p' "$0"
+      sed -n '2,16p' "$0"
       exit 0
       ;;
     *)
@@ -29,49 +39,83 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# --- select examples -------------------------------------------------------
+select_examples() {
+  case "$MODE" in
+    example) printf '%s\n' "$EXPLICIT_EXAMPLE" ;;
+    all) for d in examples/*_quickstart/; do basename "$d"; done | sort ;;
+    changed)
+      git diff --name-only "${GITHUB_BASE_SHA:-origin/main}" HEAD -- 'examples/' 2>/dev/null \
+        | awk -F/ '/^examples\/[^/]+_quickstart\// {print $2}' | sort -u
+      ;;
+  esac
+}
+
+# Collect into an array without `mapfile` (absent on macOS bash 3.2).
+EXAMPLES=()
+while IFS= read -r _slug; do
+  [[ -n "$_slug" ]] && EXAMPLES+=("$_slug")
+done < <(select_examples)
+
+# --- dry-run: print selection and stop ------------------------------------
+if [[ "$DRY_RUN" == "1" ]]; then
+  [[ ${#EXAMPLES[@]} -gt 0 ]] && printf '%s\n' "${EXAMPLES[@]}"
+  exit 0
+fi
+
+if [[ ${#EXAMPLES[@]} -eq 0 ]]; then
+  echo "apply_smoke.sh: no examples selected — skip"
+  exit 0
+fi
+
 PROJECT_ID="${GCP_PROJECT_ID:-${GCP_VALIDATE_PROJECT_ID:-}}"
 if [[ -z "$PROJECT_ID" ]]; then
   echo "apply_smoke.sh: set GCP_PROJECT_ID or GCP_VALIDATE_PROJECT_ID" >&2
   exit 64
 fi
-
 export GCP_PROJECT_ID="$PROJECT_ID"
 export DB_PASSWORD="${DB_PASSWORD:-apply-smoke-placeholder}"
 
-mapfile -t EXAMPLES < <(
-  if [[ -n "$EXPLICIT_EXAMPLE" ]]; then
-    echo "$EXPLICIT_EXAMPLE"
-  else
-    git diff --name-only "${GITHUB_BASE_SHA:-origin/main}" HEAD -- 'examples/' 2>/dev/null \
-      | awk -F/ '/^examples\/[^/]+_quickstart\// {print $2}' \
-      | sort -u
-  fi
-)
-
-if [[ ${#EXAMPLES[@]} -eq 0 ]]; then
-  echo "apply_smoke.sh: no changed examples — skip"
-  exit 0
-fi
-
 dart pub get
 
-for slug in "${EXAMPLES[@]}"; do
-  [[ -n "$slug" ]] || continue
-  dir="examples/$slug"
+# --- apply one example, ALWAYS destroying afterwards ----------------------
+apply_one() {
+  local slug="$1"
+  local dir="examples/$slug"
   if [[ ! -f "$dir/bin/infra.dart" ]]; then
-    echo "apply_smoke.sh: skip $slug (no bin/infra.dart)" >&2
-    continue
+    echo "  skip $slug (no bin/infra.dart)"
+    return 0
   fi
-  echo ">> apply-smoke: $slug"
   (
     cd "$dir"
     dart pub get
     dart run bin/infra.dart
     cd tf-out
     terraform init -backend=false -input=false
+    # From here on, destroy on ANY exit (apply success or failure).
+    trap 'terraform destroy -auto-approve -input=false >/dev/null 2>&1 || true' EXIT
     terraform apply -auto-approve -input=false
-    terraform destroy -auto-approve -input=false
   )
+}
+
+FAILED=()
+for slug in "${EXAMPLES[@]}"; do
+  [[ -n "$slug" ]] || continue
+  echo ">> apply-smoke: $slug"
+  if apply_one "$slug"; then
+    echo "  OK: $slug"
+  else
+    echo "  FAILED: $slug"
+    FAILED+=("$slug")
+    if [[ "$MODE" != "all" ]]; then
+      echo "apply_smoke.sh: FAILED: ${FAILED[*]}" >&2
+      exit 1
+    fi
+  fi
 done
 
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  echo "apply_smoke.sh: ${#FAILED[@]} of ${#EXAMPLES[@]} FAILED: ${FAILED[*]}" >&2
+  exit 1
+fi
 echo "apply_smoke.sh: OK (${#EXAMPLES[@]} example(s))"

--- a/tool/apply_smoke_test.sh
+++ b/tool/apply_smoke_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tests apply_smoke.sh selection + dry-run WITHOUT touching GCP/terraform.
+# --dry-run prints the chosen example slugs (one per line) and exits 0.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+fail() {
+  echo "apply_smoke_test: FAIL: $*" >&2
+  exit 1
+}
+
+# 1. --all --dry-run lists every examples/*_quickstart, no GCP project needed.
+all_out="$(tool/apply_smoke.sh --all --dry-run)" || fail "--all --dry-run exited non-zero"
+expected="$(for d in examples/*_quickstart/; do basename "$d"; done | sort)"
+[[ "$all_out" == "$expected" ]] || fail "--all selection mismatch:
+got:
+$all_out
+want:
+$expected"
+
+# 2. --example X --dry-run lists exactly that slug.
+one_out="$(tool/apply_smoke.sh --example gke_quickstart --dry-run)" || fail "--example dry-run non-zero"
+[[ "$one_out" == "gke_quickstart" ]] || fail "--example selection: got '$one_out'"
+
+# 3. --dry-run must NOT require a GCP project (selection is GCP-free).
+GCP_PROJECT_ID="" GCP_VALIDATE_PROJECT_ID="" tool/apply_smoke.sh --all --dry-run >/dev/null \
+  || fail "--dry-run should not require GCP project"
+
+echo "apply_smoke_test: OK"


### PR DESCRIPTION
## Why

terradart curates 209 resource factories, but until now nothing *applied* them. examples are synth + `terraform validate` only; `apply-smoke.yml` existed but never ran (WIF unset); the cookbook last applied at 0.11.0. So a Wave could add a resource, pass every gate, and ship to pub.dev **without anyone ever `terraform apply`-ing it**. Apply-time failures (bad defaults, missing API/IAM/ordering, `projects/{project}` ID forms) were the one correction class with no machine coverage.

Spec: Approach 1 from brainstorming — a PR change-gate plus a nightly full sweep, on the monorepo side (cookbook keeps its user-facing role).

## What's in this PR

**`tool/apply_smoke.sh` hardening** — one driver for both modes:
- `--all` — sweep every `examples/*_quickstart` (nightly), sorted.
- `--dry-run` — print the selected slugs and exit; GCP-free, so selection/aggregation is unit-testable.
- **Guaranteed teardown** — `terraform destroy` now runs on *any* exit after apply starts (trap), so a failed apply still tears down (previously it leaked until the janitor ran).
- **Aggregation** — `--all` continues past a failing example and exits non-zero with a summary; PR/`--example` mode stays fail-fast.
- bash 3.2-compatible (no `mapfile`) so it runs in the local agent gate on macOS.

**`apply-smoke-nightly.yml`** — cron 02:00 UTC + `workflow_dispatch`, WIF auth, `apply_smoke.sh --all`, opens/updates a single dedup'd issue on failure.

**`tool/apply_smoke_test.sh`** — selection + dry-run test (no GCP), wired into `agent_verify.sh` and `docs-consistency.yml`.

**AGENTS.md** — `apply-smoke` label policy + gate-table rows.

`apply-smoke.yml` (PR change-gate) and `apply-smoke-janitor.yml` are unchanged — WIF secrets are now configured, so the PR gate is live when a PR carries the `apply-smoke` label.

## Heads-up

The first nightly sweep (or a manual `workflow_dispatch`) will be the **first-ever real apply** of the 0.12/0.13 resources (AlloyDB, Spanner, Filestore, Redis, Memcache, Cert Manager, Private CA, …). Expect some to fail — that is the point; it surfaces the never-applied surface so we can fix it.

## Verification

`tool/agent_verify.sh` exit 0 (now includes the GCP-free apply_smoke selection test). The real apply path needs GCP and is exercised via `workflow_dispatch` after merge, not in unit tests.
