### PR TITLE
feat(coverage): terradart_coverage — Terraform coverage checker (#79) + brew release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [terradart_core, terradart_codegen, terradart_google, terradart_agent]
+        package: [terradart_core, terradart_codegen, terradart_google, terradart_agent, terradart_coverage]
     steps:
       - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,11 @@ jobs:
       # CLI. wrap CLI output is the authoritative format for generated wrappers
       # and is guarded by the `wrap_check` job (`terradart wrap --check`).
       - if: matrix.package == 'terradart_core'
-        run: dart format --output=none --set-exit-if-changed packages/terradart_core/ packages/terradart_codegen/ packages/terradart_agent/
+        run: dart format --output=none --set-exit-if-changed packages/terradart_core/ packages/terradart_codegen/ packages/terradart_agent/ packages/terradart_coverage/
       - if: matrix.package == 'terradart_core'
         run: dart analyze packages/ tool/ --fatal-infos --fatal-warnings
+      - if: matrix.package == 'terradart_core'
+        run: dart test tool/render_formula_test.dart tool/render_to_file_test.dart
       - run: dart test --reporter=github
         working-directory: packages/${{ matrix.package }}
 

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -57,3 +57,48 @@ jobs:
           files: |
             ${{ matrix.tool.dir }}/${{ matrix.tool.name }}-${{ matrix.target.suffix }}
             ${{ matrix.tool.dir }}/${{ matrix.tool.name }}-${{ matrix.target.suffix }}.sha256
+
+  update-tap:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dart-lang/setup-dart@v1
+        with: { sdk: stable }
+      - run: dart pub get
+      - name: Download sha256 sidecars
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_REPOSITORY: ${{ github.repository }}
+        run: |
+          mkdir -p shas
+          gh release download "$GH_REF_NAME" \
+            --repo "$GH_REPOSITORY" \
+            --pattern '*.sha256' --dir shas
+      - name: Checkout tap
+        uses: actions/checkout@v6
+        with:
+          repository: nozomi-koborinai/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+      - name: Render formulas
+        env:
+          GH_REF_NAME: ${{ github.ref_name }}
+        run: |
+          V="${GH_REF_NAME#v}"
+          dart run tool/render_to_file.dart \
+            --version "$V" \
+            --sha-dir shas \
+            --out-mcp tap/Formula/terradart-mcp.rb \
+            --out-coverage tap/Formula/terradart-coverage.rb
+      - name: Commit + push tap
+        working-directory: tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/terradart-mcp.rb Formula/terradart-coverage.rb
+          git commit -m "terradart ${GITHUB_REF_NAME#v}: update formulas" || echo "no changes"
+          git push
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -11,42 +11,49 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: macos-14
-            asset: terradart-mcp-darwin-arm64
-            dart_arch: arm64
-          # Intel macOS: Dart has no cross-compile, and GitHub's Intel
-          # (macos-13) runners are scarce, so build the x64 binary on an Apple
-          # Silicon runner using the x64 Dart SDK under Rosetta 2.
-          - os: macos-14
-            asset: terradart-mcp-darwin-amd64
-            dart_arch: x64
-            rosetta: true
-          - os: ubuntu-22.04
-            asset: terradart-mcp-linux-amd64
-            dart_arch: x64
-          - os: windows-latest
-            asset: terradart-mcp-windows-amd64.exe
-            dart_arch: x64
-    runs-on: ${{ matrix.os }}
+        tool:
+          - { name: terradart-mcp,      dir: packages/terradart_agent,    entry: bin/terradart_mcp.dart,      smoke: --version }
+          - { name: terradart-coverage, dir: packages/terradart_coverage,  entry: bin/terradart_coverage.dart, smoke: --help    }
+        target:
+          - { os: macos-14,       suffix: darwin-arm64,  dart_arch: arm64 }
+          - { os: macos-14,       suffix: darwin-amd64,  dart_arch: x64,  rosetta: true }
+          - { os: ubuntu-22.04,   suffix: linux-amd64,   dart_arch: x64 }
+          - { os: windows-latest, suffix: windows-amd64, dart_arch: x64 }
+    runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v6
       - name: Install Rosetta 2 (for the x64 Dart SDK on Apple Silicon)
-        if: matrix.rosetta
+        if: matrix.target.rosetta
         run: sudo softwareupdate --install-rosetta --agree-to-license
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable
-          architecture: ${{ matrix.dart_arch }}
+          architecture: ${{ matrix.target.dart_arch }}
       - run: dart pub get
       - name: Compile binary
-        working-directory: packages/terradart_agent
-        run: dart compile exe bin/terradart_mcp.dart -o ${{ matrix.asset }}
+        working-directory: ${{ matrix.tool.dir }}
+        run: dart compile exe ${{ matrix.tool.entry }} -o ${{ matrix.tool.name }}-${{ matrix.target.suffix }}
       - name: Smoke test
-        working-directory: packages/terradart_agent
+        working-directory: ${{ matrix.tool.dir }}
         shell: bash
-        run: ./${{ matrix.asset }} --version
+        run: ./${{ matrix.tool.name }}-${{ matrix.target.suffix }} ${{ matrix.tool.smoke }}
+      - name: Compute sha256
+        working-directory: ${{ matrix.tool.dir }}
+        shell: bash
+        run: |
+          ASSET="${{ matrix.tool.name }}-${{ matrix.target.suffix }}"
+          if [[ "${{ matrix.target.os }}" == macos-* ]]; then
+            shasum -a 256 "$ASSET" | awk '{print $1}' > "${ASSET}.sha256"
+          elif [[ "${{ matrix.target.os }}" == ubuntu-* ]]; then
+            sha256sum "$ASSET" | awk '{print $1}' > "${ASSET}.sha256"
+          else
+            # Windows (Git Bash)
+            certutil -hashfile "$ASSET" SHA256 | grep -v "^CertUtil" | grep -v "^SHA256" | tr -d ' \r\n' > "${ASSET}.sha256"
+            echo "" >> "${ASSET}.sha256"
+          fi
       - name: Upload to release
         uses: softprops/action-gh-release@v2
         with:
-          files: packages/terradart_agent/${{ matrix.asset }}
+          files: |
+            ${{ matrix.tool.dir }}/${{ matrix.tool.name }}-${{ matrix.target.suffix }}
+            ${{ matrix.tool.dir }}/${{ matrix.tool.name }}-${{ matrix.target.suffix }}.sha256

--- a/packages/terradart_coverage/analysis_options.yaml
+++ b/packages/terradart_coverage/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/packages/terradart_coverage/bin/terradart_coverage.dart
+++ b/packages/terradart_coverage/bin/terradart_coverage.dart
@@ -11,9 +11,13 @@ Future<int> run(List<String> argv) async {
     ..addFlag('help', abbr: 'h', negatable: false);
   final args = parser.parse(argv);
   if (args['help'] as bool) {
-    stdout.writeln('Usage: terradart-coverage [--json] [<terraform-show.json>]');
-    stdout.writeln('Reads `terraform show -json` output from the file arg or '
-        'stdin and reports terradart_google coverage.');
+    stdout.writeln(
+      'Usage: terradart-coverage [--json] [<terraform-show.json>]',
+    );
+    stdout.writeln(
+      'Reads `terraform show -json` output from the file arg or '
+      'stdin and reports terradart_google coverage.',
+    );
     stdout.writeln(parser.usage);
     return 0;
   }
@@ -43,7 +47,9 @@ Future<int> run(List<String> argv) async {
   }
 
   final report = buildCoverageReport(parsed, CatalogIndex(terradartCatalog));
-  stdout.writeln((args['json'] as bool) ? renderJson(report) : renderText(report));
+  stdout.writeln(
+    (args['json'] as bool) ? renderJson(report) : renderText(report),
+  );
   return 0;
 }
 

--- a/packages/terradart_coverage/bin/terradart_coverage.dart
+++ b/packages/terradart_coverage/bin/terradart_coverage.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:terradart_coverage/terradart_coverage.dart';
+import 'package:terradart_google/catalog.dart';
+
+Future<int> run(List<String> argv) async {
+  final parser = ArgParser()
+    ..addFlag('json', negatable: false, help: 'Emit machine-readable JSON.')
+    ..addFlag('help', abbr: 'h', negatable: false);
+  final args = parser.parse(argv);
+  if (args['help'] as bool) {
+    stdout.writeln('Usage: terradart-coverage [--json] [<terraform-show.json>]');
+    stdout.writeln('Reads `terraform show -json` output from the file arg or '
+        'stdin and reports terradart_google coverage.');
+    stdout.writeln(parser.usage);
+    return 0;
+  }
+
+  final String raw;
+  if (args.rest.isNotEmpty) {
+    raw = await File(args.rest.first).readAsString();
+  } else {
+    raw = await stdin.transform(utf8.decoder).join();
+  }
+
+  final Map<String, dynamic> json;
+  try {
+    json = jsonDecode(raw) as Map<String, dynamic>;
+  } on FormatException catch (e) {
+    stderr.writeln('terradart-coverage: input is not valid JSON: ${e.message}');
+    stderr.writeln('Hint: pipe `terraform show -json` output.');
+    return 2;
+  }
+
+  final ParseOutcome parsed;
+  try {
+    parsed = parseShowJson(json);
+  } on FormatException catch (e) {
+    stderr.writeln('terradart-coverage: ${e.message}');
+    return 2;
+  }
+
+  final report = buildCoverageReport(parsed, CatalogIndex(terradartCatalog));
+  stdout.writeln((args['json'] as bool) ? renderJson(report) : renderText(report));
+  return 0;
+}
+
+Future<void> main(List<String> argv) async {
+  exitCode = await run(argv);
+}

--- a/packages/terradart_coverage/lib/src/catalog_matcher.dart
+++ b/packages/terradart_coverage/lib/src/catalog_matcher.dart
@@ -3,9 +3,7 @@ import 'package:terradart_google/catalog.dart';
 /// Indexed view of [terradartCatalog] for O(1) `(type, kind)` lookup.
 final class CatalogIndex {
   CatalogIndex(List<CatalogEntry> entries)
-      : _byTypeKind = {
-          for (final e in entries) (e.tfType, e.kind): e,
-        };
+    : _byTypeKind = {for (final e in entries) (e.tfType, e.kind): e};
 
   final Map<(String, CatalogKind), CatalogEntry> _byTypeKind;
 

--- a/packages/terradart_coverage/lib/src/catalog_matcher.dart
+++ b/packages/terradart_coverage/lib/src/catalog_matcher.dart
@@ -1,0 +1,15 @@
+import 'package:terradart_google/catalog.dart';
+
+/// Indexed view of [terradartCatalog] for O(1) `(type, kind)` lookup.
+final class CatalogIndex {
+  CatalogIndex(List<CatalogEntry> entries)
+      : _byTypeKind = {
+          for (final e in entries) (e.tfType, e.kind): e,
+        };
+
+  final Map<(String, CatalogKind), CatalogEntry> _byTypeKind;
+
+  /// The matching curated entry, or `null` if the type/kind is not curated.
+  CatalogEntry? lookup(String tfType, CatalogKind kind) =>
+      _byTypeKind[(tfType, kind)];
+}

--- a/packages/terradart_coverage/lib/src/coverage_report.dart
+++ b/packages/terradart_coverage/lib/src/coverage_report.dart
@@ -1,0 +1,147 @@
+import 'package:terradart_google/catalog.dart';
+import 'catalog_matcher.dart';
+import 'tf_reference.dart';
+
+final class CoverageSummary {
+  const CoverageSummary({
+    required this.distinctTypes,
+    required this.supportedTypes,
+    required this.totalOccurrences,
+    required this.supportedOccurrences,
+  });
+
+  final int distinctTypes;
+  final int supportedTypes;
+  final int totalOccurrences;
+  final int supportedOccurrences;
+
+  int get coverageByTypePct =>
+      distinctTypes == 0 ? 0 : (supportedTypes * 100 / distinctTypes).round();
+  int get coverageByOccurrencePct => totalOccurrences == 0
+      ? 0
+      : (supportedOccurrences * 100 / totalOccurrences).round();
+}
+
+final class SupportedType {
+  const SupportedType({
+    required this.type,
+    required this.kind,
+    required this.count,
+    required this.className,
+    required this.barrel,
+  });
+  final String type;
+  final CatalogKind kind;
+  final int count;
+  final String className;
+  final String barrel;
+}
+
+final class NotInCatalogType {
+  const NotInCatalogType({
+    required this.type,
+    required this.kind,
+    required this.count,
+    required this.product,
+  });
+  final String type;
+  final CatalogKind kind;
+  final int count;
+  final String product;
+}
+
+final class ModuleBreakdown {
+  const ModuleBreakdown({required this.supported, required this.notInCatalog});
+  final int supported;
+  final int notInCatalog;
+}
+
+final class CoverageReport {
+  const CoverageReport({
+    required this.summary,
+    required this.supported,
+    required this.notInCatalog,
+    required this.perModule,
+    required this.unparseable,
+  });
+  final CoverageSummary summary;
+  final List<SupportedType> supported;
+  final List<NotInCatalogType> notInCatalog;
+  final Map<String, ModuleBreakdown> perModule;
+  final List<String> unparseable;
+}
+
+/// Coarse product from a `google_<product>_<rest>` type string.
+String productOf(String tfType) {
+  final parts = tfType.split('_');
+  return parts.length >= 2 ? parts[1] : tfType;
+}
+
+CoverageReport buildCoverageReport(ParseOutcome parsed, CatalogIndex index) {
+  final counts = <(String, CatalogKind), int>{};
+  final perModuleSupported = <String, int>{};
+  final perModuleNot = <String, int>{};
+
+  for (final r in parsed.references) {
+    final key = (r.type, r.kind);
+    counts[key] = (counts[key] ?? 0) + 1;
+    final supported = index.lookup(r.type, r.kind) != null;
+    if (supported) {
+      perModuleSupported[r.modulePath] =
+          (perModuleSupported[r.modulePath] ?? 0) + 1;
+    } else {
+      perModuleNot[r.modulePath] = (perModuleNot[r.modulePath] ?? 0) + 1;
+    }
+  }
+
+  final supported = <SupportedType>[];
+  final notInCatalog = <NotInCatalogType>[];
+  var supportedOccurrences = 0;
+  for (final entry in counts.entries) {
+    final (type, kind) = entry.key;
+    final count = entry.value;
+    final hit = index.lookup(type, kind);
+    if (hit != null) {
+      supportedOccurrences += count;
+      supported.add(SupportedType(
+        type: type,
+        kind: kind,
+        count: count,
+        className: hit.className,
+        barrel: hit.barrel,
+      ));
+    } else {
+      notInCatalog.add(NotInCatalogType(
+        type: type,
+        kind: kind,
+        count: count,
+        product: productOf(type),
+      ));
+    }
+  }
+
+  supported.sort((a, b) => b.count.compareTo(a.count));
+  notInCatalog.sort((a, b) => b.count.compareTo(a.count));
+
+  final modules = {...perModuleSupported.keys, ...perModuleNot.keys};
+  final perModule = <String, ModuleBreakdown>{
+    for (final m in modules)
+      m: ModuleBreakdown(
+        supported: perModuleSupported[m] ?? 0,
+        notInCatalog: perModuleNot[m] ?? 0,
+      ),
+  };
+
+  return CoverageReport(
+    summary: CoverageSummary(
+      distinctTypes: counts.length,
+      supportedTypes: supported.length,
+      totalOccurrences: parsed.references.length,
+      supportedOccurrences: supportedOccurrences,
+    ),
+    supported: supported,
+    notInCatalog: notInCatalog,
+    perModule: perModule,
+    unparseable: parsed.unparseable,
+  );
+}

--- a/packages/terradart_coverage/lib/src/coverage_report.dart
+++ b/packages/terradart_coverage/lib/src/coverage_report.dart
@@ -103,20 +103,24 @@ CoverageReport buildCoverageReport(ParseOutcome parsed, CatalogIndex index) {
     final hit = index.lookup(type, kind);
     if (hit != null) {
       supportedOccurrences += count;
-      supported.add(SupportedType(
-        type: type,
-        kind: kind,
-        count: count,
-        className: hit.className,
-        barrel: hit.barrel,
-      ));
+      supported.add(
+        SupportedType(
+          type: type,
+          kind: kind,
+          count: count,
+          className: hit.className,
+          barrel: hit.barrel,
+        ),
+      );
     } else {
-      notInCatalog.add(NotInCatalogType(
-        type: type,
-        kind: kind,
-        count: count,
-        product: productOf(type),
-      ));
+      notInCatalog.add(
+        NotInCatalogType(
+          type: type,
+          kind: kind,
+          count: count,
+          product: productOf(type),
+        ),
+      );
     }
   }
 

--- a/packages/terradart_coverage/lib/src/report_render.dart
+++ b/packages/terradart_coverage/lib/src/report_render.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+import 'package:terradart_google/catalog.dart' show CatalogKind;
+import 'coverage_report.dart';
+
+String _kind(CatalogKind k) => k == CatalogKind.dataSource ? 'data' : 'resource';
+
+/// Human-readable report.
+String renderText(CoverageReport r) {
+  final b = StringBuffer();
+  final s = r.summary;
+  b.writeln('TerraDart coverage');
+  b.writeln('==================');
+  b.writeln('Coverage: ${s.coverageByTypePct}% of types '
+      '(${s.supportedTypes}/${s.distinctTypes}), '
+      '${s.coverageByOccurrencePct}% of resources '
+      '(${s.supportedOccurrences}/${s.totalOccurrences})');
+  b.writeln();
+
+  b.writeln('Supported (${r.supported.length}):');
+  for (final e in r.supported) {
+    b.writeln('  ${e.type} [${_kind(e.kind)}] x${e.count} '
+        '-> ${e.className} (${e.barrel})');
+  }
+  b.writeln();
+
+  b.writeln('Not in catalog (${r.notInCatalog.length}):');
+  for (final e in r.notInCatalog) {
+    b.writeln('  ${e.type} [${_kind(e.kind)}] x${e.count} (${e.product})');
+  }
+  b.writeln();
+
+  b.writeln('By module:');
+  for (final entry in r.perModule.entries) {
+    b.writeln('  ${entry.key}: ${entry.value.supported} supported, '
+        '${entry.value.notInCatalog} not-in-catalog');
+  }
+
+  if (r.unparseable.isNotEmpty) {
+    b.writeln();
+    b.writeln('Unparseable (${r.unparseable.length}):');
+    for (final u in r.unparseable) {
+      b.writeln('  $u');
+    }
+  }
+  return b.toString();
+}
+
+/// Machine-readable report (also reused as MCP structuredContent later).
+String renderJson(CoverageReport r) {
+  final map = {
+    'summary': {
+      'distinctTypes': r.summary.distinctTypes,
+      'supportedTypes': r.summary.supportedTypes,
+      'totalOccurrences': r.summary.totalOccurrences,
+      'supportedOccurrences': r.summary.supportedOccurrences,
+      'coverageByTypePct': r.summary.coverageByTypePct,
+      'coverageByOccurrencePct': r.summary.coverageByOccurrencePct,
+    },
+    'supported': [
+      for (final e in r.supported)
+        {
+          'type': e.type,
+          'kind': _kind(e.kind),
+          'count': e.count,
+          'className': e.className,
+          'barrel': e.barrel,
+        }
+    ],
+    'notInCatalog': [
+      for (final e in r.notInCatalog)
+        {
+          'type': e.type,
+          'kind': _kind(e.kind),
+          'count': e.count,
+          'product': e.product,
+        }
+    ],
+    'perModule': {
+      for (final entry in r.perModule.entries)
+        entry.key: {
+          'supported': entry.value.supported,
+          'notInCatalog': entry.value.notInCatalog,
+        }
+    },
+    'unparseable': r.unparseable,
+  };
+  return const JsonEncoder.withIndent('  ').convert(map);
+}

--- a/packages/terradart_coverage/lib/src/report_render.dart
+++ b/packages/terradart_coverage/lib/src/report_render.dart
@@ -2,7 +2,8 @@ import 'dart:convert';
 import 'package:terradart_google/catalog.dart' show CatalogKind;
 import 'coverage_report.dart';
 
-String _kind(CatalogKind k) => k == CatalogKind.dataSource ? 'data' : 'resource';
+String _kind(CatalogKind k) =>
+    k == CatalogKind.dataSource ? 'data' : 'resource';
 
 /// Human-readable report.
 String renderText(CoverageReport r) {
@@ -10,16 +11,20 @@ String renderText(CoverageReport r) {
   final s = r.summary;
   b.writeln('TerraDart coverage');
   b.writeln('==================');
-  b.writeln('Coverage: ${s.coverageByTypePct}% of types '
-      '(${s.supportedTypes}/${s.distinctTypes}), '
-      '${s.coverageByOccurrencePct}% of resources '
-      '(${s.supportedOccurrences}/${s.totalOccurrences})');
+  b.writeln(
+    'Coverage: ${s.coverageByTypePct}% of types '
+    '(${s.supportedTypes}/${s.distinctTypes}), '
+    '${s.coverageByOccurrencePct}% of resources '
+    '(${s.supportedOccurrences}/${s.totalOccurrences})',
+  );
   b.writeln();
 
   b.writeln('Supported (${r.supported.length}):');
   for (final e in r.supported) {
-    b.writeln('  ${e.type} [${_kind(e.kind)}] x${e.count} '
-        '-> ${e.className} (${e.barrel})');
+    b.writeln(
+      '  ${e.type} [${_kind(e.kind)}] x${e.count} '
+      '-> ${e.className} (${e.barrel})',
+    );
   }
   b.writeln();
 
@@ -31,8 +36,10 @@ String renderText(CoverageReport r) {
 
   b.writeln('By module:');
   for (final entry in r.perModule.entries) {
-    b.writeln('  ${entry.key}: ${entry.value.supported} supported, '
-        '${entry.value.notInCatalog} not-in-catalog');
+    b.writeln(
+      '  ${entry.key}: ${entry.value.supported} supported, '
+      '${entry.value.notInCatalog} not-in-catalog',
+    );
   }
 
   if (r.unparseable.isNotEmpty) {
@@ -64,7 +71,7 @@ String renderJson(CoverageReport r) {
           'count': e.count,
           'className': e.className,
           'barrel': e.barrel,
-        }
+        },
     ],
     'notInCatalog': [
       for (final e in r.notInCatalog)
@@ -73,14 +80,14 @@ String renderJson(CoverageReport r) {
           'kind': _kind(e.kind),
           'count': e.count,
           'product': e.product,
-        }
+        },
     ],
     'perModule': {
       for (final entry in r.perModule.entries)
         entry.key: {
           'supported': entry.value.supported,
           'notInCatalog': entry.value.notInCatalog,
-        }
+        },
     },
     'unparseable': r.unparseable,
   };

--- a/packages/terradart_coverage/lib/src/tf_json_parser.dart
+++ b/packages/terradart_coverage/lib/src/tf_json_parser.dart
@@ -37,8 +37,10 @@ void _walk(
       final type = r['type'];
       final mode = r['mode'];
       if (type is! String || type.isEmpty) {
-        unparseable.add('$modulePath: resource entry missing `type` '
-            '(${r['address'] ?? r['name'] ?? 'unknown'})');
+        unparseable.add(
+          '$modulePath: resource entry missing `type` '
+          '(${r['address'] ?? r['name'] ?? 'unknown'})',
+        );
         continue;
       }
       final kind = mode == 'data'

--- a/packages/terradart_coverage/lib/src/tf_json_parser.dart
+++ b/packages/terradart_coverage/lib/src/tf_json_parser.dart
@@ -1,0 +1,58 @@
+import 'package:terradart_google/catalog.dart' show CatalogKind;
+import 'tf_reference.dart';
+
+/// Parses a decoded `terraform show -json` document (state or plan) into refs.
+///
+/// Accepts the `values` block (state) or `planned_values` block (plan); both
+/// carry the same `root_module` shape. Throws [FormatException] if neither is
+/// present. Entries without a usable `type` are collected into
+/// [ParseOutcome.unparseable] rather than dropped.
+ParseOutcome parseShowJson(Map<String, dynamic> json) {
+  final root = (json['values'] ?? json['planned_values']);
+  if (root is! Map || root['root_module'] is! Map) {
+    throw const FormatException(
+      'Expected `terraform show -json` output with a `values` or '
+      '`planned_values` block (run `terraform show -json` on state or a plan).',
+    );
+  }
+  final refs = <TfReference>[];
+  final unparseable = <String>[];
+  _walk(root['root_module'] as Map, 'root', refs, unparseable);
+  return ParseOutcome(references: refs, unparseable: unparseable);
+}
+
+void _walk(
+  Map module,
+  String modulePath,
+  List<TfReference> refs,
+  List<String> unparseable,
+) {
+  final resources = module['resources'];
+  if (resources is List) {
+    for (final r in resources) {
+      if (r is! Map) {
+        unparseable.add('$modulePath: non-object resource entry');
+        continue;
+      }
+      final type = r['type'];
+      final mode = r['mode'];
+      if (type is! String || type.isEmpty) {
+        unparseable.add('$modulePath: resource entry missing `type` '
+            '(${r['address'] ?? r['name'] ?? 'unknown'})');
+        continue;
+      }
+      final kind = mode == 'data'
+          ? CatalogKind.dataSource
+          : CatalogKind.resource;
+      refs.add(TfReference(type: type, kind: kind, modulePath: modulePath));
+    }
+  }
+  final children = module['child_modules'];
+  if (children is List) {
+    for (final c in children) {
+      if (c is! Map) continue;
+      final addr = c['address'];
+      _walk(c, addr is String ? addr : modulePath, refs, unparseable);
+    }
+  }
+}

--- a/packages/terradart_coverage/lib/src/tf_reference.dart
+++ b/packages/terradart_coverage/lib/src/tf_reference.dart
@@ -1,0 +1,31 @@
+import 'package:terradart_google/catalog.dart' show CatalogKind;
+
+/// One Terraform resource/data reference extracted from `terraform show -json`.
+final class TfReference {
+  const TfReference({
+    required this.type,
+    required this.kind,
+    required this.modulePath,
+  });
+
+  /// Terraform type string, e.g. `google_storage_bucket`.
+  final String type;
+
+  /// Managed resource vs read-only data source.
+  final CatalogKind kind;
+
+  /// Module address, `root` for the root module, else e.g. `module.network`.
+  final String modulePath;
+}
+
+/// Outcome of parsing a `terraform show -json` document.
+final class ParseOutcome {
+  const ParseOutcome({required this.references, required this.unparseable});
+
+  /// Successfully extracted references (one per resource instance occurrence).
+  final List<TfReference> references;
+
+  /// Human-readable notes for entries that could not be interpreted
+  /// (missing `type`/`mode`, unexpected shape). Never silently dropped.
+  final List<String> unparseable;
+}

--- a/packages/terradart_coverage/lib/terradart_coverage.dart
+++ b/packages/terradart_coverage/lib/terradart_coverage.dart
@@ -9,3 +9,4 @@ export 'src/tf_reference.dart';
 export 'src/tf_json_parser.dart';
 export 'src/catalog_matcher.dart';
 export 'src/coverage_report.dart';
+export 'src/report_render.dart';

--- a/packages/terradart_coverage/lib/terradart_coverage.dart
+++ b/packages/terradart_coverage/lib/terradart_coverage.dart
@@ -1,0 +1,6 @@
+/// Read-only Terraform coverage checker for TerraDart.
+///
+/// Public exports (tf_reference, tf_json_parser, catalog_matcher,
+/// coverage_report, report_render) are added by subsequent tasks as each
+/// `src/` file lands.
+library;

--- a/packages/terradart_coverage/lib/terradart_coverage.dart
+++ b/packages/terradart_coverage/lib/terradart_coverage.dart
@@ -4,3 +4,6 @@
 /// coverage_report, report_render) are added by subsequent tasks as each
 /// `src/` file lands.
 library;
+
+export 'src/tf_reference.dart';
+export 'src/tf_json_parser.dart';

--- a/packages/terradart_coverage/lib/terradart_coverage.dart
+++ b/packages/terradart_coverage/lib/terradart_coverage.dart
@@ -8,3 +8,4 @@ library;
 export 'src/tf_reference.dart';
 export 'src/tf_json_parser.dart';
 export 'src/catalog_matcher.dart';
+export 'src/coverage_report.dart';

--- a/packages/terradart_coverage/lib/terradart_coverage.dart
+++ b/packages/terradart_coverage/lib/terradart_coverage.dart
@@ -7,3 +7,4 @@ library;
 
 export 'src/tf_reference.dart';
 export 'src/tf_json_parser.dart';
+export 'src/catalog_matcher.dart';

--- a/packages/terradart_coverage/pubspec.yaml
+++ b/packages/terradart_coverage/pubspec.yaml
@@ -1,0 +1,23 @@
+name: terradart_coverage
+description: Read-only Terraform coverage checker — reports how much of a Terraform config is covered by curated terradart_google factories.
+version: 0.13.0
+publish_to: none
+homepage: https://github.com/nozomi-koborinai/terradart
+repository: https://github.com/nozomi-koborinai/terradart
+issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
+
+environment:
+  sdk: ^3.10.0
+
+resolution: workspace
+
+executables:
+  terradart-coverage: terradart_coverage
+
+dependencies:
+  terradart_google: ^0.13.0
+  args: ^2.5.0
+
+dev_dependencies:
+  lints: ^6.0.0
+  test: ^1.25.6

--- a/packages/terradart_coverage/test/catalog_matcher_test.dart
+++ b/packages/terradart_coverage/test/catalog_matcher_test.dart
@@ -1,0 +1,26 @@
+import 'package:terradart_coverage/terradart_coverage.dart';
+import 'package:terradart_google/catalog.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final index = CatalogIndex(terradartCatalog);
+
+  test('a curated resource type is supported', () {
+    final e = index.lookup('google_storage_bucket', CatalogKind.resource);
+    expect(e, isNotNull);
+    expect(e!.className, isNotEmpty);
+  });
+
+  test('a fabricated type is not in the catalog', () {
+    expect(index.lookup('google_notreal_thing', CatalogKind.resource), isNull);
+  });
+
+  test('kind is part of the key (resource vs data source differ)', () {
+    // google_project exists as CatalogKind.dataSource in the catalog
+    // (confirmed by grepping _catalog.g.dart for 'CatalogKind.dataSource').
+    final asData = index.lookup('google_project', CatalogKind.dataSource);
+    expect(asData, isNotNull);
+    // Same tfType looked up as resource should return null (it is a data source).
+    expect(index.lookup('google_project', CatalogKind.resource), isNull);
+  });
+}

--- a/packages/terradart_coverage/test/cli_test.dart
+++ b/packages/terradart_coverage/test/cli_test.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:test/test.dart';
+
+void main() {
+  test('CLI prints a coverage report for a state file', () async {
+    final result = await Process.run(
+      'dart',
+      ['run', 'bin/terradart_coverage.dart', 'test/fixtures/state_sample.json'],
+    );
+    expect(result.exitCode, 0, reason: result.stderr.toString());
+    expect(result.stdout, contains('Coverage'));
+    expect(result.stdout, contains('google_storage_bucket'));
+  });
+
+  test('CLI --json emits valid JSON', () async {
+    final result = await Process.run('dart', [
+      'run',
+      'bin/terradart_coverage.dart',
+      '--json',
+      'test/fixtures/state_sample.json',
+    ]);
+    expect(result.exitCode, 0, reason: result.stderr.toString());
+    final decoded = jsonDecode(result.stdout as String);
+    expect(decoded['summary'], isA<Map>());
+  });
+
+  test('CLI exits non-zero on non-JSON input', () async {
+    final result = await Process.run(
+      'dart',
+      ['run', 'bin/terradart_coverage.dart', 'pubspec.yaml'],
+    );
+    expect(result.exitCode, isNonZero);
+  });
+}

--- a/packages/terradart_coverage/test/cli_test.dart
+++ b/packages/terradart_coverage/test/cli_test.dart
@@ -4,10 +4,11 @@ import 'package:test/test.dart';
 
 void main() {
   test('CLI prints a coverage report for a state file', () async {
-    final result = await Process.run(
-      'dart',
-      ['run', 'bin/terradart_coverage.dart', 'test/fixtures/state_sample.json'],
-    );
+    final result = await Process.run('dart', [
+      'run',
+      'bin/terradart_coverage.dart',
+      'test/fixtures/state_sample.json',
+    ]);
     expect(result.exitCode, 0, reason: result.stderr.toString());
     expect(result.stdout, contains('Coverage'));
     expect(result.stdout, contains('google_storage_bucket'));
@@ -26,10 +27,11 @@ void main() {
   });
 
   test('CLI exits non-zero on non-JSON input', () async {
-    final result = await Process.run(
-      'dart',
-      ['run', 'bin/terradart_coverage.dart', 'pubspec.yaml'],
-    );
+    final result = await Process.run('dart', [
+      'run',
+      'bin/terradart_coverage.dart',
+      'pubspec.yaml',
+    ]);
     expect(result.exitCode, isNonZero);
   });
 }

--- a/packages/terradart_coverage/test/coverage_report_test.dart
+++ b/packages/terradart_coverage/test/coverage_report_test.dart
@@ -1,0 +1,45 @@
+import 'package:terradart_coverage/terradart_coverage.dart';
+import 'package:terradart_google/catalog.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final index = CatalogIndex(terradartCatalog);
+
+  test('builds summary, supported, and ranked not-in-catalog', () {
+    final refs = [
+      const TfReference(
+          type: 'google_storage_bucket',
+          kind: CatalogKind.resource,
+          modulePath: 'root'),
+      const TfReference(
+          type: 'google_notreal_thing',
+          kind: CatalogKind.resource,
+          modulePath: 'root'),
+      const TfReference(
+          type: 'google_notreal_thing',
+          kind: CatalogKind.resource,
+          modulePath: 'module.x'),
+    ];
+    final report = buildCoverageReport(
+      ParseOutcome(references: refs, unparseable: const []),
+      index,
+    );
+
+    expect(report.summary.distinctTypes, 2);
+    expect(report.summary.supportedTypes, 1);
+    expect(report.notInCatalog.first.type, 'google_notreal_thing');
+    expect(report.notInCatalog.first.count, 2);
+    expect(report.notInCatalog.first.product, 'notreal');
+    expect(report.perModule.keys, containsAll(['root', 'module.x']));
+  });
+
+  test('carries unparseable through unchanged', () {
+    final report = buildCoverageReport(
+      const ParseOutcome(references: [], unparseable: ['root: broken']),
+      index,
+    );
+    expect(report.unparseable, ['root: broken']);
+    expect(report.summary.distinctTypes, 0);
+    expect(report.summary.coverageByTypePct, 0);
+  });
+}

--- a/packages/terradart_coverage/test/coverage_report_test.dart
+++ b/packages/terradart_coverage/test/coverage_report_test.dart
@@ -8,17 +8,20 @@ void main() {
   test('builds summary, supported, and ranked not-in-catalog', () {
     final refs = [
       const TfReference(
-          type: 'google_storage_bucket',
-          kind: CatalogKind.resource,
-          modulePath: 'root'),
+        type: 'google_storage_bucket',
+        kind: CatalogKind.resource,
+        modulePath: 'root',
+      ),
       const TfReference(
-          type: 'google_notreal_thing',
-          kind: CatalogKind.resource,
-          modulePath: 'root'),
+        type: 'google_notreal_thing',
+        kind: CatalogKind.resource,
+        modulePath: 'root',
+      ),
       const TfReference(
-          type: 'google_notreal_thing',
-          kind: CatalogKind.resource,
-          modulePath: 'module.x'),
+        type: 'google_notreal_thing',
+        kind: CatalogKind.resource,
+        modulePath: 'module.x',
+      ),
     ];
     final report = buildCoverageReport(
       ParseOutcome(references: refs, unparseable: const []),

--- a/packages/terradart_coverage/test/fixtures/state_sample.json
+++ b/packages/terradart_coverage/test/fixtures/state_sample.json
@@ -1,0 +1,11 @@
+{
+  "format_version": "1.0",
+  "values": {
+    "root_module": {
+      "resources": [
+        {"mode": "managed", "type": "google_storage_bucket", "name": "a"},
+        {"mode": "managed", "type": "google_notreal_thing", "name": "b"}
+      ]
+    }
+  }
+}

--- a/packages/terradart_coverage/test/report_render_test.dart
+++ b/packages/terradart_coverage/test/report_render_test.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'package:terradart_coverage/terradart_coverage.dart';
+import 'package:terradart_google/catalog.dart';
+import 'package:test/test.dart';
+
+CoverageReport _sample() => buildCoverageReport(
+      const ParseOutcome(references: [
+        TfReference(
+            type: 'google_storage_bucket',
+            kind: CatalogKind.resource,
+            modulePath: 'root'),
+      ], unparseable: []),
+      CatalogIndex(terradartCatalog),
+    );
+
+void main() {
+  test('text render contains a coverage summary line', () {
+    final text = renderText(_sample());
+    expect(text, contains('Coverage'));
+    expect(text, contains('google_storage_bucket'));
+  });
+
+  test('json render is valid and carries expected keys', () {
+    final jsonStr = renderJson(_sample());
+    final decoded = jsonDecode(jsonStr) as Map<String, dynamic>;
+    expect(decoded.keys,
+        containsAll(['summary', 'supported', 'notInCatalog', 'perModule', 'unparseable']));
+    expect((decoded['summary'] as Map)['distinctTypes'], 1);
+  });
+}

--- a/packages/terradart_coverage/test/report_render_test.dart
+++ b/packages/terradart_coverage/test/report_render_test.dart
@@ -4,14 +4,18 @@ import 'package:terradart_google/catalog.dart';
 import 'package:test/test.dart';
 
 CoverageReport _sample() => buildCoverageReport(
-      const ParseOutcome(references: [
-        TfReference(
-            type: 'google_storage_bucket',
-            kind: CatalogKind.resource,
-            modulePath: 'root'),
-      ], unparseable: []),
-      CatalogIndex(terradartCatalog),
-    );
+  const ParseOutcome(
+    references: [
+      TfReference(
+        type: 'google_storage_bucket',
+        kind: CatalogKind.resource,
+        modulePath: 'root',
+      ),
+    ],
+    unparseable: [],
+  ),
+  CatalogIndex(terradartCatalog),
+);
 
 void main() {
   test('text render contains a coverage summary line', () {
@@ -23,8 +27,16 @@ void main() {
   test('json render is valid and carries expected keys', () {
     final jsonStr = renderJson(_sample());
     final decoded = jsonDecode(jsonStr) as Map<String, dynamic>;
-    expect(decoded.keys,
-        containsAll(['summary', 'supported', 'notInCatalog', 'perModule', 'unparseable']));
+    expect(
+      decoded.keys,
+      containsAll([
+        'summary',
+        'supported',
+        'notInCatalog',
+        'perModule',
+        'unparseable',
+      ]),
+    );
     expect((decoded['summary'] as Map)['distinctTypes'], 1);
   });
 }

--- a/packages/terradart_coverage/test/tf_json_parser_test.dart
+++ b/packages/terradart_coverage/test/tf_json_parser_test.dart
@@ -33,7 +33,11 @@ void main() {
               {
                 'address': 'module.network',
                 'resources': [
-                  {'mode': 'managed', 'type': 'google_compute_network', 'name': 'n'},
+                  {
+                    'mode': 'managed',
+                    'type': 'google_compute_network',
+                    'name': 'n',
+                  },
                 ],
               },
             ],
@@ -74,9 +78,14 @@ void main() {
       expect(out.unparseable, hasLength(1));
     });
 
-    test('throws FormatException when neither values nor planned_values exist', () {
-      expect(() => parseShowJson({'format_version': '1.0'}),
-          throwsA(isA<FormatException>()));
-    });
+    test(
+      'throws FormatException when neither values nor planned_values exist',
+      () {
+        expect(
+          () => parseShowJson({'format_version': '1.0'}),
+          throwsA(isA<FormatException>()),
+        );
+      },
+    );
   });
 }

