### PR TITLE
fix(examples): firestore deletion_policy + drop gke restore-plan IAM (round 6)

### DIFF
--- a/examples/firestore_quickstart/lib/main.dart
+++ b/examples/firestore_quickstart/lib/main.dart
@@ -34,6 +34,10 @@ final class MessagesStack extends Stack {
         PointInTimeRecoveryEnablement.enabled,
       ),
       deleteProtectionState: TfArg.literal(DeleteProtectionState.disabled),
+      // DELETE (not the default ABANDON) so `terraform destroy` actually
+      // removes the named database; otherwise it lingers and the next
+      // apply-smoke run fails 409 "Database already exists".
+      deletionPolicy: TfArg.literal('DELETE'),
       concurrencyMode: TfArg.literal(ConcurrencyMode.optimistic),
     );
     add(db);

--- a/examples/gke_quickstart/lib/main.dart
+++ b/examples/gke_quickstart/lib/main.dart
@@ -179,7 +179,7 @@ final class GkeQuickstartStack extends Stack {
       ),
     );
 
-    final restorePlan = add(
+    add(
       GoogleGkeBackupRestorePlan(
         localName: 'main',
         name: TfArg.literal('main-restore-plan'),
@@ -221,15 +221,9 @@ final class GkeQuickstartStack extends Stack {
       ),
     );
 
-    add(
-      GoogleGkeBackupRestorePlanIamMember(
-        localName: 'restorer',
-        name: TfArg.ref(restorePlan.nameRef),
-        location: TfArg.literal(region),
-        role: TfArg.literal('roles/gkebackup.restoreOperator'),
-        member: TfArg.ref(backupOperator.iamMember),
-        dependsOn: [ResourceDependency(backupOperator)],
-      ),
-    );
+    // Restore-plan IAM is omitted: the backup-plan IAM above already
+    // demonstrates GKE Backup resource-level IAM, and the restore-plan binding
+    // is tracked in tool/example_debt.yaml (its role kept hitting "Invalid
+    // argument" at the restore-plan resource scope).
   }
 }

--- a/tool/example_debt.yaml
+++ b/tool/example_debt.yaml
@@ -53,3 +53,9 @@ GoogleFirestoreUserCreds: requires an Enterprise-edition (MongoDB-compatible) Fi
 # Re-add a snapshot to an example once a zonal/enterprise-tier instance is
 # exercised (those tiers cost more, so the smoke run uses BASIC_HDD).
 GoogleFilestoreSnapshot: snapshots are unsupported on the BASIC_HDD tier used by compute_quickstart's applyable instance (snapshots require the zonal/high-scale-SSD/enterprise tiers); apply 404s with "Error creating Snapshot". Basic tiers support GoogleFilestoreBackup instead, which the example keeps
+
+# Setting IAM on a restore plan rejected the binding with 400 "Invalid argument"
+# at the restore-plan resource scope. GoogleGkeBackupBackupPlanIamMember already
+# demonstrates GKE Backup resource-level IAM in gke_quickstart, so the redundant
+# per-restore-plan binding is dropped rather than chased further.
+GoogleGkeBackupRestorePlanIamMember: resource-level setIamPolicy on a restore plan failed 400 "Invalid argument"; the sibling GoogleGkeBackupBackupPlanIamMember already covers GKE Backup resource-level IAM in gke_quickstart, so this binding is dropped


### PR DESCRIPTION
## Context

The 5th sweep reached **7/9** (cloud_run now applies). These are the last two; verified the fix against the provider schema via the Terraform MCP before re-sweeping.

## Fixes
- **firestore** — the named database used the default `deletion_policy = ABANDON`, so `terraform destroy` dropped it from state but left it live; the next run then failed `409 Database already exists`. Set `deletion_policy = "DELETE"`. Confirmed via the provider docs (`google_firestore_database`): default is `ABANDON`, and `DELETE` is required for destroy to actually delete the database. (The lingering `quickstart-db` from the prior run was removed by hand via gcloud so this run starts clean.)
- **gke** — setting IAM on the restore plan failed `400 Invalid argument` at the restore-plan resource scope. The restore plan itself applies; only the binding fails. The sibling `GoogleGkeBackupBackupPlanIamMember` already demonstrates GKE Backup resource-level IAM, so the redundant restore-plan binding is dropped and debt-listed (`GoogleGkeBackupRestorePlanIamMember`).

## Verification
`tool/agent_verify.sh` green: 25/25 `terraform validate`, synth coverage (200 + 9 debt = 209), API ratchet, all tests, wrap/lint/enum/fingerprint. Firestore field verified against the live provider schema (Terraform MCP).

## Expected
This should bring the sweep to **9/9** — all applyable examples green. See #151.