### PR TITLE
ci: add apigee and dataplex to terraform_validate matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        example: [pubsub, cloud_tasks, secret_manager, cloud_scheduler, iam, compute, gke, kms, storage, bigquery, dns, ops, cloud_run, monitoring, cloud_functions, firestore, firestore_document, firebase_app_hosting, firebase_app_check, firebase_data_connect, firebase_remote_config, cloud_sql, compute_lb, cloud_build, eventarc]
+        example: [pubsub, cloud_tasks, secret_manager, cloud_scheduler, iam, compute, gke, kms, storage, bigquery, dns, ops, cloud_run, monitoring, cloud_functions, firestore, firestore_document, firebase_app_hosting, firebase_app_check, firebase_data_connect, firebase_remote_config, cloud_sql, compute_lb, cloud_build, eventarc, apigee, dataplex]
     steps:
       - name: Job start
         id: job_start


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `apigee` and `dataplex` to the `terraform_validate` job matrix in `.github/workflows/ci.yml`, matching the quickstarts landed in #169 and #170.

`check_docs_consistency.dart` already synths every quickstart locally; this keeps CI's parallel `terraform validate` matrix in lockstep per Wave shipping policy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7ea65b2-05ee-446b-abf9-636799b0fdaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7ea65b2-05ee-446b-abf9-636799b0fdaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

