### PR TITLE
fix(examples): resolve apply failures from the first apply-smoke sweep

### DIFF
--- a/examples/bigquery_quickstart/lib/main.dart
+++ b/examples/bigquery_quickstart/lib/main.dart
@@ -28,6 +28,16 @@ final class AnalyticsStack extends Stack {
             GoogleProvider(project: projectId, region: 'asia-northeast1'),
           ],
         ) {
+    // The dataset's legacy ACL (below) grants a real in-stack identity, so
+    // `terraform apply` validates the principal exists. Declared ahead of the
+    // dataset so the access entry can reference the SA's email.
+    final reader = GoogleServiceAccount(
+      localName: 'analytics_reader',
+      accountId: TfArg.literal('analytics-reader'),
+      displayName: TfArg.literal('Analytics dataset reader'),
+    );
+    add(reader);
+
     final dataset = GoogleBigqueryDataset(
       localName: 'analytics',
       datasetId: TfArg.literal('analytics_prod'),
@@ -38,8 +48,10 @@ final class AnalyticsStack extends Stack {
       defaultTableExpirationMs: TfArg.literal(30 * 24 * 60 * 60 * 1000),
       storageBillingModel: TfArg.literal(DatasetStorageBillingModel.logical),
       access: [
+        // UserByEmail variant pointed at the in-stack reader SA — a real
+        // identity once applied, not a placeholder address.
         BigqueryDatasetAccessUserByEmail(
-          userByEmail: TfArg.literal('data-eng@example.com'),
+          userByEmail: TfArg.ref(reader.email),
           role: TfArg.literal('OWNER'),
         ),
         BigqueryDatasetAccessSpecialGroup(
@@ -69,16 +81,8 @@ final class AnalyticsStack extends Stack {
 
     // ---- IAM: dataset-scoped reader ---------------------------------------
     //
-    // Wave 5 Batch 3 -- the standard "analytics consumer" pattern: a SA
-    // that needs to query the whole dataset gets `dataViewer` at the
-    // dataset scope.
-
-    final reader = GoogleServiceAccount(
-      localName: 'analytics_reader',
-      accountId: TfArg.literal('analytics-reader'),
-      displayName: TfArg.literal('Analytics dataset reader'),
-    );
-    add(reader);
+    // Wave 5 Batch 3 -- the standard "analytics consumer" pattern: the
+    // `reader` SA (declared above) gets `dataViewer` at the dataset scope.
 
     add(
       GoogleBigqueryDatasetIamMember(
@@ -135,7 +139,8 @@ final class AnalyticsStack extends Stack {
               BigqueryDatapolicyDataPolicyPredefinedExpression.emailMask,
         ),
         policyTag: TfArg.literal(
-            'projects/$projectId/locations/asia-northeast1/taxonomies/1/policyTags/1'),
+          'projects/$projectId/locations/asia-northeast1/taxonomies/1/policyTags/1',
+        ),
       ),
     );
 

--- a/examples/cloud_build_quickstart/lib/main.dart
+++ b/examples/cloud_build_quickstart/lib/main.dart
@@ -27,16 +27,65 @@ library;
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/artifact_registry.dart';
 import 'package:terradart_google/cloud_build.dart';
+import 'package:terradart_google/iam.dart';
+import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
+import 'package:terradart_google/time.dart';
 
 final class CloudBuildStack extends Stack {
   CloudBuildStack({required String projectId})
       : super(
           providers: [
             GoogleProvider(project: projectId, region: 'asia-northeast1'),
+            const TimeProvider(),
           ],
         ) {
     const region = 'asia-northeast1';
+
+    // ---- 0. Enable APIs + the build service account ----------------------
+    //
+    // The Cloud Build worker pool and trigger need `cloudbuild.googleapis.com`;
+    // the Artifact Registry repo needs `artifactregistry.googleapis.com`;
+    // provisioning the runner SA needs `iam.googleapis.com`.
+    // [Apis.enable] registers one `google_project_service` per required API
+    // plus a propagation wait, returned as `dependsOn` entries.
+    final apiDeps = Apis.enable(
+      this,
+      barrels: [Barrels.cloudBuild, Barrels.iamApi, Barrels.artifactRegistry],
+      propagationDelay: const Duration(seconds: 60),
+    );
+
+    // The trigger runs builds as a user-specified service account. A
+    // user-specified SA needs `roles/logging.logWriter` (build logs cannot go
+    // to the default bucket) and `roles/cloudbuild.builds.builder` to execute
+    // build steps; the AR IAM binding below adds `artifactregistry.writer` so
+    // the build can `docker push`.
+    final buildSa = add(
+      GoogleServiceAccount(
+        localName: 'build_sa',
+        accountId: TfArg.literal('cloud-build-sa'),
+        displayName: TfArg.literal('Cloud Build runner'),
+        dependsOn: apiDeps,
+      ),
+    );
+
+    final saLogWriter = add(
+      GoogleProjectIamMember(
+        localName: 'build_sa_log_writer',
+        project: TfArg.literal(projectId),
+        role: TfArg.literal('roles/logging.logWriter'),
+        member: TfArg.ref<String>(buildSa.iamMember),
+      ),
+    );
+
+    final saBuilder = add(
+      GoogleProjectIamMember(
+        localName: 'build_sa_builder',
+        project: TfArg.literal(projectId),
+        role: TfArg.literal('roles/cloudbuild.builds.builder'),
+        member: TfArg.ref<String>(buildSa.iamMember),
+      ),
+    );
 
     // ---- 1. GitHub App connection ----------------------------------------
     //
@@ -62,6 +111,7 @@ final class CloudBuildStack extends Stack {
             ),
           ),
         ),
+        dependsOn: apiDeps,
       ),
     );
 
@@ -78,6 +128,7 @@ final class CloudBuildStack extends Stack {
         name: TfArg.literal('myapp'),
         parentConnection: TfArg.ref<String>(lbConn.id),
         remoteUri: TfArg.literal('https://github.com/example/myapp.git'),
+        dependsOn: apiDeps,
       ),
     );
 
@@ -95,24 +146,24 @@ final class CloudBuildStack extends Stack {
         format: TfArg.literal('DOCKER'),
         mode: TfArg.literal(ArtifactRegistryMode.standardRepository),
         description: TfArg.literal('Container images built by Cloud Build'),
+        dependsOn: apiDeps,
       ),
     );
 
     // ---- 4. AR IAM: grant the build SA writer ----------------------------
     //
-    // The trigger executes as a build service account; that account needs
-    // `artifactregistry.writer` on the destination repo to `docker push` the
-    // resulting image. Substitute the real SA email for your project.
+    // The trigger executes as the build service account from step 0; that
+    // account needs `artifactregistry.writer` on the destination repo to
+    // `docker push` the resulting image. `buildSa.iamMember` is the
+    // pre-formatted `serviceAccount:<email>` binding subject.
 
-    add(
+    final arIam = add(
       GoogleArtifactRegistryRepositoryIamMember(
         localName: 'lb_ar_iam',
         location: TfArg.literal(region),
         repository: TfArg.ref<String>(lbAr.nameRef),
         role: TfArg.literal('roles/artifactregistry.writer'),
-        member: TfArg.literal(
-          'serviceAccount:cloud-build-sa@$projectId.iam.gserviceaccount.com',
-        ),
+        member: TfArg.ref<String>(buildSa.iamMember),
       ),
     );
 
@@ -138,6 +189,7 @@ final class CloudBuildStack extends Stack {
             'projects/PROJECT_ID/global/networks/cloudbuild-peered-vpc',
           ),
         ),
+        dependsOn: apiDeps,
       ),
     );
 
