### PR TITLE
chore(release): 0.14.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to file. terradart is **pre-alpha** on
-        **0.12.x** today (beta planned from v0.13.0). Single-maintainer;
+        **0.14.x** today (beta planned from v0.14.0). Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         **PII note**: synthesized `.tf.json`, error output, and schema excerpts

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to file. terradart is **pre-alpha** on
-        **0.12.x** today (beta planned from v0.13.0). Single-maintainer;
+        **0.14.x** today (beta planned from v0.14.0). Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         Feature requests are welcome — no timeline promises, but they help

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to ask. terradart is **pre-alpha** on
-        **0.12.x** today (beta planned from v0.13.0). Single-maintainer;
+        **0.14.x** today (beta planned from v0.14.0). Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         Docs: https://terradart.dev/docs/getting-started/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 All notable changes to terradart are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-Per-package changelogs live alongside each package and are the system of record for `terradart_core`, `terradart_codegen`, `terradart_google`, and `terradart_agent` — this top-level file summarises cross-cutting milestones.
+Per-package changelogs live alongside each package and are the system of record for `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_agent`, and `terradart_coverage` — this top-level file summarises cross-cutting milestones.
+
+## [0.14.0] - 2026-06-16
+
+- Provider bump to `hashicorp/google` 7.36.0 (38 new resources recorded in the
+  curation backlog; `google_compute_address.address_id`).
+- New package **`terradart_coverage`** — a read-only Terraform coverage checker
+  CLI (`terradart-coverage`, brew-distributed) plus brew release automation that
+  auto-pushes the `terradart-mcp` and `terradart-coverage` formulas.
+- `terradart_agent`: new `check_coverage` MCP tool wrapping the coverage core.
+- **Breaking** (`terradart_google`): `connection_tracking_policy` on
+  `google_compute_region_backend_service` is now typed. See MIGRATING.md.
 
 ## [0.13.0] - 2026-06-14
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing to terradart
 
