### PR TITLE
feat(agent): check_coverage MCP tool (terradart_coverage wrapper)

### DIFF
--- a/packages/terradart_agent/lib/src/server.dart
+++ b/packages/terradart_agent/lib/src/server.dart
@@ -3,6 +3,7 @@ import 'package:genkit_mcp/genkit_mcp.dart';
 import 'package:schemantic/schemantic.dart';
 import 'package:terradart_google/catalog.dart';
 
+import 'tools/check_coverage.dart';
 import 'tools/get_quickstart.dart';
 import 'tools/get_resource_schema.dart';
 import 'tools/list_barrels.dart';
@@ -33,11 +34,13 @@ SchemanticType<Map<String, dynamic>> _objectSchema({
 
 /// Builds the `terradart-mcp` MCP server.
 ///
-/// Registers the four read-only catalog tools (`list_resources`,
-/// `list_barrels`, `get_resource_schema`, `get_quickstart`) on a fresh
+/// Registers five read-only tools (`list_resources`, `list_barrels`,
+/// `get_resource_schema`, `get_quickstart`, `check_coverage`) on a fresh
 /// [Genkit] instance and exposes them over the Model Context Protocol via
-/// genkit_mcp. The tools project TerraDart's curated `terradartCatalog`
-/// (from `package:terradart_google`) into agent-friendly JSON.
+/// genkit_mcp. The first four project TerraDart's curated `terradartCatalog`
+/// (from `package:terradart_google`) into agent-friendly JSON; `check_coverage`
+/// analyses `terraform show -json` output against the catalog and reports
+/// coverage metrics.
 Future<GenkitMcpServer> buildTerradartMcpServer() async {
   final ai = Genkit();
 
@@ -131,6 +134,25 @@ Future<GenkitMcpServer> buildTerradartMcpServer() async {
         'gcs_refs': s.gcsRefs,
       };
     },
+  );
+
+  ai.defineTool<Map<String, dynamic>, Object>(
+    name: 'check_coverage',
+    description:
+        'Given `terraform show -json` output (the "tf_json" arg), report how '
+        'much of the Terraform config is covered by curated terradart_google '
+        'factories: coverage %, supported types, not-in-catalog types, and a '
+        'per-module breakdown.',
+    inputSchema: _objectSchema(
+      properties: {
+        'tf_json': $Schema.string(
+          description:
+              'The full `terraform show -json` output (state or plan JSON).',
+        ),
+      },
+      required: ['tf_json'],
+    ),
+    fn: (input, _) async => checkCoverage(input['tf_json'] as String),
   );
 
   return createMcpServer(ai, McpServerOptions(name: 'terradart'));

--- a/packages/terradart_agent/lib/src/tools/check_coverage.dart
+++ b/packages/terradart_agent/lib/src/tools/check_coverage.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+
+import 'package:terradart_coverage/terradart_coverage.dart';
+import 'package:terradart_google/catalog.dart';
+
+/// Runs coverage analysis on a `terraform show -json` string and returns a
+/// JSON-object result (MCP structuredContent). On bad input, returns an
+/// `{'error': ...}` object instead of throwing, so the MCP call still succeeds
+/// with an actionable message.
+Map<String, Object?> checkCoverage(String tfJson) {
+  final Map<String, dynamic> decoded;
+  try {
+    decoded = jsonDecode(tfJson) as Map<String, dynamic>;
+  } on FormatException catch (e) {
+    return {'error': 'input is not valid JSON: ${e.message}'};
+  }
+  final ParseOutcome parsed;
+  try {
+    parsed = parseShowJson(decoded);
+  } on FormatException catch (e) {
+    return {'error': e.message};
+  }
+  final report = buildCoverageReport(parsed, CatalogIndex(terradartCatalog));
+  return reportToJsonMap(report);
+}

--- a/packages/terradart_agent/pubspec.yaml
+++ b/packages/terradart_agent/pubspec.yaml
@@ -18,6 +18,7 @@ executables:
 dependencies:
   terradart_core: ^0.13.0
   terradart_google: ^0.13.0
+  terradart_coverage: ^0.13.0
   genkit: ^0.13.2
   genkit_mcp: ^0.1.7
   schemantic: ^0.1.3

--- a/packages/terradart_agent/test/server_test.dart
+++ b/packages/terradart_agent/test/server_test.dart
@@ -3,7 +3,7 @@ import 'package:terradart_agent/terradart_agent.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('buildTerradartMcpServer exposes the 4 catalog tools', () async {
+  test('buildTerradartMcpServer exposes the 5 catalog tools', () async {
     final GenkitMcpServer server = await buildTerradartMcpServer();
     final resp = await server.handleRequest(<String, dynamic>{
       'jsonrpc': '2.0',
@@ -20,6 +20,7 @@ void main() {
         'list_barrels',
         'get_resource_schema',
         'get_quickstart',
+        'check_coverage',
       ]),
     );
   });

--- a/packages/terradart_agent/test/tools/check_coverage_test.dart
+++ b/packages/terradart_agent/test/tools/check_coverage_test.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+import 'package:terradart_agent/src/tools/check_coverage.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('reports coverage for a state document', () {
+    final tfJson = jsonEncode({
+      'values': {
+        'root_module': {
+          'resources': [
+            {'mode': 'managed', 'type': 'google_storage_bucket', 'name': 'a'},
+            {'mode': 'managed', 'type': 'google_notreal_thing', 'name': 'b'},
+          ],
+        },
+      },
+    });
+    final out = checkCoverage(tfJson);
+    expect(out['summary'], isA<Map<String, Object?>>());
+    expect((out['summary'] as Map<String, Object?>)['distinctTypes'], 2);
+  });
+
+  test('returns an error object on invalid JSON (does not throw)', () {
+    final out = checkCoverage('not json');
+    expect(out['error'], isNotNull);
+  });
+
+  test('returns an error object on non-terraform-show JSON', () {
+    final out = checkCoverage('{"format_version":"1.0"}');
+    expect(out['error'], isNotNull);
+  });
+}