@@ -159,15 +211,25 @@ final class CloudBuildStack extends Stack {
         buildSpec: CloudbuildTriggerFilenameSpec(
           filename: TfArg.literal('cloudbuild.yaml'),
         ),
-        serviceAccount: TfArg.literal(
-          'projects/$projectId/serviceAccounts/cloud-build-sa@$projectId.iam.gserviceaccount.com',
-        ),
+        // `service_account` wants the full SA resource path
+        // `projects/{project}/serviceAccounts/{email}` — `buildSa.id` is
+        // exactly that, so reference it instead of hand-building the string.
+        serviceAccount: TfArg.ref<String>(buildSa.id),
         // Worker pool dispatch is configured inside `cloudbuild.yaml`
         // via `options.pool.name`, fed by the `_WORKER_POOL`
         // substitution exported here. (The trigger schema attaches a
         // pool only through inline `build.options`; the `filename` form
         // delegates pool selection to the in-repo build config.)
         substitutions: TfArg.literal({'_WORKER_POOL': lbPool.id.interpolation}),
+        // The trigger needs `cloudbuild.googleapis.com` enabled and the
+        // runner SA + its role bindings to exist before it can be created.
+        dependsOn: [
+          ...apiDeps,
+          ResourceDependency(buildSa),
+          ResourceDependency(saLogWriter),
+          ResourceDependency(saBuilder),
+          ResourceDependency(arIam),
+        ],
       ),
     );
   }

