### PR TITLE
fix(examples): apply-time long tail from the 2nd sweep (round 3)

### DIFF
--- a/examples/cloud_run_quickstart/README.md
+++ b/examples/cloud_run_quickstart/README.md
@@ -1,18 +1,18 @@
 # Cloud Run v2 quickstart
 
-End-to-end terradart example for a Cloud Run v2 Service with a secret-backed environment variable, Serverless VPC Access, and Memorystore Redis. Provisions a Secret Manager secret, API enablement with propagation sleep, a VPC Access connector on the default VPC, a Redis cache instance, then a Cloud Run service that consumes the secret via the sealed `EnvVarFromSecret` variant of `EnvVarSource` and routes private-range egress through the connector.
+End-to-end terradart example for a Cloud Run v2 Service with a secret-backed environment variable, Serverless VPC Access, and Memorystore (Redis + Memcache) reached over Private Service Access. Provisions a Secret Manager secret, API enablement with propagation sleep, a dedicated VPC with a Private Service Access (PSA) peering, a VPC Access connector, Redis and Memcache instances on that VPC, then a Cloud Run service that consumes the secret via the sealed `EnvVarFromSecret` variant of `EnvVarSource` and routes private-range egress through the connector.
 
 ## Prerequisites
 
 - Dart SDK >= 3.6
 - Terraform CLI >= 1.11.0
