### PR TITLE
chore(mcp): wrap gcp-cost server for Cursor Secret JSON

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,7 +1,8 @@
 {
   "mcpServers": {
     "gcp-cost": {
-      "command": "gcp-cost-mcp-server"
+      "command": "bash",
+      "args": ["tool/gcp-cost-mcp-wrapper.sh"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,8 @@
 {
   "mcpServers": {
     "gcp-cost": {
-      "command": "gcp-cost-mcp-server"
+      "command": "bash",
+      "args": ["tool/gcp-cost-mcp-wrapper.sh"]
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,8 @@ Follow the [`terradart-add-curated-resource`](.agents/skills/terradart-add-curat
 
 Cloud Agent VMs provision their toolchain from [`.cursor/environment.json`](.cursor/environment.json), whose `install` step runs the idempotent [`.cursor/install.sh`](.cursor/install.sh): it installs **Dart SDK stable** (≥ 3.10; workspace root requires ^3.6, `terradart_agent` requires ^3.10) from the official apt repo and **Terraform** (≥ 1.11) from HashiCorp apt, then runs `dart pub get`. Cursor caches the result as a snapshot, so later agent boots are fast. Edit `install.sh` when the toolchain changes — do not rely on a hand-built snapshot.
 
+**gcp-cost MCP.** `.cursor/mcp.json` launches [`tool/gcp-cost-mcp-wrapper.sh`](tool/gcp-cost-mcp-wrapper.sh), which materializes the Cursor Secret `GOOGLE_APPLICATION_CREDENTIALS` (inline JSON) to `~/.config/gcp-cost/service-account.json` (`chmod 600`) before exec'ing `gcp-cost-mcp-server`. Register the service-account JSON as a Cursor Secret; do not commit credentials. Public Cloud Billing Catalog pricing needs no project API enablement; prefer a dedicated low-privilege SA over a production key.
+
 There is no long-running dev server for core work. Primary flows:
 
 | Goal | Command (repo root) |

--- a/tool/gcp-cost-mcp-wrapper.sh
+++ b/tool/gcp-cost-mcp-wrapper.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Materialize Cursor-injected service-account JSON for gcp-cost-mcp-server.
+#
+# Cloud Agent secrets set GOOGLE_APPLICATION_CREDENTIALS to the JSON body.
+# Google's ADC and gcp-cost-mcp-server expect a filesystem path instead.
+set -euo pipefail
+
+readonly GAC_FILE="${HOME}/.config/gcp-cost/service-account.json"
+
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" && "${GOOGLE_APPLICATION_CREDENTIALS}" == \{* ]]; then
+  install -d -m 700 "$(dirname "$GAC_FILE")"
+  umask 077
+  printf '%s' "$GOOGLE_APPLICATION_CREDENTIALS" >"$GAC_FILE"
+  chmod 600 "$GAC_FILE"
+  export GOOGLE_APPLICATION_CREDENTIALS="$GAC_FILE"
+fi
+
+exec gcp-cost-mcp-server


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the **gcp-cost MCP server** work with Cursor Cloud Agent Secrets.

Cursor injects `GOOGLE_APPLICATION_CREDENTIALS` as **inline JSON**, but `gcp-cost-mcp-server` (and Google ADC) expect a **filesystem path**. This PR adds a small wrapper that materializes the secret to `~/.config/gcp-cost/service-account.json` before exec'ing the server.

## Changes

- `tool/gcp-cost-mcp-wrapper.sh` — detect inline JSON, write to `~/.config/gcp-cost/` (`chmod 600`, dir `700`), then `exec gcp-cost-mcp-server`
- `.cursor/mcp.json` / `.mcp.json` — launch via the wrapper
- `AGENTS.md` — document Secret registration and wrapper behavior

## Security notes

| Concern | Mitigation |
|---------|------------|
| Credentials in git | **Never committed** — only the wrapper script; JSON stays in Cursor Secrets |
| File on disk | Written to `$HOME/.config/gcp-cost/` with `umask 077` + `chmod 600` (owner-read only) |
| Broader exposure vs env-only | Cloud Agent already injects the JSON into the process environment; materializing to a private file is required for ADC and does not widen the trust boundary on an ephemeral VM |
| SA privileges | gcp-cost reads **public** Cloud Billing Catalog pricing via OAuth; no billing API or project mutation. Prefer a dedicated low-privilege SA, not a production admin key |
| Logging | Wrapper does not echo secret contents |

After merge: open a **new Cloud Agent session** (or reconnect MCP) so Cursor picks up the updated `.cursor/mcp.json`.

## Verification

```bash
bash tool/gcp-cost-mcp-wrapper.sh   # starts gcp-cost-mcp-server when GOOGLE_APPLICATION_CREDENTIALS Secret is set
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2de8ee3f-bf7e-46d0-ae02-9c686f90296d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2de8ee3f-bf7e-46d0-ae02-9c686f90296d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

