### PR TITLE
fix(apply-smoke): persist state in GCS so destroy + janitor can reclaim

### DIFF
--- a/tool/apply_smoke.sh
+++ b/tool/apply_smoke.sh
@@ -5,13 +5,20 @@
 #   (default)         apply the examples changed vs GITHUB_BASE_SHA/origin/main
 #   --all             apply every examples/*_quickstart (nightly sweep)
 #   --example <slug>  apply exactly one
+#   --destroy-only    skip apply; just destroy each selected example's state
+#                     (janitor reclaim — relies on the GCS backend below)
 #   --dry-run         print the selected slugs and exit (no terraform, no GCP)
 #
+# State backend:
+#   Each example uses a GCS backend (gs://$TF_STATE_BUCKET/apply-smoke/<slug>)
+#   so state PERSISTS across runs. A failed apply or a killed runner leaves
+#   reclaimable state, and `--destroy-only` (the janitor) can always tear it
+#   down. TF_STATE_BUCKET defaults to terradart-validate-tfstate.
+#
 # Behaviour:
-#   - Each example: synth -> terraform init -> apply -> destroy. destroy ALWAYS
-#     runs (trap), even when apply fails, so a failed run still tears down.
+#   - apply mode: synth -> init -> apply, with destroy on ANY exit (trap).
 #   - --all keeps going past a failing example and exits non-zero at the end
-#     with a summary; default/--example fail fast (small changed set).
+#     with a summary; default/--example fail fast.
 #
 # Requires (non-dry-run): terraform on PATH, WIF auth (CI) or ADC, and
 # GCP_PROJECT_ID or GCP_VALIDATE_PROJECT_ID.
@@ -23,13 +30,15 @@ cd "$ROOT"
 MODE="changed"
 EXPLICIT_EXAMPLE=""
 DRY_RUN=0
+DESTROY_ONLY=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --all) MODE="all"; shift ;;
     --example) MODE="example"; EXPLICIT_EXAMPLE="$2"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
+    --destroy-only) DESTROY_ONLY=1; shift ;;
     -h | --help)
-      sed -n '2,16p' "$0"
+      sed -n '2,24p' "$0"
       exit 0
       ;;
     *)
