### PR TITLE
ci(apply-smoke): lock-free teardown, weekly janitor, fix change-gate fan-out

### DIFF
--- a/.github/workflows/apply-smoke-janitor.yml
+++ b/.github/workflows/apply-smoke-janitor.yml
@@ -2,9 +2,11 @@ name: Apply smoke janitor
 
 on:
   schedule:
-    # Every 6 hours: reclaim anything a failed or cancelled apply left behind
-    # promptly (PR runs now cancel in-progress, so a teardown can be interrupted).
-    - cron: "0 */6 * * *"
+    # Weekly (Sundays 14:00 UTC). Teardown now runs with -lock=false, so a
+    # cancelled run no longer leaves a lock-blocked orphan; the janitor is just a
+    # periodic backstop for state-tracked leftovers — 6-hourly was overkill.
+    # (Avoids the monthly sweep's 02:00-on-the-1st slot.)
+    - cron: "0 14 * * 0"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,17 @@ jobs:
       - run: dart test --reporter=github
         working-directory: packages/${{ matrix.package }}
 
+  apply_smoke_selection_test:
+    name: apply_smoke.sh selection test
+    runs-on: ubuntu-latest
+    # The change-gate that scopes apply-smoke to changed examples lives in shell;
+    # a broken awk regex once fanned a pubspec-only bump out to every example (a
+    # real GCP-cost leak). Run the selection unit test so that can't regress
+    # unnoticed — it needs neither Dart nor GCP.
+    steps:
+      - uses: actions/checkout@v6
+      - run: bash tool/apply_smoke_test.sh
+
   wrap_check:
     name: terradart wrap --check
     runs-on: ubuntu-latest

--- a/tool/apply_smoke.sh
+++ b/tool/apply_smoke.sh
@@ -149,7 +149,7 @@ export DB_PASSWORD="${DB_PASSWORD:-apply-smoke-placeholder}"
 
 dart pub get
 
-# --- terraform with stale-lock recovery ------------------------------------
+# --- terraform APPLY with stale-lock recovery (teardown uses tf_destroy) ---
 # A killed apply-smoke run (e.g. GitHub's cancel-in-progress when a PR is
 # re-pushed) leaves the GCS backend lock held; the next run then dies with
 # "Error acquiring the state lock". Run terraform, and on THAT error force-
@@ -179,6 +179,16 @@ tf_lockaware() {
   terraform "$@"
 }
 
