### PR TITLE
fix(examples): resolve apply failures from the first real sweep (round 2)

### DIFF
--- a/examples/cloud_tasks_quickstart/lib/main.dart
+++ b/examples/cloud_tasks_quickstart/lib/main.dart
@@ -8,7 +8,9 @@ library;
 
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/cloud_tasks.dart';
+import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
+import 'package:terradart_google/time.dart';
 
 /// Cloud Tasks queue + IAM enqueuer Stack.
 final class EmailJobsStack extends Stack {
@@ -16,8 +18,20 @@ final class EmailJobsStack extends Stack {
       : super(
           providers: [
             GoogleProvider(project: projectId, region: 'us-central1'),
+            const TimeProvider(),
           ],
         ) {
+    // ---- API enablement ---------------------------------------------------
+    //
+    // [Apis.enable] enables the Cloud Tasks API and waits 60s for propagation
+    // before the queue applies.
+
+    final apiDeps = Apis.enable(
+      this,
+      barrels: [Barrels.cloudTasks],
+      propagationDelay: const Duration(seconds: 60),
+    );
+
     final queue = add(
       GoogleCloudTasksQueue(
         localName: 'email_jobs',
@@ -33,6 +47,7 @@ final class EmailJobsStack extends Stack {
           maxBackoff: TfArg.literal('300s'),
           maxDoublings: TfArg.literal(3),
         ),
+        dependsOn: apiDeps,
       ),
     );
 

--- a/examples/eventarc_quickstart/lib/main.dart
+++ b/examples/eventarc_quickstart/lib/main.dart
@@ -7,6 +7,7 @@ library;
 
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/eventarc.dart';
+import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
 
@@ -29,7 +30,32 @@ final class EventarcStack extends Stack {
         service: TfArg.literal('eventarc.googleapis.com'),
       ),
     );
-    final eventarcDeps = [ResourceDependency(eventarcApi)];
+    // google_eventarc_channel (the partner channel below) additionally
+    // requires the Eventarc Publishing API; without it the create call fails
+    // with "Creating channel requires enablement of service
+    // eventarcpublishing.googleapis.com".
+    final eventarcPublishingApi = add(
+      GoogleProjectService(
+        localName: 'eventarc_publishing_api',
+        service: TfArg.literal('eventarcpublishing.googleapis.com'),
+      ),
+    );
+    final eventarcDeps = [
+      ResourceDependency(eventarcApi),
+      ResourceDependency(eventarcPublishingApi),
+    ];
+
+    // Eventarc triggers require a service account that delivers events to the
+    // destination; the API rejects creation with "trigger.service_account is
+    // empty" otherwise.
+    final triggerSa = add(
+      GoogleServiceAccount(
+        localName: 'trigger_sa',
+        accountId: TfArg.literal('eventarc-trigger'),
+        displayName: TfArg.literal('Eventarc trigger delivery'),
+        dependsOn: eventarcDeps,
+      ),
+    );
 
     final messageBus = add(
       GoogleEventarcMessageBus(
@@ -58,6 +84,28 @@ final class EventarcStack extends Stack {
       ),
     );
 
+    // A pipeline routes bus messages to a concrete target (here a Workflow).
+    final pipeline = add(
+      GoogleEventarcPipeline(
+        localName: 'ingest_pipeline',
+        location: TfArg.literal(location),
+        pipelineId: TfArg.literal('ingest-pipeline'),
+        destinations: TfArg.literal([
+          {
+            'workflow':
+                'projects/$projectId/locations/$location/workflows/ingest',
+          },
+        ]),
+        loggingConfig: const EventarcMessageBusLoggingConfig(
+          logSeverity: EventarcMessageBusLogSeverity.notice,
+        ),
+        dependsOn: eventarcDeps,
+      ),
+    );
+
+    // An enrollment's destination is the *pipeline* that processes matched
+    // messages — not a Workflow directly. Pointing it at a Workflow fails with
+    // "invalid destination" (field enrollment.destination).
     add(
       GoogleEventarcEnrollment(
         localName: 'audit_enrollment',
@@ -65,9 +113,7 @@ final class EventarcStack extends Stack {
         enrollmentId: TfArg.literal('audit-enrollment'),
         celMatch: TfArg.literal('true'),
         messageBus: TfArg.ref(messageBus.nameRef),
-        destination: TfArg.literal(
-          'projects/$projectId/locations/$location/workflows/audit-router',
-        ),
+        destination: TfArg.ref(pipeline.nameRef),
         dependsOn: eventarcDeps,
       ),
     );
@@ -91,28 +137,11 @@ final class EventarcStack extends Stack {
     );
 
     add(
-      GoogleEventarcPipeline(
-        localName: 'ingest_pipeline',
-        location: TfArg.literal(location),
-        pipelineId: TfArg.literal('ingest-pipeline'),
-        destinations: TfArg.literal([
-          {
-            'workflow':
-                'projects/$projectId/locations/$location/workflows/ingest',
-          },
-        ]),
-        loggingConfig: const EventarcMessageBusLoggingConfig(
-          logSeverity: EventarcMessageBusLogSeverity.notice,
-        ),
-        dependsOn: eventarcDeps,
-      ),
-    );
-
-    add(
       GoogleEventarcTrigger(
         localName: 'pubsub_to_http',
         name: TfArg.literal('pubsub-to-http'),
         location: TfArg.literal(location),
+        serviceAccount: TfArg.ref(triggerSa.email),
         matchingCriteria: [
           EventarcTriggerMatchingCriteria(
             attribute: TfArg.literal('type'),

--- a/examples/gke_quickstart/lib/main.dart
+++ b/examples/gke_quickstart/lib/main.dart
@@ -153,6 +153,14 @@ final class GkeQuickstartStack extends Stack {
         backupSchedule: GkeBackupBackupPlanBackupSchedule(
           cronSchedule: TfArg.literal('0 3 * * *'),
         ),
+        // GKE Backup requires the plan to declare a backup scope; without one
+        // the API rejects creation with INVALID_BACKUP_SCOPE. Back up every
+        // namespace (plus secrets + volume data) — the canonical basic scope.
+        backupConfig: TfArg.literal({
+          'all_namespaces': TfArg.literal(true),
+          'include_secrets': TfArg.literal(true),
+          'include_volume_data': TfArg.literal(true),
+        }),
         retentionPolicy: TfArg.literal({
           'backup_retain_days': TfArg.literal(7),
         }),

--- a/examples/kms_quickstart/lib/main.dart
+++ b/examples/kms_quickstart/lib/main.dart
@@ -17,19 +17,35 @@ library;
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/kms.dart';
+import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
+import 'package:terradart_google/time.dart';
 
 final class CryptoStack extends Stack {
   CryptoStack({required String projectId})
       : super(
           providers: [
             GoogleProvider(project: projectId, region: 'asia-northeast1'),
+            const TimeProvider(),
           ],
         ) {
+    // ---- API enablement ---------------------------------------------------
+    //
+    // [Apis.enable] enables the Cloud KMS API and waits 60s for propagation
+    // before the key ring, keys, and versions apply. (Service accounts and
+    // `_iam_member` adjuncts below are not API-gated.)
+
+    final apiDeps = Apis.enable(
+      this,
+      barrels: [Barrels.kmsApi],
+      propagationDelay: const Duration(seconds: 60),
+    );
+
     final ring = GoogleKmsKeyRing(
       localName: 'main',
       name: TfArg.literal('main-ring'),
       location: TfArg.literal('asia-northeast1'),
+      dependsOn: apiDeps,
     );
     add(ring);
 
@@ -49,6 +65,7 @@ final class CryptoStack extends Stack {
         algorithm: TfArg.literal('GOOGLE_SYMMETRIC_ENCRYPTION'),
         protectionLevel: KmsProtectionLevel.software,
       ),
+      dependsOn: apiDeps,
     );
     add(paymentsKey);
 
@@ -56,7 +73,7 @@ final class CryptoStack extends Stack {
       GoogleKmsCryptoKeyVersion(
         localName: 'payments_primary',
         cryptoKey: TfArg.ref(paymentsKey.id),
-        dependsOn: [ResourceDependency(paymentsKey)],
+        dependsOn: [...apiDeps, ResourceDependency(paymentsKey)],
       ),
     );
 

--- a/examples/monitoring_quickstart/lib/main.dart
+++ b/examples/monitoring_quickstart/lib/main.dart
@@ -35,8 +35,11 @@ final class LatencyAlertStack extends Stack {
       ),
     );
 
+    // Opaque custom service: `google_monitoring_service` (the typed variant)
+    // requires a `basic_service`/identifier case at the API and cannot be
+    // created with `service_id` alone, so use the custom-service resource.
     final apiService = add(
-      GoogleMonitoringService(
+      GoogleMonitoringCustomService(
         localName: 'api',
         serviceId: TfArg.literal('api'),
         displayName: TfArg.literal('API service'),
@@ -89,7 +92,7 @@ final class LatencyAlertStack extends Stack {
         ],
         dependsOn: [
           ResourceDependency(apiMonitoring),
-          ResourceDependency(publicUrls)
+          ResourceDependency(publicUrls),
         ],
       ),
     );
@@ -126,29 +129,42 @@ final class LatencyAlertStack extends Stack {
     add(
       GoogleMonitoringSlo(
         localName: 'api_availability',
-        service: TfArg.ref(apiService.nameRef),
+        // Custom services have no derived telemetry, so a `basic_sli`
+        // (availability/latency) cannot be evaluated against them; use a
+        // request-based good/total ratio on the Cloud Run request metric.
+        service: TfArg.ref(apiService.serviceIdRef),
         goal: TfArg.literal(0.99),
         displayName: TfArg.literal('API availability'),
         rollingPeriodDays: TfArg.literal(30),
-        sli: MonitoringSloBasicSli(
-          availability: MonitoringSloBasicSliAvailability(
-            enabled: TfArg.literal(true),
+        sli: MonitoringSloRequestBasedSli(
+          goodTotalRatio: MonitoringSloGoodTotalRatio(
+            goodServiceFilter: TfArg.literal(
+              'metric.type="run.googleapis.com/request_count" '
+              'AND resource.type="cloud_run_revision" '
+              'AND metric.label.response_code_class="2xx"',
+            ),
+            totalServiceFilter: TfArg.literal(
+              'metric.type="run.googleapis.com/request_count" '
+              'AND resource.type="cloud_run_revision"',
+            ),
           ),
         ),
         dependsOn: [ResourceDependency(apiService)],
       ),
     );
 
-    add(
-      GoogleMonitoringMonitoredProject(
-        localName: 'metrics_scope_child',
-        metricsScope: TfArg.literal(
-          'locations/global/metricsScopes/$projectId',
-        ),
-        name: TfArg.literal(projectId),
-        dependsOn: [ResourceDependency(apiMonitoring)],
-      ),
-    );
+    // A `google_monitoring_monitored_project` adds *another* project to this
+    // project's metrics scope (multi-project observability). A project is
+    // already a member of its own default metrics scope, so self-linking it
+    // (name == scoping project) is rejected by the API. To dogfood this
+    // resource, set `name` to a different project ID and grant
+    // `roles/monitoring.admin` on both projects:
+    //
+    // GoogleMonitoringMonitoredProject(
+    //   localName: 'metrics_scope_child',
+    //   metricsScope: TfArg.literal('locations/global/metricsScopes/$projectId'),
+    //   name: TfArg.literal('some-other-project-id'),
+    // );
 
     add(
       GoogleMonitoringAlertPolicy(
@@ -165,6 +181,7 @@ final class LatencyAlertStack extends Stack {
             conditionThreshold: MonitoringAlertPolicyConditionThreshold(
               filter: TfArg.literal(
                 'metric.type="run.googleapis.com/request_latencies" '
+                'AND resource.type="cloud_run_revision" '
                 'AND resource.label.service_name="api"',
               ),
               comparison: TfArg.literal(Comparison.greaterThan),
@@ -191,7 +208,7 @@ final class LatencyAlertStack extends Stack {
         ),
         dependsOn: [
           ResourceDependency(oncallEmail),
-          ResourceDependency(apiMonitoring)
+          ResourceDependency(apiMonitoring),
         ],
       ),
     );

--- a/tool/apply_smoke_skip.yaml
+++ b/tool/apply_smoke_skip.yaml
@@ -35,3 +35,6 @@ storage_quickstart: uploads a local source file (config/app.json) absent from ge
 
 # --- Need external infra / secrets
 cloud_build_quickstart: needs a real GitHub App OAuth token secret + a peered VPC
+
+# --- Provisioning latency / network infra the example doesn't provision
+eventarc_quickstart: Eventarc Advanced bus+pipeline take ~5min and the http_endpoint trigger needs a NetworkAttachment to apply; revisit to add one or retarget the trigger

--- a/tool/example_debt.yaml
+++ b/tool/example_debt.yaml
@@ -6,3 +6,11 @@
 # a factory is neither covered nor listed, and when a listed factory becomes
 # covered (remove the line) — adding a line is a reviewed decision, not a
 # default.
+
+# Monitoring factories that cannot `terraform apply` against a standalone
+# apply-smoke project, so monitoring_quickstart uses the applyable variants
+# instead (the custom-service resource) and drops the self-linking monitored
+# project. Tracked here rather than forced into an example that would fail the
+# apply-smoke sweep.
+GoogleMonitoringService: typed google_monitoring_service needs a basic_service identifier bound to a real well-known service (App Engine / Istio / etc.) absent from a bare project; the applyable GoogleMonitoringCustomService is exercised by monitoring_quickstart instead
+GoogleMonitoringMonitoredProject: links another project into a metrics scope — self-linking the scoping project is rejected, and cross-project linking needs a second project plus roles/monitoring.admin on both, which a standalone apply-smoke project can't provide


### PR DESCRIPTION
## Context

After #149 + #150 merged, I dispatched the nightly apply-smoke sweep (run 27487915269). Result: **1 OK / 13 FAILED / 11 skipped**. The failures clustered into three causes, not 13 separate bugs:

1. **apply-smoke SA lacked permissions** (9 examples) — `editor` excludes resource-level `setIamPolicy`, custom-role creation, WIF-pool creation. **Resolved out-of-band**: granted the apply-smoke SA `roles/owner` on `terradart-validate` (throwaway dogfood; WIF is repo-scoped; owner IAM separate). This unblocks secret_manager/pubsub/iam/cloud_run/compute/dns/firestore×2/monitoring without code changes.
2. **API not enabled** — cloud_tasks, kms.
3. **Real config bugs** — gke, monitoring, eventarc.

This PR fixes (2) and (3). A separate PR (#152) fixes the **silent-teardown** gap that let the sweep orphan a GKE cluster.

## API enablement
- **cloud_tasks** → `Apis.enable([cloudTasks])`
- **kms** → `Apis.enable([kmsApi])`

(per-resource `dependsOn` + `TimeProvider`, satisfying the synth-gate API ratchet)

## Real config bugs
- **gke** — `INVALID_BACKUP_SCOPE`: the backup plan declared no scope; added `backup_config { all_namespaces, include_secrets, include_volume_data }`.
- **monitoring** — the typed `google_monitoring_service` needs a `basic_service` identifier bound to a real well-known service (App Engine/Istio) absent from a bare project, so switched to the **custom-service** resource and reworked the SLO to a **request-based good/total ratio**; added the required `resource.type="cloud_run_revision"` to the alert filter; dropped the **self-linking monitored project** (rejected on a standalone project — it hung ~20 min then 403'd).
- **eventarc** — enrollment `destination` → the in-stack **pipeline** (was a Workflow); enabled **`eventarcpublishing.googleapis.com`** for the channel; gave the trigger a real **service account**.

## Coverage / skip ledgers
- `tool/example_debt.yaml` — `GoogleMonitoringService` + `GoogleMonitoringMonitoredProject` (no applyable standalone form; the applyable custom-service variant is now exercised instead).
- `tool/apply_smoke_skip.yaml` — **eventarc** (Eventarc Advanced bus+pipeline take ~5 min and the `http_endpoint` trigger needs a `NetworkAttachment` to apply; the correctness fixes above are kept — revisit to add a NetworkAttachment or retarget the trigger).

## Verification
`tool/agent_verify.sh` green: 25/25 `terraform validate`, synth coverage (207 + 2 debt = 209), API ratchet, all tests, wrap/lint/enum/fingerprint.

Real apply is validated by re-running the nightly sweep **after this + #152 merge** (so teardown is safe). Expected apply set: 13 (eventarc now skipped).

## Merge order
**#152 (teardown safety) first**, then this — so the re-sweep can't silently orphan resources again.