-Thanks for taking time to look at this. terradart is a **pre-alpha** single-maintainer project (0.13.x today; [beta planned at v0.13.0](https://terradart.dev/docs/status/#beta-readiness-checklist)). Contributions are welcome on a best-effort basis.
+Thanks for taking time to look at this. terradart is a **pre-alpha** single-maintainer project (0.14.x today; [beta planned at v0.14.0](https://terradart.dev/docs/status/#beta-readiness-checklist)). Contributions are welcome on a best-effort basis.
 
 ## What kind of contribution?
 
 terradart ships one consumer surface:
 
-- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**209 curated resource factories + 1 data source** as of 0.13.x). Bug fixes, tests, and doc improvements welcome. New resources land via `terradart wrap` overrides — open an issue first to discuss scope.
+- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**209 curated resource factories + 1 data source** as of 0.14.x). Bug fixes, tests, and doc improvements welcome. New resources land via `terradart wrap` overrides — open an issue first to discuss scope.
 
-Within a **minor** line (`^0.13.x`), we aim to avoid breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (stricter from v0.13.0 beta — see [status](https://terradart.dev/docs/status/)).
+Within a **minor** line (`^0.14.x`), we aim to avoid breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (stricter from v0.14.0 beta — see [status](https://terradart.dev/docs/status/)).
 
 Bug reports / questions / feature requests: pick a template when [opening an issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,32 @@
 # Migrating terradart
 
+## 0.13.0 → 0.14.0
+
+**Breaking** — one curated nested block became typed.
+
+### `connection_tracking_policy` on `google_compute_region_backend_service`
+
+Previously this nested block fell through untyped (`TfArg<Map>`); it is now a
+typed helper class with two enums.
+
+```dart
+// Before
+connectionTrackingPolicy: TfArg.literal({
+  'tracking_mode': 'PER_SESSION',
+  'connection_persistence_on_unhealthy_backends': 'NEVER_PERSIST',
+}),
+
+// After
+connectionTrackingPolicy:
+    const ComputeRegionBackendServiceRegionBackendServiceConnectionTrackingPolicy(
+  trackingMode: RegionBackendServiceTrackingMode.perSession,
+  connectionPersistenceOnUnhealthyBackends:
+      RegionBackendServiceConnectionPersistence.neverPersist,
+),
+```
+
+If you did not set `connection_tracking_policy`, no change is needed.
+
 ## 0.12.20 → next release
 
 **Breaking changes** — API-enablement collapse, time-wrapper relocation, and

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 >
 > Google Cloud infrastructure as real Dart code — typed, refactor-safe, drop-in for `terraform apply`.
 
-**Pre-alpha** — no SemVer guarantees until v1.0.0. Pin `^0.13.x`, read [`MIGRATING.md`](MIGRATING.md) before bumping, and see [status on terradart.dev](https://terradart.dev/docs/status/).
+**Pre-alpha** — no SemVer guarantees until v1.0.0. Pin `^0.14.x`, read [`MIGRATING.md`](MIGRATING.md) before bumping, and see [status on terradart.dev](https://terradart.dev/docs/status/).
 
 <!-- identity -->
 [![pub: terradart_core](https://img.shields.io/pub/v/terradart_core.svg?label=pub%3A%20core)](https://pub.dev/packages/terradart_core)
@@ -202,8 +202,8 @@ GoogleCloudRunV2Service(
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.13.x
-  terradart_google: ^0.13.x
+  terradart_core: ^0.14.x
+  terradart_google: ^0.14.x
 ```
 
 ```bash
@@ -278,7 +278,7 @@ Application platform & operations
 
 ## Status
 
-**Pre-alpha**, pre-1.0 (0.13.x). No SemVer guarantees until v1.0.0; pin `^0.13.x` and read [`MIGRATING.md`](MIGRATING.md) before every minor bump. Beta is planned from **v0.13.0** once [readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met. Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
+**Pre-alpha**, pre-1.0 (0.14.x). No SemVer guarantees until v1.0.0; pin `^0.14.x` and read [`MIGRATING.md`](MIGRATING.md) before every minor bump. Beta is planned from **v0.14.0** once [readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met. Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
 
 ## Schema-bump automation (Plan 5.E)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,13 +31,13 @@ What does **not** count:
 
 ## Supported versions
 
-Pin dependencies with `^0.13.x` on [pub.dev](https://pub.dev/packages/terradart_core) today.
+Pin dependencies with `^0.14.x` on [pub.dev](https://pub.dev/packages/terradart_core) today.
 
 | Version | Status | Security fixes |
 |---|---|---|
-| **0.13.x** (pre-alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
-| **0.11.x and older** | Unsupported | Upgrade to 0.13.x; see [MIGRATING.md](MIGRATING.md) |
-| **0.13.x** (beta, planned) | Best-effort with clearer minor-boundary policy | See [status on terradart.dev](https://terradart.dev/docs/status/) |
+| **0.14.x** (pre-alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
+| **0.11.x and older** | Unsupported | Upgrade to 0.14.x; see [MIGRATING.md](MIGRATING.md) |
+| **0.14.x** (beta, planned) | Best-effort with clearer minor-boundary policy | See [status on terradart.dev](https://terradart.dev/docs/status/) |
 
 ## Disclosure policy
 

--- a/examples/bigquery_quickstart/pubspec.yaml
+++ b/examples/bigquery_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_build_quickstart/pubspec.yaml
+++ b/examples/cloud_build_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_functions_quickstart/pubspec.yaml
+++ b/examples/cloud_functions_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_quickstart/pubspec.yaml
+++ b/examples/cloud_run_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_scheduler_quickstart/pubspec.yaml
+++ b/examples/cloud_scheduler_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_sql_quickstart/pubspec.yaml
+++ b/examples/cloud_sql_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_tasks_quickstart/pubspec.yaml
+++ b/examples/cloud_tasks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_lb_quickstart/pubspec.yaml
+++ b/examples/compute_lb_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_quickstart/pubspec.yaml
+++ b/examples/compute_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dns_quickstart/pubspec.yaml
+++ b/examples/dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/eventarc_quickstart/pubspec.yaml
+++ b/examples/eventarc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_check_quickstart/pubspec.yaml
+++ b/examples/firebase_app_check_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_hosting_quickstart/pubspec.yaml
+++ b/examples/firebase_app_hosting_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_data_connect_quickstart/pubspec.yaml
+++ b/examples/firebase_data_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_remote_config_quickstart/pubspec.yaml
+++ b/examples/firebase_remote_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_document_quickstart/pubspec.yaml
+++ b/examples/firestore_document_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_quickstart/pubspec.yaml
+++ b/examples/firestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_quickstart/pubspec.yaml
+++ b/examples/gke_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iam_quickstart/pubspec.yaml
+++ b/examples/iam_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_quickstart/pubspec.yaml
+++ b/examples/kms_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/monitoring_quickstart/pubspec.yaml
+++ b/examples/monitoring_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ops_quickstart/pubspec.yaml
+++ b/examples/ops_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/pubsub_quickstart/pubspec.yaml
+++ b/examples/pubsub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/secret_manager_quickstart/pubspec.yaml
+++ b/examples/secret_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_quickstart/pubspec.yaml
+++ b/examples/storage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/terradart_agent/CHANGELOG.md
+++ b/packages/terradart_agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.14.0 - 2026-06-16
+
+Add the `check_coverage` MCP tool (5th catalog tool): given `terraform show -json`
+output, it reports terradart_google coverage. Wraps the new `terradart_coverage`
+package.
+
 ## 0.13.0 - 2026-06-14
 
 Lockstep version bump for `terradart_google` v0.13.0. MCP catalog: **210 entries** (35 service barrels). `TimeProvider` / `TimeSleep` now come from `package:terradart_google/time.dart` (moved out of `terradart_core`).

--- a/packages/terradart_agent/lib/src/version.dart
+++ b/packages/terradart_agent/lib/src/version.dart
@@ -1,4 +1,4 @@
 /// The terradart-mcp binary version, kept in lockstep with pubspec.yaml's
 /// `version:` field by `tool/bump_version.sh`. The lockstep is guarded by
 /// test/version_test.dart so the two can never silently drift.
-const String packageVersion = '0.13.0';
+const String packageVersion = '0.14.0';

--- a/packages/terradart_agent/pubspec.yaml
+++ b/packages/terradart_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_agent
 description: terradart-mcp — MCP server exposing the curated GCP factory catalog of TerraDart.
-version: 0.13.0
+version: 0.14.0
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -16,9 +16,9 @@ executables:
   terradart-mcp: terradart_mcp
 
 dependencies:
-  terradart_core: ^0.13.0
-  terradart_google: ^0.13.0
-  terradart_coverage: ^0.13.0
+  terradart_core: ^0.14.0
+  terradart_google: ^0.14.0
+  terradart_coverage: ^0.14.0
   genkit: ^0.13.2
   genkit_mcp: ^0.1.7
   schemantic: ^0.1.3

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.14.0 - 2026-06-16
+
+- Refresh the provider schema fixture to `hashicorp/google` 7.36.0.
+- Type the `google_compute_region_backend_service.connection_tracking_policy`
+  nested block in the wrapper override (2 enums + block class), closing the last
+  `check_override_enum_gaps --strict-nested` gap.
+
 ## 0.13.0 - 2026-06-14
 
 **BREAKING** — removes the `terradart codegen` CLI subcommand, `runCodegen`, `CodegenResult`, and `FileEmitter`. Maintainer generation is `terradart wrap` only. See [MIGRATING.md](../../MIGRATING.md).

--- a/packages/terradart_codegen/README.md
+++ b/packages/terradart_codegen/README.md
@@ -15,7 +15,7 @@ End users depend on [`terradart_google`](https://pub.dev/packages/terradart_goog
 Activate on the same minor line as your workspace when working on the repo:
 
 ```bash
-dart pub global activate terradart_codegen ^0.13.x
+dart pub global activate terradart_codegen ^0.14.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_codegen) for the latest patch.

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart maintainer tooling — parses Terraform provider schema JSON and Magic Modules YAML and emits curated factory wrappers via terradart wrap. Ships the terradart CLI.
-version: 0.13.0
+version: 0.14.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -33,7 +33,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.13.0
+  terradart_core: ^0.14.0
 
 dev_dependencies:
   http: ^1.0.0

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.0 - 2026-06-16
+
+Lockstep release. No `terradart_core` API changes.
+
 ## 0.13.0 - 2026-06-14
 
 Lockstep release. **Breaking** — see [MIGRATING.md](../../MIGRATING.md).

--- a/packages/terradart_core/README.md
+++ b/packages/terradart_core/README.md
@@ -36,7 +36,7 @@ enum RoutingMode implements TerraformEnum {
 
 ```yaml
 dependencies:
-  terradart_core: ^0.13.x
+  terradart_core: ^0.14.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch. Read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before minor bumps.

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.13.0
+version: 0.14.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_coverage/CHANGELOG.md
+++ b/packages/terradart_coverage/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.14.0 - 2026-06-16
+
+First release. `terradart-coverage` — a read-only CLI that reads
+`terraform show -json` output and reports how much of an existing Terraform
+config is covered by curated `terradart_google` factories (coverage %, supported
+types, not-in-catalog types ranked by usage, per-module breakdown). Text or
+`--json` output; distributed via Homebrew (no Dart SDK required). Also exposed as
+the `check_coverage` MCP tool in `terradart_agent`.

--- a/packages/terradart_coverage/pubspec.yaml
+++ b/packages/terradart_coverage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_coverage
 description: Read-only Terraform coverage checker — reports how much of a Terraform config is covered by curated terradart_google factories.
-version: 0.13.0
+version: 0.14.0
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -15,7 +15,7 @@ executables:
   terradart-coverage: terradart_coverage
 
 dependencies:
-  terradart_google: ^0.13.0
+  terradart_google: ^0.14.0
   args: ^2.5.0
 
 dev_dependencies:

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.14.0 - 2026-06-16
+
+- Provider 7.36.0: `google_compute_address` gains the computed `address_id`
+  getter.
+- **Breaking**: `google_compute_region_backend_service.connection_tracking_policy`
+  is now a typed `ComputeRegionBackendServiceRegionBackendServiceConnectionTrackingPolicy`
+  (with `RegionBackendServiceConnectionPersistence` /
+  `RegionBackendServiceTrackingMode` enums) instead of `TfArg<Map>`. See
+  [MIGRATING.md](../../MIGRATING.md).
+
 ## 0.13.0 - 2026-06-14
 
 Lockstep release. Folds in the unreleased 0.12.20 (Waves 33–35) plus the

--- a/packages/terradart_google/README.md
+++ b/packages/terradart_google/README.md
@@ -16,8 +16,8 @@ Runtime primitives (`Stack`, `TfArg`, `writeTo`) live in [`terradart_core`](http
 
 ```yaml
 dependencies:
-  terradart_core: ^0.13.x
-  terradart_google: ^0.13.x
+  terradart_core: ^0.14.x
+  terradart_google: ^0.14.x
 ```
 
 ## Usage example

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: Curated factory wrappers for Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.
-version: 0.13.0
+version: 0.14.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -22,11 +22,11 @@ false_secrets:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.13.0
+  terradart_core: ^0.14.0
   meta: ^1.15.0
 
 dev_dependencies:
-  terradart_codegen: ^0.13.0
+  terradart_codegen: ^0.14.0
   path: ^1.9.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/tool/bump_version.sh
+++ b/tool/bump_version.sh
@@ -15,8 +15,16 @@
 #   - packages/terradart_agent/pubspec.yaml       (version: + terradart_core caret + terradart_google caret)
 #   - packages/terradart_agent/lib/src/version.dart  (packageVersion const — lockstep with its pubspec)
 #   - examples/*/pubspec.yaml                     (terradart_core + terradart_google carets)
-#   - README.md                                   (Quickstart pubspec sample + `dart pub global activate terradart_codegen ^...` line)
-#   - website/src/content/docs/docs/getting-started.md  (pubspec sample caret note)
+#   - README.md                                   (Quickstart pubspec sample + `dart pub global activate terradart_codegen ^...` line + status blurb)
+#   - CONTRIBUTING.md                             (minor-line caret references)
+#   - SECURITY.md                                 (supported-versions pin + table)
+#   - packages/terradart_core/README.md           (pubspec sample caret)
+#   - packages/terradart_google/README.md         (pubspec sample carets)
+#   - packages/terradart_codegen/README.md        (`dart pub global activate` caret)
+#   - website/src/content/docs/docs/getting-started.md  (pubspec sample caret note + version line)
+#   - .github/ISSUE_TEMPLATE/bug.yml              (pre-alpha banner version)
+#   - .github/ISSUE_TEMPLATE/feature.yml          (pre-alpha banner version)
+#   - .github/ISSUE_TEMPLATE/question.yml         (pre-alpha banner version)
 #
 # What it does NOT touch (write these by hand after the bump):
 #   - CHANGELOG.md (root + per-package) — release notes are prose
@@ -133,6 +141,68 @@ for md in README.md website/src/content/docs/docs/getting-started.md; do
   fi
 done
 
+# Extract old/new minor for plain x.y.x-style references (e.g. "0.13.x").
+OLD_MINOR="$(printf '%s' "$OLD" | sed 's/\.[^.]*$//')"
+NEW_MINOR="$(printf '%s' "$NEW" | sed 's/\.[^.]*$//')"
+OLD_MINOR_RE="$(printf '%s' "$OLD_MINOR" | sed 's/[.]/\\./g')"
+
+# 4b. Additional doc/template files that reference the minor line.
+#     Pattern set per file (only the version token is replaced; surrounding
+#     text is left intact so prose stays correct):
+#
+#   CONTRIBUTING.md  — "X.Y.x today", "^X.Y.x" caret, "vX.Y.0 beta" labels
+#   SECURITY.md      — "^X.Y.x" pin + table rows "**X.Y.x**"
+#   package READMEs  — pubspec/activate caret samples (same pattern as above)
+#   getting-started  — "**X.Y.x** line" + "vX.Y.0" planned-label
+#   ISSUE_TEMPLATE   — "**X.Y.x** today" + "vX.Y.0" planned-label in markdown value
+echo "  Additional doc/template files:"
+
+# CONTRIBUTING.md: replace ^X.Y.x and "X.Y.x today" and "vX.Y.0 beta" labels.
+if [ -f CONTRIBUTING.md ]; then
+  sed_inplace "s#\\^${OLD_MINOR_RE}\\.x#^${NEW_MINOR}.x#g" CONTRIBUTING.md
+  sed_inplace "s#${OLD_MINOR_RE}\\.x today#${NEW_MINOR}.x today#g" CONTRIBUTING.md
+  sed_inplace "s#v${OLD_MINOR_RE}\\.0#v${NEW_MINOR}.0#g" CONTRIBUTING.md
+  echo "    - CONTRIBUTING.md"
+fi
+
+# SECURITY.md: replace ^X.Y.x pin and **X.Y.x** table cells and "X.Y.x" upgrade references.
+if [ -f SECURITY.md ]; then
+  sed_inplace "s#\\^${OLD_MINOR_RE}\\.x#^${NEW_MINOR}.x#g" SECURITY.md
+  sed_inplace "s#\\*\\*${OLD_MINOR_RE}\\.x\\*\\*#**${NEW_MINOR}.x**#g" SECURITY.md
+  sed_inplace "s#${OLD_MINOR_RE}\\.x; see#${NEW_MINOR}.x; see#g" SECURITY.md
+  echo "    - SECURITY.md"
+fi
+
+# Package READMEs: pubspec caret samples + activate caret.
+for pkg_readme in packages/terradart_core/README.md \
+                  packages/terradart_google/README.md \
+                  packages/terradart_codegen/README.md; do
+  if [ -f "$pkg_readme" ]; then
+    sed_inplace "s#terradart_(core|codegen|google): \\^${OLD_RE}#terradart_\\1: ^${NEW}#g" "$pkg_readme"
+    sed_inplace "s#(dart pub global activate terradart_codegen) \\^${OLD_RE}#\\1 ^${NEW}#g" "$pkg_readme"
+    echo "    - $pkg_readme"
+  fi
+done
+
+# website/getting-started.md: "**X.Y.x** line" and "vX.Y.0" planned-label.
+GSTART="website/src/content/docs/docs/getting-started.md"
+if [ -f "$GSTART" ]; then
+  sed_inplace "s#\\*\\*${OLD_MINOR_RE}\\.x\\*\\* line#**${NEW_MINOR}.x** line#g" "$GSTART"
+  sed_inplace "s#v${OLD_MINOR_RE}\\.0#v${NEW_MINOR}.0#g" "$GSTART"
+  echo "    - $GSTART"
+fi
+
+# ISSUE_TEMPLATE ymls: "**X.Y.x** today" and "vX.Y.0" planned-label.
+for tpl in .github/ISSUE_TEMPLATE/bug.yml \
+           .github/ISSUE_TEMPLATE/feature.yml \
+           .github/ISSUE_TEMPLATE/question.yml; do
+  if [ -f "$tpl" ]; then
+    sed_inplace "s#\\*\\*${OLD_MINOR_RE}\\.x\\*\\* today#**${NEW_MINOR}.x** today#g" "$tpl"
+    sed_inplace "s#v${OLD_MINOR_RE}\\.0#v${NEW_MINOR}.0#g" "$tpl"
+    echo "    - $tpl"
+  fi
+done
+
 echo
 
 # 5. Verify no stale OLD carets / version lines remain in the scoped files.
@@ -142,10 +212,24 @@ STALE=$(
   grep -nE "^version: ${OLD_RE}\$" packages/*/pubspec.yaml 2>/dev/null
   grep -nE "terradart_(core|codegen|google|coverage): \\^${OLD_RE}([^0-9A-Za-z.-]|\$)" \
     packages/*/pubspec.yaml examples/*/pubspec.yaml \
-    README.md website/src/content/docs/docs/getting-started.md 2>/dev/null
+    README.md website/src/content/docs/docs/getting-started.md \
+    packages/terradart_core/README.md \
+    packages/terradart_google/README.md \
+    packages/terradart_codegen/README.md 2>/dev/null
   grep -nE "dart pub global activate terradart_codegen \\^${OLD_RE}([^0-9A-Za-z.-]|\$)" \
-    README.md website/src/content/docs/docs/getting-started.md 2>/dev/null
+    README.md \
+    website/src/content/docs/docs/getting-started.md \
+    packages/terradart_codegen/README.md 2>/dev/null
   grep -nE "packageVersion = '${OLD_RE}'" packages/terradart_agent/lib/src/version.dart 2>/dev/null
+  grep -nE "\\^${OLD_MINOR_RE}\\.x" \
+    CONTRIBUTING.md SECURITY.md 2>/dev/null
+  grep -nE "\\*\\*${OLD_MINOR_RE}\\.x\\*\\* (today|\\()" \
+    CONTRIBUTING.md SECURITY.md \
+    .github/ISSUE_TEMPLATE/bug.yml \
+    .github/ISSUE_TEMPLATE/feature.yml \
+    .github/ISSUE_TEMPLATE/question.yml 2>/dev/null
+  grep -nE "\\*\\*${OLD_MINOR_RE}\\.x\\*\\* line" \
+    website/src/content/docs/docs/getting-started.md 2>/dev/null
 )
 set -e
 

--- a/tool/bump_version.sh
+++ b/tool/bump_version.sh
@@ -82,7 +82,7 @@ sed_inplace() {
 
 # 1. `version:` field on the package pubspecs.
 echo "  Package versions:"
-for pkg in terradart_core terradart_codegen terradart_google terradart_agent; do
+for pkg in terradart_core terradart_codegen terradart_google terradart_agent terradart_coverage; do
   sed_inplace "s#^version: ${OLD_RE}\$#version: ${NEW}#" "packages/$pkg/pubspec.yaml"
   echo "    - packages/$pkg/pubspec.yaml -> $NEW"
 done
@@ -100,6 +100,10 @@ sed_inplace "s#^( *terradart_core): \\^${OLD_RE}\$#\\1: ^${NEW}#" packages/terra
 echo "    - terradart_agent.dependencies.terradart_core: ^${NEW}"
 sed_inplace "s#^( *terradart_google): \\^${OLD_RE}\$#\\1: ^${NEW}#" packages/terradart_agent/pubspec.yaml
 echo "    - terradart_agent.dependencies.terradart_google: ^${NEW}"
+sed_inplace "s#^( *terradart_coverage): \\^${OLD_RE}\$#\\1: ^${NEW}#" packages/terradart_agent/pubspec.yaml
+echo "    - terradart_agent.dependencies.terradart_coverage: ^${NEW}"
+sed_inplace "s#^( *terradart_google): \\^${OLD_RE}\$#\\1: ^${NEW}#" packages/terradart_coverage/pubspec.yaml
+echo "    - terradart_coverage.dependencies.terradart_google: ^${NEW}"
 
 # 2b. terradart_agent binary version const (lockstep with its pubspec;
 #     guarded by packages/terradart_agent/test/version_test.dart).
@@ -136,7 +140,7 @@ echo "==> Verifying no stale '$OLD' references remain"
 set +e
 STALE=$(
   grep -nE "^version: ${OLD_RE}\$" packages/*/pubspec.yaml 2>/dev/null
-  grep -nE "terradart_(core|codegen|google): \\^${OLD_RE}([^0-9A-Za-z.-]|\$)" \
+  grep -nE "terradart_(core|codegen|google|coverage): \\^${OLD_RE}([^0-9A-Za-z.-]|\$)" \
     packages/*/pubspec.yaml examples/*/pubspec.yaml \
     README.md website/src/content/docs/docs/getting-started.md 2>/dev/null
   grep -nE "dart pub global activate terradart_codegen \\^${OLD_RE}([^0-9A-Za-z.-]|\$)" \

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -3,7 +3,7 @@ title: Getting Started
 description: Install TerraDart and generate your first *.tf.json from a Stack.
 ---
 
-This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.13.x** line. TerraDart is **pre-alpha** until [beta gates](/docs/status/#beta-readiness-checklist) are complete (planned label: **v0.13.0**).
+This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.14.x** line. TerraDart is **pre-alpha** until [beta gates](/docs/status/#beta-readiness-checklist) are complete (planned label: **v0.14.0**).
 
 ## Prerequisites
 
@@ -16,8 +16,8 @@ This guide matches the [README quickstart](https://github.com/nozomi-koborinai/t
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.13.x
-  terradart_google: ^0.13.x
+  terradart_core: ^0.14.x
+  terradart_google: ^0.14.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch, then run:


### PR DESCRIPTION
## Summary

0.14.0 lockstep release carrying merged work #158–163:
- provider bump to `hashicorp/google` 7.36.0 (`compute_address.address_id`; 38 new backlog resources)
- **`terradart_coverage`** (#161) — Terraform coverage checker CLI + brew release automation
- `check_coverage` MCP tool (#162)
- `connection_tracking_policy` typed on `google_compute_region_backend_service` (#163) — **breaking**, see MIGRATING.md

Also fixes `tool/bump_version.sh` to include `terradart_coverage` in the lockstep bump (the package was added in #161 *after* the tool was written, so it was being left at 0.13.0 — that gap is closed here).

## Release mechanics
- All 5 packages → **0.14.0**; inter-package carets (incl. `agent→coverage`, `coverage→google`) + 25 example carets + agent `version.dart` const bumped.
- CHANGELOGs: root + 5 packages (coverage's CHANGELOG created) + a `0.13.0 → 0.14.0` MIGRATING section.
- pub.dev publishes **core / codegen / google**; **agent + coverage are `publish_to: none`** (brew binaries via `release-binary.yml`).

## After merge
Tag **`v0.14.0`** to trigger `publish.yml` (pub.dev) + `release-binary.yml` (brew: `terradart-mcp` + `terradart-coverage`, tap auto-push). Tagging is maintainer-manual. This is the first release where the brew tap auto-push runs end-to-end — watch that run.

## Test plan
- [x] `dart pub get` (workspace) + `dart analyze` (5 packages) — clean
- [x] CHANGELOG `## 0.14.0` entries present for core/codegen/google (the `prepare_publish.sh` gate)
- [ ] CI: per-package `pub publish --dry-run` (core/codegen/google), `agent_verify`, full matrix