--- a/examples/cloud_run_quickstart/lib/main.dart
+++ b/examples/cloud_run_quickstart/lib/main.dart
@@ -87,6 +87,8 @@ final class ApiServiceStack extends Stack {
       region: TfArg.literal('asia-northeast1'),
       ipCidrRange: TfArg.literal('10.8.0.0/28'),
       network: TfArg.literal('default'),
+      minInstances: TfArg.literal(2),
+      maxInstances: TfArg.literal(3),
       dependsOn: apiDeps,
     );
     add(runConnector);
@@ -113,7 +115,11 @@ final class ApiServiceStack extends Stack {
           memorySizeMb: TfArg.literal(1024),
         ),
         region: TfArg.literal('asia-northeast1'),
-        authorizedNetwork: TfArg.literal('default'),
+        // Memcache requires the full network path
+        // (projects/<project>/global/networks/<network>); a short name like
+        // 'default' fails apply with "Invalid format for authorized network".
+        authorizedNetwork:
+            TfArg.literal('projects/$projectId/global/networks/default'),
         dependsOn: apiDeps,
       ),
     );

--- a/examples/cloud_scheduler_quickstart/lib/main.dart
+++ b/examples/cloud_scheduler_quickstart/lib/main.dart
@@ -11,8 +11,10 @@ library;
 
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/cloud_scheduler.dart';
+import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/pubsub.dart';
+import 'package:terradart_google/time.dart';
 
 /// Cloud Scheduler job + Pub/Sub topic Stack.
 final class NightlyCleanupStack extends Stack {
@@ -20,12 +22,22 @@ final class NightlyCleanupStack extends Stack {
       : super(
           providers: [
             GoogleProvider(project: projectId, region: 'us-central1'),
+            const TimeProvider(),
           ],
         ) {
+    // Enable the Cloud Scheduler and Pub/Sub APIs and wait for propagation
+    // before the topic and job apply.
+    final apiDeps = Apis.enable(
+      this,
+      barrels: [Barrels.cloudScheduler, Barrels.pubsub],
+      propagationDelay: const Duration(seconds: 60),
+    );
+
     final topic = add(
       GooglePubsubTopic(
         localName: 'nightly_cleanup',
         name: TfArg.literal('nightly-cleanup'),
+        dependsOn: apiDeps,
       ),
     );
 
@@ -52,6 +64,7 @@ final class NightlyCleanupStack extends Stack {
           minBackoffDuration: TfArgLiteral<String>('5s'),
           maxBackoffDuration: TfArgLiteral<String>('60s'),
         ),
+        dependsOn: apiDeps,
       ),
     );
 

--- a/examples/cloud_tasks_quickstart/bin/infra.dart
+++ b/examples/cloud_tasks_quickstart/bin/infra.dart
@@ -1,10 +1,23 @@
 /// Synth entry point. Run `dart run bin/infra.dart` to emit
 /// `tf-out/main.tf.json` and `lib/generated/email_jobs_stack.app.dart`.
+///
+/// Requires the GCP_PROJECT_ID environment variable.
 library;
+
+import 'dart:io';
 
 import 'package:terradart_example_cloud_tasks_quickstart/main.dart';
 
 Future<void> main() async {
-  final stack = EmailJobsStack(projectId: 'YOUR-PROJECT-ID');
+  final projectId = Platform.environment['GCP_PROJECT_ID'];
+  if (projectId == null || projectId.isEmpty) {
+    stderr.writeln(
+      'error: set GCP_PROJECT_ID env var (e.g. GCP_PROJECT_ID=my-proj-123)',
+    );
+    exit(64);
+  }
+
+  final stack = EmailJobsStack(projectId: projectId);
   await stack.writeTo('tf-out');
+  print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/compute_quickstart/lib/main.dart
+++ b/examples/compute_quickstart/lib/main.dart
@@ -18,7 +18,9 @@ library;
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/compute.dart';
 import 'package:terradart_google/filestore.dart';
+import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
+import 'package:terradart_google/time.dart';
 
 /// Network stack: a VPC + a public IP for a load balancer.
 final class NetworkStack extends Stack {
@@ -26,14 +28,25 @@ final class NetworkStack extends Stack {
       : super(
           providers: [
             GoogleProvider(project: projectId, region: 'asia-northeast1'),
+            const TimeProvider(),
           ],
         ) {
+    // Enable the Compute + Filestore APIs and wait for propagation before
+    // the resources below apply; otherwise apply fails with SERVICE_DISABLED.
+    // Every API-gated resource below carries `dependsOn: apiDeps`.
+    final apiDeps = Apis.enable(
+      this,
+      barrels: [Barrels.compute, Barrels.filestore],
+      propagationDelay: const Duration(seconds: 60),
+    );
+
     final mainVpc = GoogleComputeNetwork(
       localName: 'main',
       name: TfArg.literal('main-vpc'),
       // Custom-mode VPC: no auto-subnets, explicit subnetwork resources.
       autoCreateSubnetworks: TfArg.literal(false),
       routingMode: TfArg.literal(RoutingMode.regional),
+      dependsOn: apiDeps,
     );
     add(mainVpc);
 
@@ -45,6 +58,7 @@ final class NetworkStack extends Stack {
         addressType: TfArg.literal(AddressType.external),
         networkTier: TfArg.literal(NetworkTier.premium),
         ipVersion: TfArg.literal(IpVersion.ipv4),
+        dependsOn: apiDeps,
       ),
     );
 
@@ -60,6 +74,7 @@ final class NetworkStack extends Stack {
       region: TfArg.literal('asia-northeast1'),
       network: TfArg.ref(mainVpc.id),
       ipCidrRange: TfArg.literal('10.10.0.0/20'),
+      dependsOn: apiDeps,
     );
     add(workloadSubnet);
 
@@ -74,6 +89,7 @@ final class NetworkStack extends Stack {
           advertiseMode: ComputeRouterBgpAdvertiseMode.defaultMode,
           asn: TfArg.literal(64514),
         ),
+        dependsOn: apiDeps,
       ),
     );
 
@@ -95,6 +111,7 @@ final class NetworkStack extends Stack {
             modes: const [FilestoreInstanceNetworkMode.modeIpv4],
           ),
         ],
+        dependsOn: apiDeps,
       ),
     );
 
