### PR TITLE
fix(apply-smoke): pass TF_VAR placeholders so plan doesn't abort

### DIFF
--- a/tool/apply_smoke.sh
+++ b/tool/apply_smoke.sh
@@ -102,6 +102,14 @@ apply_one() {
     dart pub get
     dart run bin/infra.dart
     cd tf-out
+    # Placeholder for any input variable the synth references (`${var.X}`), so
+    # `terraform -input=false` doesn't abort on "No value for required
+    # variable". Examples needing a REAL secret / cert / org id still fail at
+    # apply time — those are tracked as example issues, not a tool gap.
+    for _v in $(grep -oE '\$\{var\.[a-zA-Z_][a-zA-Z0-9_]*\}' main.tf.json 2>/dev/null \
+      | sed -E 's/^\$\{var\.//; s/\}$//' | sort -u); do
+      export "TF_VAR_$_v"="apply-smoke-placeholder"
+    done
     # Persist state in GCS so destroy can always reclaim (across runs / janitor).
     printf '{"terraform":{"backend":{"gcs":{"bucket":"%s","prefix":"apply-smoke/%s"}}}}\n' \
       "$STATE_BUCKET" "$slug" > backend.tf.json


### PR DESCRIPTION
## Why

The first apply-smoke sweep (run 27484883595) hit **10 `No value for required variable`** failures. Examples using `TfArg.variable()` (compute_lb, firebase_app_check, cloud_sql, ops) emit `${var.X}` into `main.tf.json`, but `apply_smoke.sh` passed no `TF_VAR_X`, so `terraform -input=false` aborted at plan before any resource was even attempted.

## What

`apply_smoke.sh` now extracts every `${var.X}` from the synthesized `main.tf.json` and exports `TF_VAR_X=apply-smoke-placeholder` before `init`. Plan no longer aborts on declared variables, so apply-smoke actually exercises these stacks.

## Scope

This is the tool-side gap only. Examples needing a **real** cert / private key / org id still fail at apply with a placeholder — that's a coverage-policy decision tracked in #147. Other first-sweep failures are #145 (API enablement) and #146 (example placeholders + apply bugs).

## Verification

`tool/agent_verify.sh` exit 0 (selection test green; var-extraction verified against the compute_lb synth — 6 vars picked up).
