### PR TITLE
chore(release): 0.15.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to file. terradart is **pre-alpha** on
-        **0.14.x** today (beta planned from v0.14.0). Single-maintainer;
+        **0.15.x** today (beta planned from v0.15.0). Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         **PII note**: synthesized `.tf.json`, error output, and schema excerpts

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to file. terradart is **pre-alpha** on
-        **0.14.x** today (beta planned from v0.14.0). Single-maintainer;
+        **0.15.x** today (beta planned from v0.15.0). Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         Feature requests are welcome — no timeline promises, but they help

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to ask. terradart is **pre-alpha** on
-        **0.14.x** today (beta planned from v0.14.0). Single-maintainer;
+        **0.15.x** today (beta planned from v0.15.0). Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         Docs: https://terradart.dev/docs/getting-started/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to terradart are documented here. The format follows [Keep a
 
 Per-package changelogs live alongside each package and are the system of record for `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_agent`, and `terradart_coverage` — this top-level file summarises cross-cutting milestones.
 
+## [0.15.0] - 2026-06-20
+
+Lockstep release across the workspace. **No breaking changes** vs `0.14.0`.
+
+### Added
+
+- **`terradart_google`** — catalog grows to **256 curated resource factories + 1 data source** (257 entries; 46 service barrels), including Apigee, Dataplex, License Manager, Discovery Engine, Config Deployment, Contact Center Insights, Dialogflow SIP trunk, Network Connectivity transport, Chronicle, Migration Center, Network Security ULL, Oracle Database@Google Cloud Waves 36–40, and Wave 41 IAM binding/policy adjuncts.
+- **Examples** — new or extended quickstarts cover the added factories, including Config Deployment, Network Connectivity, Network Security ULL, Migration Center, Chronicle, Oracle GoldenGate / Autonomous Database / DB System / Exadata, and IAM binding/policy adjuncts.
+
+### Changed
+
+- **CI / release maintenance** — opt GitHub workflows into Node 24 and expand the Terraform validate matrix for Apigee and Dataplex quickstarts.
+- **Docs** — release Waves 34–41 in the public waves guide and align package/site version references with the `0.15.x` line.
+
+### Fixed
+
+- **Examples / generation** — backfill Filestore snapshot coverage in `compute_quickstart`, align the Contact Center Insights barrel output directory with the wrap-init anchor, and add Config Deployment Gate 6 thunks.
+
 ## [0.14.0] - 2026-06-16
 
 - Provider bump to `hashicorp/google` 7.36.0 (38 new resources recorded in the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing to terradart
 
-Thanks for taking time to look at this. terradart is a **pre-alpha** single-maintainer project (0.14.x today; [beta planned at v0.14.0](https://terradart.dev/docs/status/#beta-readiness-checklist)). Contributions are welcome on a best-effort basis.
+Thanks for taking time to look at this. terradart is a **pre-alpha** single-maintainer project (0.15.x today; [beta planned at v0.15.0](https://terradart.dev/docs/status/#beta-readiness-checklist)). Contributions are welcome on a best-effort basis.
 
 ## What kind of contribution?
 
 terradart ships one consumer surface:
 
-- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**256 curated resource factories + 1 data source** as of 0.14.x). Bug fixes, tests, and doc improvements welcome. New resources land via `terradart wrap` overrides — open an issue first to discuss scope.
+- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**256 curated resource factories + 1 data source** as of 0.15.x). Bug fixes, tests, and doc improvements welcome. New resources land via `terradart wrap` overrides — open an issue first to discuss scope.
 
-Within a **minor** line (`^0.14.x`), we aim to avoid breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (stricter from v0.14.0 beta — see [status](https://terradart.dev/docs/status/)).
+Within a **minor** line (`^0.15.x`), we aim to avoid breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (stricter from v0.15.0 beta — see [status](https://terradart.dev/docs/status/)).
 
 Bug reports / questions / feature requests: pick a template when [opening an issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 >
 > Google Cloud infrastructure as real Dart code — typed, refactor-safe, drop-in for `terraform apply`.
 
-**Pre-alpha** — no SemVer guarantees until v1.0.0. Pin `^0.14.x`, read [`MIGRATING.md`](MIGRATING.md) before bumping, and see [status on terradart.dev](https://terradart.dev/docs/status/).
+**Pre-alpha** — no SemVer guarantees until v1.0.0. Pin `^0.15.x`, read [`MIGRATING.md`](MIGRATING.md) before bumping, and see [status on terradart.dev](https://terradart.dev/docs/status/).
 
 <!-- identity -->
 [![pub: terradart_core](https://img.shields.io/pub/v/terradart_core.svg?label=pub%3A%20core)](https://pub.dev/packages/terradart_core)
@@ -202,8 +202,8 @@ GoogleCloudRunV2Service(
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.14.x
-  terradart_google: ^0.14.x
+  terradart_core: ^0.15.x
+  terradart_google: ^0.15.x
 ```
 
 ```bash
@@ -216,7 +216,7 @@ Runnable end-to-end:  [`examples/pubsub_quickstart/`](examples/pubsub_quickstart
 
 ## terradart-mcp
 
-**Pre-alpha.** [`terradart-mcp`](packages/terradart_agent/) is an MCP server that exposes the curated factory **catalog** to coding agents (Claude Code, Cursor, Claude Desktop). Four read-only tools — `list_barrels`, `list_resources`, `get_resource_schema`, `get_quickstart` — help agents author correct Dart without guessing factory names. It does **not** run Terraform or touch GCP.
+**Pre-alpha.** [`terradart-mcp`](packages/terradart_agent/) is an MCP server that exposes the curated factory **catalog** to coding agents (Claude Code, Cursor, Claude Desktop). Five read-only tools — `list_barrels`, `list_resources`, `get_resource_schema`, `get_quickstart`, and `check_coverage` — help agents author correct Dart without guessing factory names. It does **not** run Terraform or touch GCP.
 
 ```sh
 brew install nozomi-koborinai/tap/terradart-mcp
@@ -293,7 +293,7 @@ Application platform & operations
 
 ## Status
 
-**Pre-alpha**, pre-1.0 (0.14.x). No SemVer guarantees until v1.0.0; pin `^0.14.x` and read [`MIGRATING.md`](MIGRATING.md) before every minor bump. Beta is planned from **v0.14.0** once [readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met. Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
+**Pre-alpha**, pre-1.0 (0.15.x). No SemVer guarantees until v1.0.0; pin `^0.15.x` and read [`MIGRATING.md`](MIGRATING.md) before every minor bump. Beta is planned from **v0.15.0** once [readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met. Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
 
 ## Schema-bump automation (Plan 5.E)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Checklist
 
-terradart releases 3 packages in lockstep: `terradart_core`, `terradart_codegen`, `terradart_google`. All 3 share the same version (e.g. `0.11.0`).
+terradart bumps 5 packages in lockstep: `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_agent`, and `terradart_coverage`. All 5 share the same version (e.g. `0.15.0`). The pub.dev publish workflow currently publishes the 3 hosted packages: `terradart_core`, `terradart_codegen`, and `terradart_google`.
 
 ## Pre-flight (local)
 
@@ -11,8 +11,8 @@ terradart releases 3 packages in lockstep: `terradart_core`, `terradart_codegen`
   tool/bump_version.sh 0.X.Y
   ```
 
-  This updates all 3 package pubspecs, their inter-package carets, the 23 example pubspec carets, and the README + website pubspec samples in one shot. Idempotent: re-running with the same version is a no-op. Run `git diff --stat` afterwards to review.
-- [ ] Add `## <version> - YYYY-MM-DD` entry to root `CHANGELOG.md` and to each of the 3 `packages/*/CHANGELOG.md` files. Release notes are prose — the bump script intentionally does not generate them.
+  This updates all 5 package pubspecs, their inter-package carets, the example pubspec carets, and the README + website pubspec samples in one shot. Idempotent: re-running with the same version is a no-op. Run `git diff --stat` afterwards to review.
+- [ ] Add `## <version> - YYYY-MM-DD` entry to root `CHANGELOG.md` and to each package `CHANGELOG.md` file. Release notes are prose — the bump script intentionally does not generate them.
 - [ ] If the release is breaking, add a `# Migrating from terradart X.Y.Z to A.B.C` section at the top of `MIGRATING.md` with before / after snippets.
 - [ ] Run pana score check on each package:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,13 +31,13 @@ What does **not** count:
 
 ## Supported versions
 
-Pin dependencies with `^0.14.x` on [pub.dev](https://pub.dev/packages/terradart_core) today.
+Pin dependencies with `^0.15.x` on [pub.dev](https://pub.dev/packages/terradart_core) today.
 
 | Version | Status | Security fixes |
 |---|---|---|
-| **0.14.x** (pre-alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
-| **0.11.x and older** | Unsupported | Upgrade to 0.14.x; see [MIGRATING.md](MIGRATING.md) |
-| **0.14.x** (beta, planned) | Best-effort with clearer minor-boundary policy | See [status on terradart.dev](https://terradart.dev/docs/status/) |
+| **0.15.x** (pre-alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
+| **0.11.x and older** | Unsupported | Upgrade to 0.15.x; see [MIGRATING.md](MIGRATING.md) |
+| **0.15.x** (beta, planned) | Best-effort with clearer minor-boundary policy | See [status on terradart.dev](https://terradart.dev/docs/status/) |
 
 ## Disclosure policy
 

--- a/examples/apigee_quickstart/pubspec.yaml
+++ b/examples/apigee_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_quickstart/pubspec.yaml
+++ b/examples/bigquery_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/chronicle_quickstart/pubspec.yaml
+++ b/examples/chronicle_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_build_quickstart/pubspec.yaml
+++ b/examples/cloud_build_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_functions_quickstart/pubspec.yaml
+++ b/examples/cloud_functions_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_quickstart/pubspec.yaml
+++ b/examples/cloud_run_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_scheduler_quickstart/pubspec.yaml
+++ b/examples/cloud_scheduler_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_sql_quickstart/pubspec.yaml
+++ b/examples/cloud_sql_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_tasks_quickstart/pubspec.yaml
+++ b/examples/cloud_tasks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_lb_quickstart/pubspec.yaml
+++ b/examples/compute_lb_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_quickstart/README.md
+++ b/examples/compute_quickstart/README.md
@@ -15,7 +15,7 @@ examples/compute_quickstart/
 ├── lib/main.dart        # NetworkStack: VPC + load-balancer VIP
 ├── bin/infra.dart       # Synth entry: stack.writeTo('tf-out')
 ├── tf-out/              # (created on synth) main.tf.json
-└── pubspec.yaml         # workspace member (terradart_core: ^0.12.x)
+└── pubspec.yaml         # workspace member (terradart_core: ^0.15.x)
 ```
 
 ## Usage

--- a/examples/compute_quickstart/pubspec.yaml
+++ b/examples/compute_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/config_deployment_quickstart/pubspec.yaml
+++ b/examples/config_deployment_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataplex_quickstart/pubspec.yaml
+++ b/examples/dataplex_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_quickstart/pubspec.yaml
+++ b/examples/dialogflow_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/discovery_engine_quickstart/pubspec.yaml
+++ b/examples/discovery_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dns_quickstart/pubspec.yaml
+++ b/examples/dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/eventarc_quickstart/pubspec.yaml
+++ b/examples/eventarc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/filestore_quickstart/pubspec.yaml
+++ b/examples/filestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_check_quickstart/pubspec.yaml
+++ b/examples/firebase_app_check_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_hosting_quickstart/pubspec.yaml
+++ b/examples/firebase_app_hosting_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_data_connect_quickstart/pubspec.yaml
+++ b/examples/firebase_data_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_remote_config_quickstart/pubspec.yaml
+++ b/examples/firebase_remote_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_document_quickstart/pubspec.yaml
+++ b/examples/firestore_document_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_quickstart/pubspec.yaml
+++ b/examples/firestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_quickstart/README.md
+++ b/examples/gke_quickstart/README.md
@@ -15,7 +15,7 @@ examples/gke_quickstart/
 ├── lib/main.dart        # GkeQuickstartStack
 ├── bin/infra.dart       # Synth entry: stack.writeTo('tf-out')
 ├── tf-out/              # (created on synth) main.tf.json
-└── pubspec.yaml         # workspace member (terradart_core: ^0.12.x)
+└── pubspec.yaml         # workspace member (terradart_core: ^0.15.x)
 ```
 
 ## Usage

--- a/examples/gke_quickstart/pubspec.yaml
+++ b/examples/gke_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iam_quickstart/pubspec.yaml
+++ b/examples/iam_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_quickstart/pubspec.yaml
+++ b/examples/kms_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/license_manager_quickstart/pubspec.yaml
+++ b/examples/license_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/migration_center_quickstart/pubspec.yaml
+++ b/examples/migration_center_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/monitoring_quickstart/pubspec.yaml
+++ b/examples/monitoring_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_connectivity_quickstart/pubspec.yaml
+++ b/examples/network_connectivity_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_ull_quickstart/pubspec.yaml
+++ b/examples/network_security_ull_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ops_quickstart/pubspec.yaml
+++ b/examples/ops_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_autonomous_database_quickstart/pubspec.yaml
+++ b/examples/oracle_autonomous_database_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_db_system_quickstart/pubspec.yaml
+++ b/examples/oracle_db_system_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_exadata_quickstart/pubspec.yaml
+++ b/examples/oracle_exadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_goldengate_quickstart/pubspec.yaml
+++ b/examples/oracle_goldengate_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/pubsub_quickstart/pubspec.yaml
+++ b/examples/pubsub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/secret_manager_quickstart/pubspec.yaml
+++ b/examples/secret_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_quickstart/pubspec.yaml
+++ b/examples/storage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/terradart_agent/CHANGELOG.md
+++ b/packages/terradart_agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.15.0 - 2026-06-20
+
+Lockstep version bump for `terradart_google` v0.15.0. MCP catalog grows to
+**257 entries** (256 curated resource factories + 1 data source) across
+46 service barrels. No MCP protocol or tool changes.
+
 ## 0.14.0 - 2026-06-16
 
 Add the `check_coverage` MCP tool (5th catalog tool): given `terraform show -json`

--- a/packages/terradart_agent/README.md
+++ b/packages/terradart_agent/README.md
@@ -2,7 +2,7 @@
 
 `terradart-mcp` — a [Model Context Protocol](https://modelcontextprotocol.io) server that exposes the curated GCP factory catalog of [TerraDart](https://terradart.dev) to AI coding agents.
 
-It reads the static catalog compiled into [`terradart_google`](https://pub.dev/packages/terradart_google) (`package:terradart_google/catalog.dart`) and surfaces it as four read-only MCP tools so agents can discover constructor signatures, nested types, and quickstart snippets without guessing factory names.
+It reads the static catalog compiled into [`terradart_google`](https://pub.dev/packages/terradart_google) (`package:terradart_google/catalog.dart`) and surfaces it as five read-only MCP tools so agents can discover constructor signatures, nested types, quickstart snippets, and coverage gaps without guessing factory names.
 
 Built on [`genkit`](https://pub.dev/packages/genkit) + [`genkit_mcp`](https://pub.dev/packages/genkit_mcp). Ships as a single `terradart-mcp` binary (not published to pub.dev).
 
@@ -48,6 +48,7 @@ Full walkthroughs: [terradart.dev — terradart-mcp](https://terradart.dev/docs/
 | `list_resources` | Resources / data sources (optional `barrel` filter) |
 | `get_resource_schema` | Constructor params and nested types for one factory |
 | `get_quickstart` | Ready-made `Stack` template for a resource |
+| `check_coverage` | Coverage report for `terraform show -json` input |
 
 The catalog currently holds 257 entries (256 curated resource factories + 1 data source) across 46 service barrels.
 

--- a/packages/terradart_agent/lib/src/version.dart
+++ b/packages/terradart_agent/lib/src/version.dart
@@ -1,4 +1,4 @@
 /// The terradart-mcp binary version, kept in lockstep with pubspec.yaml's
 /// `version:` field by `tool/bump_version.sh`. The lockstep is guarded by
 /// test/version_test.dart so the two can never silently drift.
-const String packageVersion = '0.14.0';
+const String packageVersion = '0.15.0';

--- a/packages/terradart_agent/pubspec.yaml
+++ b/packages/terradart_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_agent
 description: terradart-mcp — MCP server exposing the curated GCP factory catalog of TerraDart.
-version: 0.14.0
+version: 0.15.0
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -16,9 +16,9 @@ executables:
   terradart-mcp: terradart_mcp
 
 dependencies:
-  terradart_core: ^0.14.0
-  terradart_google: ^0.14.0
-  terradart_coverage: ^0.14.0
+  terradart_core: ^0.15.0
+  terradart_google: ^0.15.0
+  terradart_coverage: ^0.15.0
   genkit: ^0.13.2
   genkit_mcp: ^0.1.7
   schemantic: ^0.1.3

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.15.0 - 2026-06-20
+
+Lockstep release. No user-facing CLI changes.
+
+### Added
+
+- Wrapper overrides / manifest entries for the post-`0.14.0` curated expansion through Wave 41, covering Apigee, Dataplex, License Manager, Discovery Engine, Config Deployment, Contact Center Insights, Dialogflow, Network Connectivity, Chronicle, Migration Center, Network Security ULL, Oracle Database@Google Cloud, and IAM binding/policy adjuncts.
+
+### Fixed
+
+- Aligned the Contact Center Insights output directory with the wrap-init anchor.
+- Added Config Deployment Gate 6 thunks for blueprint source variants.
+
 ## 0.14.0 - 2026-06-16
 
 - Refresh the provider schema fixture to `hashicorp/google` 7.36.0.

--- a/packages/terradart_codegen/README.md
+++ b/packages/terradart_codegen/README.md
@@ -15,7 +15,7 @@ End users depend on [`terradart_google`](https://pub.dev/packages/terradart_goog
 Activate on the same minor line as your workspace when working on the repo:
 
 ```bash
-dart pub global activate terradart_codegen ^0.14.x
+dart pub global activate terradart_codegen ^0.15.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_codegen) for the latest patch.

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart maintainer tooling — parses Terraform provider schema JSON and Magic Modules YAML and emits curated factory wrappers via terradart wrap. Ships the terradart CLI.
-version: 0.14.0
+version: 0.15.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -33,7 +33,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.14.0
+  terradart_core: ^0.15.0
 
 dev_dependencies:
   http: ^1.0.0

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.15.0 - 2026-06-20
+
+Lockstep release. No `terradart_core` API changes.
+
 ## 0.14.0 - 2026-06-16
 
 Lockstep release. No `terradart_core` API changes.

--- a/packages/terradart_core/README.md
+++ b/packages/terradart_core/README.md
@@ -13,7 +13,7 @@ This package ships the small set of primitives every terradart Stack uses:
 This package is the **runtime layer only**. It is intentionally small and dependency-free. The companion packages are:
 
 - [`terradart_codegen`](https://pub.dev/packages/terradart_codegen) — maintainer `terradart` CLI (`wrap`, `wrap-init`, `wrap-promote`) used to regenerate curated factories in `terradart_google`.
-- [`terradart_google`](https://pub.dev/packages/terradart_google) — **147 curated GCP factories + 1 data source**, plus generated schema carriers.
+- [`terradart_google`](https://pub.dev/packages/terradart_google) — **256 curated GCP resource factories + 1 data source**, plus generated schema carriers.
 
 For project-level documentation, see the [terradart repo README](https://github.com/nozomi-koborinai/terradart#readme) and [terradart.dev](https://terradart.dev/docs/getting-started/).
 
@@ -36,7 +36,7 @@ enum RoutingMode implements TerraformEnum {
 
 ```yaml
 dependencies:
-  terradart_core: ^0.14.x
+  terradart_core: ^0.15.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch. Read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before minor bumps.

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.14.0
+version: 0.15.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_coverage/CHANGELOG.md
+++ b/packages/terradart_coverage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.15.0 - 2026-06-20
+
+Lockstep version bump for the v0.15.0 binary release. No
+`terradart_coverage` API or CLI changes.
+
 ## 0.14.0 - 2026-06-16
 
 First release. `terradart-coverage` — a read-only CLI that reads

--- a/packages/terradart_coverage/pubspec.yaml
+++ b/packages/terradart_coverage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_coverage
 description: Read-only Terraform coverage checker — reports how much of a Terraform config is covered by curated terradart_google factories.
-version: 0.14.0
+version: 0.15.0
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -15,7 +15,7 @@ executables:
   terradart-coverage: terradart_coverage
 
 dependencies:
-  terradart_google: ^0.14.0
+  terradart_google: ^0.15.0
   args: ^2.5.0
 
 dev_dependencies:

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.15.0 - 2026-06-20
+
+Lockstep release. **No breaking changes** vs `0.14.0`.
+
+### Added
+
+- Catalog grows to **256 curated resource factories + 1 data source** (257 entries; 46 service barrels).
+- BigQuery: `google_bigquery_routine_iam_member` plus authoritative routine IAM binding / policy adjuncts.
+- Compute: zonal disk, regional instant snapshot, and regional instant snapshot IAM member / binding / policy adjuncts.
+- New and extended service coverage: Apigee data collector / datastore, Dataplex data product / IAM member, License Manager configuration, Discovery Engine data store / search engine / IAM member / binding / policy, Config Deployment, Contact Center Insights encryption spec, Dialogflow SIP trunk, Network Connectivity service connection token transport, Chronicle custom list / native dashboard / dashboard chart, Migration Center wave, and Network Security ULL mirroring wave.
+- Oracle Database@Google Cloud Waves 36–40: GoldenGate deployment / connection / assignment, ODB network / subnet, Autonomous Database, Base Database DB System, and Exadata / ExaDB infrastructure factories.
+- Wave 41 IAM binding/policy adjuncts for BigQuery routine, Compute regional instant snapshot, and Discovery Engine search engine.
+
+### Changed
+
+- Quickstarts and docs now exercise every added catalog entry; examples include Apigee, Dataplex, Config Deployment, Network Connectivity, Network Security ULL, Migration Center, Chronicle, Oracle, and IAM binding/policy adjunct coverage.
+
+### Fixed
+
+- Backfilled `GoogleFilestoreSnapshot` in `compute_quickstart`.
+- Aligned the Contact Center Insights barrel output directory with the wrap-init anchor.
+- Added Config Deployment Gate 6 thunks for blueprint source variants.
+
 ## 0.14.0 - 2026-06-16
 
 - Provider 7.36.0: `google_compute_address` gains the computed `address_id`

--- a/packages/terradart_google/README.md
+++ b/packages/terradart_google/README.md
@@ -16,8 +16,8 @@ Runtime primitives (`Stack`, `TfArg`, `writeTo`) live in [`terradart_core`](http
 
 ```yaml
 dependencies:
-  terradart_core: ^0.14.x
-  terradart_google: ^0.14.x
+  terradart_core: ^0.15.x
+  terradart_google: ^0.15.x
 ```
 
 ## Usage example

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: Curated factory wrappers for Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.
-version: 0.14.0
+version: 0.15.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -22,11 +22,11 @@ false_secrets:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.14.0
+  terradart_core: ^0.15.0
   meta: ^1.15.0
 
 dev_dependencies:
-  terradart_codegen: ^0.14.0
+  terradart_codegen: ^0.15.0
   path: ^1.9.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/tool/apply_smoke_skip.yaml
+++ b/tool/apply_smoke_skip.yaml
@@ -53,6 +53,7 @@ iam_quickstart: creates a WIF pool id 'github-actions' that COLLIDES with the ap
 kms_quickstart: KMS key rings (and keys) cannot be deleted, so a re-run fails 409 "KeyRing already exists"; no way to reclaim the name in a reused project
 firestore_document_quickstart: creates the Firestore (default) database, which cannot be deleted, so a re-run fails 409 "Database already exists"
 cloud_tasks_quickstart: a deleted Cloud Tasks queue name is locked ~7 days ("queue cannot be created because a queue with this name existed too recently"), so a daily sweep with a fixed name always 409s
+discovery_engine_quickstart: Discovery Engine data stores are soft-deleted for hours; fixed example IDs can fail reruns with "being deleted" before the previous deletion completes
 # --- Infrastructure Manager actuation needs config.agent SA + network admin and applies a live VPC module
 config_deployment_quickstart: needs config.agent and compute.networkAdmin IAM on a dedicated SA plus a long-running Git blueprint apply (terraform-google-network VPC module)
 

--- a/tool/bump_version.sh
+++ b/tool/bump_version.sh
@@ -242,7 +242,7 @@ fi
 echo "==> Lockstep bump complete: $OLD -> $NEW"
 echo
 echo "Next:"
-echo "  1. Update CHANGELOG.md (root + 3 packages) by hand — release notes are prose."
+echo "  1. Update CHANGELOG.md (root + package changelogs) by hand — release notes are prose."
 echo "  2. If breaking, add a MIGRATING.md section."
 echo "  3. dart pub get && dart analyze packages/terradart_core packages/terradart_codegen packages/terradart_google"
 echo "  4. git diff --stat   # review the bump"

--- a/website/src/content/docs/docs/agent/clients.md
+++ b/website/src/content/docs/docs/agent/clients.md
@@ -15,7 +15,7 @@ The shared shape of the config across MCP clients is just:
 }
 ```
 
-The server registers itself under the name `terradart`, and exposes the four catalog tools described in the [Tools reference](/docs/agent/tools-reference/).
+The server registers itself under the name `terradart`, and exposes the five read-only tools described in the [Tools reference](/docs/agent/tools-reference/).
 
 ## Claude Code
 

--- a/website/src/content/docs/docs/agent/index.md
+++ b/website/src/content/docs/docs/agent/index.md
@@ -12,7 +12,7 @@ It is built with [genkit_mcp](https://pub.dev/packages/genkit_mcp) (Genkit's MCP
 ```mermaid
 graph LR
   agent["coding agent<br/>(Claude Code / Cursor / Claude Desktop)"]
-  mcp["terradart-mcp<br/>list_barrels · list_resources<br/>get_resource_schema · get_quickstart"]
+  mcp["terradart-mcp<br/>list_barrels · list_resources<br/>get_resource_schema · get_quickstart<br/>check_coverage"]
   catalog["static catalog in terradart_google<br/>257 entries · 46 service barrels"]
   agent -->|stdio JSON-RPC MCP| mcp
   mcp -->|reads in-process| catalog
@@ -35,5 +35,5 @@ If an agent wants to actually synthesize and apply a stack, that still happens t
 
 - [Install](/docs/agent/install/) — Homebrew or a direct binary download.
 - [Connecting clients](/docs/agent/clients/) — Claude Code, Claude Desktop, Cursor, and Genkit Dart.
-- [Tools reference](/docs/agent/tools-reference/) — the 4 tools, with request/response examples.
+- [Tools reference](/docs/agent/tools-reference/) — the 5 tools, with request/response examples.
 - [Recipes](/docs/agent/recipes/) — prompt patterns for discovery, schema lookup, scaffolding, and plan review.

--- a/website/src/content/docs/docs/agent/install.md
+++ b/website/src/content/docs/docs/agent/install.md
@@ -38,7 +38,7 @@ sudo mv terradart-mcp-darwin-arm64 /usr/local/bin/terradart-mcp
 
 ```sh
 terradart-mcp --version
-# terradart-mcp 0.12.x
+# terradart-mcp 0.15.x
 ```
 
 If you see the version printed, the binary is ready. Next, point an MCP client at it: [Connecting clients](/docs/agent/clients/).

--- a/website/src/content/docs/docs/agent/tools-reference.md
+++ b/website/src/content/docs/docs/agent/tools-reference.md
@@ -1,9 +1,9 @@
 ---
 title: Tools reference
-description: The four read-only catalog tools exposed by terradart-mcp, with request/response examples.
+description: The five read-only tools exposed by terradart-mcp, with request/response examples.
 ---
 
-`terradart-mcp` exposes four read-only tools over MCP. All four are invoked with the standard MCP `tools/call` method. The envelope looks like this:
+`terradart-mcp` exposes five read-only tools over MCP. All five are invoked with the standard MCP `tools/call` method. The envelope looks like this:
 
 ```json
 {
@@ -145,3 +145,42 @@ Returns a runnable Dart `Stack` template for a named scenario. If the scenario k
 ```
 
 Each template is adapted from a CI-validated example in the repository, so the class names, constructor parameters, and imports compile against the current TerraDart API. The `gcs_refs` link to the full, deployable example for that scenario.
+
+## `check_coverage`
+
+Returns a coverage report for an existing Terraform plan or state JSON. Pass the full output of `terraform show -json`; the tool reports how much of the config is already covered by curated `terradart_google` factories and which Terraform types are not in the catalog.
+
+**Input** (required `tf_json`)
+
+```json
+{ "tf_json": "{\"values\":{\"root_module\":{\"resources\":[]}}}" }
+```
+
+**Output** — on valid input:
+
+```json
+{
+  "summary": {
+    "distinctTypes": 0,
+    "supportedTypes": 0,
+    "totalOccurrences": 0,
+    "supportedOccurrences": 0,
+    "coverageByTypePct": 100.0,
+    "coverageByOccurrencePct": 100.0
+  },
+  "supported": [],
+  "notInCatalog": [],
+  "perModule": {},
+  "unparseable": []
+}
+```
+
+**Output** — on invalid JSON:
+
+```json
+{
+  "error": "input is not valid JSON: ..."
+}
+```
+
+The report is read-only analysis. It does not run Terraform, read local files, or contact Google Cloud.

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -3,7 +3,7 @@ title: Getting Started
 description: Install TerraDart and generate your first *.tf.json from a Stack.
 ---
 
-This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.14.x** line. TerraDart is **pre-alpha** until [beta gates](/docs/status/#beta-readiness-checklist) are complete (planned label: **v0.14.0**).
+This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.15.x** line. TerraDart is **pre-alpha** until [beta gates](/docs/status/#beta-readiness-checklist) are complete (planned label: **v0.15.0**).
 
 ## Prerequisites
 
@@ -16,8 +16,8 @@ This guide matches the [README quickstart](https://github.com/nozomi-koborinai/t
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.14.x
-  terradart_google: ^0.14.x
+  terradart_core: ^0.15.x
+  terradart_google: ^0.15.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch, then run:

--- a/website/src/content/docs/docs/index.md
+++ b/website/src/content/docs/docs/index.md
@@ -5,16 +5,16 @@ description: Guides for TerraDart — type-safe Google Cloud IaC for Dart.
 
 Welcome to the TerraDart docs.
 
-Guides track the **0.12.x** line on pub.dev. The repo [README](https://github.com/nozomi-koborinai/terradart/blob/main/README.md) and [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) stay the deepest references; this site mirrors onboarding and release expectations.
+Guides track the **0.15.x** line on pub.dev. The repo [README](https://github.com/nozomi-koborinai/terradart/blob/main/README.md) and [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) stay the deepest references; this site mirrors onboarding and release expectations.
 
 ## Guides
 
 - [Getting Started](/docs/getting-started/) — install, first `*.tf.json`, boundary export
 - [Why TerraDart](/docs/why-terradart/) — motivation, comparison, and curated coverage
 - [Architecture](/docs/architecture/) — generate `*.tf.json`, `synth()` / `writeTo()`, AppExport
-- [Waves 23–26](/docs/waves/) — curated factory waves (v0.12.10–0.12.11) and example pointers
+- [Waves 23–41](/docs/waves/) — curated factory waves and example pointers
 - [Migrating](/docs/migrating/) — upgrade from 0.12.9 (enum / nested-helper breaking changes)
-- [Status & versioning](/docs/status/) — pre-alpha, beta readiness (from v0.13.0), 1.0
+- [Status & versioning](/docs/status/) — pre-alpha, beta readiness (from v0.15.0), 1.0
 
 ## For AI assistants
 

--- a/website/src/content/docs/docs/status.md
+++ b/website/src/content/docs/docs/status.md
@@ -3,25 +3,25 @@ title: Status & versioning
 description: Pre-alpha expectations, beta readiness, and how TerraDart versions releases.
 ---
 
-TerraDart is **pre-alpha** on the **0.12.x** line today. We remain pre-alpha until the [beta readiness](#beta-readiness-checklist) required gates are all complete; we plan to label the project **beta** starting with **v0.13.0**, not retroactively on 0.12.x.
+TerraDart is **pre-alpha** on the **0.15.x** line today. We remain pre-alpha until the [beta readiness](#beta-readiness-checklist) required gates are all complete; we plan to label the project **beta** starting with **v0.15.0**, not retroactively on earlier 0.x lines.
 
-There are no SemVer guarantees until **v1.0.0**. Pin with `^0.12.x` and read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before every **minor** bump. Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch.
+There are no SemVer guarantees until **v1.0.0**. Pin with `^0.15.x` and read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before every **minor** bump. Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch.
 
 ## Release phases
 
 | Phase | Version line | What we promise |
 | --- | --- | --- |
-| **Pre-alpha** | 0.12.x (current) | Docs and automation are catching up. Breaking changes may land in any 0.x release until beta policy applies. |
-| **Beta** | from **0.13.0** (planned) | Trustworthy onboarding on terradart.dev and GitHub. **No breaking changes within a minor** (`^0.N.x`); breaking changes only on minor bumps, always documented in `MIGRATING.md`. Not SemVer-frozen until 1.0.0. |
+| **Pre-alpha** | 0.15.x (current) | Docs and automation are catching up. Breaking changes may land in any 0.x release until beta policy applies. |
+| **Beta** | from **0.15.0** (planned) | Trustworthy onboarding on terradart.dev and GitHub. **No breaking changes within a minor** (`^0.N.x`); breaking changes only on minor bumps, always documented in `MIGRATING.md`. Not SemVer-frozen until 1.0.0. |
 | **1.0.0** | TBD | Stable SemVer for `terradart_core`, `terradart_google`, and `terradart_codegen`. |
 
 ## What to expect today (pre-alpha)
 
 - Surface and emitted Terraform JSON may change between releases, especially across **minor** bumps.
-- Use hosted `^0.12.x` carets on [pub.dev](https://pub.dev/packages/terradart_core) — not legacy `0.x.y-dev` pre-release tags.
+- Use hosted `^0.15.x` carets on [pub.dev](https://pub.dev/packages/terradart_core) — not legacy `0.x.y-dev` pre-release tags.
 - Only the **curated** `terradart_google` surface is supported for users; non-curated resources require a curation request.
 
-## Beta change policy (applies from v0.13.0)
+## Beta change policy (applies from v0.15.0)
 
 When we declare beta:
 
@@ -31,9 +31,9 @@ When we declare beta:
 
 ## Beta readiness checklist
 
-We will label the project **beta** starting with **v0.13.0** when every **required** item below is done.
+We will label the project **beta** starting with **v0.15.0** when every **required** item below is done.
 
-### Required (all must be ✅ before v0.13.0)
+### Required (all must be ✅ before v0.15.0)
 
 - [x] **Getting Started** on terradart.dev matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart); no “Coming soon” placeholders on Status or Getting Started.
 - [x] **`tool/check_docs_consistency`** runs in CI and passes (workspace + examples caret minor, catalog count, key meta docs). Workflow: [`.github/workflows/docs-consistency.yml`](https://github.com/nozomi-koborinai/terradart/blob/main/.github/workflows/docs-consistency.yml).
@@ -42,14 +42,14 @@ We will label the project **beta** starting with **v0.13.0** when every **requir
 - [x] **Boundary demo**: [pubsub_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart) documents `addExport` / generated `.app.dart` and includes a subscriber stub that `dart analyze` accepts.
 - [x] **Meta docs aligned** with the current minor: CONTRIBUTING, SECURITY, issue templates, package READMEs, and root README agree on pre-alpha/beta wording, `^0.N.x` pins, and **256 curated resource factories + 1 data source** (257 catalog entries).
 - [x] **Full example coverage**: `tool/example_debt.yaml` is empty — all catalog entries appear in at least one quickstart synth (`check_docs_consistency.dart`).
-- [x] **Beta change policy** published on this page (see [Beta change policy](#beta-change-policy-applies-from-v0130)).
+- [x] **Beta change policy** published on this page (see [Beta change policy](#beta-change-policy-applies-from-v0150)).
 
 ### Optional (does not block beta)
 
-- [x] **`MIGRATING.md` / site migration guide** — [Migrating](/docs/migrating/) mirrors the `0.12.9 → 0.12.10` breaking changes; [MIGRATING.md on GitHub](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) remains canonical for older releases. *Two-minor depth across minors is still a beta quality bar when `0.13.0` ships.*
+- [x] **`MIGRATING.md` / site migration guide** — [Migrating](/docs/migrating/) mirrors the `0.12.9 → 0.12.10` breaking changes; [MIGRATING.md on GitHub](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) remains canonical for older releases. *Two-minor depth across minors remains a beta quality bar for current and future minor releases.*
 - [ ] **External quickstart**: someone outside the core team completes the README path once; feedback captured in an issue or discussion.
 - [ ] **Real apply dogfood** via [terradart-cookbook](https://github.com/nozomi-koborinai/terradart-cookbook): at least one non-trivial recipe documents a successful `terraform apply`.
-- [ ] **`terradart-mcp`**: [Agent install](/docs/agent/install/) verified on a clean machine (Homebrew or release binary + four tools).
+- [ ] **`terradart-mcp`**: [Agent install](/docs/agent/install/) verified on a clean machine (Homebrew or release binary + five tools).
 - [ ] **1.0.0 criteria** drafted (what “stable” means for curated names and `terradart_core` API).
 
 ## What beta does *not* mean

--- a/website/src/content/docs/docs/waves.md
+++ b/website/src/content/docs/docs/waves.md
@@ -1,6 +1,6 @@
 ---
-title: Waves 23–29
-description: Curated google_* factories shipped in Waves 23–29 (v0.12.10–0.12.15) with example stack pointers.
+title: Waves 23–41
+description: Curated google_* factories shipped through Wave 41 (v0.12.10–v0.15.0) with example stack pointers.
 ---
 
 ## v0.12.10 — Waves 23–24
@@ -290,7 +290,7 @@ GoogleAlloydbCluster(
 );
 ```
 
-## Wave 35 — AlloyDB backup, Memcache, Spanner (unreleased)
+## v0.15.0 — Wave 35 — AlloyDB backup, Memcache, Spanner
 
 Adds `google_alloydb_backup`, `google_memcache_instance`, `google_spanner_instance`, and `google_spanner_database`.
 
@@ -303,7 +303,7 @@ Catalog after Wave 35: **206 curated resource factories + 1 data source** (207 c
 | `google_spanner_instance` | `GoogleSpannerInstance` | `spanner` | [ops_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/ops_quickstart) |
 | `google_spanner_database` | `GoogleSpannerDatabase` | `spanner` | [ops_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/ops_quickstart) |
 
-## Wave 41 — IAM binding/policy adjuncts (unreleased)
+## v0.15.0 — Wave 41 — IAM binding/policy adjuncts
 
 Adds authoritative IAM `*_iam_binding` and `*_iam_policy` factories where sibling `*_iam_member` resources already ship, extending existing quickstarts.
 
@@ -318,7 +318,7 @@ Catalog after Wave 41: **256 curated resource factories + 1 data source** (257 c
 | `google_discovery_engine_search_engine_iam_binding` | `GoogleDiscoveryEngineSearchEngineIamBinding` | `discovery_engine` | [discovery_engine_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/discovery_engine_quickstart) |
 | `google_discovery_engine_search_engine_iam_policy` | `GoogleDiscoveryEngineSearchEngineIamPolicy` | `discovery_engine` | [discovery_engine_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/discovery_engine_quickstart) |
 
-## Wave 40 — Oracle Exadata (unreleased)
+## v0.15.0 — Wave 40 — Oracle Exadata
 
 Adds four Oracle Exadata factories on the `oracle` barrel with [oracle_exadata_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/oracle_exadata_quickstart).
 
@@ -331,7 +331,7 @@ Catalog after Wave 40: **256 curated resource factories + 1 data source** (257 c
 | `google_oracle_database_exadb_vm_cluster` | `GoogleOracleDatabaseExadbVmCluster` | `oracle` | [oracle_exadata_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/oracle_exadata_quickstart) |
 | `google_oracle_database_exascale_db_storage_vault` | `GoogleOracleDatabaseExascaleDbStorageVault` | `oracle` | [oracle_exadata_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/oracle_exadata_quickstart) |
 
-## Wave 39 — Oracle DB System (unreleased)
+## v0.15.0 — Wave 39 — Oracle DB System
 
 Adds `google_oracle_database_db_system` on the `oracle` barrel with [oracle_db_system_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/oracle_db_system_quickstart).
 
@@ -341,7 +341,7 @@ Catalog after Wave 39: **256 curated resource factories + 1 data source** (257 c
 | --- | --- | --- | --- |
 | `google_oracle_database_db_system` | `GoogleOracleDatabaseDbSystem` | `oracle` | [oracle_db_system_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/oracle_db_system_quickstart) |
 
-## Wave 38 — Oracle Autonomous Database (unreleased)
+## v0.15.0 — Wave 38 — Oracle Autonomous Database
 
 Adds `google_oracle_database_autonomous_database` on the `oracle` barrel with [oracle_autonomous_database_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/oracle_autonomous_database_quickstart).
 
@@ -351,7 +351,7 @@ Catalog after Wave 38: **245 curated resource factories + 1 data source** (246 c
 | --- | --- | --- | --- |
 | `google_oracle_database_autonomous_database` | `GoogleOracleDatabaseAutonomousDatabase` | `oracle` | [oracle_autonomous_database_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/oracle_autonomous_database_quickstart) |
 
-## Wave 37 — Oracle ODB networking (unreleased)
+## v0.15.0 — Wave 37 — Oracle ODB networking
 
 Extends the `oracle` barrel with ODB network and subnet factories and tightens [oracle_goldengate_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/oracle_goldengate_quickstart) to provision VPC → ODB network → subnet before GoldenGate resources.
 
@@ -362,7 +362,7 @@ Catalog after Wave 37: **244 curated resource factories + 1 data source** (245 c
 | `google_oracle_database_odb_network` | `GoogleOracleDatabaseOdbNetwork` | `oracle` | [oracle_goldengate_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/oracle_goldengate_quickstart) |
 | `google_oracle_database_odb_subnet` | `GoogleOracleDatabaseOdbSubnet` | `oracle` | [oracle_goldengate_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/oracle_goldengate_quickstart) |
 
-## Wave 36 — Oracle GoldenGate (unreleased)
+## v0.15.0 — Wave 36 — Oracle GoldenGate
 
 Adds Oracle Database@Google Cloud GoldenGate deployment, connection, and connection assignment on a new `oracle` barrel. New [oracle_goldengate_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/oracle_goldengate_quickstart).
 
@@ -374,7 +374,7 @@ Catalog after Wave 36: **242 curated resource factories + 1 data source** (243 c
 | `google_oracle_database_goldengate_connection` | `GoogleOracleDatabaseGoldengateConnection` | `oracle` | [oracle_goldengate_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/oracle_goldengate_quickstart) |
 | `google_oracle_database_goldengate_connection_assignment` | `GoogleOracleDatabaseGoldengateConnectionAssignment` | `oracle` | [oracle_goldengate_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/oracle_goldengate_quickstart) |
 
-## Wave 34 — Cloud Filestore (unreleased)
+## v0.15.0 — Wave 34 — Cloud Filestore
 
 Adds managed NFS (`google_filestore_instance`) plus backup and snapshot adjuncts on a new `filestore` barrel. Extends [compute_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/compute_quickstart).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bump the TerraDart workspace to `0.15.0` in lockstep across package pubspecs, example carets, and current-version docs.
- Add root and per-package `0.15.0` changelog entries for the post-0.14 catalog expansion through Wave 41.
- Mark Waves 34–41 as released in the waves guide and refresh README / CONTRIBUTING / SECURITY / package README / agent docs version wording.
- Keep this PR release-focused: no new `google_*` curation beyond what is already merged on `main`.
- Add `discovery_engine_quickstart` to the apply-smoke skip ledger after the live PR gate hit Discovery Engine data-store soft-delete reuse (`being deleted`, can take hours); synth + Terraform validate coverage remains active.

## Pre-flight

- Open PRs: none found, so no pre-release merge was needed.
- `main` CI after #188: CI, Docs consistency, and Website were green.

## Verification

- `dart pub get`
- `dart tool/check_docs_consistency.dart` — OK
- `tool/agent_verify.sh` — `agent_verify: OK`
- Re-ran `tool/agent_verify.sh` after the apply-smoke skip ledger update — `agent_verify: OK`

## Release follow-up after merge

- Create lightweight tag `v0.15.0` on the merged release commit and push it.
- Monitor tag workflows: `Publish to pub.dev` and `release-binary`.
- Confirm GitHub Release assets and pub.dev package versions for `terradart_core`, `terradart_codegen`, and `terradart_google`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d35bfc6b-6d84-4629-93a6-2421523248a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d35bfc6b-6d84-4629-93a6-2421523248a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