@@ -161,6 +178,7 @@ final class NetworkStack extends Stack {
             ComputeInstanceNetworkPerformanceConfigTotalEgressBandwidthTier
                 .platformDefault,
       ),
+      dependsOn: apiDeps,
     );
     add(bastion);
 

--- a/examples/dns_quickstart/lib/main.dart
+++ b/examples/dns_quickstart/lib/main.dart
@@ -4,13 +4,11 @@
 /// - a VPC network (`gnd-vpc`) the private zone attaches to,
 /// - a private DNS managed zone (`internal.corp.`) scoped to the VPC via
 ///   `PrivateVisibilityConfig(networks: [PrivateVisibilityNetwork(...)])`,
-/// - DNSSEC enabled via typed enums (`DnssecState.on`,
-///   `DnssecKeyAlgorithm.rsasha256`, `DnssecKeyType.keySigning`),
 ///
-/// demonstrating the 10 nested-block helper classes from
-/// `google_dns_managed_zone` and the 6 schema-faithful enums
-/// (visibility / DNSSEC state / DNSSEC non-existence / DNSSEC algorithm /
-/// DNSSEC key-type / forwarding-path).
+/// demonstrating the nested-block helper classes from
+/// `google_dns_managed_zone` and the schema-faithful enums
+/// (visibility / forwarding-path). DNSSEC is a public-zone-only feature and
+/// is therefore not configured on this private zone.
 ///
 /// Wave 5 Batch 4 adds a `roles/dns.admin` binding on the zone for a
 /// per-zone admin SA -- the standard delegated-DNS pattern where a team
@@ -51,22 +49,10 @@ final class InternalDnsStack extends Stack {
           ),
         ],
       ),
