### PR TITLE
ci(apply-smoke): defer cloud_run from per-PR apply to the full sweep

### DIFF
--- a/tool/apply_smoke_pr_skip.yaml
+++ b/tool/apply_smoke_pr_skip.yaml
@@ -1,6 +1,7 @@
 # Examples the PER-PR change-gate does NOT `terraform apply` because they
 # provision expensive, hourly-billed resources (GKE control plane + node VMs,
-# Compute Engine VMs). They are NOT skipped wholesale: the full sweep
+# Compute Engine VMs, Memorystore Redis/Memcache). They are NOT skipped
+# wholesale: the full sweep
 # (apply-smoke-weekly.yml / `apply_smoke.sh --all`) still applies them, and
 # per-PR they still synth + `terraform validate`. This keeps per-PR apply cost
 # low on Wave PRs (which push many times) while preserving apply coverage.
@@ -14,3 +15,4 @@
 
 gke_quickstart: GKE control plane management fee + node VMs bill hourly; apply only in the full sweep
 compute_quickstart: Compute Engine VM bills hourly; apply only in the full sweep
+cloud_run_quickstart: Memorystore Redis + Memcache bill hourly; apply only in the full sweep


### PR DESCRIPTION
## Why

`cloud_run_quickstart` stands up **Memorystore Redis + Memcache** (both hourly-billed) on apply — the same cost tier as `gke`/`compute`, which the per-PR change-gate already defers to the full sweep. A scan of the Waves 42–70 additions found no new GKE-cluster/VM/DB-tier examples; this surfaced the pre-existing `cloud_run` case.

## What

- Add `cloud_run_quickstart` to `tool/apply_smoke_pr_skip.yaml`.
- Per-PR it still runs synth + `terraform validate`; the monthly full sweep (`apply_smoke.sh --all`) still applies it, so apply coverage is preserved.
- `apply_smoke_test.sh` partition assertions pass (disjoint from the apply skip-list; present in the `--all` set).