### PR TITLE
fix(tooling): resilient version bump (.x carets) + apply-smoke stale-lock recovery

### DIFF
--- a/tool/apply_smoke.sh
+++ b/tool/apply_smoke.sh
@@ -147,6 +147,36 @@ export DB_PASSWORD="${DB_PASSWORD:-apply-smoke-placeholder}"
 
 dart pub get
 
+# --- terraform with stale-lock recovery ------------------------------------
+# A killed apply-smoke run (e.g. GitHub's cancel-in-progress when a PR is
+# re-pushed) leaves the GCS backend lock held; the next run then dies with
+# "Error acquiring the state lock". Run terraform, and on THAT error force-
+# unlock the reported lock id and retry once — but only when the lock is
+# demonstrably old (created > 15 min ago), so a genuinely live concurrent run
+# (another PR, or the weekly sweep, on the same slug) is never stolen. When the
+# lock age can't be determined (no GNU `date`), treat it as stale. Output is
+# streamed via `tee` so CI logs stay live while we capture it to parse the id.
+tf_lockaware() {
+  local out rc id created lock_epoch now_epoch age
+  out="$(terraform "$@" 2>&1 | tee /dev/stderr)"
+  rc=$?
+  (( rc == 0 )) && return 0
+  grep -q 'Error acquiring the state lock' <<<"$out" || return "$rc"
+  id="$(grep -oE 'ID:[[:space:]]+[0-9]+' <<<"$out" | grep -oE '[0-9]+' | head -1)"
+  [[ -n "$id" ]] || return "$rc"
+  created="$(grep -oE 'Created:[[:space:]]+[0-9].*UTC' <<<"$out" | head -1 | sed -E 's/^Created:[[:space:]]+//; s/ UTC$//')"
+  lock_epoch="$(date -u -d "$created" +%s 2>/dev/null || echo 0)"
+  now_epoch="$(date -u +%s)"
+  age=$(( now_epoch - lock_epoch ))
+  if [[ "$lock_epoch" != "0" && $age -lt 900 ]]; then
+    echo "  !! state lock $id is only ${age}s old — assuming a live run; NOT force-unlocking" >&2
+    return "$rc"
+  fi
+  echo "  !! stale state lock $id (age ${age}s) — force-unlock + retry once" >&2
+  terraform force-unlock -force "$id" >&2 || true
+  terraform "$@"
+}
+
 # --- apply (or destroy-only) one example, with a GCS-backed state ----------
 apply_one() {
   local slug="$1"
@@ -173,7 +203,7 @@ apply_one() {
       "$STATE_BUCKET" "$slug" > backend.tf.json
     terraform init -input=false -reconfigure || exit 1
     if [[ "$DESTROY_ONLY" == "1" ]]; then
-      terraform destroy -auto-approve -input=false
+      tf_lockaware destroy -auto-approve -input=false
       exit $?
     fi
     # Apply, then ALWAYS tear down — capturing the apply result separately.
@@ -181,11 +211,11 @@ apply_one() {
     # silently-failed destroy once left a running GKE cluster orphaned that
     # only a manual gcloud sweep caught. Recorded failures fail the run below.
     apply_rc=0
-    terraform apply -auto-approve -input=false || apply_rc=$?
-    if ! terraform destroy -auto-approve -input=false; then
+    tf_lockaware apply -auto-approve -input=false || apply_rc=$?
+    if ! tf_lockaware destroy -auto-approve -input=false; then
       echo "  !! teardown failed for $slug — retrying in 15s" >&2
       sleep 15
-      if ! terraform destroy -auto-approve -input=false; then
+      if ! tf_lockaware destroy -auto-approve -input=false; then
         echo "  !! TEARDOWN FAILED for $slug after retry — ORPHAN RISK; run tool/apply_smoke_janitor.sh" >&2
         echo "$slug" >> "$TEARDOWN_FAILS_FILE"
       fi

--- a/tool/bump_version.sh
+++ b/tool/bump_version.sh
@@ -203,6 +203,27 @@ for tpl in .github/ISSUE_TEMPLATE/bug.yml \
   fi
 done
 
+# `.x`-style minor carets + pre-alpha banner. The pubspec samples in the
+# READMEs and the website getting-started page, plus the README pre-alpha
+# banner, use the ^X.Y.x minor form — distinct from the ^X.Y.Z full-semver
+# samples handled above, which is why those passes leave them untouched. Sweep
+# them in one pass so the docs-consistency check (which expects ^X.Y.x) stays
+# green every release.
+echo "  Minor (.x) caret samples + banner:"
+for f in README.md \
+         website/src/content/docs/docs/getting-started.md \
+         packages/terradart_core/README.md \
+         packages/terradart_google/README.md \
+         packages/terradart_codegen/README.md; do
+  [ -f "$f" ] || continue
+  # Blanket ^X.Y.x replace (like CONTRIBUTING/SECURITY below) covers every
+  # caret form — pubspec samples, the `dart pub global activate` line, and bare
+  # "Pin `^X.Y.x`" prose — in one go.
+  sed_inplace "s#\\^${OLD_MINOR_RE}\\.x#^${NEW_MINOR}.x#g" "$f"
+  sed_inplace "s#pre-1\\.0 \\(${OLD_MINOR_RE}\\.x\\)#pre-1.0 (${NEW_MINOR}.x)#g" "$f"
+  echo "    - $f"
+done
+
 echo
 
 # 5. Verify no stale OLD carets / version lines remain in the scoped files.
@@ -230,6 +251,12 @@ STALE=$(
     .github/ISSUE_TEMPLATE/question.yml 2>/dev/null
   grep -nE "\\*\\*${OLD_MINOR_RE}\\.x\\*\\* line" \
     website/src/content/docs/docs/getting-started.md 2>/dev/null
+  grep -nE "\\^${OLD_MINOR_RE}\\.x" \
+    README.md website/src/content/docs/docs/getting-started.md \
+    packages/terradart_core/README.md \
+    packages/terradart_google/README.md \
+    packages/terradart_codegen/README.md 2>/dev/null
+  grep -nE "pre-1\\.0 \\(${OLD_MINOR_RE}\\.x\\)" README.md 2>/dev/null
 )
 set -e
 


### PR DESCRIPTION
Two release-tooling fixes surfaced while shipping 0.17.0.

## `bump_version.sh` — handle `^X.Y.x` minor carets + banner
The READMEs and `website/.../getting-started.md` pin dependencies with the **minor-style** caret `^X.Y.x` (and the README carries a `pre-1.0 (X.Y.x)` banner). The script only rewrote the **full-semver** `^X.Y.Z` form, so those `.x` carets were left stale every release and `check_docs_consistency` failed (it expects `^<current-minor>.x`). This already bit the 0.17.0 release PR.

- Add a blanket `^X.Y.x` sweep over the READMEs + getting-started (same approach already used for `CONTRIBUTING.md` / `SECURITY.md`), covering pubspec samples, the `dart pub global activate` line, and bare `Pin \`^X.Y.x\`` prose, plus the banner.
- Extend the verify step to catch stale `.x` carets + banner.
- Verified end-to-end: running `bump_version.sh` now leaves zero stale `.x` refs and `check_docs_consistency` passes.

## `apply_smoke.sh` — recover from a stale state lock
When a PR is re-pushed, GitHub's `cancel-in-progress` kills the running apply-smoke job mid-apply. The GCS backend lock is not released, so the next run dies with `Error acquiring the state lock` and never self-heals (the tooling had no force-unlock).

- Add `tf_lockaware`: run terraform (streaming output via `tee`), and on a lock error force-unlock the reported id and retry once — **only** when the lock is provably old (created > 15 min ago), so a genuinely live concurrent run (another PR / the weekly sweep on the same slug) is never stolen. Falls back to force-unlock when the age can't be determined (no GNU `date`).
- Wrap the apply / destroy / teardown calls.
- Unit-tested in isolation (mock terraform + date): stale lock → force-unlock + retry succeeds; live lock → not stolen.

Note: this addresses the **lock** failure mode. A resource created by a killed apply but not yet written to state (e.g. a Firestore DB) is a separate orphan that still needs a manual `gcloud` cleanup; not re-pushing an apply-smoke PR mid-run avoids both.