### PR TITLE
docs(agent): GitHub release notes template in ship-wave skill

### DIFF
--- a/.agents/skills/terradart-ship-wave/SKILL.md
+++ b/.agents/skills/terradart-ship-wave/SKILL.md
@@ -2,7 +2,7 @@
 name: terradart-ship-wave
 description: Ship a TerraDart Wave release — curated factories, examples/docs debt, catalog counts, CHANGELOG, and agent_verify. Use when landing multiple related google_* resources as one user-visible release.
 metadata:
-  last_modified: 2026-06-09
+  last_modified: 2026-06-22
 ---
 # Ship a TerraDart Wave
 
@@ -41,6 +41,7 @@ A Wave PR is **not done** when wrappers and `curatedDoc` land alone. It is done 
 - [ ] 6. **Version & CHANGELOG** — lockstep `0.N.P` across four packages; root + per-package CHANGELOG entries.
 - [ ] 7. **CI** — new quickstart in `terraform_validate` matrix when applicable.
 - [ ] 8. **Verify** — `tool/agent_verify.sh` (add `--maintainer` when touching wrap-init / wrap-promote).
+- [ ] 9. **Tag & GitHub release** — after merge and green CI: push `v0.N.P`, publish via `.github/workflows/publish.yml`, create the GitHub release using the template below (title is **`v0.N.P` only** — no Wave subtitle in the release name).
 
 ## Example patterns
 
@@ -49,6 +50,75 @@ A Wave PR is **not done** when wrappers and `curatedDoc` land alone. It is done 
 | New service area (e.g. GKE) | Add `examples/gke_quickstart/` from `compute_quickstart` template |
 | Extends existing stack (e.g. WIF provider on IAM pool) | Extend `examples/iam_quickstart/lib/main.dart` |
 | Breaking constructor change | `MIGRATING.md` + fix all examples importing the factory |