--- a/packages/terradart_coverage/lib/src/report_render.dart
+++ b/packages/terradart_coverage/lib/src/report_render.dart
@@ -52,44 +52,47 @@ String renderText(CoverageReport r) {
   return b.toString();
 }
 
-/// Machine-readable report (also reused as MCP structuredContent later).
-String renderJson(CoverageReport r) {
-  final map = {
-    'summary': {
-      'distinctTypes': r.summary.distinctTypes,
-      'supportedTypes': r.summary.supportedTypes,
-      'totalOccurrences': r.summary.totalOccurrences,
-      'supportedOccurrences': r.summary.supportedOccurrences,
-      'coverageByTypePct': r.summary.coverageByTypePct,
-      'coverageByOccurrencePct': r.summary.coverageByOccurrencePct,
-    },
-    'supported': [
-      for (final e in r.supported)
-        {
-          'type': e.type,
-          'kind': _kind(e.kind),
-          'count': e.count,
-          'className': e.className,
-          'barrel': e.barrel,
-        },
-    ],
-    'notInCatalog': [
-      for (final e in r.notInCatalog)
-        {
-          'type': e.type,
-          'kind': _kind(e.kind),
-          'count': e.count,
-          'product': e.product,
-        },
-    ],
-    'perModule': {
-      for (final entry in r.perModule.entries)
-        entry.key: {
-          'supported': entry.value.supported,
-          'notInCatalog': entry.value.notInCatalog,
-        },
-    },
-    'unparseable': r.unparseable,
-  };
-  return const JsonEncoder.withIndent('  ').convert(map);
-}
+/// Returns the coverage report as a plain [Map] suitable for JSON encoding or
+/// MCP structuredContent. This is the canonical map structure shared by
+/// [renderJson] and `check_coverage` in terradart_agent.
+Map<String, Object?> reportToJsonMap(CoverageReport r) => {
+  'summary': {
+    'distinctTypes': r.summary.distinctTypes,
+    'supportedTypes': r.summary.supportedTypes,
+    'totalOccurrences': r.summary.totalOccurrences,
+    'supportedOccurrences': r.summary.supportedOccurrences,
+    'coverageByTypePct': r.summary.coverageByTypePct,
+    'coverageByOccurrencePct': r.summary.coverageByOccurrencePct,
+  },
+  'supported': [
+    for (final e in r.supported)
+      {
+        'type': e.type,
+        'kind': _kind(e.kind),
+        'count': e.count,
+        'className': e.className,
+        'barrel': e.barrel,
+      },
+  ],
+  'notInCatalog': [
+    for (final e in r.notInCatalog)
+      {
+        'type': e.type,
+        'kind': _kind(e.kind),
+        'count': e.count,
+        'product': e.product,
+      },
+  ],
+  'perModule': {
+    for (final entry in r.perModule.entries)
+      entry.key: {
+        'supported': entry.value.supported,
+        'notInCatalog': entry.value.notInCatalog,
+      },
+  },
+  'unparseable': r.unparseable,
+};
+
+/// Machine-readable report. Encodes [reportToJsonMap] as indented JSON.
+String renderJson(CoverageReport r) =>
+    const JsonEncoder.withIndent('  ').convert(reportToJsonMap(r));

--- a/packages/terradart_coverage/test/report_render_test.dart
+++ b/packages/terradart_coverage/test/report_render_test.dart
@@ -39,4 +39,24 @@ void main() {
     );
     expect((decoded['summary'] as Map)['distinctTypes'], 1);
   });
+
+  test('reportToJsonMap returns same structure as json render', () {
+    final sample = _sample();
+    final m = reportToJsonMap(sample);
+    expect(m['summary'], isA<Map>());
+    expect((m['summary'] as Map)['distinctTypes'], 1);
+    expect(
+      m.keys,
+      containsAll([
+        'summary',
+        'supported',
+        'notInCatalog',
+        'perModule',
+        'unparseable',
+      ]),
+    );
+    // Verify the map round-trips to the same JSON as renderJson.
+    final fromMap = const JsonEncoder.withIndent('  ').convert(m);
+    expect(fromMap, equals(renderJson(sample)));
+  });
 }


### PR DESCRIPTION
## Summary

Adds a 5th MCP tool `check_coverage` to `terradart-mcp`: given `terraform show -json`
output (the `tf_json` arg), it reports how much of the config is covered by curated
`terradart_google` factories — coverage %, supported types, not-in-catalog types,
and a per-module breakdown. This is the spec'd follow-up that exposes the
`terradart_coverage` core (merged in #161) to AI agents (Genkit).

- `refactor(coverage)`: extract `reportToJsonMap` from `renderJson` so the report
  map is reusable as MCP `structuredContent` (renderJson now just JSON-encodes it).
- `feat(agent)`: `terradart_agent` depends on `terradart_coverage`; new
  `tools/check_coverage.dart` (invalid input returns `{'error': ...}` rather than
  throwing, so the MCP call still succeeds with an actionable message); registered
  in `server.dart` (now 5 tools).

## Test plan
- [x] `cd packages/terradart_coverage && dart test` — green
- [x] `cd packages/terradart_agent && dart test` — 15 green (check_coverage 3 + server 5-tool assertion)
- [x] `dart analyze` clean

Note: the pre-existing `check_override_enum_gaps` (2 gaps on
`google_compute_region_backend_service`) is unrelated and addressed separately;
`ci.yml` does not run that gate.
