### PR TITLE
ci(apply-smoke): skip-list examples that can't apply to a standalone project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@ When a Wave also pays down example `pubspec.yaml` carets or docs debt, **prefer 
 
 Maintainer prerequisite: GCP WIF pool + `terradart-validate` project (bootstrap is not cloud-agent automatable). A scheduled janitor workflow destroys orphaned resources from failed runs.
 
+**Skip-list.** [`tool/apply_smoke_skip.yaml`](tool/apply_smoke_skip.yaml) records the examples the sweep does **not** `terraform apply` — org-only resources, examples needing real external secrets/certs/ids, Firebase project registration, or a local source artifact that `terradart-validate` (a standalone project) can't supply. Listed examples still synth + `terraform validate` via the synth gate; they're excluded only from real apply. `apply_smoke.sh` honors it in `--all` and the PR change-gate; `--example <slug>` overrides it (applies anyway), and `--destroy-only` (the janitor) ignores it so leftover state is always reclaimable. Treat the file as a coverage-debt ledger — deleting an entry re-includes that example. `tool/apply_smoke_test.sh` (run by `agent_verify`) asserts the partition stays consistent.
+
 ## Documentation Policy
 
 - `AGENTS.md` is the committed operational guide for agents.
@@ -184,7 +186,7 @@ Inputs: a checked-in or task-provided `schema.json` (plus Magic Modules YAML whe
 7. **Export the full public surface from the per-service barrel.** `lib/<service>.dart` must `show` every public type the generated wrapper declares — the catalog advertises all of them to MCP agents (enforced by the barrel-completeness group in `per_service_barrel_test`).
 8. **Wire API enablement in examples through `Apis.enable`** (`package:terradart_google/project.dart`; the propagation `TimeSleep` needs `const TimeProvider()` from `package:terradart_google/time.dart` on the stack). Synth fails fast when any resource's provider is missing from `Stack.providers`.
 9. **Test:** targeted tests first, then `tool/agent_verify.sh` (add `--maintainer` when touching wrap-init / wrap-promote).
-10. **For real-apply coverage, add the `apply-smoke` label to the PR** when it adds or changes a curated resource or an example. The label runs `apply-smoke.yml`, which applies the changed examples to `terradart-validate` and blocks merge on failure. Every example is also applied nightly by `apply-smoke-nightly.yml` (`tool/apply_smoke.sh --all`), which opens a dedup'd issue on failure — so a resource that only `validate`s but cannot `apply` is caught within a day even without the label. `terraform validate` (synth gate) does **not** prove a resource applies.
+10. **For real-apply coverage, add the `apply-smoke` label to the PR** when it adds or changes a curated resource or an example. The label runs `apply-smoke.yml`, which applies the changed examples to `terradart-validate` and blocks merge on failure. Every example is also applied nightly by `apply-smoke-nightly.yml` (`tool/apply_smoke.sh --all`), which opens a dedup'd issue on failure — so a resource that only `validate`s but cannot `apply` is caught within a day even without the label. `terraform validate` (synth gate) does **not** prove a resource applies. If a new example fundamentally can't apply against a standalone project (needs an org, real external secrets/certs, Firebase registration, or a staged source artifact), record it in [`tool/apply_smoke_skip.yaml`](tool/apply_smoke_skip.yaml) with a reason rather than leaving the sweep red.
 
 ### Handle Provider Schema Or MM YAML Drift
 

--- a/tool/apply_smoke.sh
+++ b/tool/apply_smoke.sh
@@ -63,19 +63,56 @@ select_examples() {
 }
 
 # Collect into an array without `mapfile` (absent on macOS bash 3.2).
-EXAMPLES=()
+SELECTED=()
 while IFS= read -r _slug; do
-  [[ -n "$_slug" ]] && EXAMPLES+=("$_slug")
+  [[ -n "$_slug" ]] && SELECTED+=("$_slug")
 done < <(select_examples)
 
-# --- dry-run: print selection and stop ------------------------------------
+# --- skip-list -------------------------------------------------------------
+# Examples that can't `terraform apply` against terradart-validate (org-only
+# resources, external secrets/certs, Firebase registration, source artifacts)
+# are recorded in tool/apply_smoke_skip.yaml. Honor it in apply modes (--all
+# and the PR change-gate) but NOT for an explicit `--example` (override) or
+# `--destroy-only` (the janitor must reclaim any leftover state).
+SKIP_FILE="tool/apply_smoke_skip.yaml"
+is_skipped() {
+  [[ -f "$SKIP_FILE" ]] || return 1
+  grep -qE "^$1:[[:space:]]" "$SKIP_FILE"
+}
+skip_reason() { grep -E "^$1:[[:space:]]" "$SKIP_FILE" | head -1 | sed -E 's/^[^:]+:[[:space:]]*//'; }
+
+HONOR_SKIP=1
+[[ "$DESTROY_ONLY" == "1" || "$MODE" == "example" ]] && HONOR_SKIP=0
+
+EXAMPLES=()
+SKIPPED=()
+# bash 3.2 + `set -u`: expanding "${arr[@]}" on an empty array errors, so guard
+# every array iteration with a length check.
+if [[ ${#SELECTED[@]} -gt 0 ]]; then
+  for _slug in "${SELECTED[@]}"; do
+    if [[ "$HONOR_SKIP" == "1" ]] && is_skipped "$_slug"; then
+      SKIPPED+=("$_slug")
+    else
+      EXAMPLES+=("$_slug")
+    fi
+  done
+fi
+
+# --- dry-run: print the apply set (post-skip) and stop --------------------
 if [[ "$DRY_RUN" == "1" ]]; then
   [[ ${#EXAMPLES[@]} -gt 0 ]] && printf '%s\n' "${EXAMPLES[@]}"
+  if [[ ${#SKIPPED[@]} -gt 0 ]]; then
+    for _s in "${SKIPPED[@]}"; do echo "skip $_s ($(skip_reason "$_s"))" >&2; done
+  fi
   exit 0
 fi
 
+if [[ ${#SKIPPED[@]} -gt 0 ]]; then
+  for _s in "${SKIPPED[@]}"; do echo ">> skip $_s ($(skip_reason "$_s"))"; done
+fi
+
 if [[ ${#EXAMPLES[@]} -eq 0 ]]; then
-  echo "apply_smoke.sh: no examples selected — skip"
+  echo "apply_smoke.sh: no examples to apply — skip"
   exit 0
 fi
 

--- a/tool/apply_smoke_skip.yaml
+++ b/tool/apply_smoke_skip.yaml
@@ -1,0 +1,37 @@
+# Examples the apply-smoke sweep does NOT `terraform apply`, with the reason.
+#
+# These examples still get `dart run bin/infra.dart` (synth) + `terraform
+# validate` via tool/example_synth_gates.dart. They are excluded ONLY from real
+# `terraform apply` because they need inputs that terradart-validate (a
+# standalone project: no organization, no real secrets/certs, not registered
+# with Firebase) cannot provide. The list doubles as a coverage-debt ledger —
+# delete an entry to put that example back in the sweep.
+#
+# Honored by tool/apply_smoke.sh in apply modes (--all and the PR change-gate).
+# `--example <slug>` applies even a listed example (explicit override), and
+# `--destroy-only` (the janitor) never skips, so leftover state stays
+# reclaimable.
+#
+# Format (one per line):  <example_slug>: <reason>
+
+# --- Org-only: the resource requires the project to belong to an organization
+bigquery_quickstart: datapolicy + analyticshub resources require an organization
+
+# --- Need real external secrets / certs / ids
+compute_lb_quickstart: needs a real TLS cert + private key + CAS CSR / trust anchor
+cloud_sql_quickstart: needs a real source-replica password
+ops_quickstart: needs a real organization id / folder id
+firebase_app_check_quickstart: needs real App Check debug token / DeviceCheck key / reCAPTCHA secret
+
+# --- Need the project registered with Firebase (firebase.googleapis.com is not
+#     enough; the project must be added to Firebase, which Terraform can't do here)
+firebase_data_connect_quickstart: needs the project registered with Firebase
+firebase_remote_config_quickstart: needs the project registered with Firebase
+firebase_app_hosting_quickstart: needs the project registered with Firebase + a connected source repo
+
+# --- Need a source artifact staged into the generated tf-out at apply time
+cloud_functions_quickstart: needs a real function source zip staged into tf-out
+storage_quickstart: uploads a local source file (config/app.json) absent from generated tf-out
+
+# --- Need external infra / secrets
+cloud_build_quickstart: needs a real GitHub App OAuth token secret + a peered VPC

--- a/tool/apply_smoke_test.sh
+++ b/tool/apply_smoke_test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tests apply_smoke.sh selection + dry-run WITHOUT touching GCP/terraform.
-# --dry-run prints the chosen example slugs (one per line) and exits 0.
+# Tests apply_smoke.sh selection + skip-list + dry-run WITHOUT touching
+# GCP/terraform. --dry-run prints the chosen example slugs (one per line) and
+# exits 0.
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -11,14 +12,19 @@ fail() {
   exit 1
 }
 
-# 1. --all --dry-run lists every examples/*_quickstart, no GCP project needed.
+all_slugs="$(for d in examples/*_quickstart/; do basename "$d"; done | sort)"
+skip_slugs="$(grep -vE '^[[:space:]]*#' tool/apply_smoke_skip.yaml \
+  | grep -E '^[a-z0-9_]+:' | sed -E 's/:.*//' | sort)"
+# The apply set is every quickstart minus the skip-listed ones.
+apply_set="$(comm -23 <(printf '%s\n' "$all_slugs") <(printf '%s\n' "$skip_slugs"))"
+
+# 1. --all --dry-run lists the apply set (every quickstart minus the skip-list).
 all_out="$(tool/apply_smoke.sh --all --dry-run)" || fail "--all --dry-run exited non-zero"
-expected="$(for d in examples/*_quickstart/; do basename "$d"; done | sort)"
-[[ "$all_out" == "$expected" ]] || fail "--all selection mismatch:
+[[ "$all_out" == "$apply_set" ]] || fail "--all apply-set mismatch:
 got:
 $all_out
 want:
-$expected"
+$apply_set"
 
 # 2. --example X --dry-run lists exactly that slug.
 one_out="$(tool/apply_smoke.sh --example gke_quickstart --dry-run)" || fail "--example dry-run non-zero"
@@ -28,8 +34,23 @@ one_out="$(tool/apply_smoke.sh --example gke_quickstart --dry-run)" || fail "--e
 GCP_PROJECT_ID="" GCP_VALIDATE_PROJECT_ID="" tool/apply_smoke.sh --all --dry-run >/dev/null \
   || fail "--dry-run should not require GCP project"
 
-# 4. --destroy-only is a recognized flag and selects the same set.
+# 4. --destroy-only ignores the skip-list (the janitor must reclaim everything).
 do_out="$(tool/apply_smoke.sh --all --destroy-only --dry-run)" || fail "--destroy-only dry-run non-zero"
-[[ "$do_out" == "$expected" ]] || fail "--destroy-only selection mismatch"
+[[ "$do_out" == "$all_slugs" ]] || fail "--destroy-only should select ALL examples (skip-list ignored):
+got:
+$do_out
+want:
+$all_slugs"
+
+# 5. skip-list semantics: a listed example is absent from the apply set, present
+#    for destroy, and applied when named explicitly (--example override).
+sample_skip="$(printf '%s\n' "$skip_slugs" | head -1)"
+[[ -n "$sample_skip" ]] || fail "skip-list is empty — expected at least one entry"
+printf '%s\n' "$all_out" | grep -qxF "$sample_skip" \
+  && fail "skip-listed '$sample_skip' must be absent from the --all apply set"
+printf '%s\n' "$do_out" | grep -qxF "$sample_skip" \
+  || fail "skip-listed '$sample_skip' must be present in the --destroy-only set"
+ov_out="$(tool/apply_smoke.sh --example "$sample_skip" --dry-run)" || fail "--example override non-zero"
+[[ "$ov_out" == "$sample_skip" ]] || fail "--example must override the skip-list: got '$ov_out'"
 
 echo "apply_smoke_test: OK"


### PR DESCRIPTION
## What

Resolves the coverage-policy decision in #147 with the **skip-list** option.

The first apply-smoke sweep failed every example, but ~11 of those are not bugs — they need inputs that `terradart-validate` (a standalone project: no organization, no real secrets, not registered with Firebase) can't provide. This adds [`tool/apply_smoke_skip.yaml`](tool/apply_smoke_skip.yaml) recording them with a reason, and teaches `apply_smoke.sh` to honor it.

## Partition (14 apply / 11 skip)

**Skipped** (with reason in the file):
- **Org-only:** bigquery (datapolicy + analyticshub)
- **External secret/cert/id:** compute_lb, cloud_sql, ops, firebase_app_check
- **Firebase registration:** firebase_data_connect, firebase_remote_config, firebase_app_hosting
- **Source artifact not staged into tf-out:** cloud_functions, storage
- **External infra:** cloud_build (GitHub App OAuth secret + peered VPC)

**Applied:** cloud_run, cloud_scheduler, cloud_tasks, compute, dns, eventarc, firestore, firestore_document, gke, iam, kms, monitoring, pubsub, secret_manager.

## Behavior

- Honored in `--all` (nightly sweep) and the PR change-gate.
- `--example <slug>` **overrides** it (applies a listed example anyway).
- `--destroy-only` (the janitor) **ignores** it, so leftover state is always reclaimable.
- Listed examples still synth + `terraform validate` via the synth gate — they're excluded only from real `terraform apply`.
- The file doubles as a **coverage-debt ledger**: delete an entry to put an example back in the sweep (e.g. once a throwaway cert or a Firebase-enabled test project is available).

## Tests

`tool/apply_smoke_test.sh` (run by `agent_verify`, GCP-free) asserts the apply/skip partition, the `--destroy-only` override, and the `--example` override. `AGENTS.md` documents the policy.

## Relationship to #149

Together with #149 (the example bug fixes), this is what makes the nightly sweep meaningfully green: #149 fixes the ~13 apply-able examples; this excludes the ~11 that can't apply by design. Recommend merging this first so #149's apply-smoke gate (if labeled) skips the impossible examples.

Closes #147.