### PR TITLE
ci: opt into Node 24 runtime across workflows

### DIFF
--- a/.github/workflows/apply-smoke-janitor.yml
+++ b/.github/workflows/apply-smoke-janitor.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   janitor:
     name: terradart-validate janitor

--- a/.github/workflows/apply-smoke-weekly.yml
+++ b/.github/workflows/apply-smoke-weekly.yml
@@ -17,6 +17,9 @@ permissions:
   id-token: write
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   sweep:
     name: weekly apply sweep (terradart-validate)

--- a/.github/workflows/apply-smoke.yml
+++ b/.github/workflows/apply-smoke.yml
@@ -18,6 +18,9 @@ permissions:
   id-token: write
   pull-requests: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   apply_smoke:
     name: apply smoke (terradart-validate)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     name: test (${{ matrix.package }})

--- a/.github/workflows/docs-consistency.yml
+++ b/.github/workflows/docs-consistency.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   docs_consistency:
     name: docs consistency + pubsub smoke

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -20,6 +20,9 @@ permissions:
   pull-requests: write
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: pr-labeler-${{ github.event.pull_request.number || format('backfill-{0}', github.run_id) }}
   cancel-in-progress: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 # Publish ordering rationale.
 #
 # terradart_codegen's published pubspec declares `terradart_core: ^X.Y.Z-dev`,

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -12,6 +12,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   regenerate:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/schema-bump.yml
+++ b/.github/workflows/schema-bump.yml
@@ -15,6 +15,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   detect-and-pr:
     name: detect schema/MM drift and open PR

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -21,6 +21,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     name: website build & typecheck


### PR DESCRIPTION
## Summary

Clears the "Node.js 20 actions are deprecated" runner warnings (Node 20 is removed from GitHub runners 2026-09-16). Adds GitHub's documented opt-in env `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at the **top level of all 11 workflows**, which forces actions still declaring Node 20 (`softprops/action-gh-release@v2`, `hashicorp/setup-terraform@v3`, `google-github-actions/auth@v2`, `dart-lang/setup-dart@v1`, …) to run on Node 24.

No action version bumps — this is the recommended migration step until each action ships a Node 24 runtime, and it's a no-op for actions that are already Node-24-ready.

## Test plan
- [x] all 11 workflow YAMLs parse
- [x] all 11 carry the env key at top level (column 0)

CI hygiene only; independent of the 0.14.0 release (already shipped to pub.dev + brew).