-- A GCP project with credentials configured (`gcloud auth application-default login`). The stack enables the Run, Secret Manager, VPC Access, and Redis APIs via `Apis.enable`.
+- A GCP project with credentials configured (`gcloud auth application-default login`). The stack enables the Compute, Run, Secret Manager, Service Networking, VPC Access, Redis, and Memcache APIs via `Apis.enable`.
 
 ## Layout
 
 ```
 examples/cloud_run_quickstart/
-├── lib/main.dart        # ApiServiceStack: secret + APIs + VPC connector + Redis + Cloud Run service
+├── lib/main.dart        # ApiServiceStack: secret + APIs + VPC + PSA + connector + Redis/Memcache + Cloud Run service
 ├── bin/infra.dart       # Synth entry
 ├── tf-out/              # (created on synth) main.tf.json
 └── pubspec.yaml
@@ -31,10 +31,12 @@ terraform apply
 
 ## What gets created
 
-- API enablement via [`Apis.enable`](../../packages/terradart_google/lib/src/project/apis.dart) (`Barrels.cloudRun`, `Barrels.secretManager`, `Barrels.serviceNetworking`, `Barrels.redis`) with a 60s `TimeSleep` propagation wait (`TimeProvider` on the stack).
+- API enablement via [`Apis.enable`](../../packages/terradart_google/lib/src/project/apis.dart) (`Barrels.compute`, `Barrels.cloudRun`, `Barrels.secretManager`, `Barrels.serviceNetworking`, `Barrels.redis`, `Barrels.memcache`) with a 60s `TimeSleep` propagation wait (`TimeProvider` on the stack).
 - A Secret Manager secret `api-db-password` with user-managed replication in `asia-northeast1`.
-- A Serverless VPC Access connector `run-vpc` (`10.8.0.0/28` on the `default` VPC).
-- A Memorystore Redis instance `api-cache` (1 GiB, basic tier on the `default` VPC).
+- A dedicated VPC `app-vpc` (`auto_create_subnetworks = false`) plus a Private Service Access chain: a `VPC_PEERING`/`INTERNAL` global address `app-psa-range` (`/16`) and a `google_service_networking_connection` that peers `servicenetworking.googleapis.com` into the VPC. Memorystore instances reach the project over this peering.
+- A Serverless VPC Access connector `run-vpc` (`10.8.0.0/28` on `app-vpc`).
+- A Memorystore Redis instance `api-cache` (1 GiB, basic tier) on `app-vpc` with `connect_mode = PRIVATE_SERVICE_ACCESS`.
+- A Memorystore Memcache instance `api-sessions` (1 node, 1 vCPU / 1 GiB) on `app-vpc`.
 - A Cloud Run v2 Service `api` running `gcr.io/cloudrun/hello`:
   - 1 literal env var: `LOG_LEVEL=info` via `EnvVarFromLiteral`.
   - 1 secret-backed env var: `DB_PASSWORD` via `EnvVarFromSecret(secret: 'api-db-password', version: 'latest')`.

--- a/examples/cloud_run_quickstart/lib/main.dart
+++ b/examples/cloud_run_quickstart/lib/main.dart
@@ -33,6 +33,7 @@ library;
 
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/cloud_run.dart';
+import 'package:terradart_google/compute.dart';
 import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
@@ -52,13 +53,17 @@ final class ApiServiceStack extends Stack {
         ) {
     // ---- API enablement + Wave 25 VPC Access + Wave 32 Redis --------------
     //
-    // [Apis.enable] enables the Run, Secret Manager, VPC Access, Redis,
-    // and Memcache APIs and waits 60s for propagation before dependents
-    // apply.
+    // [Apis.enable] enables the Compute, Run, Secret Manager, Service
+    // Networking, VPC Access, Redis, and Memcache APIs and waits 60s for
+    // propagation before dependents apply. Compute + Service Networking back
+    // the Private Service Access (PSA) chain the Memorystore instances peer
+    // into; without them apply fails with "Google private service access is
+    // not enabled".
 
     final apiDeps = Apis.enable(
       this,
       barrels: [
+        Barrels.compute,
         Barrels.cloudRun,
         Barrels.secretManager,
         Barrels.serviceNetworking,
@@ -81,12 +86,58 @@ final class ApiServiceStack extends Stack {
       ),
     );
 
+    // ---- Private Service Access (PSA) for Memorystore ---------------------
+    //
+    // Memorystore Redis (private) and Memcache reach the project over VPC
+    // peering, which requires a Private Service Access connection on a real
+    // VPC. The `default` network has no PSA range, so apply fails with
+    // "Google private service access is not enabled" / "Invalid authorized
+    // network 'default'". Provision the standard three-resource PSA chain
+    // against a dedicated VPC and point both caches at it:
+    //
+    //   1. GoogleComputeNetwork        — the consumer VPC.
+    //   2. GoogleComputeGlobalAddress  — reserves an internal /16 for Google
+    //      services to peer into (purpose VPC_PEERING, address_type INTERNAL).
+    //   3. GoogleServiceNetworkingConnection — peers
+    //      servicenetworking.googleapis.com into the VPC against that range.
+
+    final vpc = add(
+      GoogleComputeNetwork(
+        localName: 'app_vpc',
+        name: TfArg.literal('app-vpc'),
+        autoCreateSubnetworks: TfArg.literal(false),
+        dependsOn: apiDeps,
+      ),
+    );
+
+    final psaRange = add(
+      GoogleComputeGlobalAddress(
+        localName: 'psa_range',
+        name: TfArg.literal('app-psa-range'),
+        addressType: TfArg.literal(GlobalAddressType.internal),
+        purpose: TfArg.literal(GlobalAddressPurpose.vpcPeering),
+        prefixLength: TfArg.literal(16),
+        network: TfArg.ref(vpc.id),
+        dependsOn: apiDeps,
+      ),
+    );
+
+    final psaConnection = add(
+      GoogleServiceNetworkingConnection(
+        localName: 'psa',
+        network: TfArg.ref(vpc.id),
+        service: TfArg.literal('servicenetworking.googleapis.com'),
+        reservedPeeringRanges: TfArg.literal([psaRange.nameRef.interpolation]),
+        dependsOn: apiDeps,
+      ),
+    );
+
     final runConnector = GoogleVpcAccessConnector(
       localName: 'run_vpc',
       name: TfArg.literal('run-vpc'),
       region: TfArg.literal('asia-northeast1'),
       ipCidrRange: TfArg.literal('10.8.0.0/28'),
-      network: TfArg.literal('default'),
+      network: TfArg.ref(vpc.id),
       minInstances: TfArg.literal(2),
       maxInstances: TfArg.literal(3),
       dependsOn: apiDeps,
@@ -100,8 +151,17 @@ final class ApiServiceStack extends Stack {
         memorySizeGb: TfArg.literal(1),
         region: TfArg.literal('asia-northeast1'),
         tier: TfArg.literal(RedisInstanceTier.basic),
-        authorizedNetwork: TfArg.literal('default'),
-        dependsOn: apiDeps,
+        // Private Service Access: peer the instance into the dedicated VPC
+        // over the PSA range reserved above. The provider takes the network
+        // id (projects/<project>/global/networks/<name>), not a short name.
+        authorizedNetwork: TfArg.ref(vpc.id),
+        connectMode: TfArg.literal(
+          RedisInstanceConnectMode.privateServiceAccess,
+        ),
+        dependsOn: [
+          ...apiDeps,
+          ResourceDependency(psaConnection),
+        ],
       ),
     );
 
@@ -115,12 +175,17 @@ final class ApiServiceStack extends Stack {
           memorySizeMb: TfArg.literal(1024),
         ),
         region: TfArg.literal('asia-northeast1'),
-        // Memcache requires the full network path
-        // (projects/<project>/global/networks/<network>); a short name like
-        // 'default' fails apply with "Invalid format for authorized network".
-        authorizedNetwork:
-            TfArg.literal('projects/$projectId/global/networks/default'),
-        dependsOn: apiDeps,
+        // Memcache reaches the project only over Private Service Access, so
+        // it must peer into a VPC that has a PSA connection. Point it at the
+        // dedicated VPC's id (projects/<project>/global/networks/<name>) and
+        // order it after the peering; a short name or the default network
+        // (no PSA range) fails apply with "Google private service access is
+        // not enabled".
+        authorizedNetwork: TfArg.ref(vpc.id),
+        dependsOn: [
+          ...apiDeps,
+          ResourceDependency(psaConnection),
+        ],
       ),
     );
 
@@ -275,13 +340,19 @@ final class ApiServiceStack extends Stack {
       ),
     );
 
-    // ---- Wave 24: worker pool invoker -------------------------------------
+    // ---- Wave 24: worker pool access --------------------------------------
+    //
+    // Worker pools have no request-driven invocation path, so the IAM API
+    // rejects `roles/run.invoker` here ("Role roles/run.invoker is not
+    // supported for this resource"). Grant the resource-scoped Cloud Run
+    // Developer role (`roles/run.developer`) instead -- the documented role
+    // for managing a worker pool and its revisions -- to the same SA.
 
     add(
       GoogleCloudRunV2WorkerPoolIamMember(
-        localName: 'batch_workers_invoker',
+        localName: 'batch_workers_developer',
         name: TfArg.ref(batchWorkers.nameRef),
-        role: TfArg.literal('roles/run.invoker'),
+        role: TfArg.literal('roles/run.developer'),
         member: TfArg.ref(schedulerSa.iamMember),
         location: TfArg.literal('asia-northeast1'),
       ),

--- a/examples/cloud_tasks_quickstart/lib/main.dart
+++ b/examples/cloud_tasks_quickstart/lib/main.dart
@@ -8,6 +8,7 @@ library;
 
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/cloud_tasks.dart';
+import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/time.dart';
@@ -51,6 +52,21 @@ final class EmailJobsStack extends Stack {
       ),
     );
 
+    // The service account that enqueues tasks. The IAM binding below grants it
+    // the enqueuer role; without this SA the binding fails with "Service
+    // account ... does not exist". `google_service_account` is not API-gated,
+    // so no Apis dependency is required.
+    final enqueuerSa = add(
+      GoogleServiceAccount(
+        localName: 'enqueuer',
+        accountId: TfArg.literal('enqueuer'),
+        displayName: TfArg.literal('Cloud Tasks enqueuer'),
+      ),
+    );
+
+    // Grant the enqueuer role. The member is derived from the SA's
+    // pre-formatted `serviceAccount:<email>` ref, and dependsOn ensures the SA
+    // exists before the policy is applied.
     add(
       GoogleCloudTasksQueueIamMember(
         localName: 'email_jobs_enqueuer',
@@ -58,9 +74,8 @@ final class EmailJobsStack extends Stack {
         name: TfArg.ref(queue.nameRef),
         location: TfArg.ref(queue.locationRef),
         role: TfArg.literal('roles/cloudtasks.enqueuer'),
-        member: TfArg.literal(
-          'serviceAccount:enqueuer@$projectId.iam.gserviceaccount.com',
-        ),
+        member: TfArg.ref(enqueuerSa.iamMember),
+        dependsOn: [ResourceDependency(enqueuerSa)],
       ),
     );
 

--- a/examples/compute_quickstart/lib/main.dart
+++ b/examples/compute_quickstart/lib/main.dart
@@ -17,7 +17,9 @@ library;
 
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/compute.dart';
+import 'package:terradart_google/data.dart';
 import 'package:terradart_google/filestore.dart';
+import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/time.dart';
@@ -38,6 +40,31 @@ final class NetworkStack extends Stack {
       this,
       barrels: [Barrels.compute, Barrels.filestore],
       propagationDelay: const Duration(seconds: 60),
+    );
+
+    // Look up the live project so IAM bindings can reference the real
+    // Google APIs service agent (`<number>@cloudservices.gserviceaccount.com`)
+    // instead of a hardcoded, non-existent project number. The cloudservices
+    // agent always exists for a project, so the binding is valid once the
+    // real number is interpolated. Data source + IAM members are not
+    // API-gated, so no `dependsOn: apiDeps` is required here.
+    final current = addData(
+      GoogleProject(
+        localName: 'current',
+        projectId: TfArg.literal(projectId),
+      ),
+    );
+
+    // Service accounts that the instance- and disk-scoped IAM bindings below
+    // grant access to. We create them in-stack (rather than referencing a
+    // Google Group or an out-of-band SA that does not exist) so apply
+    // succeeds end to end. SAs are not API-gated.
+    final oncallSre = add(
+      GoogleServiceAccount(
+        localName: 'oncall_sre',
+        accountId: TfArg.literal('oncall-sre'),
+        displayName: TfArg.literal('On-call SRE (bastion power-cycle)'),
+      ),
     );
 
     final mainVpc = GoogleComputeNetwork(
@@ -100,7 +127,8 @@ final class NetworkStack extends Stack {
         localName: 'shared_nfs',
         name: TfArg.literal('shared-nfs'),
         tier: TfArg.literal(FilestoreInstanceTier.basicHdd),
-        location: TfArg.literal('asia-northeast1'),
+        // Basic-tier Filestore is zonal — location must be a zone, not a region.
+        location: TfArg.literal('asia-northeast1-a'),
         fileShares: FilestoreInstanceFileShare(
           name: TfArg.literal('share1'),
           capacityGb: TfArg.literal(1024),
@@ -119,7 +147,8 @@ final class NetworkStack extends Stack {
       GoogleFilestoreSnapshot(
         localName: 'share_snap',
         name: TfArg.literal('share-snap-1'),
-        location: TfArg.literal('asia-northeast1'),
+        // Snapshot lives in the source instance's zone.
+        location: TfArg.literal('asia-northeast1-a'),
         instance: TfArg.ref(sharedNfs.id),
       ),
     );
@@ -145,8 +174,12 @@ final class NetworkStack extends Stack {
         localName: 'workload_subnet_user',
         subnetwork: TfArg.ref(workloadSubnet.nameRef),
         role: TfArg.literal('roles/compute.networkUser'),
+        // Google APIs service agent for this project. Interpolate the real
+        // project number from the `google_project` data source so the
+        // member resolves to an identity that actually exists.
         member: TfArg.literal(
-          'serviceAccount:111111111111@cloudservices.gserviceaccount.com',
+          'serviceAccount:${current.number.interpolation}'
+          '@cloudservices.gserviceaccount.com',
         ),
       ),
     );
@@ -187,29 +220,21 @@ final class NetworkStack extends Stack {
         localName: 'bastion_admin',
         instanceName: TfArg.ref(bastion.nameRef),
         role: TfArg.literal('roles/compute.instanceAdmin.v1'),
-        member: TfArg.literal('group:on-call-sre@example.com'),
+        // Google Groups can't be created via Terraform, so a `group:` member
+        // referencing a non-existent group fails apply. Bind an in-stack SA
+        // instead via its pre-formatted `serviceAccount:<email>` member.
+        member: TfArg.ref(oncallSre.iamMember),
         zone: TfArg.literal('asia-northeast1-a'),
+        dependsOn: [ResourceDependency(oncallSre)],
       ),
     );
 
     // ---- Disk-scoped IAM (backup-only access) -----------------------------
     //
-    // A persistent data disk created out-of-band (gcloud / imported); the
-    // backup tooling SA gets `roles/compute.storageAdmin` on *this one
-    // disk* so it can snapshot it without project-wide disk admin. The
-    // disk name is a string literal -- substitute the real disk resource
-    // once it lands in the curated set.
-
-    add(
-      GoogleComputeDiskIamMember(
-        localName: 'data_disk_backup',
-        name: TfArg.literal('persistent-data-disk'),
-        role: TfArg.literal('roles/compute.storageAdmin'),
-        member: TfArg.literal(
-          'serviceAccount:backup@example.iam.gserviceaccount.com',
-        ),
-        zone: TfArg.literal('asia-northeast1-a'),
-      ),
-    );
+    // Disk-scoped IAM (`google_compute_disk_iam_member`) needs a real disk to
+    // attach to, but `google_compute_disk` is not curated yet, so there is no
+    // applyable disk to bind in-stack. The binding is tracked in
+    // tool/example_debt.yaml until a curated disk resource lands; re-add it
+    // here (pointing at the in-stack disk) then.
   }
 }

--- a/examples/dns_quickstart/lib/main.dart
+++ b/examples/dns_quickstart/lib/main.dart
@@ -128,7 +128,11 @@ final class InternalDnsStack extends Stack {
         localData: DnsResponsePolicyRuleLocalData(
           localDatas: [
             DnsResponsePolicyRuleLocalDataEntry(
-              name: TfArg.literal('legacy'),
+              // The local-data rrSet name must be a fully-qualified DNS name
+              // (trailing dot), matching the rule's `dns_name` above. A bare
+              // label such as 'legacy' is rejected at apply time
+              // ("Invalid value for ...localData.rrSet.Name: 'legacy'").
+              name: TfArg.literal('legacy.internal.corp.'),
               type: DnsResponsePolicyRuleRecordType.a,
               ttl: TfArg.literal(300),
               rrdatas: const ['10.0.0.20'],

--- a/examples/firestore_quickstart/lib/main.dart
+++ b/examples/firestore_quickstart/lib/main.dart
@@ -1,9 +1,11 @@
 /// Firestore quickstart -- Wave 4 Round 1 end-to-end example.
 ///
 /// Defines a `MessagesStack` that provisions:
-/// - the project's `(default)` Firestore database in Native mode, anchored
+/// - a named `quickstart-db` Firestore database in Native mode, anchored
 ///   to `asia-northeast1`, with point-in-time recovery enabled and delete
-///   protection on;
+///   protection off (so the database can be torn down cleanly -- the
+///   `(default)` database cannot be deleted once created, which makes a
+///   create/destroy cycle impossible);
 /// - a composite index on the `messages` collection ordered by `user_id`
 ///   ascending then `created_at` descending (suitable for "show me a given
 ///   user's most recent messages" queries).
@@ -24,14 +26,14 @@ final class MessagesStack extends Stack {
           ],
         ) {
     final db = GoogleFirestoreDatabase(
-      localName: 'default',
-      name: TfArg.literal('(default)'),
+      localName: 'messages',
+      name: TfArg.literal('quickstart-db'),
       locationId: TfArg.literal('asia-northeast1'),
       type: TfArg.literal(FirestoreDatabaseType.firestoreNative),
       pointInTimeRecoveryEnablement: TfArg.literal(
         PointInTimeRecoveryEnablement.enabled,
       ),
-      deleteProtectionState: TfArg.literal(DeleteProtectionState.enabled),
+      deleteProtectionState: TfArg.literal(DeleteProtectionState.disabled),
       concurrencyMode: TfArg.literal(ConcurrencyMode.optimistic),
     );
     add(db);

--- a/examples/gke_quickstart/README.md
+++ b/examples/gke_quickstart/README.md
@@ -1,6 +1,6 @@
 # GKE quickstart
 
-End-to-end terradart example for Google Kubernetes Engine, GKE Hub, and GKE Backup. Provisions a custom-mode VPC, cluster + node pool, Hub fleet membership, backup/restore channels and plans, and plan-scoped IAM members.
+End-to-end terradart example for Google Kubernetes Engine, GKE Hub, and GKE Backup. Provisions a custom-mode VPC, cluster + node pool, Hub fleet membership, and a backup plan + restore plan with plan-scoped IAM members bound to a dedicated service account.
 
 ## Prerequisites
 
@@ -35,8 +35,10 @@ terraform apply
 - VPC `gke-vpc` and subnet `gke-subnet` in `asia-northeast1`.
 - Regional cluster `main-gke` with `remove_default_node_pool = true`.
 - Node pool `primary-pool` attached to the cluster.
-- Default GKE Hub fleet and membership `main-cluster`.
-- GKE Backup channels, backup plan `main-backup-plan`, restore plan `main-restore-plan`, and plan IAM members.
+- GKE Hub membership `main-cluster`, enrolled in the project's auto-created default fleet.
+- GKE Backup plan `main-backup-plan` (daily schedule) and restore plan `main-restore-plan`, each with a plan-scoped IAM binding to the `gke-backup-operator` service account.
+
+> Backup/restore *channels* and the default *fleet* resource are intentionally omitted. Channels are inherently cross-project (source must differ from destination), and the default fleet is auto-created (creating it returns 409). Both are tracked in `tool/example_debt.yaml`.
 
 ## Related examples
 

--- a/examples/gke_quickstart/lib/main.dart
+++ b/examples/gke_quickstart/lib/main.dart
@@ -6,14 +6,21 @@
 /// - a regional GKE cluster (Backup for GKE agent enabled, default node
 ///   pool removed);
 /// - a dedicated node pool on that cluster;
-/// - the project default GKE Hub fleet + membership;
-/// - backup/restore channels, backup + restore plans, and plan IAM members.
+/// - a GKE Hub membership enrolling the cluster in the project's
+///   auto-created default fleet;
+/// - a backup plan (+ schedule) and a restore plan, each with a
+///   resource-scoped IAM binding to a dedicated service account.
+///
+/// Backup/restore *channels* are intentionally omitted: they connect a
+/// source project to a *different* destination project, so they cannot
+/// apply in a single standalone project (the API rejects source==dest).
 library;
 
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/compute.dart';
 import 'package:terradart_google/container.dart';
 import 'package:terradart_google/gke_backup.dart';
+import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
 
@@ -92,14 +99,11 @@ final class GkeQuickstartStack extends Stack {
       ),
     );
 
-    final fleet = add(
-      GoogleGkeHubFleet(
-        localName: 'default',
-        displayName: TfArg.literal('Quickstart fleet'),
-        dependsOn: [ResourceDependency(apiGkeHub)],
-      ),
-    );
-
+    // Every project has exactly one fleet, and it is auto-created on first
+    // use of GKE Hub — creating `google_gke_hub_fleet` for the default fleet
+    // fails with "Resource '.../fleets/default' already exists" (409). So we
+    // skip the fleet resource and enroll the cluster directly; the membership
+    // registers against the auto-created default fleet.
     add(
       GoogleGkeHubMembership(
         localName: 'main',
@@ -115,7 +119,7 @@ final class GkeQuickstartStack extends Stack {
           ),
         }),
         dependsOn: [
-          ResourceDependency(fleet),
+          ResourceDependency(apiGkeHub),
           ResourceDependency(cluster),
         ],
       ),
@@ -123,24 +127,15 @@ final class GkeQuickstartStack extends Stack {
 
     // ---- Wave 10: GKE Backup ------------------------------------------------
 
-    add(
-      GoogleGkeBackupBackupChannel(
-        localName: 'default',
-        name: TfArg.literal('default-backup-channel'),
-        location: TfArg.literal(region),
-        // The API requires the `projects/{project}` form, not a bare ID.
-        destinationProject: TfArg.literal('projects/$projectId'),
-        dependsOn: [ResourceDependency(apiGkeBackup)],
-      ),
-    );
-
-    add(
-      GoogleGkeBackupRestoreChannel(
-        localName: 'default',
-        name: TfArg.literal('default-restore-channel'),
-        location: TfArg.literal(region),
-        destinationProject: TfArg.literal('projects/$projectId'),
-        dependsOn: [ResourceDependency(apiGkeBackup)],
+    // A dedicated service account is the IAM grantee for the backup/restore
+    // plans below. Resource-scoped `setIamPolicy` validates that the member
+    // exists, so binding a fabricated group (e.g. group:...@example.com)
+    // fails with "Invalid argument"; an in-stack SA is a real principal.
+    final backupOperator = add(
+      GoogleServiceAccount(
+        localName: 'backup_operator',
+        accountId: TfArg.literal('gke-backup-operator'),
+        displayName: TfArg.literal('GKE Backup operator'),
       ),
     );
 
@@ -176,7 +171,10 @@ final class GkeQuickstartStack extends Stack {
         localName: 'main',
         name: TfArg.literal('main-restore-plan'),
         location: TfArg.literal(region),
-        backupPlan: TfArg.ref(backupPlan.nameRef),
+        // The API requires the full backup-plan resource name
+        // (`projects/.../locations/.../backupPlans/...`); the bare `name`
+        // attribute is rejected with INVALID_FIELD. `id` is that full path.
+        backupPlan: TfArg.ref(backupPlan.id),
         cluster: TfArg.ref(cluster.id),
         restoreConfig: GkeBackupRestorePlanRestoreConfig(
           allNamespaces: TfArg.literal(true),
@@ -195,7 +193,8 @@ final class GkeQuickstartStack extends Stack {
         name: TfArg.ref(backupPlan.nameRef),
         location: TfArg.literal(region),
         role: TfArg.literal('roles/gkebackup.viewer'),
-        member: TfArg.literal('group:platform-admins@example.com'),
+        member: TfArg.ref(backupOperator.iamMember),
+        dependsOn: [ResourceDependency(backupOperator)],
       ),
     );
 
@@ -205,7 +204,8 @@ final class GkeQuickstartStack extends Stack {
         name: TfArg.ref(restorePlan.nameRef),
         location: TfArg.literal(region),
         role: TfArg.literal('roles/gkebackup.restoreOperator'),
-        member: TfArg.literal('group:platform-admins@example.com'),
+        member: TfArg.ref(backupOperator.iamMember),
+        dependsOn: [ResourceDependency(backupOperator)],
       ),
     );
   }

--- a/examples/monitoring_quickstart/lib/main.dart
+++ b/examples/monitoring_quickstart/lib/main.dart
@@ -200,11 +200,13 @@ final class LatencyAlertStack extends Stack {
             ),
           ),
         ],
+        // `notification_rate_limit` is only valid on log-based alert policies
+        // (those with a `condition_matched_log` condition). This is a
+        // metric-threshold policy, so the API rejects it ("only log-based
+        // alert policies may specify a notification rate limit"); keep only
+        // `auto_close`.
         alertStrategy: MonitoringAlertPolicyAlertStrategy(
           autoClose: TfArg.literal('1800s'),
-          notificationRateLimit: MonitoringAlertPolicyNotificationRateLimit(
-            period: TfArg.literal('300s'),
-          ),
         ),
         dependsOn: [
           ResourceDependency(oncallEmail),

--- a/examples/pubsub_quickstart/lib/main.dart
+++ b/examples/pubsub_quickstart/lib/main.dart
@@ -44,7 +44,13 @@ final class OrdersStack extends Stack {
       GooglePubsubSchemaIamMember(
         localName: 'orders_schema_publisher',
         schema: TfArg.ref(ordersSchema.id),
-        role: TfArg.literal('roles/pubsub.schemaAdmin'),
+        // `roles/pubsub.schemaAdmin` is a project-level role and is NOT
+        // grantable on an individual schema resource (apply fails with
+        // "Role ... is not supported for this resource"). At the schema
+        // resource level the publisher only needs to read/validate the
+        // schema, which `roles/pubsub.viewer` covers
+        // (pubsub.schemas.get/list/validate).
+        role: TfArg.literal('roles/pubsub.viewer'),
         member: TfArg.literal('serviceAccount:orders-publisher@example.com'),
         dependsOn: [ResourceDependency(ordersSchema)],
       ),

--- a/examples/secret_manager_quickstart/lib/main.dart
+++ b/examples/secret_manager_quickstart/lib/main.dart
@@ -10,6 +10,7 @@
 library;
 
 import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/secret_manager.dart';
 
@@ -47,16 +48,29 @@ final class DbCredentialsStack extends Stack {
       ),
     );
 
-    // 3. Grant accessor to the application service account.
+    // 3. The application service account that reads the secret. The IAM
+    //    binding below grants it accessor; without this SA the binding fails
+    //    with "Service account ... does not exist". Account IDs must be
+    //    6-30 chars, so use `app-runner` (the bare `app` is too short).
+    final appSa = add(
+      GoogleServiceAccount(
+        localName: 'app',
+        accountId: TfArg.literal('app-runner'),
+        displayName: TfArg.literal('Application runtime (secret reader)'),
+      ),
+    );
+
+    // 4. Grant accessor to the application service account. The member is
+    //    derived from the SA's pre-formatted `serviceAccount:<email>` ref, and
+    //    dependsOn ensures the SA exists before the policy is applied.
     add(
       GoogleSecretManagerSecretIamMember(
         localName: 'db_password_accessor',
         // Secret IAM identity is `secret_id` (NOT `id` / `name`).
         secretId: TfArg.ref(secret.secretIdRef),
         role: TfArg.literal('roles/secretmanager.secretAccessor'),
-        member: TfArg.literal(
-          'serviceAccount:app@$projectId.iam.gserviceaccount.com',
-        ),
+        member: TfArg.ref(appSa.iamMember),
+        dependsOn: [ResourceDependency(appSa)],
       ),
     );
 

--- a/tool/apply_smoke_skip.yaml
+++ b/tool/apply_smoke_skip.yaml
@@ -38,3 +38,6 @@ cloud_build_quickstart: needs a real GitHub App OAuth token secret + a peered VP
 
 # --- Provisioning latency / network infra the example doesn't provision
 eventarc_quickstart: Eventarc Advanced bus+pipeline take ~5min and the http_endpoint trigger needs a NetworkAttachment to apply; revisit to add one or retarget the trigger
+
+# --- Collides with the apply-smoke WIF auth infrastructure (must never apply here)
+iam_quickstart: creates a WIF pool id 'github-actions' that COLLIDES with the apply-smoke auth pool — applying it would 409 and its teardown could delete the pool CI auth depends on; WIF pools also have a 30-day soft-delete lock that breaks repeated sweeps

--- a/tool/example_debt.yaml
+++ b/tool/example_debt.yaml
@@ -14,3 +14,24 @@
 # apply-smoke sweep.
 GoogleMonitoringService: typed google_monitoring_service needs a basic_service identifier bound to a real well-known service (App Engine / Istio / etc.) absent from a bare project; the applyable GoogleMonitoringCustomService is exercised by monitoring_quickstart instead
 GoogleMonitoringMonitoredProject: links another project into a metrics scope — self-linking the scoping project is rejected, and cross-project linking needs a second project plus roles/monitoring.admin on both, which a standalone apply-smoke project can't provide
+
+# GKE Backup channels are inherently cross-project: a channel connects a source
+# project to a *different* destination project. In a standalone apply-smoke
+# project source==dest, which the API rejects with "source and destination
+# project cannot be same". Exercising them needs a second project, so
+# gke_quickstart drops them (it keeps the applyable backup/restore plans).
+GoogleGkeBackupBackupChannel: connects a source project to a different destination project; with only one project source==dest and creation fails 400 "source and destination project cannot be same". Needs a second project an apply-smoke run can't provide
+GoogleGkeBackupRestoreChannel: same cross-project constraint as GoogleGkeBackupBackupChannel — destination project must differ from the source, which a single standalone apply-smoke project cannot satisfy
+
+# Every project has exactly one fleet, auto-created on first GKE Hub use, so
+# creating google_gke_hub_fleet for the default fleet always fails 409
+# "Resource '.../fleets/default' already exists". gke_quickstart enrolls the
+# cluster via GoogleGkeHubMembership against the auto-created default fleet
+# instead of creating the fleet resource.
+GoogleGkeHubFleet: the project default fleet is auto-created, so applying google_gke_hub_fleet returns 409 "fleets/default already exists"; there is no second fleet to create in a standalone project and the provider exposes no data source to adopt the existing one
+
+# Disk-scoped IAM needs a real google_compute_disk to attach to, but
+# google_compute_disk is not curated yet, so compute_quickstart has no
+# applyable disk to bind. Re-add the binding to compute_quickstart (pointing at
+# an in-stack disk) once a disk resource is curated.
+GoogleComputeDiskIamMember: needs a real google_compute_disk to bind, which is not a curated factory yet; the binding 404s against a non-existent disk and there is no in-stack disk to attach in a standalone apply-smoke run


### PR DESCRIPTION
## Context

Trajectory: 1st sweep **1/14 OK** → owner-grant re-sweep **3/13 OK** (every permission error gone) → this round targets the remaining real apply-time bugs the re-sweep exposed. User opted for **max coverage** (fix everything, including PSA + named-DB), skip-listing only what's fundamentally impossible on a standalone project.

## Fixes (apply-time, invisible to synth/validate)
- **cloud_run** — Memorystore needs Private Service Access: added a dedicated VPC + `GoogleComputeGlobalAddress` (VPC_PEERING) + `GoogleServiceNetworkingConnection`, wired Redis (`connect_mode=PRIVATE_SERVICE_ACCESS`) / Memcache / connector to it; worker-pool IAM `run.invoker` → `run.developer`
- **firestore** — named database `quickstart-db` instead of `(default)` (the default DB can't be deleted → 409 every re-apply)
- **gke** — dropped the cross-project backup/restore **channels** and the singleton **default fleet** (debt-listed); restore plan now references the backup plan by full id; backup-plan IAM binds a real in-stack SA
- **secret_manager / cloud_tasks** — created the service accounts their IAM bindings referenced (were non-existent → 400)
- **compute** — real identities (project cloudservices agent via a `google_project` data source; in-stack SAs); Filestore basic tier is **zonal** (region → zone); dropped disk-scoped IAM (no curated `google_compute_disk` to attach → debt-listed)
- **pubsub** — schema IAM `roles/pubsub.schemaAdmin` → `roles/pubsub.viewer`
- **dns** — response-policy rule rrSet name must be an FQDN (`legacy` → `legacy.internal.corp.`)
- **monitoring** — dropped `notificationRateLimit` (only valid on log-based alerts)

## Coverage debt (no applyable standalone form)
`GoogleGkeBackupBackupChannel`, `GoogleGkeBackupRestoreChannel`, `GoogleGkeHubFleet`, `GoogleComputeDiskIamMember`.

## Verification
`tool/agent_verify.sh` green: 25/25 `terraform validate`, synth coverage (203 + 6 debt = 209), API ratchet, all tests, wrap/lint/enum/fingerprint. Real apply validated by the next sweep (teardown safety from #152 is already on main, so it can't silently orphan).

Expected apply set after merge: **12** (iam now skipped too).