@@ -38,6 +47,8 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+STATE_BUCKET="${TF_STATE_BUCKET:-terradart-validate-tfstate}"
 
 # --- select examples -------------------------------------------------------
 select_examples() {
@@ -78,7 +89,7 @@ export DB_PASSWORD="${DB_PASSWORD:-apply-smoke-placeholder}"
 
 dart pub get
 
-# --- apply one example, ALWAYS destroying afterwards ----------------------
+# --- apply (or destroy-only) one example, with a GCS-backed state ----------
 apply_one() {
   local slug="$1"
   local dir="examples/$slug"
@@ -91,17 +102,27 @@ apply_one() {
     dart pub get
     dart run bin/infra.dart
     cd tf-out
-    terraform init -backend=false -input=false
-    # From here on, destroy on ANY exit (apply success or failure).
-    trap 'terraform destroy -auto-approve -input=false >/dev/null 2>&1 || true' EXIT
-    terraform apply -auto-approve -input=false
+    # Persist state in GCS so destroy can always reclaim (across runs / janitor).
+    printf '{"terraform":{"backend":{"gcs":{"bucket":"%s","prefix":"apply-smoke/%s"}}}}\n' \
+      "$STATE_BUCKET" "$slug" > backend.tf.json
+    terraform init -input=false -reconfigure
+    if [[ "$DESTROY_ONLY" == "1" ]]; then
+      terraform destroy -auto-approve -input=false
+    else
+      # destroy on ANY exit after apply starts (apply success or failure).
+      trap 'terraform destroy -auto-approve -input=false >/dev/null 2>&1 || true' EXIT
+      terraform apply -auto-approve -input=false
+    fi
   )
 }
+
+VERB="apply-smoke"
+[[ "$DESTROY_ONLY" == "1" ]] && VERB="destroy-only"
 
 FAILED=()
 for slug in "${EXAMPLES[@]}"; do
   [[ -n "$slug" ]] || continue
-  echo ">> apply-smoke: $slug"
+  echo ">> $VERB: $slug"
   if apply_one "$slug"; then
     echo "  OK: $slug"
   else
@@ -118,4 +139,4 @@ if [[ ${#FAILED[@]} -gt 0 ]]; then
   echo "apply_smoke.sh: ${#FAILED[@]} of ${#EXAMPLES[@]} FAILED: ${FAILED[*]}" >&2
   exit 1
 fi
-echo "apply_smoke.sh: OK (${#EXAMPLES[@]} example(s))"
+echo "apply_smoke.sh: OK (${#EXAMPLES[@]} example(s), $VERB)"

--- a/tool/apply_smoke_janitor.sh
+++ b/tool/apply_smoke_janitor.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-# Destroy leftover Terraform state in the terradart-validate canary project.
+# Reclaim leftover apply-smoke resources in the terradart-validate project.
 #
-# Scheduled by .github/workflows/apply-smoke-janitor.yml after failed apply-smoke runs.
+# Scheduled by .github/workflows/apply-smoke-janitor.yml. State lives in the
+# GCS backend (gs://$TF_STATE_BUCKET/apply-smoke/<slug>), so this re-synths
+# each example's config, points it at that persisted state, and destroys —
+# reclaiming anything a failed apply or a killed runner left behind.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -12,27 +15,7 @@ if [[ -z "$PROJECT_ID" ]]; then
   echo "apply_smoke_janitor.sh: set GCP_PROJECT_ID or GCP_VALIDATE_PROJECT_ID" >&2
   exit 64
 fi
+export GCP_PROJECT_ID="$PROJECT_ID"
 
-if ! command -v gcloud >/dev/null 2>&1; then
-  echo "apply_smoke_janitor.sh: gcloud not on PATH" >&2
-  exit 127
-fi
-
-echo ">> janitor: listing active resources in $PROJECT_ID (manual review project)"
-# Best-effort: enumerate common Wave resources and delete by label if present.
-# Maintainers can extend this script as apply-smoke coverage grows.
-
-for slug in examples/*_quickstart; do
-  [[ -d "$slug/tf-out" ]] || continue
-  name="$(basename "$slug")"
-  echo ">> janitor: terraform destroy $name (if state exists)"
-  (
-    cd "$slug/tf-out"
-    if [[ -f main.tf.json ]]; then
-      terraform init -backend=false -input=false >/dev/null 2>&1 || true
-      terraform destroy -auto-approve -input=false >/dev/null 2>&1 || true
-    fi
-  ) || true
-done
-
-echo "apply_smoke_janitor.sh: done"
+echo ">> janitor: destroy-only sweep over all quickstarts (state from GCS)"
+exec tool/apply_smoke.sh --all --destroy-only

--- a/tool/apply_smoke_test.sh
+++ b/tool/apply_smoke_test.sh
@@ -28,4 +28,8 @@ one_out="$(tool/apply_smoke.sh --example gke_quickstart --dry-run)" || fail "--e
 GCP_PROJECT_ID="" GCP_VALIDATE_PROJECT_ID="" tool/apply_smoke.sh --all --dry-run >/dev/null \
   || fail "--dry-run should not require GCP project"
 
+# 4. --destroy-only is a recognized flag and selects the same set.
+do_out="$(tool/apply_smoke.sh --all --destroy-only --dry-run)" || fail "--destroy-only dry-run non-zero"
+[[ "$do_out" == "$expected" ]] || fail "--destroy-only selection mismatch"
+
 echo "apply_smoke_test: OK"


### PR DESCRIPTION
## Why

Follow-up to #143, prompted by the state-backend question: `apply_smoke.sh` ran with `terraform init -backend=false`, so state lived only on the CI runner and vanished with it. A failed apply or a killed runner left orphaned GCP resources with **no recoverable state**, and the janitor (which destroyed local `tf-out` state) found nothing on a fresh checkout — so it reclaimed nothing. The orphan safety net wasn't actually a net.

## What

- Each example now uses a **GCS backend** (`gs://$TF_STATE_BUCKET/apply-smoke/<slug>`, default `terradart-validate-tfstate` — the bucket already exists from the cookbook `remote-backend` recipe). State persists across runs.
- `apply_smoke.sh --destroy-only` added; the janitor is rewritten to `apply_smoke.sh --all --destroy-only` (synth → GCS state → destroy), so it can now actually reclaim leaked resources.
- Selection test covers `--destroy-only`. Examples synth no Terraform backend of their own, so the injected override never conflicts.

## Note on the in-flight sweep

The nightly sweep dispatched before this lands ran on **local state**, so this PR does not retroactively clean anything it leaked. Those orphans (if any) are reclaimed manually now; from the next sweep on, state persists and destroy/janitor always reclaim.

## Verification

`tool/agent_verify.sh` exit 0 (selection test green incl. `--destroy-only`). The real apply/destroy path needs GCP and runs in the workflows.