+
+## GitHub release notes
+
+Release tags and GitHub releases are **maintainer manual** (see [`AGENTS.md`](../../../AGENTS.md)). After `v0.N.P` is pushed and pub.dev publish succeeds, create the GitHub release body to match recent releases (canonical examples: [`v0.19.0`](https://github.com/nozomi-koborinai/terradart/releases/tag/v0.19.0), [`v0.20.0`](https://github.com/nozomi-koborinai/terradart/releases/tag/v0.20.0)). Do **not** use a bare CHANGELOG paste or a one-paragraph summary.
+
+### Required sections (in order)
+
+1. **Opening** — lockstep packages list + **No breaking changes** vs the previous published semver (or call out breaking changes + link `MIGRATING.md`).
+2. **Bundled Waves (optional)** — when one semver ships multiple Waves (e.g. `0.19.0` = Wave 71 + 72), explain merge/publish ordering if any intermediate tag was skipped.
+3. **`## Highlights`** — catalog counts (`N curated + 1 data source`, entries, barrels), number of new factories, new/extended examples (linked).
+4. **`## Wave …`** — one subsection per Wave: `## Wave N — Title (\`barrel\` barrel)`; table of Terraform type → Dart factory; 1–2 sentences on sealed types / IAM-member-only policy when relevant.
+5. **`## Tooling` (optional)** — only when the release includes CI/apply-smoke/agent-guide changes worth calling out.
+6. **`## Upgrade`** — `pubspec.yaml` snippet with `terradart_core` + `terradart_google` carets at the new version.
+7. **Docs links** — `Waves guide` · `Getting started` (terradart.dev URLs).
+8. **`## What's Changed`** — bullet per merged PR: `* Wave N: … by @author in <PR URL>`.
+9. **`**Full Changelog**`** — compare link `v0.(N-1).0...v0.N.P` (adjust when the previous tag is not the immediate predecessor).
+
+### Template (single Wave)
+
+Replace placeholders; duplicate the Wave section when shipping multiple Waves in one semver.
+
+```markdown
+Lockstep release across `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_agent`, and `terradart_coverage`. **No breaking changes** vs `0.PREV`.
+
+## Highlights
+
+- **`terradart_google` catalog:** **NNN curated resource factories + 1 data source** (**NNN entries**; **NN service barrels**)
+- **K new curated factories** for <service area>
+- **New example:** [`foo_quickstart`](examples/foo_quickstart/)
+- **Extended example:** [`bar_quickstart`](examples/bar_quickstart/) — <one line on what was added> *(omit when N/A)*
+
+## Wave N — <Title> (`<barrel>` barrel)
+
+<K> curated factories:
+
+| Terraform type | Dart factory |
+| --- | --- |
+| `google_foo` | `GoogleFoo` |
+| … | … |
+
+<Optional: sealed dispatch, typed nested blocks, IAM-member-only note.>
+
+## Tooling
+
+- **<Area>:** <one line> *(omit section when nothing user-visible)*
+
+## Upgrade
+
+    dependencies:
+      terradart_core: ^0.N.P
+      terradart_google: ^0.N.P
+
+Docs: [Waves guide](https://terradart.dev/docs/waves/) · [Getting started](https://terradart.dev/docs/getting-started/)
+
+## What's Changed
+
+* Wave N: <title> by @author in https://github.com/nozomi-koborinai/terradart/pull/NNN
+
+**Full Changelog**: https://github.com/nozomi-koborinai/terradart/compare/v0.PREV...v0.N.P
+```
+
+```bash
+# Tag triggers pub.dev publish (.github/workflows/publish.yml)
+git tag -a v0.N.P -m "Release v0.N.P — Wave N <Title>"
+git push origin v0.N.P
+
+# GitHub release (after publish workflow is green)
+gh release create v0.N.P --title "v0.N.P" --notes-file /path/to/notes.md
+```
 
 ## Useful commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Committed maintainer skills live under [`.agents/skills/`](.agents/skills/) (Age
 |-------|----------|
 | [`terradart-agent-verify`](.agents/skills/terradart-agent-verify/SKILL.md) | Finishing any agent or maintainer change |
 | [`terradart-add-curated-resource`](.agents/skills/terradart-add-curated-resource/SKILL.md) | Adding or updating a curated `google_*` factory |
-| [`terradart-ship-wave`](.agents/skills/terradart-ship-wave/SKILL.md) | Landing a Wave release (curated + example/docs + counts + CHANGELOG) |
+| [`terradart-ship-wave`](.agents/skills/terradart-ship-wave/SKILL.md) | Landing a Wave release (curated + example/docs + counts + CHANGELOG + GitHub release notes) |
 | [`terradart-backfill-examples`](.agents/skills/terradart-backfill-examples/SKILL.md) | Covering `tool/example_debt.yaml` gaps in existing quickstarts |
 | [`terradart-tighten-example-topology`](.agents/skills/terradart-tighten-example-topology/SKILL.md) | Wiring backfilled factories into sibling refs; `tool/check_example_topology.dart` |
 
@@ -192,7 +192,7 @@ Follow the [`terradart-add-curated-resource`](.agents/skills/terradart-add-curat
 - Example stacks do not declare Terraform variables. Use Dart interpolation for constructor values such as `projectId`, not Terraform literals like `${var.project_id}`.
 - When adding resources in batches, update hard-coded curated-count assertions in the same PR or batch.
 - When bumping versions, check inter-package caret constraints with per-package CI in mind; workspace resolution can hide stale constraints locally.
-- Release tags and GitHub releases are created manually by the maintainer.
+- Release tags and GitHub releases are created manually by the maintainer. Use the **GitHub release notes** checklist in [`terradart-ship-wave`](.agents/skills/terradart-ship-wave/SKILL.md) (match [`v0.19.0`](https://github.com/nozomi-koborinai/terradart/releases/tag/v0.19.0) / [`v0.20.0`](https://github.com/nozomi-koborinai/terradart/releases/tag/v0.20.0) format — not a CHANGELOG paste).
 
 ## Cursor Cloud specific instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,13 @@ When a Wave also pays down example `pubspec.yaml` carets or docs debt, **prefer 
 - Cloud agents: create `cursor/<descriptive-name>-fc7b` (or the repo's active agent suffix), commit, push, and open/update a PR before claiming work is done.
 - Emergency publish fixes still get a PR (can merge immediately after CI green); do not bypass review habit.
 
+### Cloud agent commits (no co-authorship)
+
+When **Cursor Cloud Agent** is the active maintainer, feature work lands only through Cursor-opened PRs on `cursor/*` branches.
+
+- **Do not add `Co-authored-by:` trailers** to commit messages. Cursor Cloud may inject them via a platform `commit-msg` hook — use [`tool/agent_commit.sh`](tool/agent_commit.sh) (or `git commit --no-verify`) and confirm with `git log -1 --format='%B'` before push.
+- Release tags and GitHub release bodies follow [`terradart-ship-wave`](.agents/skills/terradart-ship-wave/SKILL.md).
+
 ## Override lint coverage (`exactly_one_of`)
 
 `terradart lint-override` enforces MM YAML `exactly_one_of` groups via:

--- a/tool/agent_commit.sh
+++ b/tool/agent_commit.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Commit from a Cloud Agent without Co-authored-by trailers.
+#
+# Cursor Cloud may inject Co-authored-by via a platform commit-msg hook.
+# This wrapper uses --no-verify and fails if the trailer is still present.
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: tool/agent_commit.sh -m \"subject\" [-m \"body\"]" >&2
+  exit 64
+fi
+
+git commit --no-verify "$@"
+
+if git log -1 --format='%B' | grep -qi '^Co-authored-by:'; then
+  echo 'agent_commit.sh: Co-authored-by trailer present after commit; aborting' >&2
+  exit 1
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents Wave release conventions and cloud-agent commit policy.

## Changes

- **`terradart-ship-wave` skill** — GitHub release notes template (v0.19.0 / v0.20.0 style): Highlights, Wave tables, Upgrade, What's Changed; task step 9 for tag + release.
- **`AGENTS.md`** — pointer to release-notes checklist; **Cloud agent commits (no co-authorship)** policy — Cursor-only PRs, no `Co-authored-by:` trailers.
- **`tool/agent_commit.sh`** — `git commit --no-verify` wrapper that fails if a co-author trailer is still present (Cursor platform hook bypass).

No runtime or API changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a9cfca4-6dcd-432a-a135-4c5ac983ccb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a9cfca4-6dcd-432a-a135-4c5ac983ccb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

