### PR TITLE
fix(examples): cloud_run secret version + gke restore/membership (round 5)

### DIFF
--- a/examples/cloud_run_quickstart/lib/main.dart
+++ b/examples/cloud_run_quickstart/lib/main.dart
@@ -86,6 +86,19 @@ final class ApiServiceStack extends Stack {
       ),
     );
 
+    // The secret needs a VERSION holding the value; without it the service's
+    // `versions/latest` reference 404s ("Secret ... versions/latest was not
+    // found"). Write-only data keeps the value out of Terraform state (§10.4).
+    final dbPasswordV1 = add(
+      GoogleSecretManagerSecretVersion(
+        localName: 'db_password_v1',
+        secret: TfArg.ref(dbPassword.id),
+        secretDataWo: TfArg.literal('apply-smoke-placeholder'),
+        secretDataWoVersion: TfArg.literal(1),
+        dependsOn: [ResourceDependency(dbPassword)],
+      ),
+    );
+
     // ---- Runtime service account for the Cloud Run service ----------------
     //
     // The service mounts `api-db-password` as a secret-backed env var. Cloud
@@ -105,7 +118,7 @@ final class ApiServiceStack extends Stack {
       ),
     );
 
-    add(
+    final secretAccessor = add(
       GoogleSecretManagerSecretIamMember(
         localName: 'api_runtime_secret_accessor',
         secretId: TfArg.ref(dbPassword.secretIdRef),
@@ -283,6 +296,10 @@ final class ApiServiceStack extends Stack {
       dependsOn: [
         ...apiDeps,
         ResourceDependency(runConnector),
+        // The secret version must exist (so `latest` resolves) and the runtime
+        // SA must already have accessor on it, before the revision starts.
+        ResourceDependency(dbPasswordV1),
+        ResourceDependency(secretAccessor),
       ],
     );
     add(apiService);

--- a/examples/gke_quickstart/lib/main.dart
+++ b/examples/gke_quickstart/lib/main.dart
@@ -97,7 +97,7 @@ final class GkeQuickstartStack extends Stack {
       ),
     );
 
-    add(
+    final primaryPool = add(
       GoogleContainerNodePool(
         localName: 'primary',
         name: TfArg.literal('primary-pool'),
@@ -130,6 +130,10 @@ final class GkeQuickstartStack extends Stack {
         dependsOn: [
           ResourceDependency(apiGkeHub),
           ResourceDependency(cluster),
+          // Wait for the node pool so the cluster isn't mid-operation when the
+          // membership registers ("cluster is currently running another
+          // operation").
+          ResourceDependency(primaryPool),
         ],
       ),
     );
@@ -193,6 +197,10 @@ final class GkeQuickstartStack extends Stack {
           namespacedResourceRestoreMode:
               GkeBackupRestorePlanNamespacedResourceRestoreMode
                   .deleteAndRestore,
+          // Required whenever namespaced resources are selected; this demo has
+          // no persistent volumes to restore.
+          volumeDataRestorePolicy: GkeBackupRestorePlanVolumeDataRestorePolicy
+              .noVolumeDataRestoration,
         ),
         dependsOn: [
           ResourceDependency(apiGkeBackup),


### PR DESCRIPTION
## Context

The 4th sweep reached **7/9 OK** (no teardown orphans — the round-4 `deletion_protection=false` fix worked). These are the last two failures.

## Fixes
- **cloud_run** — the service mounts secret `api-db-password` version `latest`, but the stack created the secret with **no version**, so apply failed `Secret ... versions/latest was not found`. Added a `GoogleSecretManagerSecretVersion` (write-only data, kept out of state per §10.4) and made the service `dependsOn` the version + the accessor IAM binding so `latest` resolves and the runtime SA can read it before the revision starts.
- **gke** — two issues:
  - `RestorePlan: volumeDataRestorePolicy is required` once namespaced resources are selected → set `NO_VOLUME_DATA_RESTORATION` (no PVs in this demo).
  - `Membership: cluster is currently running another operation` (the membership raced the cluster's node-pool creation) → the membership now also `dependsOn` the node pool, so it waits until the cluster is stable.

## Verification
`tool/agent_verify.sh` green: 25/25 `terraform validate`, synth coverage (201 + 8 debt = 209), API ratchet, all tests, wrap/lint/enum/fingerprint.

## Expected
This should bring the sweep to **9/9** (the 7 already-green plus these two). See #151.