-      dnssecConfig: DnsManagedZoneDnssecConfig(
-        state: DnssecState.on,
-        nonExistence: DnssecNonExistence.nsec3,
-        defaultKeySpecs: [
-          DnsManagedZoneDnssecKeySpec(
-            algorithm: DnssecKeyAlgorithm.rsasha256,
-            keyType: DnssecKeyType.keySigning,
-            keyLength: TfArg.literal(2048),
-          ),
-          DnsManagedZoneDnssecKeySpec(
-            algorithm: DnssecKeyAlgorithm.rsasha256,
-            keyType: DnssecKeyType.zoneSigning,
-            keyLength: TfArg.literal(1024),
-          ),
-        ],
-      ),
+      // NOTE: DNSSEC is a public-internet chain-of-trust feature and is only
+      // valid on PUBLIC managed zones; a PRIVATE zone rejects `dnssec_config`
+      // at apply time ("Private zones do not support DNSSEC"). This zone is
+      // private (visibility above), so no `dnssecConfig` block is set.
     );
     add(internalZone);
 
@@ -116,7 +102,7 @@ final class InternalDnsStack extends Stack {
 
     // ---- Wave 24: response policy + override rule ---------------------------
 
-    add(
+    final overrides = add(
       GoogleDnsResponsePolicy(
         localName: 'internal_overrides',
         responsePolicyName: TfArg.literal('internal-overrides'),
@@ -129,7 +115,14 @@ final class InternalDnsStack extends Stack {
     add(
       GoogleDnsResponsePolicyRule(
         localName: 'legacy_fallback',
+        // `response_policy` takes the policy's `response_policy_name` value.
+        // The wrapper exposes no `response_policy_name` attribute ref, so the
+        // literal (matching the policy above) supplies the value and the
+        // explicit `dependsOn` guarantees the policy is created first
+        // (otherwise apply fails: the rule references a policy that doesn't
+        // exist yet).
         responsePolicy: TfArg.literal('internal-overrides'),
+        dependsOn: [ResourceDependency(overrides)],
         ruleName: TfArg.literal('legacy-fallback'),
         dnsName: TfArg.literal('legacy.internal.corp.'),
         localData: DnsResponsePolicyRuleLocalData(

--- a/examples/eventarc_quickstart/lib/main.dart
+++ b/examples/eventarc_quickstart/lib/main.dart
@@ -14,10 +14,14 @@ final class EventarcStack extends Stack {
   EventarcStack({required String projectId})
       : super(
           providers: [
-            GoogleProvider(project: projectId, region: 'asia-northeast1'),
+            GoogleProvider(project: projectId, region: 'us-central1'),
           ],
         ) {
-    const location = 'asia-northeast1';
+    // Eventarc Advanced (MessageBus, GoogleApiSource, Enrollment, Pipeline) is
+    // GA only in a limited set of regions; asia-northeast1 is not one of them.
+    // us-central1 supports both Eventarc Advanced and Eventarc Standard, and a
+    // bus + its enrollments/pipelines must all share one region.
+    const location = 'us-central1';
 
     final eventarcApi = add(
       GoogleProjectService(

--- a/examples/firebase_data_connect_quickstart/analysis_options.yaml
+++ b/examples/firebase_data_connect_quickstart/analysis_options.yaml
@@ -1,0 +1,16 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+  errors:
+    unused_import: error
+    unused_local_variable: error
+    dead_code: error
+
+linter:
+  rules:
+    - prefer_final_locals
+    - require_trailing_commas

--- a/examples/firebase_data_connect_quickstart/lib/main.dart
+++ b/examples/firebase_data_connect_quickstart/lib/main.dart
@@ -18,15 +18,26 @@ library;
 
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/firebase_data_connect.dart';
+import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
+import 'package:terradart_google/time.dart';
 
 final class DataConnectStack extends Stack {
   DataConnectStack({required String projectId})
       : super(
           providers: [
             GoogleProvider(project: projectId, region: 'us-central1'),
+            const TimeProvider(),
           ],
         ) {
+    // Enable the Firebase Data Connect API and wait for propagation before
+    // the service applies.
+    final apiDeps = Apis.enable(
+      this,
+      barrels: [Barrels.firebaseDataConnect],
+      propagationDelay: const Duration(seconds: 60),
+    );
+
     // Top-level Data Connect service container.
     // The service_id becomes the final segment of the full resource name and
     // is referenced by downstream schema / connector resources. It is NOT
@@ -41,6 +52,7 @@ final class DataConnectStack extends Stack {
         // schemas or connectors still exist. Omit (or use DEFAULT) in
         // production to guard against accidental teardown.
         deletionPolicy: TfArg.literal(DataConnectDeletionPolicy.force),
+        dependsOn: apiDeps,
       ),
     );
   }

--- a/examples/firebase_remote_config_quickstart/analysis_options.yaml
+++ b/examples/firebase_remote_config_quickstart/analysis_options.yaml
@@ -1,0 +1,16 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+  errors:
+    unused_import: error
+    unused_local_variable: error
+    dead_code: error
+
+linter:
+  rules:
+    - prefer_final_locals
+    - require_trailing_commas

--- a/examples/firebase_remote_config_quickstart/lib/main.dart
+++ b/examples/firebase_remote_config_quickstart/lib/main.dart
@@ -17,15 +17,26 @@ library;
 
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/firebase_remote_config.dart';
+import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
+import 'package:terradart_google/time.dart';
 
 final class RemoteConfigStack extends Stack {
   RemoteConfigStack({required String projectId})
       : super(
           providers: [
             GoogleProvider(project: projectId, region: 'us-central1'),
+            const TimeProvider(),
           ],
         ) {
+    // Enable the Firebase Remote Config API and wait for propagation before
+    // the template applies.
+    final apiDeps = Apis.enable(
+      this,
+      barrels: [Barrels.firebaseRemoteConfig],
+      propagationDelay: const Duration(seconds: 60),
+    );
+
     // A condition that fires for users in Japan.
     final japanCondition =
         FirebaseRemoteConfigRemoteConfigRemoteConfigCondition(
@@ -88,6 +99,7 @@ final class RemoteConfigStack extends Stack {
             ],
           ),
         ],
+        dependsOn: apiDeps,
       ),
     );
   }


### PR DESCRIPTION
## What

Fixes the concrete apply-time bugs the first apply-smoke sweep (run 27484883595) surfaced. `terraform validate` already passed for all of these — they only failed at `terraform apply`, which is exactly what apply-smoke exists to catch.

Closes #146. Addresses the example side of #145 (API enablement).

## API enablement (#145)

Route API-gated examples through `Apis.enable` (adds `TimeProvider`, one `google_project_service` per required API, a propagation `time_sleep`, and per-resource `dependsOn`):

- **cloud_scheduler** — `cloudscheduler` + `pubsub`
- **compute** — `compute` alongside `filestore`; every compute resource now gates on the API
- **cloud_build** — `artifactregistry` alongside `cloudbuild` + `iam`
- **firebase_data_connect / firebase_remote_config** — the product API

The synth gate's API-enablement ratchet enforces that once an example uses `Apis.enable`, *every* API-requiring resource is transitively covered.

## Apply-time bugs (#146)

- **cloud_tasks** — read `GCP_PROJECT_ID` from the env instead of the `YOUR-PROJECT-ID` placeholder
- **bigquery** — point the dataset `UserByEmail` grant at an in-stack service-account email (was `data-eng@example.com`, which fails the dataset ACL validation)
- **cloud_run** — VPC connector now sets `min/max_instances`; memcache `authorized_network` uses the full `projects/<p>/global/networks/<n>` path
- **eventarc** — moved to `us-central1` (Eventarc Advanced is not GA in `asia-northeast1`)
- **dns** — dropped DNSSEC from the private zone (public-zone-only feature); the response-policy rule now `dependsOn` the policy so it is created first
- **cloud_build** — create a real trigger service account with `logging.logWriter` + `cloudbuild.builds.builder` and reference it from the trigger / AR binding (the trigger previously pointed at a non-existent SA → `trigger.service_account is empty`)

Also adds the standard `analysis_options.yaml` to the two firebase examples that were missing it.

## Verification

`tool/agent_verify.sh` green: 25/25 quickstarts `terraform validate`, all package tests, `wrap --check`, lint-override, enum-gap, MM-fingerprint, apply_smoke selection test, smoke_quickstart.

## Not in this PR

~12 examples cannot apply against `terradart-validate` regardless of code (org-only resources, external secrets/certs, Firebase project registration, source artifacts). Those are handled by an apply-smoke skip-list in a follow-up PR (#147), not by changing the examples.