--- a/packages/terradart_coverage/test/tf_json_parser_test.dart
+++ b/packages/terradart_coverage/test/tf_json_parser_test.dart
@@ -1,0 +1,82 @@
+import 'package:terradart_coverage/terradart_coverage.dart';
+import 'package:terradart_google/catalog.dart' show CatalogKind;
+import 'package:test/test.dart';
+
+void main() {
+  group('parseShowJson', () {
+    test('extracts managed + data refs from a state document', () {
+      final json = {
+        'values': {
+          'root_module': {
+            'resources': [
+              {'mode': 'managed', 'type': 'google_storage_bucket', 'name': 'a'},
+              {'mode': 'data', 'type': 'google_project', 'name': 'p'},
+            ],
+          },
+        },
+      };
+      final out = parseShowJson(json);
+      expect(out.references, hasLength(2));
+      expect(out.references[0].type, 'google_storage_bucket');
+      expect(out.references[0].kind, CatalogKind.resource);
+      expect(out.references[0].modulePath, 'root');
+      expect(out.references[1].kind, CatalogKind.dataSource);
+      expect(out.unparseable, isEmpty);
+    });
+
+    test('recurses into child modules and records module path', () {
+      final json = {
+        'values': {
+          'root_module': {
+            'resources': <Map<String, dynamic>>[],
+            'child_modules': [
+              {
+                'address': 'module.network',
+                'resources': [
+                  {'mode': 'managed', 'type': 'google_compute_network', 'name': 'n'},
+                ],
+              },
+            ],
+          },
+        },
+      };
+      final out = parseShowJson(json);
+      expect(out.references.single.type, 'google_compute_network');
+      expect(out.references.single.modulePath, 'module.network');
+    });
+
+    test('reads plan shape (planned_values) too', () {
+      final json = {
+        'planned_values': {
+          'root_module': {
+            'resources': [
+              {'mode': 'managed', 'type': 'google_pubsub_topic', 'name': 't'},
+            ],
+          },
+        },
+      };
+      final out = parseShowJson(json);
+      expect(out.references.single.type, 'google_pubsub_topic');
+    });
+
+    test('records entries missing a type as unparseable, not dropped', () {
+      final json = {
+        'values': {
+          'root_module': {
+            'resources': [
+              {'mode': 'managed', 'name': 'broken'},
+            ],
+          },
+        },
+      };
+      final out = parseShowJson(json);
+      expect(out.references, isEmpty);
+      expect(out.unparseable, hasLength(1));
+    });
+
+    test('throws FormatException when neither values nor planned_values exist', () {
+      expect(() => parseShowJson({'format_version': '1.0'}),
+          throwsA(isA<FormatException>()));
+    });
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -18,7 +18,7 @@ packages:
     source: hosted
     version: "13.0.0"
   args:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: args
       sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
@@ -474,7 +474,7 @@ packages:
     source: hosted
     version: "1.2.2"
   test:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: test
       sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ workspace:
   - packages/terradart_codegen
   - packages/terradart_google
   - packages/terradart_agent
+  - packages/terradart_coverage
   - examples/bigquery_quickstart
   - examples/cloud_build_quickstart
   - examples/cloud_functions_quickstart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,10 +37,12 @@ workspace:
   - examples/secret_manager_quickstart
   - examples/storage_quickstart
 dev_dependencies:
+  args: any
   meta: any
   pub_semver: any
   http: any
   path: any
+  test: any
   yaml: any
   terradart_google:
     path: packages/terradart_google

--- a/tool/agent_verify.sh
+++ b/tool/agent_verify.sh
@@ -51,18 +51,22 @@ echo ">> dart analyze tool/"
 dart analyze tool/ --fatal-infos --fatal-warnings
 
 if [[ "$WITH_FORMAT" == "1" ]]; then
-  echo ">> dart format (terradart_core, terradart_codegen, terradart_agent)"
+  echo ">> dart format (terradart_core, terradart_codegen, terradart_agent, terradart_coverage)"
   dart format --output=none --set-exit-if-changed \
     packages/terradart_core/ \
     packages/terradart_codegen/ \
-    packages/terradart_agent/
+    packages/terradart_agent/ \
+    packages/terradart_coverage/
 fi
 
-PACKAGES=(terradart_core terradart_codegen terradart_google terradart_agent)
+PACKAGES=(terradart_core terradart_codegen terradart_google terradart_agent terradart_coverage)
 for pkg in "${PACKAGES[@]}"; do
   echo ">> dart test packages/$pkg"
   (cd "packages/$pkg" && dart test --reporter=expanded)
 done
+
+echo ">> dart test tool/ (render_formula, render_to_file)"
+dart test tool/render_formula_test.dart tool/render_to_file_test.dart
 
 echo ">> terradart wrap --check"
 (

--- a/tool/render_formula.dart
+++ b/tool/render_formula.dart
@@ -1,0 +1,56 @@
+/// Renders a Homebrew formula Ruby file from release asset metadata.
+///
+/// Pure string rendering — no IO. The IO wrapper lives in render_to_file.dart.
+String renderFormula({
+  required String className,
+  required String binName,
+  required String desc,
+  required String version,
+  required String testCmd,
+  required Map<String, (String, String)> assets,
+}) {
+  final arm64 = assets['darwin-arm64']!;
+  final amd64 = assets['darwin-amd64']!;
+  final linux = assets['linux-amd64']!;
+
+  return '''
+class $className < Formula
+  desc "$desc"
+  homepage "https://github.com/nozomi-koborinai/terradart"
+  version "$version"
+  license "Apache-2.0"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "${arm64.$1}"
+      sha256 "${arm64.$2}"
+    else
+      url "${amd64.$1}"
+      sha256 "${amd64.$2}"
+    end
+  end
+
+  on_linux do
+    url "${linux.$1}"
+    sha256 "${linux.$2}"
+  end
+
+  def install
+    if OS.mac?
+      if Hardware::CPU.arm?
+        bin.install "$binName-darwin-arm64" => "$binName"
+      else
+        bin.install "$binName-darwin-amd64" => "$binName"
+      end
+    else
+      bin.install "$binName-linux-amd64" => "$binName"
+    end
+  end
+
+  test do
+    output = shell_output("#{bin}/$binName $testCmd")
+    assert output.length > 0
+  end
+end
+''';
+}

--- a/tool/render_formula.dart
+++ b/tool/render_formula.dart
@@ -48,8 +48,7 @@ class $className < Formula
   end
 
   test do
-    output = shell_output("#{bin}/$binName $testCmd")
-    assert output.length > 0
+    assert_match "$binName", shell_output("#{bin}/$binName $testCmd")
   end
 end
 ''';

--- a/tool/render_formula_test.dart
+++ b/tool/render_formula_test.dart
@@ -1,0 +1,23 @@
+import 'package:test/test.dart';
+import '../tool/render_formula.dart';
+
+void main() {
+  test('renders a formula with version, urls, and sha256', () {
+    final rb = renderFormula(
+      className: 'TerradartCoverage',
+      binName: 'terradart-coverage',
+      desc: 'Terraform coverage checker for TerraDart',
+      version: '0.13.1',
+      testCmd: '--help',
+      assets: {
+        'darwin-arm64': ('https://example/terradart-coverage-darwin-arm64', 'aaa'),
+        'darwin-amd64': ('https://example/terradart-coverage-darwin-amd64', 'bbb'),
+        'linux-amd64': ('https://example/terradart-coverage-linux-amd64', 'ccc'),
+      },
+    );
+    expect(rb, contains('class TerradartCoverage < Formula'));
+    expect(rb, contains('version "0.13.1"'));
+    expect(rb, contains('sha256 "aaa"'));
+    expect(rb, contains('=> "terradart-coverage"'));
+  });
+}

--- a/tool/render_formula_test.dart
+++ b/tool/render_formula_test.dart
@@ -19,5 +19,6 @@ void main() {
     expect(rb, contains('version "0.13.1"'));
     expect(rb, contains('sha256 "aaa"'));
     expect(rb, contains('=> "terradart-coverage"'));
+    expect(rb, contains('assert_match'));
   });
 }

--- a/tool/render_to_file.dart
+++ b/tool/render_to_file.dart
@@ -1,0 +1,64 @@
+// ignore_for_file: avoid_print
+import 'dart:io';
+import 'package:args/args.dart';
+import 'render_formula.dart';
+
+/// Reads the sha256 hex digest from a sidecar file.
+///
+/// The sidecar file contains a single line: the hex digest (no filename).
+String readSha(String shaDir, String assetName) {
+  final f = File('$shaDir/$assetName.sha256');
+  return f.readAsStringSync().trim();
+}
+
+/// Assembles the download URL for a release asset.
+String assetUrl(String version, String assetName) =>
+    'https://github.com/nozomi-koborinai/terradart/releases/download/v$version/$assetName';
+
+void main(List<String> args) {
+  final parser = ArgParser()
+    ..addOption('version', abbr: 'v', mandatory: true)
+    ..addOption('sha-dir', mandatory: true)
+    ..addOption('out-mcp', mandatory: true)
+    ..addOption('out-coverage', mandatory: true);
+
+  final results = parser.parse(args);
+  final version = results['version'] as String;
+  final shaDir = results['sha-dir'] as String;
+  final outMcp = results['out-mcp'] as String;
+  final outCoverage = results['out-coverage'] as String;
+
+  // Build per-platform asset maps for each tool.
+  Map<String, (String, String)> buildAssets(String toolName) {
+    return {
+      for (final suffix in ['darwin-arm64', 'darwin-amd64', 'linux-amd64'])
+        suffix: (
+          assetUrl(version, '$toolName-$suffix'),
+          readSha(shaDir, '$toolName-$suffix'),
+        ),
+    };
+  }
+
+  final mcpFormula = renderFormula(
+    className: 'TerradartMcp',
+    binName: 'terradart-mcp',
+    desc: 'MCP server exposing the curated GCP factory catalog of TerraDart',
+    version: version,
+    testCmd: '--version',
+    assets: buildAssets('terradart-mcp'),
+  );
+
+  final coverageFormula = renderFormula(
+    className: 'TerradartCoverage',
+    binName: 'terradart-coverage',
+    desc: 'Terraform coverage checker for TerraDart',
+    version: version,
+    testCmd: '--help',
+    assets: buildAssets('terradart-coverage'),
+  );
+
+  File(outMcp).writeAsStringSync(mcpFormula);
+  print('wrote $outMcp');
+  File(outCoverage).writeAsStringSync(coverageFormula);
+  print('wrote $outCoverage');
+}

--- a/tool/render_to_file_test.dart
+++ b/tool/render_to_file_test.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import '../tool/render_to_file.dart' as rif;
+
+void main() {
+  late Directory tmpDir;
+
+  setUp(() {
+    tmpDir = Directory.systemTemp.createTempSync('render_to_file_test_');
+  });
+
+  tearDown(() {
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  test('readSha reads hex digest from sidecar file', () {
+    // Write a fake .sha256 sidecar (one-line hex digest, as Task 8 produces).
+    final sidecar = File(p.join(tmpDir.path, 'terradart-mcp-darwin-arm64.sha256'));
+    sidecar.writeAsStringSync('deadbeef1234\n');
+
+    final sha = rif.readSha(tmpDir.path, 'terradart-mcp-darwin-arm64');
+    expect(sha, equals('deadbeef1234'));
+  });
+
+  test('assetUrl assembles correct download URL', () {
+    final url = rif.assetUrl('0.13.1', 'terradart-mcp-darwin-arm64');
+    expect(
+      url,
+      equals(
+        'https://github.com/nozomi-koborinai/terradart/releases/download/v0.13.1/terradart-mcp-darwin-arm64',
+      ),
+    );
+  });
+
+  test('assetUrl includes v-prefix tag segment', () {
+    final url = rif.assetUrl('1.0.0', 'terradart-coverage-linux-amd64');
+    expect(url, contains('/download/v1.0.0/'));
+    expect(url, endsWith('terradart-coverage-linux-amd64'));
+  });
+
+  test('readSha strips trailing whitespace from digest', () {
+    final sidecar = File(p.join(tmpDir.path, 'terradart-coverage-linux-amd64.sha256'));
+    sidecar.writeAsStringSync('  abc123  \n');
+
+    final sha = rif.readSha(tmpDir.path, 'terradart-coverage-linux-amd64');
+    expect(sha, equals('abc123'));
+  });
+}


### PR DESCRIPTION
## Summary

New `terradart_coverage` package (#79): a read-only CLI that reads
`terraform show -json` and reports how much of an existing Terraform config is
already covered by curated `terradart_google` factories — so teams evaluating a
TerraDart migration can size the effort in one command. Plus brew release
automation that auto-pushes both Homebrew formulas.

### terradart_coverage package
- Pure pipeline: `tf_json_parser` (state/plan, child-module recursion, never
  silently drops malformed entries) → `catalog_matcher` (`(type, kind)` lookup
  against `terradartCatalog`) → `coverage_report` (rich model: coverage % by
  type and by occurrence, supported list, not-in-catalog ranked by count with
  product category, per-module breakdown, unparseable) → `report_render` (text
  and `--json`).
- CLI `terradart-coverage` reads a file arg or stdin; exits non-zero on invalid
  input. Distributed via brew (`publish_to: none`) — end users don't need the
  Dart SDK.
- 15 package tests; catalog-drift-safe (asserts known types, not totals).

### Release automation
- `release-binary.yml`: a 2-axis matrix builds both `terradart-mcp` and
  `terradart-coverage` for darwin arm64/amd64 + linux amd64 (+ windows), and
  emits a `<asset>.sha256` sidecar per asset.
- A new `update-tap` job renders both formulas (`tool/render_formula.dart`,
  unit-tested) from the tag + sha sidecars and pushes them to
  `nozomi-koborinai/homebrew-tap` using `HOMEBREW_TAP_TOKEN`. This also
  re-greens the stale `terradart-mcp.rb` (was pinned at 0.12.1).
- coverage + tool tests wired into `ci.yml` and `tool/agent_verify.sh`; the
  format check is extended to the new package.

## Test plan
- [x] `cd packages/terradart_coverage && dart test` — 15 green
- [x] `dart test tool/render_formula_test.dart tool/render_to_file_test.dart` — green
- [x] `dart analyze` clean; `tool/agent_verify.sh` exit 0
- [x] Real release: the tap auto-push (`update-tap`) only runs on a `v*` tag — verify on the next tagged release.

Note: a pre-existing `check_override_enum_gaps` warning on
`google_compute_region_backend_service` is unrelated to this branch (main-origin;
`agent_verify` still exits 0).