+# Teardown runs with -lock=false on purpose: apply-smoke processes slugs
+# serially (no concurrent writer to guard), and a stale lock from a cancelled
+# run — whose age is always < 15 min, so tf_lockaware treats it as "live" and
+# refuses to break it — must never block reclaiming state. tf_lockaware above
+# is therefore apply-only. State-UNtracked orphans (a killed apply mid-create,
+# never written to state) still need a gcloud-based janitor (separate task).
+tf_destroy() {
+  terraform destroy -auto-approve -input=false -lock=false
+}
+
 # --- apply (or destroy-only) one example, with a GCS-backed state ----------
 apply_one() {
   local slug="$1"
@@ -205,7 +215,7 @@ apply_one() {
       "$STATE_BUCKET" "$slug" > backend.tf.json
     terraform init -input=false -reconfigure || exit 1
     if [[ "$DESTROY_ONLY" == "1" ]]; then
-      tf_lockaware destroy -auto-approve -input=false
+      tf_destroy
       exit $?
     fi
     # Apply, then ALWAYS tear down — capturing the apply result separately.
@@ -218,10 +228,10 @@ apply_one() {
     if [[ "$apply_rc" != "0" ]] && grep -qE 'already exists|AlreadyExists' <<<"$apply_out"; then
       echo "  !! apply hit alreadyExists — GCP resources likely orphaned outside state (e.g. a cancelled prior run); destroy can only remove resources tracked in state" >&2
     fi
-    if ! tf_lockaware destroy -auto-approve -input=false; then
+    if ! tf_destroy; then
       echo "  !! teardown failed for $slug — retrying in 15s" >&2
       sleep 15
-      if ! tf_lockaware destroy -auto-approve -input=false; then
+      if ! tf_destroy; then
         echo "  !! TEARDOWN FAILED for $slug after retry — ORPHAN RISK; run tool/apply_smoke_janitor.sh" >&2
         echo "$slug" >> "$TEARDOWN_FAILS_FILE"
       fi

--- a/tool/apply_smoke.sh
+++ b/tool/apply_smoke.sh
@@ -58,8 +58,12 @@ select_examples() {
     changed)
       # Only infra sources (bin/lib) — pubspec/README/analysis_options bumps must
       # not fan out apply-smoke to every quickstart on a Wave version bump.
+      # grep + cut, NOT awk: awk's literal-regex /…[^/]…/ breaks on the embedded
+      # slash (BSD errors "nonterminated character class"; gawk silently matches
+      # every line → full fan-out, which shipped pubspec bumps to all examples).
       git diff --name-only "${GITHUB_BASE_SHA:-origin/main}" HEAD -- 'examples/' 2>/dev/null \
-        | awk -F/ '/^examples\/[^/]+_quickstart\/(bin|lib)\// {print $2}' | sort -u
+        | grep -E '^examples/[^/]+_quickstart/(bin|lib)/' \
+        | cut -d/ -f2 | sort -u
       ;;
   esac
 }

--- a/tool/apply_smoke_test.sh
+++ b/tool/apply_smoke_test.sh
@@ -67,8 +67,9 @@ while IFS= read -r s; do
 done <<< "$pr_skip_slugs"
 
 # 7. changed-mode filter: only bin/lib paths select an example (not pubspec/README).
+#    Mirrors the pipeline in apply_smoke.sh's `changed` branch — keep in sync.
 filter_changed_paths() {
-  awk -F/ '/^examples\/[^/]+_quickstart\/(bin|lib)\// {print $2}' | sort -u
+  grep -E '^examples/[^/]+_quickstart/(bin|lib)/' | cut -d/ -f2 | sort -u
 }
 changed_out="$(printf '%s\n' \
   'examples/dns_quickstart/pubspec.yaml' \
@@ -80,5 +81,20 @@ changed_out="$(printf '%s\n' \
   || fail "changed-mode path filter:
 got:
 $changed_out"
+
+# 8. changed-mode regression: a pubspec/README-only bump (a Wave version bump)
+#    must select NOTHING. The old awk literal-regex /…[^/]…/ broke on the
+#    embedded slash and silently matched every line under gawk, fanning a
+#    pubspec bump out to every example — a real cost leak. Guard it.
+fanout_out="$(printf '%s\n' \
+  'examples/dns_quickstart/pubspec.yaml' \
+  'examples/biglake_quickstart/pubspec.yaml' \
+  'examples/app_engine_quickstart/README.md' \
+  'examples/app_engine_quickstart/analysis_options.yaml' \
+  | filter_changed_paths)"
+[[ -z "$fanout_out" ]] \
+  || fail "pubspec/README-only bump must select no examples (fan-out regression):
+got:
+$fanout_out"
 
 echo "apply_smoke_test: OK"


### PR DESCRIPTION
## Context

After Wave 71 (#199), apply-smoke FAILED twice (runs 27905682211, 27905948711)
and left four `dns_quickstart` resources orphaned in terradart-validate (a VPC,
a service account, a DNS policy, a DNS response policy), reclaimed by hand. Two
independent root causes:

### 1. Teardown stalled on a stale state lock

A cancelled run (GitHub cancel-in-progress on a PR re-push) leaves the GCS
backend lock held. `tf_lockaware` refuses to break a lock younger than 15 min to
protect live runs — but a cancel-orphaned lock is always younger than that, so
teardown died with `Error 412` and never reclaimed state.

Teardown never needs the lock (apply-smoke runs slugs serially), so add a
`tf_destroy` helper running `terraform destroy -lock=false`, used for both the
post-apply teardown and the `--destroy-only` janitor. `tf_lockaware` stays for
apply only. Drop the janitor from 6-hourly to weekly — it's now just a backstop
for state-tracked leftovers.

### 2. change-gate fanned pubspec bumps out to every example

The changed-mode selector used an awk literal regex whose `[^/]` embeds a slash
awk reads as the regex terminator. gawk (CI) silently matched every line, so a
Wave version bump (touching only pubspec.yaml) selected all ~39 examples and
applied every non-skipped one — defeating the #192 cost control, and the root of
the orphan-prone churn. Replace it with `grep -E | cut`, fix + extend the unit
test (new test 8 guards the regression), and wire `apply_smoke_test.sh` into CI
(it wasn't running, which is why this shipped unnoticed).

## Out of scope (tracked separately)

- State-UNtracked orphans (a killed apply mid-create, never written to state)
  can't be reclaimed by the state-based janitor — needs a gcloud-based sweep.
- `ci.yml`'s changes job has the same awk bug for the validate matrix, but a
  `packages/` change falls back to `all()`, so impact is CI-time only.

## Testing

- `tool/apply_smoke_test.sh` green locally (now runs under macOS BSD awk too)
- `bash -n tool/apply_smoke.sh`, ci.yml / janitor yaml parse OK