### PR TITLE
docs(cookbook): add monorepo cookbook recipes

### DIFF
--- a/cookbook/.gitignore
+++ b/cookbook/.gitignore
@@ -1,0 +1,28 @@
+# Dart
+.dart_tool/
+
+# Terraform working dirs (synth output + state)
+*/tf-out/
+*/tf-bootstrap/
+*/terraform/
+**/.terraform/
+**/*.tfstate
+**/*.tfstate.backup
+**/terraform.tfstate.d/
+
+# IDE
+.idea/
+*.iml
+.vscode/
+
+# pubspec.lock policy: COMMITTED.
+# Recipes are apps (not libraries), so pinning transitive versions in
+# pubspec.lock gives reproducible local apply behavior across machines.
+# Do NOT add `pubspec.lock` to this ignore list.
+
+# macOS
+.DS_Store
+
+# Dart legacy / build artifacts
+build/
+.packages

--- a/cookbook/LICENSE
+++ b/cookbook/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -1,0 +1,40 @@
+# TerraDart cookbook
+
+Real-world recipes for [terradart](https://github.com/nozomi-koborinai/terradart), the Dart-first IaC library for Google Cloud.
+
+Each recipe is a self-contained Dart project under `cookbook/<name>/` that uses the monorepo workspace packages and ships a working Stack you can `terraform plan + apply` against a real GCP project.
+
+## Recipes
+
+| Recipe | Pattern | Status | Barrels |
+|---|---|---|---|
+| [`lunch-concierge`](lunch-concierge/README.md) | Flutter Web + Dart server + Genkit Vertex AI + Cloud Run sidecar + private Cloud SQL | Demo recipe | 8 |
+| [`single-project-app`](single-project-app/README.md) | Single GCP project, end-to-end app surface (Cloud Run + Cloud SQL + Pub/Sub + Monitoring + Secret Manager + IAM) | Imported | 8 |
+| [`remote-backend`](remote-backend/README.md) | GCS-backed Terraform remote state (Stage 0 bootstrap + state migration) | Imported | 1 |
+| [`firestore-seeded-data`](firestore-seeded-data/README.md) | Cloud Firestore master-data seeding (11 docs across 4 collections + composite index + daily backup) via `GoogleFirestoreDocument` + `FirestoreFields.encode` | Imported | 3 |
+
+(Coming in future iterations: `multi-env-dev-prod` for env separation and `dynamic-iam-for-each` for `locals`/`for_each` patterns.)
+
+## Usage
+
+```bash
+cd cookbook/<name>
+dart pub get
+dart run bin/infra.dart    # synth to tf-out/
+cd tf-out
+terraform init
+terraform plan
+terraform apply
+# ...smoke test...
+terraform destroy
+```
+
+Each recipe's README documents required env vars (e.g. `GCP_PROJECT_ID`, secrets).
+
+## Versions
+
+Recipes in this monorepo use Dart workspace resolution against the checked-out TerraDart packages. Published cookbook snippets should still follow the current `terradart_core` / `terradart_google` release line documented in the root README.
+
+## How recipes feed back into terradart
+
+Each recipe's `FRICTIONS.md` is the canonical log of "things the recipe author hit that should be cleaner in terradart core / cookbook docs". Each friction entry is classified (P0 / P1 / P2 / P3) and consolidated into upstream issues on the [terradart repo](https://github.com/nozomi-koborinai/terradart). The cookbook is the dogfood vehicle: the more real-world recipes we ship, the more strategic input lands on terradart's roadmap.

--- a/cookbook/firestore-seeded-data/.gitignore
+++ b/cookbook/firestore-seeded-data/.gitignore
@@ -1,0 +1,8 @@
+.dart_tool/
+.packages
+tf-out/
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.backup
+tfplan

--- a/cookbook/firestore-seeded-data/FRICTIONS.md
+++ b/cookbook/firestore-seeded-data/FRICTIONS.md
@@ -1,0 +1,81 @@
+# firestore-seeded-data — FRICTIONS
+
+Findings from dogfooding the recipe against `terradart-validate` GCP project.
+
+Cycle 1: **2026-05-22 — initial validation against terradart v0.10.0** published to pub.dev. Apply → smoke → destroy against `terradart-validate`. Followed by a second dogfood cycle the same day after discovering a P1 recipe-correctness omission (see below).
+
+Summary: **4 frictions found**. The originally-reported "P0 provider destroy bug" was reclassified to P1 (recipe correctness): the recipe was missing `deletionPolicy: TfArg.literal('DELETE')` on the database resource, so the provider's documented default (`ABANDON`) left the `(default)` database in place on `terraform destroy`. The fix is in the same PR as this update; the second dogfood cycle confirmed destroy now deletes the database in ~2s.
+
+---
+
+## Format
+
+Each entry follows the cookbook template:
+
+- **Context**: what was being done when the friction surfaced.
+- **Friction**: what was unexpected / painful.
+- **Proposed fix**: what would prevent the friction next time. May be a terradart change, a doc change, or a process change.
+- **Tracked**: GitHub issue link if filed, or `none` if a memo-only.
+
+---
+
+## P1 — recipe omitted `deletionPolicy: TfArg.literal('DELETE')`; provider default `ABANDON` leaves DB on destroy
+
+- **Context**: First dogfood cycle's `terraform destroy` reported success (`Destroy complete! Resources: 15 destroyed.`) but `gcloud firestore databases list --project=terradart-validate` showed `(default)` still alive. Initial hypothesis was an upstream `hashicorp/google` provider bug.
+- **Friction**: The Cycle-1 Stack did not pass `deletionPolicy` to `GoogleFirestoreDatabase(...)`, so the field was omitted from synth output and the provider applied its documented schema default. Per `schema.json`:
+  > "If the deletion policy is 'ABANDON', the database will be removed from Terraform state but not deleted from Google Cloud upon destruction. ... **The default value is 'ABANDON'**."
+
+  `ABANDON` behavior is deliberate — Firestore databases are expensive to recreate, so the safe default is to leave them in place. But for an IaC recipe where the entire stack is intentionally throwaway (cookbook dogfood / dev / staging spin-up), `DELETE` is the right policy. The recipe should have set it explicitly.
+- **Proposed fix**:
+  1. **Recipe** (fixed in this PR): add `deletionPolicy: TfArg.literal('DELETE')` to the `GoogleFirestoreDatabase(...)` call in `lib/main.dart`, with an inline comment explaining the default-behavior gotcha.
+  2. **Verification** (this PR): second dogfood cycle 2026-05-22 — `terraform destroy` cleanly removed the `(default)` database in ~2s. `gcloud firestore databases list` returned empty afterwards. No manual `gcloud` workaround needed.
+  3. **Documentation**: the README destroy section is rewritten to drop the manual `gcloud` workaround.
+  4. **Upstream issue filing**: not needed — the provider behavior is documented and intentional.
+- **Tracked**: closed by this PR's recipe fix.
+
+---
+
+## P1 — `gcloud firestore documents` subcommand does not exist
+
+- **Context**: Plan B Task 7 (smoke verification) called for `gcloud firestore documents list --database='(default)' --collection-id=feature_flags ...` to count seeded documents per collection.
+- **Friction**: `gcloud firestore documents` is not a valid subcommand. `gcloud firestore` only exposes `databases`, `backups`, `locations`, `operations`, `user-creds`. There is no document-level CRUD via gcloud. To verify documents you need:
+  - Firestore REST API via `curl` + ADC access token (used here: `curl -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" "https://firestore.googleapis.com/v1/projects/<p>/databases/(default)/documents/<col>"`), OR
+  - Firebase CLI (`firebase firestore:get`) — separate tool with its own auth, OR
+  - Firestore client libraries — for programmatic checks
+- **Proposed fix**: this recipe's README + the upstream `firestore_document_quickstart` README in terradart should both show the REST-API smoke pattern (it's the lowest-dependency option — gcloud is already in scope for ADC anyway). Plan templates that follow this recipe should also use the REST pattern, not the imaginary gcloud subcommand.
+- **Tracked**: `none` (doc-only change captured inline in the README — already in this recipe's README from Cycle 1).
+
+---
+
+## P2 — Composite index creation takes ~6 minutes (vs documents <1s each)
+
+- **Context**: `terraform apply` for the 15-resource Stack. Most resources created in seconds; the database took 12s, then 11 documents created in parallel in ~13s each. The composite index `pricing_tiers_by_price` (2 fields: `monthly_usd ASC, label ASC`) was the long pole — Cycle 1 measured 5m57s, Cycle 2 measured 6m5s.
+- **Friction**: A first-time user reading the apply log will see "Still creating... 5m00s elapsed" and reasonably worry something is stuck. The 6-minute composite-index creation time is normal Firestore behavior (indexes provision asynchronously on a separate Firestore worker pool) but the Cycle-1 README claimed "1-3 minutes" for total apply.
+- **Proposed fix**: README updated (Cycle 1) — `## Run` section sets expectations as 5-10 minutes dominated by the composite index, with a note that documents themselves complete in seconds and that `skip_wait: true` is a knob for CI-driven workflows that don't need the index ready immediately.
+- **Tracked**: `none` (doc-only).
+
+---
+
+## P3 — Plan B's database destroy timing estimate ("1-5 minutes") was pessimistic
+
+- **Context**: Plan B Task 8 warned that `google_firestore_database` destruction takes 1-5 minutes.
+- **Friction**: With `deletionPolicy = "DELETE"` (P1 fix), actual destruction was `Destruction complete after 2s`. Without it (Cycle 1), Terraform's "Destruction complete after 0s" was a no-op anyway. There is no scenario in current GCP behavior where `(default)` Native-mode delete takes minutes — it's near-instant either way.
+- **Proposed fix**: README destroy section (Cycle 1 + Cycle 2 rewrites) drops the "1-5 minute" estimate. Standard expectation is now <5s for the entire destroy.
+- **Tracked**: `none` (folded into the same README rewrite as P1).
+
+---
+
+## What worked well (positive signals for v0.10.0)
+
+These are not frictions but worth recording as positive validation of Plan A:
+
+- **`FirestoreFields.encode` end-to-end correctness**: every type round-tripped correctly through the wire format → Firestore storage → REST API read-back. `booleanValue: true`, `integerValue: "100"` (string-encoded for 64-bit precision per spec), `timestampValue: "2026-05-22T00:00:00Z"` (UTC ISO 8601), `geoPointValue: {latitude: 37.7749, longitude: -122.4194}`, `referenceValue: projects/.../billing_profiles/annual`, Unicode `stringValue: "こんにちは"` + nested `mapValue.fields.subscribe.stringValue: "登録"` all confirmed via REST.
+- **11 documents create in parallel**: Terraform's default parallelism naturally fanned out the document creates; total document-creation wall time was ~13s for all 11 (dominated by the slowest single document, not the sum).
+- **`FirestoreReference` to non-existent target accepted silently**: as designed — the helper does not validate target existence; Firestore stores the path verbatim and lets the application decide. This is the right design for IaC-seeded master data that may reference documents created elsewhere.
+- **Composite index READY after creation**: index reached `READY` state immediately after the create operation returned (no separate polling needed in this Stack — Terraform's index resource waits for READY by default).
+- **`Stack(devMode: true)` did NOT inject `deletion_protection: false` on Firestore resources**: confirmed expected — the devMode injection only targets the 6 Plan-1 resources (Cloud Run v2 service+job, Cloud SQL, Secret Manager standard+regional, BigQuery table). Firestore database uses `delete_protection_state` (not `deletion_protection`) and the user-supplied `DeleteProtectionState.disabled` in the Stack already covered it.
+- **Clean destroy after `deletionPolicy: DELETE`** (Cycle 2): all 15 resources teardown in seconds, `(default)` database actually removed from GCP, no manual cleanup. Recipe pattern is now safe to run repeatedly in CI / dev / staging environments without leaving database stragglers.
+
+---
+
+Cycle 3: **v0.11.0 surface dogfood**. Fresh-state apply → 15 added (composite index dominated, 6m4s — matches Cycle 1 timing). REST smoke reconfirmed all 11 documents with correct typed encodings (`integerValue` / `booleanValue` / `timestampValue`). Destroy clean in seconds, `(default)` database removed in 2s. No new frictions; the Cycle 2 `deletionPolicy: DELETE` fix carries through.

--- a/cookbook/firestore-seeded-data/README.md
+++ b/cookbook/firestore-seeded-data/README.md
@@ -1,0 +1,108 @@
+# firestore-seeded-data
+
+> **Status:** Verified on terradart v0.11.0. 15-resource Stack (default Firestore database + 11 documents across 4 collections + composite index + daily backup schedule). See [FRICTIONS.md](FRICTIONS.md) for dogfood findings.
+
+A Cloud Firestore master-data seeding recipe. Demonstrates how to manage **small fixed master-data sets** (feature flags, pricing tiers, lookup tables, regional config) via IaC, with the new `GoogleFirestoreDocument` resource + `FirestoreFields.encode(Map)` helper introduced in terradart v0.10.0.
+
+## What this recipe demonstrates
+
+- `google_firestore_database` — the singleton `(default)` Native-mode database in `asia-northeast1`.
+- `google_firestore_document` × 11 across 4 collections:
+  - **feature_flags** (3) — `dark_mode`, `new_checkout`, `beta_invites`. Booleans + integers + lists + nested maps.
+  - **pricing_tiers** (3) — `free`, `pro`, `enterprise`. Strings + integers + lists. `enterprise` includes a `FirestoreReference` to a `billing_profiles/annual` document (note: that doc is referenced but not created here — the helper does not validate target existence).
+  - **i18n** (3) — `en`, `ja`, `ko`. Unicode strings + nested maps.
+  - **regions** (2) — `us`, `jp`. `FirestoreGeoPoint` lat/lon for office locations.
+- `google_firestore_index` — composite index on `pricing_tiers` (`monthly_usd ASC, label ASC`).
+- `google_firestore_backup_schedule` — daily backups, 7-day retention.
+
+## Why master data in IaC
+
+- **Reproducibility**: spin up `dev` / `staging` / `prod` projects with identical master data via `terraform apply`.
+- **Audit-via-PR**: master-data changes go through code review, not manual console clicks.
+- **Env parity**: when you rebuild a project for any reason, master data is recreated by Terraform alongside the database.
+
+## When NOT to use this pattern
+
+For **production-scale** Firestore collections (1000s of documents, frequent app-side writes, transactional data), prefer a separate seed script using the Firebase Admin SDK. IaC ownership of frequently-mutating collections causes Terraform state to diverge from Firestore reality.
+
+This recipe demonstrates the **opposite** end of the spectrum: a small fixed set of documents, infrequently changed via PR review, naturally fitting IaC.
+
+See [terradart_google CHANGELOG `0.10.0` § Supersedes 0.3.0-dev note](https://pub.dev/packages/terradart_google/changelog#0100) for the rationale behind v0.10.0 reversing the original "not curated" decision.
+
+## Prerequisites
+
+- Terraform 1.11+
+- `gcloud auth application-default login` with `roles/datastore.owner` on the target project
+- A GCP project (e.g., `terradart-validate`). The default `(default)` Firestore database must NOT already exist (Firestore creates one automatically the first time the API is enabled — if `(default)` already exists, see "Recovery" below).
+
+## Run
+
+```bash
+export GCP_PROJECT_ID=my-project-id
+dart pub get
+dart run bin/infra.dart        # → tf-out/main.tf.json
+cd tf-out
+terraform init
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+Expected apply duration: **5-10 minutes**, dominated by the composite index. Documents themselves create in seconds (Terraform fans them out in parallel — all 11 typically finish within ~15s total). The `(default)` database takes ~12s. The composite index on `pricing_tiers` is the long pole and takes 5-6 minutes to provision (Firestore index workers run asynchronously — this is normal and well-documented). If you don't need the index ready immediately (e.g. CI synth-and-validate workflows), consider adding `skip_wait: true` on the `GoogleFirestoreIndex` resource so Terraform returns as soon as the API accepts the request.
+
+## Smoke test
+
+`gcloud firestore` does NOT expose document-level commands (only databases / backups / locations / operations). To verify the seeded documents, use the Firestore REST API via `curl` + an ADC access token:
+
+```bash
+TOKEN=$(gcloud auth application-default print-access-token)
+for col in feature_flags pricing_tiers i18n regions; do
+  count=$(curl -s -H "Authorization: Bearer $TOKEN" \
+    "https://firestore.googleapis.com/v1/projects/$GCP_PROJECT_ID/databases/(default)/documents/$col" \
+    | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('documents',[])))")
+  echo "$col: $count"
+done
+```
+
+Expected counts: `feature_flags: 3`, `pricing_tiers: 3`, `i18n: 3`, `regions: 2`.
+
+To inspect a specific document's encoded field types:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://firestore.googleapis.com/v1/projects/$GCP_PROJECT_ID/databases/(default)/documents/feature_flags/dark_mode" \
+  | python3 -m json.tool
+```
+
+Expect `enabled.booleanValue: true`, `rollout_pct.integerValue: "100"` (string-encoded for 64-bit precision), and `last_updated.timestampValue: "2026-05-22T00:00:00Z"`.
+
+Alternatively, the Firebase / Firestore console: open the project, switch to Firestore Data, confirm the 4 collections with their documents and field types (`enabled` is `boolean`, `rollout_pct` is `number`, `office_location` is `geopoint`).
+
+## Destroy
+
+```bash
+cd tf-out
+terraform destroy
+```
+
+Expected: `Destroy complete! Resources: 15 destroyed.` in a few seconds. The `(default)` database deletes in ~2s.
+
+The recipe sets `deletionPolicy: TfArg.literal('DELETE')` on the database resource — without it, the provider's documented default (`ABANDON`) leaves the database in place on destroy. See [`FRICTIONS.md`](FRICTIONS.md) §P1.
+
+## Recovery: `(default)` database already exists
+
+If the project's `(default)` database was created previously (e.g., by manually enabling the Firestore API), `terraform apply` will fail with "already exists" on the `google_firestore_database` resource. Recovery:
+
+```bash
+cd tf-out
+terraform import google_firestore_database.default \
+  "projects/$GCP_PROJECT_ID/databases/(default)"
+terraform apply tfplan
+```
+
+Subsequent applies will reconcile cleanly.
+
+## See also
+
+- `FRICTIONS.md` — dogfood findings during the 2026-05-22 cycle.
+- [`../single-project-app/`](../single-project-app/) — the larger end-to-end pattern (Cloud Run + Cloud SQL + Pub/Sub + Monitoring).
+- `terradart/examples/firestore_document_quickstart/` — a simpler 2-document quickstart inside the terradart repo.

--- a/cookbook/firestore-seeded-data/analysis_options.yaml
+++ b/cookbook/firestore-seeded-data/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/cookbook/firestore-seeded-data/bin/infra.dart
+++ b/cookbook/firestore-seeded-data/bin/infra.dart
@@ -1,0 +1,17 @@
+/// Synth entry. `dart run bin/infra.dart` → `tf-out/main.tf.json`.
+library;
+
+import 'dart:io';
+
+import 'package:firestore_seeded_data/main.dart';
+
+Future<void> main() async {
+  final projectId = Platform.environment['GCP_PROJECT_ID'];
+  if (projectId == null || projectId.isEmpty) {
+    stderr.writeln('error: set GCP_PROJECT_ID env var');
+    exit(64);
+  }
+  final stack = FirestoreSeededDataStack(projectId: projectId);
+  await stack.writeTo('tf-out');
+  print('synthesized to tf-out/main.tf.json');
+}

--- a/cookbook/firestore-seeded-data/lib/main.dart
+++ b/cookbook/firestore-seeded-data/lib/main.dart
@@ -1,0 +1,265 @@
+library;
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/firestore.dart';
+import 'package:terradart_google/project.dart';
+import 'package:terradart_google/provider.dart';
+
+/// Stack demonstrating Firestore master-data seeding via terradart v0.11.0.
+///
+/// Resources (~15):
+///   - 1 google_project_service (firestore.googleapis.com)
+///   - 1 google_firestore_database ((default), Native mode, asia-northeast1)
+///   - 11 google_firestore_document across 4 collections:
+///       feature_flags/{dark_mode, new_checkout, beta_invites}
+///       pricing_tiers/{free, pro, enterprise}
+///       i18n/{en, ja, ko}
+///       regions/{us, jp}
+///   - 1 google_firestore_index (pricing_tiers: monthly_usd ASC, label ASC)
+///   - 1 google_firestore_backup_schedule (daily, 7-day retention)
+final class FirestoreSeededDataStack extends Stack {
+  FirestoreSeededDataStack({required String projectId})
+      : super(
+          providers: [
+            GoogleProvider(project: projectId, region: 'asia-northeast1'),
+          ],
+          backend: const LocalBackend(),
+          devMode: true,
+        ) {
+    final apiFirestore = add(
+      GoogleProjectService(
+        localName: 'api_firestore',
+        service: TfArg.literal('firestore.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+    );
+
+    final db = add(
+      GoogleFirestoreDatabase(
+        localName: 'default',
+        name: TfArg.literal('(default)'),
+        locationId: TfArg.literal('asia-northeast1'),
+        type: TfArg.literal(FirestoreDatabaseType.firestoreNative),
+        deleteProtectionState: TfArg.literal(DeleteProtectionState.disabled),
+        // Without this, the provider default (`ABANDON`) leaves the
+        // database in place on `terraform destroy` — Terraform reports
+        // success but the resource survives in GCP. See FRICTIONS.md §P1.
+        deletionPolicy: TfArg.literal('DELETE'),
+        dependsOn: [ResourceDependency(apiFirestore)],
+      ),
+    );
+
+    // feature_flags collection (3 docs)
+    add(
+      GoogleFirestoreDocument(
+        localName: 'flag_dark_mode',
+        collection: TfArg.literal('feature_flags'),
+        documentId: TfArg.literal('dark_mode'),
+        fields: FirestoreFields.encode({
+          'enabled': true,
+          'rollout_pct': 100,
+          'last_updated': DateTime.utc(2026, 5, 22),
+        }),
+        dependsOn: [ResourceDependency(db)],
+      ),
+    );
+
+    add(
+      GoogleFirestoreDocument(
+        localName: 'flag_new_checkout',
+        collection: TfArg.literal('feature_flags'),
+        documentId: TfArg.literal('new_checkout'),
+        fields: FirestoreFields.encode({
+          'enabled': false,
+          'rollout_pct': 0,
+          'target_regions': ['us', 'jp'],
+        }),
+        dependsOn: [ResourceDependency(db)],
+      ),
+    );
+
+    add(
+      GoogleFirestoreDocument(
+        localName: 'flag_beta_invites',
+        collection: TfArg.literal('feature_flags'),
+        documentId: TfArg.literal('beta_invites'),
+        fields: FirestoreFields.encode({
+          'enabled': true,
+          'rollout_pct': 5,
+          'target_users': ['founder@example.com'],
+          'metadata': {'requested_by': 'product-team'},
+        }),
+        dependsOn: [ResourceDependency(db)],
+      ),
+    );
+
+    // pricing_tiers collection (3 docs; enterprise references billing_profiles)
+    add(
+      GoogleFirestoreDocument(
+        localName: 'tier_free',
+        collection: TfArg.literal('pricing_tiers'),
+        documentId: TfArg.literal('free'),
+        fields: FirestoreFields.encode({
+          'label': 'Free',
+          'monthly_usd': 0,
+          'features': ['analytics_basic'],
+        }),
+        dependsOn: [ResourceDependency(db)],
+      ),
+    );
+
+    add(
+      GoogleFirestoreDocument(
+        localName: 'tier_pro',
+        collection: TfArg.literal('pricing_tiers'),
+        documentId: TfArg.literal('pro'),
+        fields: FirestoreFields.encode({
+          'label': 'Pro',
+          'monthly_usd': 29,
+          'features': ['analytics_basic', 'priority_support'],
+        }),
+        dependsOn: [ResourceDependency(db)],
+      ),
+    );
+
+    add(
+      GoogleFirestoreDocument(
+        localName: 'tier_enterprise',
+        collection: TfArg.literal('pricing_tiers'),
+        documentId: TfArg.literal('enterprise'),
+        fields: FirestoreFields.encode({
+          'label': 'Enterprise',
+          'monthly_usd': 499,
+          'features': [
+            'analytics_basic',
+            'priority_support',
+            'sso',
+            'audit_log',
+          ],
+          'preferred_billing': FirestoreReference(
+            'projects/$projectId/databases/(default)/documents/billing_profiles/annual',
+          ),
+        }),
+        dependsOn: [ResourceDependency(db)],
+      ),
+    );
+
+    // i18n collection (3 docs)
+    add(
+      GoogleFirestoreDocument(
+        localName: 'i18n_en',
+        collection: TfArg.literal('i18n'),
+        documentId: TfArg.literal('en'),
+        fields: FirestoreFields.encode({
+          'greeting': 'Hello',
+          'currency_symbol': r'$',
+          'date_format': 'MM/DD/YYYY',
+          'translations': {'subscribe': 'Subscribe', 'cancel': 'Cancel'},
+        }),
+        dependsOn: [ResourceDependency(db)],
+      ),
+    );
+
+    add(
+      GoogleFirestoreDocument(
+        localName: 'i18n_ja',
+        collection: TfArg.literal('i18n'),
+        documentId: TfArg.literal('ja'),
+        fields: FirestoreFields.encode({
+          'greeting': 'こんにちは',
+          'currency_symbol': '¥',
+          'date_format': 'YYYY/MM/DD',
+          'translations': {'subscribe': '登録', 'cancel': 'キャンセル'},
+        }),
+        dependsOn: [ResourceDependency(db)],
+      ),
+    );
+
+    add(
+      GoogleFirestoreDocument(
+        localName: 'i18n_ko',
+        collection: TfArg.literal('i18n'),
+        documentId: TfArg.literal('ko'),
+        fields: FirestoreFields.encode({
+          'greeting': '안녕하세요',
+          'currency_symbol': '₩',
+          'date_format': 'YYYY-MM-DD',
+          'translations': {'subscribe': '구독', 'cancel': '취소'},
+        }),
+        dependsOn: [ResourceDependency(db)],
+      ),
+    );
+
+    // regions collection (2 docs; both have geo-point office_location)
+    add(
+      GoogleFirestoreDocument(
+        localName: 'region_us',
+        collection: TfArg.literal('regions'),
+        documentId: TfArg.literal('us'),
+        fields: FirestoreFields.encode({
+          'name': 'United States',
+          'currency': 'USD',
+          'office_location': const FirestoreGeoPoint(
+            latitude: 37.7749,
+            longitude: -122.4194,
+          ),
+          'shipping_zones': ['west', 'central', 'east'],
+        }),
+        dependsOn: [ResourceDependency(db)],
+      ),
+    );
+
+    add(
+      GoogleFirestoreDocument(
+        localName: 'region_jp',
+        collection: TfArg.literal('regions'),
+        documentId: TfArg.literal('jp'),
+        fields: FirestoreFields.encode({
+          'name': 'Japan',
+          'currency': 'JPY',
+          'office_location': const FirestoreGeoPoint(
+            latitude: 35.6762,
+            longitude: 139.6503,
+          ),
+          'vat_rate': 0.10,
+        }),
+        dependsOn: [ResourceDependency(db)],
+      ),
+    );
+
+    // Composite index on pricing_tiers.monthly_usd (ASC) + label (ASC).
+    add(
+      GoogleFirestoreIndex(
+        localName: 'pricing_tiers_by_price',
+        collection: TfArg.literal('pricing_tiers'),
+        database: TfArg.ref(db.nameRef),
+        queryScope: TfArg.literal(FirestoreIndexQueryScope.collection),
+        fields: [
+          FirestoreIndexIndexField(
+            fieldPath: TfArg.literal('monthly_usd'),
+            spec: const FirestoreIndexIndexFieldOrder(
+              FirestoreIndexOrder.ascending,
+            ),
+          ),
+          FirestoreIndexIndexField(
+            fieldPath: TfArg.literal('label'),
+            spec: const FirestoreIndexIndexFieldOrder(
+              FirestoreIndexOrder.ascending,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    // Daily backup schedule, 7-day retention.
+    add(
+      GoogleFirestoreBackupSchedule(
+        localName: 'daily',
+        database: TfArg.ref(db.nameRef),
+        retention: TfArg.literal('604800s'),
+        recurrence: const FirestoreBackupScheduleDailyRecurrence(),
+        dependsOn: [ResourceDependency(db)],
+      ),
+    );
+  }
+}

--- a/cookbook/firestore-seeded-data/pubspec.yaml
+++ b/cookbook/firestore-seeded-data/pubspec.yaml
@@ -1,0 +1,16 @@
+name: firestore_seeded_data
+description: terradart cookbook recipe — seed 11 Firestore master-data documents (feature flags, pricing tiers, lookup tables, regions) into the default Native-mode database. Demonstrates GoogleFirestoreDocument + FirestoreFields helper.
+publish_to: none
+version: 0.1.0
+
+environment:
+  sdk: ^3.6.0
+
+resolution: workspace
+
+dependencies:
+  terradart_core: ^0.21.0
+  terradart_google: ^0.21.0
+
+dev_dependencies:
+  lints: ^6.0.0

--- a/cookbook/lunch-concierge/README.md
+++ b/cookbook/lunch-concierge/README.md
@@ -1,0 +1,100 @@
+# Lunch Concierge
+
+Lunch Concierge is a full-stack TerraDart cookbook recipe for showing how
+Flutter Web, a Dart server, Genkit, Vertex AI, Cloud Run, and Cloud SQL can be
+connected through Dart-authored infrastructure.
+
+## Architecture
+
+```text
+User
+  |
+  v
+Cloud Run service: lunch-concierge
+  app container
+    - Flutter Web static files
+    - shelf HTTP server
+    - genkit_shelf endpoint
+    - Genkit Dart + Vertex AI Gemini
+    - postgres client
+
+  cloud-sql-proxy sidecar
+    - private IP
+    - IAM DB authentication
+    - localhost:5432
+  |
+  v
+Cloud SQL PostgreSQL
+  - private IP only
+  - IAM DB authentication
+```
+
+TerraDart defines the Artifact Registry repository, Cloud Run service, Cloud
+SQL instance/database/IAM user, VPC, Private Service Access, IAM grants, API
+enablement, and generated app exports.
+
+## Layout
+
+```text
+cookbook/lunch-concierge/
+├── client/   # Flutter Web app (built inside the Dockerfile)
+├── server/   # shelf + genkit_shelf + postgres server
+├── shared/   # generated TerraDart AppExport constants
+└── infra/    # TerraDart Stack
+```
+
+The Flutter client is intentionally not a root Dart workspace member because
+the TerraDart monorepo agent environment does not install Flutter. The Docker
+build uses a Flutter builder image for the client stage.
+
+## Deploy flow
+
+From the repository root:
+
+```bash
+export GCP_PROJECT_ID=flutter-gakkai-10
+export REGION=asia-northeast1
+export IMAGE_URI="$REGION-docker.pkg.dev/$GCP_PROJECT_ID/lunch-concierge/app:demo"
+export INVOKER_EMAIL="you@example.com"
+
+dart pub get
+cd cookbook/lunch-concierge/server
+dart run build_runner build --delete-conflicting-outputs
+
+cd ../infra
+dart run bin/infra.dart
+cd tf-out
+terraform init
+terraform apply -target=google_artifact_registry_repository.app_images
+
+cd ../../../..
+gcloud auth configure-docker "$REGION-docker.pkg.dev"
+docker build -f cookbook/lunch-concierge/server/Dockerfile -t "$IMAGE_URI" .
+docker push "$IMAGE_URI"
+
+cd cookbook/lunch-concierge/infra/tf-out
+terraform apply
+```
+
+The targeted first apply creates the Artifact Registry repository so the image
+can be pushed. The second apply creates or updates the rest of the stack.
+
+## Boundary contract
+
+`infra` writes generated constants to `shared`:
+
+```dart
+setAppExportsOutputPath('../shared/lib/generated/lunch_stack.app.dart');
+```
+
+The server imports those constants:
+
+```dart
+import 'package:lunch_concierge_shared/generated/lunch_stack.app.dart';
+
+final databaseUrl = LunchStackExports.DATABASE_URL;
+```
+
+This is the demo boundary: infrastructure-owned values such as database name,
+database user, region, and Cloud SQL connection name are handed to application
+code as typed Dart constants instead of duplicated string literals.

--- a/cookbook/lunch-concierge/client/lib/main.dart
+++ b/cookbook/lunch-concierge/client/lib/main.dart
@@ -1,0 +1,154 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+void main() {
+  runApp(const LunchConciergeApp());
+}
+
+final class LunchConciergeApp extends StatelessWidget {
+  const LunchConciergeApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Lunch Concierge',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange),
+        useMaterial3: true,
+      ),
+      home: const LunchPage(),
+    );
+  }
+}
+
+final class LunchPage extends StatefulWidget {
+  const LunchPage({super.key});
+
+  @override
+  State<LunchPage> createState() => _LunchPageState();
+}
+
+final class _LunchPageState extends State<LunchPage> {
+  final _areaController = TextEditingController(text: '渋谷');
+  final _moodController = TextEditingController(text: 'あっさり');
+  final _budgetController = TextEditingController(text: '1200');
+
+  bool _loading = false;
+  String? _error;
+  Map<String, Object?>? _result;
+
+  @override
+  void dispose() {
+    _areaController.dispose();
+    _moodController.dispose();
+    _budgetController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _ask() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+      _result = null;
+    });
+
+    try {
+      final response = await http.post(
+        Uri.parse('/api/lunch'),
+        headers: {'content-type': 'application/json'},
+        body: jsonEncode({
+          'data': {
+            'area': _areaController.text,
+            'mood': _moodController.text,
+            'budgetYen': int.tryParse(_budgetController.text) ?? 1200,
+          },
+        }),
+      );
+      if (response.statusCode >= 400) {
+        throw StateError('HTTP ${response.statusCode}: ${response.body}');
+      }
+      final decoded = jsonDecode(response.body) as Map<String, Object?>;
+      setState(() {
+        _result = (decoded['result'] ?? decoded['data'] ?? decoded)
+            as Map<String, Object?>;
+      });
+    } catch (error) {
+      setState(() => _error = error.toString());
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final result = _result;
+    final suggestions = (result?['suggestions'] as List<Object?>?)
+            ?.cast<Map<String, Object?>>() ??
+        const <Map<String, Object?>>[];
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Lunch Concierge')),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 720),
+          child: ListView(
+            padding: const EdgeInsets.all(24),
+            children: [
+              Text(
+                'AI ランチ相談',
+                style: Theme.of(context).textTheme.headlineMedium,
+              ),
+              const SizedBox(height: 8),
+              const Text('気分・場所・予算から、今日のランチ候補を提案します。'),
+              const SizedBox(height: 24),
+              TextField(
+                controller: _areaController,
+                decoration: const InputDecoration(labelText: 'エリア'),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _moodController,
+                decoration: const InputDecoration(labelText: '気分'),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _budgetController,
+                decoration: const InputDecoration(labelText: '予算（円）'),
+                keyboardType: TextInputType.number,
+              ),
+              const SizedBox(height: 20),
+              FilledButton(
+                onPressed: _loading ? null : _ask,
+                child: Text(_loading ? '相談中...' : 'ランチを相談する'),
+              ),
+              if (_error != null) ...[
+                const SizedBox(height: 20),
+                Text(_error!, style: const TextStyle(color: Colors.red)),
+              ],
+              if (result != null) ...[
+                const SizedBox(height: 28),
+                Text(
+                  result['message'] as String? ?? '',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 12),
+                for (final suggestion in suggestions)
+                  Card(
+                    child: ListTile(
+                      title: Text(suggestion['name'] as String? ?? ''),
+                      subtitle: Text(suggestion['reason'] as String? ?? ''),
+                      trailing: Text(
+                        '${suggestion['estimatedPriceYen'] ?? '?'}円',
+                      ),
+                    ),
+                  ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/cookbook/lunch-concierge/client/pubspec.yaml
+++ b/cookbook/lunch-concierge/client/pubspec.yaml
@@ -1,0 +1,17 @@
+name: lunch_concierge_client
+description: Flutter Web client for the Lunch Concierge cookbook recipe.
+publish_to: none
+
+environment:
+  sdk: ^3.6.0
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: any
+
+dev_dependencies:
+  flutter_lints: any
+
+flutter:
+  uses-material-design: true

--- a/cookbook/lunch-concierge/client/web/index.html
+++ b/cookbook/lunch-concierge/client/web/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base href="$FLUTTER_BASE_HREF">
+  <meta charset="UTF-8">
+  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <meta name="description" content="Lunch Concierge Flutter Web demo.">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lunch Concierge</title>
+</head>
+<body>
+  <script src="flutter_bootstrap.js" async></script>
+</body>
+</html>

--- a/cookbook/lunch-concierge/infra/bin/infra.dart
+++ b/cookbook/lunch-concierge/infra/bin/infra.dart
@@ -1,0 +1,34 @@
+/// Synth entry point for the Lunch Concierge cookbook recipe.
+///
+/// Required environment variables:
+/// - GCP_PROJECT_ID: target project ID.
+/// - IMAGE_URI: pushed container image URI for the combined web/server app.
+/// - INVOKER_EMAIL: Google account allowed to invoke the Cloud Run service.
+library;
+
+import 'dart:io';
+
+import 'package:lunch_concierge_infra/lunch_concierge_stack.dart';
+
+Future<void> main() async {
+  final projectId = _requiredEnv('GCP_PROJECT_ID');
+  final imageUri = _requiredEnv('IMAGE_URI');
+  final invokerEmail = _requiredEnv('INVOKER_EMAIL');
+
+  final stack = LunchStack(
+    projectId: projectId,
+    imageUri: imageUri,
+    invokerEmail: invokerEmail,
+  );
+  await stack.writeTo('tf-out');
+  stdout.writeln('synthesized to tf-out/main.tf.json');
+}
+
+String _requiredEnv(String name) {
+  final value = Platform.environment[name];
+  if (value == null || value.isEmpty) {
+    stderr.writeln('error: set $name');
+    exit(64);
+  }
+  return value;
+}

--- a/cookbook/lunch-concierge/infra/lib/lunch_concierge_stack.dart
+++ b/cookbook/lunch-concierge/infra/lib/lunch_concierge_stack.dart
@@ -1,0 +1,317 @@
+/// Lunch Concierge infrastructure.
+///
+/// This Stack keeps Terraform as the execution layer while authoring the
+/// Cloud Run + Cloud SQL + Vertex AI surface in Dart.
+library;
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/artifact_registry.dart';
+import 'package:terradart_google/cloud_run.dart';
+import 'package:terradart_google/cloud_sql.dart';
+import 'package:terradart_google/compute.dart';
+import 'package:terradart_google/iam.dart';
+import 'package:terradart_google/project.dart';
+import 'package:terradart_google/provider.dart';
+import 'package:terradart_google/service_networking.dart';
+import 'package:terradart_google/time.dart';
+
+const _region = 'asia-northeast1';
+const _serviceName = 'lunch-concierge';
+const _repositoryId = 'lunch-concierge';
+const _vpcName = 'lunch-vpc';
+const _subnetName = 'lunch-subnet';
+const _subnetCidr = '10.10.0.0/24';
+const _psaRangeName = 'lunch-psa-range';
+const _sqlInstanceName = 'lunch-sql';
+const _databaseName = 'lunch';
+const _sqlClientAccountId = 'lunch-sql-client';
+const _cloudSqlProxyImage =
+    'gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.22.1';
+
+final class LunchStack extends Stack {
+  LunchStack({
+    required String projectId,
+    required String imageUri,
+    required String invokerEmail,
+  }) : super(
+          providers: [
+            GoogleProvider(project: projectId, region: _region),
+            const TimeProvider(),
+          ],
+        ) {
+    final apiDeps = Apis.enable(
+      this,
+      barrels: [
+        Barrels.artifactRegistry,
+        Barrels.cloudRun,
+        Barrels.compute,
+        Barrels.serviceNetworking,
+        Barrels.sql,
+      ],
+    );
+
+    final vertexApi = add(
+      GoogleProjectService(
+        localName: 'api_aiplatform',
+        service: TfArg.literal('aiplatform.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+    );
+
+    add(
+      GoogleArtifactRegistryRepository(
+        localName: 'app_images',
+        repositoryId: TfArg.literal(_repositoryId),
+        format: TfArg.literal('DOCKER'),
+        location: TfArg.literal(_region),
+        description: TfArg.literal('Lunch Concierge demo container images'),
+        dependsOn: apiDeps,
+      ),
+    );
+
+    final vpc = add(
+      GoogleComputeNetwork(
+        localName: 'lunch_vpc',
+        name: TfArg.literal(_vpcName),
+        autoCreateSubnetworks: TfArg.literal(false),
+        dependsOn: apiDeps,
+      ),
+    );
+
+    final subnet = add(
+      GoogleComputeSubnetwork(
+        localName: 'lunch_subnet',
+        name: TfArg.literal(_subnetName),
+        region: TfArg.literal(_region),
+        network: TfArg.ref(vpc.selfLink),
+        ipCidrRange: TfArg.literal(_subnetCidr),
+        privateIpGoogleAccess: TfArg.literal(true),
+        dependsOn: [ResourceDependency(vpc)],
+      ),
+    );
+
+    final psaRange = add(
+      GoogleComputeGlobalAddress(
+        localName: 'psa_range',
+        name: TfArg.literal(_psaRangeName),
+        addressType: TfArg.literal(GlobalAddressType.internal),
+        purpose: TfArg.literal(GlobalAddressPurpose.vpcPeering),
+        prefixLength: TfArg.literal(16),
+        network: TfArg.ref(vpc.selfLink),
+        dependsOn: [ResourceDependency(vpc)],
+      ),
+    );
+
+    final psaConnection = add(
+      GoogleServiceNetworkingConnection(
+        localName: 'psa',
+        network: TfArg.ref(vpc.selfLink),
+        service: TfArg.literal('servicenetworking.googleapis.com'),
+        reservedPeeringRanges: TfArg.literal([psaRange.nameRef.interpolation]),
+        dependsOn: [
+          ...apiDeps,
+          ResourceDependency(psaRange),
+        ],
+      ),
+    );
+
+    final sql = add(
+      GoogleSqlDatabaseInstance(
+        localName: 'lunch_sql',
+        name: TfArg.literal(_sqlInstanceName),
+        databaseVersion: TfArg.literal(DatabaseVersion.postgres15),
+        region: TfArg.literal(_region),
+        deletionProtection: TfArg.literal(false),
+        settings: SqlDatabaseInstanceSettings(
+          tier: TfArg.literal('db-f1-micro'),
+          availabilityType: TfArg.literal(SqlAvailabilityType.zonal),
+          edition: TfArg.literal(SqlEdition.enterprise),
+          diskSize: TfArg.literal(10),
+          diskType: TfArg.literal(SqlDiskType.pdSsd),
+          databaseFlags: [
+            SqlDatabaseInstanceDatabaseFlag(
+              name: TfArg.literal('cloudsql.iam_authentication'),
+              value: TfArg.literal('on'),
+            ),
+          ],
+          ipConfiguration: SqlDatabaseInstanceIpConfiguration(
+            ipv4Enabled: TfArg.literal(false),
+            privateNetwork: TfArg.ref(vpc.selfLink),
+            allocatedIpRange: TfArg.ref(psaRange.nameRef),
+          ),
+        ),
+        dependsOn: [ResourceDependency(psaConnection)],
+      ),
+    );
+
+    add(
+      GoogleSqlDatabase(
+        localName: 'lunch',
+        instance: TfArg.ref(sql.nameRef),
+        name: TfArg.literal(_databaseName),
+        dependsOn: [ResourceDependency(sql)],
+      ),
+    );
+
+    final sqlClient = add(
+      GoogleServiceAccount(
+        localName: 'sql_client',
+        accountId: TfArg.literal(_sqlClientAccountId),
+        displayName: TfArg.literal('Lunch Concierge runtime and SQL client'),
+      ),
+    );
+
+    final sqlIamUserName =
+        '$_sqlClientAccountId@$projectId.iam.gserviceaccount.com';
+    final databaseUser = '$_sqlClientAccountId@$projectId.iam';
+    add(
+      GoogleSqlUser(
+        localName: 'sql_client',
+        instance: TfArg.ref(sql.nameRef),
+        name: TfArg.literal(sqlIamUserName),
+        type: TfArg.literal(SqlUserType.cloudIamServiceAccount),
+        dependsOn: [
+          ResourceDependency(sql),
+          ResourceDependency(sqlClient),
+        ],
+      ),
+    );
+
+    add(
+      GoogleProjectIamMember(
+        localName: 'sql_client_cloudsql_client',
+        project: TfArg.literal(projectId),
+        role: TfArg.literal('roles/cloudsql.client'),
+        member: TfArg.ref(sqlClient.iamMember),
+        dependsOn: [ResourceDependency(sqlClient)],
+      ),
+    );
+
+    add(
+      GoogleProjectIamMember(
+        localName: 'sql_client_instance_user',
+        project: TfArg.literal(projectId),
+        role: TfArg.literal('roles/cloudsql.instanceUser'),
+        member: TfArg.ref(sqlClient.iamMember),
+        dependsOn: [ResourceDependency(sqlClient)],
+      ),
+    );
+
+    add(
+      GoogleProjectIamMember(
+        localName: 'sql_client_vertex_user',
+        project: TfArg.literal(projectId),
+        role: TfArg.literal('roles/aiplatform.user'),
+        member: TfArg.ref(sqlClient.iamMember),
+        dependsOn: [
+          ResourceDependency(sqlClient),
+          ResourceDependency(vertexApi),
+        ],
+      ),
+    );
+
+    final instanceConnectionName = '$projectId:$_region:$_sqlInstanceName';
+    final databaseUrl =
+        'postgresql://$databaseUser@localhost:5432/$_databaseName';
+
+    final service = add(
+      GoogleCloudRunV2Service(
+        localName: 'lunch_concierge',
+        name: TfArg.literal(_serviceName),
+        location: TfArg.literal(_region),
+        ingress: TfArg.literal(Ingress.all),
+        deletionProtection: TfArg.literal(false),
+        template: CloudRunV2ServiceTemplate(
+          serviceAccount: TfArg.ref(sqlClient.email),
+          maxInstanceRequestConcurrency: TfArg.literal(80),
+          timeout: TfArg.literal('300s'),
+          vpcAccess: CloudRunV2ServiceVpcAccess(
+            networkInterfaces: [
+              CloudRunV2ServiceVpcNetworkInterface(
+                network: TfArg.ref(vpc.id),
+                subnetwork: TfArg.ref(subnet.id),
+              ),
+            ],
+            egress: TfArg.literal(VpcAccessEgress.privateRangesOnly),
+          ),
+          scaling: const CloudRunV2ServiceTemplateScaling(
+            minInstanceCount: TfArgLiteral(0),
+            maxInstanceCount: TfArgLiteral(2),
+          ),
+          containers: [
+            CloudRunV2ServiceServiceContainer(
+              name: TfArg.literal('app'),
+              image: TfArg.literal(imageUri),
+              dependsOn: TfArg.literal(['cloud-sql-proxy']),
+              ports: const CloudRunV2ServiceContainerPort(
+                containerPort: TfArgLiteral(8080),
+              ),
+              resources: CloudRunV2ServiceContainerResources(
+                limits: TfArg.literal({'cpu': '1', 'memory': '512Mi'}),
+                cpuIdle: TfArg.literal(true),
+                startupCpuBoost: TfArg.literal(true),
+              ),
+            ),
+            CloudRunV2ServiceServiceContainer(
+              name: TfArg.literal('cloud-sql-proxy'),
+              image: TfArg.literal(_cloudSqlProxyImage),
+              args: TfArg.literal([
+                '--private-ip',
+                '--port=5432',
+                '--auto-iam-authn',
+                instanceConnectionName,
+              ]),
+              startupProbe: const CloudRunV2ServiceStartupProbe(
+                tcpSocket: CloudRunV2ServiceTcpSocketAction(
+                  port: TfArgLiteral(5432),
+                ),
+                periodSeconds: TfArgLiteral(2),
+                failureThreshold: TfArgLiteral(30),
+              ),
+              resources: CloudRunV2ServiceContainerResources(
+                limits: TfArg.literal({'cpu': '0.5', 'memory': '256Mi'}),
+                cpuIdle: TfArg.literal(false),
+              ),
+            ),
+          ],
+        ),
+        traffic: const [
+          CloudRunV2ServiceTraffic(
+            type: TfArgLiteral(TrafficTargetAllocationType.latest),
+            percent: TfArgLiteral(100),
+          ),
+        ],
+        dependsOn: [
+          ...apiDeps,
+          ResourceDependency(vertexApi),
+          ResourceDependency(subnet),
+          ResourceDependency(sql),
+          ResourceDependency(sqlClient),
+        ],
+      ),
+    );
+
+    add(
+      GoogleCloudRunV2ServiceIamMember(
+        localName: 'speaker_invoker',
+        name: TfArg.ref(service.nameRef),
+        location: TfArg.literal(_region),
+        role: TfArg.literal('roles/run.invoker'),
+        member: TfArg.literal('user:$invokerEmail'),
+        dependsOn: [ResourceDependency(service)],
+      ),
+    );
+
+    addExport('REGION', StringExport(_region));
+    addExport('PROJECT_ID', StringExport(projectId));
+    addExport('SERVICE_NAME', StringExport(_serviceName));
+    addExport('DATABASE_NAME', StringExport(_databaseName));
+    addExport('DATABASE_USER', StringExport(databaseUser));
+    addExport('DATABASE_URL', StringExport(databaseUrl));
+    addExport(
+      'CLOUD_SQL_INSTANCE_CONNECTION_NAME',
+      StringExport(instanceConnectionName),
+    );
+    setAppExportsOutputPath('../shared/lib/generated/lunch_stack.app.dart');
+  }
+}

--- a/cookbook/lunch-concierge/infra/pubspec.yaml
+++ b/cookbook/lunch-concierge/infra/pubspec.yaml
@@ -1,0 +1,15 @@
+name: lunch_concierge_infra
+description: TerraDart infrastructure stack for the Lunch Concierge cookbook recipe.
+publish_to: none
+
+environment:
+  sdk: ^3.6.0
+
+resolution: workspace
+
+dependencies:
+  terradart_core: ^0.21.0
+  terradart_google: ^0.21.0
+
+dev_dependencies:
+  lints: ^6.0.0

--- a/cookbook/lunch-concierge/server/Dockerfile
+++ b/cookbook/lunch-concierge/server/Dockerfile
@@ -1,0 +1,29 @@
+# Build with the repository root as the Docker context:
+# docker build -f cookbook/lunch-concierge/server/Dockerfile -t <image-uri> .
+
+FROM ghcr.io/cirruslabs/flutter:stable AS client_builder
+WORKDIR /src/cookbook/lunch-concierge/client
+COPY cookbook/lunch-concierge/client/pubspec.yaml ./
+RUN flutter pub get
+COPY cookbook/lunch-concierge/client ./
+RUN flutter build web --release
+
+FROM dart:stable AS server_builder
+WORKDIR /src
+COPY pubspec.yaml pubspec.lock ./
+COPY packages ./packages
+COPY cookbook ./cookbook
+RUN dart pub get
+WORKDIR /src/cookbook/lunch-concierge/server
+RUN dart run build_runner build --delete-conflicting-outputs
+RUN dart compile exe bin/server.dart -o /out/server
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=server_builder /out/server /app/server
+COPY --from=client_builder /src/cookbook/lunch-concierge/client/build/web /app/public
+ENV PORT=8080
+CMD ["/app/server"]

--- a/cookbook/lunch-concierge/server/bin/server.dart
+++ b/cookbook/lunch-concierge/server/bin/server.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:genkit_shelf/genkit_shelf.dart';
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as io;
+import 'package:shelf_router/shelf_router.dart';
+import 'package:shelf_static/shelf_static.dart';
+
+import 'package:lunch_concierge_server/lunch_flow.dart';
+
+Future<void> main() async {
+  final bundle = await createLunchFlow();
+  final router = Router()
+    ..get('/healthz', (_) => Response.ok('ok'))
+    ..post('/api/lunch', shelfHandler(bundle.flow));
+
+  final staticHandler = createStaticHandler(
+    Platform.environment['PUBLIC_DIR'] ?? '/app/public',
+    defaultDocument: 'index.html',
+  );
+
+  final handler = const Pipeline()
+      .addMiddleware(logRequests())
+      .addHandler(Cascade().add(router.call).add(staticHandler).handler);
+
+  final port = int.parse(Platform.environment['PORT'] ?? '8080');
+  final server = await io.serve(handler, InternetAddress.anyIPv4, port);
+  stdout.writeln('Lunch Concierge listening on :${server.port}');
+}

--- a/cookbook/lunch-concierge/server/lib/db.dart
+++ b/cookbook/lunch-concierge/server/lib/db.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:lunch_concierge_shared/generated/lunch_stack.app.dart';
+import 'package:postgres/postgres.dart';
+
+import 'schema.dart';
+
+final class LunchHistoryRepository {
+  LunchHistoryRepository(this._connection);
+
+  final Connection _connection;
+
+  static Future<LunchHistoryRepository> connect() async {
+    final connection = await _withRetry(
+      () => Connection.open(
+        Endpoint(
+          host: '127.0.0.1',
+          port: 5432,
+          database: LunchStackExports.DATABASE_NAME,
+          username: LunchStackExports.DATABASE_USER,
+        ),
+      ),
+    );
+    final repository = LunchHistoryRepository(connection);
+    await repository.ensureSchema();
+    return repository;
+  }
+
+  Future<void> ensureSchema() async {
+    await _connection.execute('''
+      create table if not exists lunch_suggestions (
+        id bigserial primary key,
+        area text not null,
+        mood text not null,
+        budget_yen integer not null,
+        suggestion_json jsonb not null,
+        created_at timestamptz not null default now()
+      )
+    ''');
+  }
+
+  Future<void> save(LunchRequest request, LunchResponse response) async {
+    await _connection.execute(
+      Sql.named('''
+        insert into lunch_suggestions
+          (area, mood, budget_yen, suggestion_json)
+        values
+          (@area, @mood, @budgetYen, @suggestionJson)
+      '''),
+      parameters: {
+        'area': request.area,
+        'mood': request.mood,
+        'budgetYen': request.budgetYen,
+        'suggestionJson': jsonEncode(response.toJson()),
+      },
+    );
+  }
+}
+
+Future<T> _withRetry<T>(
+  Future<T> Function() operation, {
+  int maxAttempts = 10,
+  Duration delay = const Duration(seconds: 2),
+}) async {
+  Object? lastError;
+  StackTrace? lastStackTrace;
+  for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await operation();
+    } catch (error, stackTrace) {
+      lastError = error;
+      lastStackTrace = stackTrace;
+      if (attempt == maxAttempts) break;
+      await Future<void>.delayed(delay);
+    }
+  }
+  Error.throwWithStackTrace(lastError!, lastStackTrace!);
+}

--- a/cookbook/lunch-concierge/server/lib/lunch_flow.dart
+++ b/cookbook/lunch-concierge/server/lib/lunch_flow.dart
@@ -1,0 +1,60 @@
+import 'package:genkit/genkit.dart';
+import 'package:genkit_vertexai/genkit_vertexai.dart';
+import 'package:lunch_concierge_shared/generated/lunch_stack.app.dart';
+
+import 'db.dart';
+import 'schema.dart';
+
+final class LunchFlowBundle {
+  LunchFlowBundle({required this.ai, required this.flow});
+
+  final Genkit ai;
+  final Flow<LunchRequest, LunchResponse, void, void> flow;
+}
+
+Future<LunchFlowBundle> createLunchFlow() async {
+  final repository = await LunchHistoryRepository.connect();
+  final ai = Genkit(
+    plugins: [
+      vertexAI(
+        projectId: LunchStackExports.PROJECT_ID,
+        location: LunchStackExports.REGION,
+      ),
+    ],
+  );
+
+  final flow = ai.defineFlow(
+    name: 'suggestLunch',
+    inputSchema: LunchRequest.$schema,
+    outputSchema: LunchResponse.$schema,
+    fn: (input, _) async {
+      final response = await ai.generate(
+        model: vertexAI.gemini('gemini-2.5-flash'),
+        prompt:
+            '''
+あなたは日本のランチ相談に乗るコンシェルジュです。
+
+エリア: ${input.area}
+気分: ${input.mood}
+予算: ${input.budgetYen}円
+
+条件に合うランチ候補を3つ提案してください。
+理由は短く、午後の仕事や勉強に戻りやすい観点も入れてください。
+''',
+        outputSchema: LunchResponse.$schema,
+      );
+      final output = response.output;
+      if (output == null) {
+        throw GenkitException(
+          'Gemini response did not match LunchResponse schema.',
+          status: StatusCodes.INTERNAL,
+        );
+      }
+
+      await repository.save(input, output);
+      return output;
+    },
+  );
+
+  return LunchFlowBundle(ai: ai, flow: flow);
+}

--- a/cookbook/lunch-concierge/server/lib/schema.dart
+++ b/cookbook/lunch-concierge/server/lib/schema.dart
@@ -1,0 +1,28 @@
+import 'package:schemantic/schemantic.dart';
+
+part 'schema.g.dart';
+
+@Schema()
+abstract class $LunchRequest {
+  @Field(description: 'Area or station where the user wants to eat.')
+  String get area;
+
+  @Field(description: 'Current lunch mood, such as light, spicy, or warm.')
+  String get mood;
+
+  @Field(description: 'Expected budget in Japanese yen.')
+  int get budgetYen;
+}
+
+@Schema()
+abstract class $LunchSuggestion {
+  String get name;
+  String get reason;
+  int get estimatedPriceYen;
+}
+
+@Schema()
+abstract class $LunchResponse {
+  String get message;
+  List<$LunchSuggestion> get suggestions;
+}

--- a/cookbook/lunch-concierge/server/lib/schema.g.dart
+++ b/cookbook/lunch-concierge/server/lib/schema.g.dart
@@ -1,0 +1,257 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'schema.dart';
+
+// **************************************************************************
+// SchemaGenerator
+// **************************************************************************
+
+base class LunchRequest {
+  /// Creates a [LunchRequest] from a JSON map.
+  factory LunchRequest.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  LunchRequest._(this._json);
+
+  LunchRequest({
+    required String area,
+    required String mood,
+    required int budgetYen,
+  }) {
+    _json = {'area': area, 'mood': mood, 'budgetYen': budgetYen};
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [LunchRequest].
+  static const SchemanticType<LunchRequest> $schema =
+      _LunchRequestTypeFactory();
+
+  String get area {
+    return _json['area'] as String;
+  }
+
+  set area(String value) {
+    _json['area'] = value;
+  }
+
+  String get mood {
+    return _json['mood'] as String;
+  }
+
+  set mood(String value) {
+    _json['mood'] = value;
+  }
+
+  int get budgetYen {
+    return _json['budgetYen'] as int;
+  }
+
+  set budgetYen(int value) {
+    _json['budgetYen'] = value;
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [LunchRequest] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _LunchRequestTypeFactory extends SchemanticType<LunchRequest> {
+  const _LunchRequestTypeFactory();
+
+  @override
+  LunchRequest parse(Object? json) {
+    return LunchRequest._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'LunchRequest',
+    definition: $Schema
+        .object(
+          properties: {
+            'area': $Schema.string(
+              description: 'Area or station where the user wants to eat.',
+            ),
+            'mood': $Schema.string(
+              description: 'Current lunch mood, such as light, spicy, or warm.',
+            ),
+            'budgetYen': $Schema.integer(
+              description: 'Expected budget in Japanese yen.',
+            ),
+          },
+          required: ['area', 'mood', 'budgetYen'],
+        )
+        .value,
+    dependencies: [],
+  );
+}
+
+base class LunchSuggestion {
+  /// Creates a [LunchSuggestion] from a JSON map.
+  factory LunchSuggestion.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  LunchSuggestion._(this._json);
+
+  LunchSuggestion({
+    required String name,
+    required String reason,
+    required int estimatedPriceYen,
+  }) {
+    _json = {
+      'name': name,
+      'reason': reason,
+      'estimatedPriceYen': estimatedPriceYen,
+    };
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [LunchSuggestion].
+  static const SchemanticType<LunchSuggestion> $schema =
+      _LunchSuggestionTypeFactory();
+
+  String get name {
+    return _json['name'] as String;
+  }
+
+  set name(String value) {
+    _json['name'] = value;
+  }
+
+  String get reason {
+    return _json['reason'] as String;
+  }
+
+  set reason(String value) {
+    _json['reason'] = value;
+  }
+
+  int get estimatedPriceYen {
+    return _json['estimatedPriceYen'] as int;
+  }
+
+  set estimatedPriceYen(int value) {
+    _json['estimatedPriceYen'] = value;
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [LunchSuggestion] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _LunchSuggestionTypeFactory extends SchemanticType<LunchSuggestion> {
+  const _LunchSuggestionTypeFactory();
+
+  @override
+  LunchSuggestion parse(Object? json) {
+    return LunchSuggestion._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'LunchSuggestion',
+    definition: $Schema
+        .object(
+          properties: {
+            'name': $Schema.string(),
+            'reason': $Schema.string(),
+            'estimatedPriceYen': $Schema.integer(),
+          },
+          required: ['name', 'reason', 'estimatedPriceYen'],
+        )
+        .value,
+    dependencies: [],
+  );
+}
+
+base class LunchResponse {
+  /// Creates a [LunchResponse] from a JSON map.
+  factory LunchResponse.fromJson(Map<String, dynamic> json) =>
+      $schema.parse(json);
+
+  LunchResponse._(this._json);
+
+  LunchResponse({
+    required String message,
+    required List<LunchSuggestion> suggestions,
+  }) {
+    _json = {
+      'message': message,
+      'suggestions': suggestions.map((e) => e.toJson()).toList(),
+    };
+  }
+
+  late final Map<String, dynamic> _json;
+
+  /// The JSON schema and type descriptor for [LunchResponse].
+  static const SchemanticType<LunchResponse> $schema =
+      _LunchResponseTypeFactory();
+
+  String get message {
+    return _json['message'] as String;
+  }
+
+  set message(String value) {
+    _json['message'] = value;
+  }
+
+  List<LunchSuggestion> get suggestions {
+    return (_json['suggestions'] as List)
+        .map((e) => LunchSuggestion.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  set suggestions(List<LunchSuggestion> value) {
+    _json['suggestions'] = value.toList();
+  }
+
+  @override
+  String toString() {
+    return _json.toString();
+  }
+
+  /// Serializes this [LunchResponse] to a JSON map.
+  Map<String, dynamic> toJson() {
+    return _json;
+  }
+}
+
+base class _LunchResponseTypeFactory extends SchemanticType<LunchResponse> {
+  const _LunchResponseTypeFactory();
+
+  @override
+  LunchResponse parse(Object? json) {
+    return LunchResponse._(json as Map<String, dynamic>);
+  }
+
+  @override
+  JsonSchemaMetadata get schemaMetadata => JsonSchemaMetadata(
+    name: 'LunchResponse',
+    definition: $Schema
+        .object(
+          properties: {
+            'message': $Schema.string(),
+            'suggestions': $Schema.list(
+              items: $Schema.fromMap({'\$ref': r'#/$defs/LunchSuggestion'}),
+            ),
+          },
+          required: ['message', 'suggestions'],
+        )
+        .value,
+    dependencies: [LunchSuggestion.$schema],
+  );
+}

--- a/cookbook/lunch-concierge/server/pubspec.yaml
+++ b/cookbook/lunch-concierge/server/pubspec.yaml
@@ -1,0 +1,24 @@
+name: lunch_concierge_server
+description: Shelf + Genkit server for the Lunch Concierge cookbook recipe.
+publish_to: none
+
+environment:
+  sdk: ^3.10.0
+
+resolution: workspace
+
+dependencies:
+  genkit: any
+  genkit_shelf: any
+  genkit_vertexai: any
+  lunch_concierge_shared:
+    path: ../shared
+  postgres: any
+  schemantic: any
+  shelf: any
+  shelf_router: any
+  shelf_static: any
+
+dev_dependencies:
+  build_runner: any
+  lints: ^6.0.0

--- a/cookbook/lunch-concierge/shared/lib/generated/lunch_stack.app.dart
+++ b/cookbook/lunch-concierge/shared/lib/generated/lunch_stack.app.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// terradart synth output for stack: LunchStack
+// dart format off
+// ignore_for_file: type=lint
+
+abstract final class LunchStackExports {
+  LunchStackExports._();
+
+  static const String REGION = r'asia-northeast1';
+
+  static const String PROJECT_ID = r'flutter-gakkai-10';
+
+  static const String SERVICE_NAME = r'lunch-concierge';
+
+  static const String DATABASE_NAME = r'lunch';
+
+  static const String DATABASE_USER = r'lunch-sql-client@flutter-gakkai-10.iam';
+
+  static const String DATABASE_URL =
+      r'postgresql://lunch-sql-client@flutter-gakkai-10.iam@localhost:5432/lunch';
+
+  static const String CLOUD_SQL_INSTANCE_CONNECTION_NAME =
+      r'flutter-gakkai-10:asia-northeast1:lunch-sql';
+}

--- a/cookbook/lunch-concierge/shared/pubspec.yaml
+++ b/cookbook/lunch-concierge/shared/pubspec.yaml
@@ -1,0 +1,11 @@
+name: lunch_concierge_shared
+description: Shared generated constants for the Lunch Concierge cookbook recipe.
+publish_to: none
+
+environment:
+  sdk: ^3.6.0
+
+resolution: workspace
+
+dev_dependencies:
+  lints: ^6.0.0

--- a/cookbook/remote-backend/FRICTIONS.md
+++ b/cookbook/remote-backend/FRICTIONS.md
@@ -1,0 +1,41 @@
+# Friction log — remote-backend recipe
+
+Findings from authoring + dogfooding the `remote-backend` recipe. Separate from `single-project-app/FRICTIONS.md` because the patterns surfaced are state-management-specific.
+
+## Entry template
+
+```markdown
+### <short title>
+
+**Context:** which step / which terraform command / which env.
+
+**Friction:** what was unexpected — symptom + observed behavior.
+
+**Proposed fix:** rename / add abstraction / docs update / etc.
+
+**Tracked:** terradart#XXX (added after issue is filed).
+```
+
+## D1b (GCS backend — Stage 0 + migration)
+
+(filled in during the GCS backend dogfood cycle.)
+
+### `terraform init -migrate-state` fails with 404 when ADC quota project differs from the GCS bucket's project
+
+**Context:** D1b Step 2 (`terraform init -migrate-state` for `cookbook/remote-backend/tf-out/` to migrate Stage 0 local state into GCS).
+
+**Friction:** `Error inspecting states in the "local" backend: querying Cloud Storage failed: storage: bucket doesn't exist: googleapi: Error 404: The requested project was not found., notFound`. The bucket `terradart-validate-tfstate` exists (verified `gsutil ls -p terradart-validate | grep tfstate` returns it before the init), but terraform's `backend "gcs"` block uses ADC's quota project for billing the GCS API call. The dev had `gcloud config project = aizap-dev` (their personal project), which lacks any `terradart-validate-tfstate` bucket, so the GCS API rejects the lookup with a confusing "project not found" 404 instead of a more direct "bucket not found in this quota project".
+
+**Workaround applied:** `gcloud auth application-default set-quota-project terradart-validate`. Alternative: `export GOOGLE_CLOUD_PROJECT=terradart-validate` per shell session, or `gcloud config set project terradart-validate` if the dev is fine switching their default.
+
+This is a Terraform / Google provider behavior, not a terradart bug. But terradart users will hit it the first time they configure a backend in a non-default project — the error message is unhelpfully generic.
+
+**Proposed fix (v1.0 cookbook docs):** the `remote-backend` recipe's README should call out this gotcha explicitly in the "Migrate Stage 0 state into the new bucket" section. Suggested README addition:
+
+> Before running `terraform init -migrate-state`, ensure your ADC quota project matches the bucket's project:
+> ```bash
+> gcloud auth application-default set-quota-project <BUCKET_PROJECT_ID>
+> ```
+> or set `GOOGLE_CLOUD_PROJECT=<BUCKET_PROJECT_ID>` per session. Otherwise terraform's GCS backend lookup will hit a 404 "project not found" against your default quota project.
+
+**Tracked:** Documented in cookbook (no terradart code issue).

--- a/cookbook/remote-backend/README.md
+++ b/cookbook/remote-backend/README.md
@@ -1,0 +1,87 @@
+> Part of the [TerraDart cookbook](../README.md). Library: [terradart](https://github.com/nozomi-koborinai/terradart).
+>
+> **Status:** Verified on terradart v0.11.0. Stage 0 bucket apply + destroy cycle confirmed end-to-end via the synth-emitted local backend. See [FRICTIONS.md](./FRICTIONS.md) for dogfood findings.
+
+# remote-backend
+
+GCS-backed Terraform remote state pattern. Demonstrates the canonical workflow:
+
+1. Apply this recipe with a **local backend** → creates the GCS bucket that will hold remote state.
+2. Migrate this recipe's own state into the new bucket via `terraform init -migrate-state`.
+3. Retarget other recipes (e.g. `single-project-app`) at this bucket by switching their `tf-out/terraform.tf` to `backend "gcs"`.
+
+Pattern demonstrated: **introduce GCS remote state to a previously local-backed Terraform project**. The bucket itself is intentionally a separate (minimal) Stack so that destroying app-level resources never touches the state container.
+
+## Run (Stage 0 — create the bucket with local backend)
+
+```bash
+export GCP_PROJECT_ID=terradart-validate
+# Optional: override default bucket name (default: <GCP_PROJECT_ID>-tfstate)
+# export BUCKET_NAME=my-custom-tfstate-name
+
+dart pub get
+dart run bin/infra.dart              # synth -> tf-out/main.tf.json
+
+cd tf-out
+terraform init                       # local backend (Stage 0)
+terraform plan                       # expect: 1 resource to add (google_storage_bucket)
+terraform apply -auto-approve
+
+# Confirm the bucket exists
+gsutil ls -p terradart-validate | grep tfstate
+```
+
+## Migrate Stage 0 state into the new bucket
+
+After the bucket is created, switch this recipe's own state into it.
+Stage 0 uses the local backend emitted by the Stack in `main.tf.json`
+(`terraform { backend "local" {} }`); to migrate, create a new
+`tf-out/terraform.tf` that overrides it with the GCS backend
+(Terraform picks the HCL `terraform.tf` over the JSON-embedded block
+when both are present in the working directory):
+
+1. Create `tf-out/terraform.tf`:
+
+   ```hcl
+   terraform {
+     backend "gcs" {
+       bucket = "terradart-validate-tfstate"   # match BUCKET_NAME from Stage 0
+       prefix = "remote-backend"               # path inside the bucket
+     }
+   }
+   ```
+
+2. **(One-time setup)** Ensure your ADC quota project matches the bucket's GCP project, otherwise terraform's GCS backend lookup hits a confusing 404:
+
+   ```bash
+   gcloud auth application-default set-quota-project terradart-validate
+   # OR (per-session): export GOOGLE_CLOUD_PROJECT=terradart-validate
+   ```
+
+3. Run `terraform init -migrate-state`. When prompted, type `yes` to copy local state to GCS.
+4. Confirm: `gsutil ls -r gs://terradart-validate-tfstate/remote-backend/` shows `default.tfstate`.
+
+## Migrate `single-project-app` state into the bucket
+
+In `cookbook/single-project-app/tf-out/terraform.tf`, switch the backend block:
+
+```hcl
+terraform {
+  backend "gcs" {
+    bucket = "terradart-validate-tfstate"
+    prefix = "single-project-app"
+  }
+}
+```
+
+Then `terraform init -migrate-state` in `single-project-app/tf-out/`. The 28-resource state moves into GCS.
+
+Same ADC quota project gotcha applies here — if you see a 404 "project not found" on init, run `gcloud auth application-default set-quota-project terradart-validate` (or set `GOOGLE_CLOUD_PROJECT=terradart-validate`) before retrying.
+
+## Cost notes
+
+A regional GCS bucket with versioning + a few KB of state files costs essentially zero (~$0.02/month). Safe to leave long-lived.
+
+## When to destroy
+
+The state bucket is long-lived by design. `terraform destroy` on this recipe should be **manual / deliberate** (e.g., when retiring the GCP project entirely). The recipe's `force_destroy = false` ensures versioned objects block accidental deletion.

--- a/cookbook/remote-backend/analysis_options.yaml
+++ b/cookbook/remote-backend/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/cookbook/remote-backend/bin/infra.dart
+++ b/cookbook/remote-backend/bin/infra.dart
@@ -1,0 +1,22 @@
+/// Stage 0 synth entry. `dart run bin/infra.dart` -> `tf-out/main.tf.json`.
+library;
+
+import 'dart:io';
+
+import 'package:remote_backend/main.dart';
+
+Future<void> main() async {
+  final projectId = Platform.environment['GCP_PROJECT_ID'];
+  if (projectId == null || projectId.isEmpty) {
+    stderr.writeln('error: set GCP_PROJECT_ID env var (target GCP project)');
+    exit(64);
+  }
+  final bucketName =
+      Platform.environment['BUCKET_NAME'] ?? '$projectId-tfstate';
+  final stack = RemoteBackendStack(
+    projectId: projectId,
+    bucketName: bucketName,
+  );
+  await stack.writeTo('tf-out');
+  print('synthesized to tf-out/main.tf.json (bucket: $bucketName)');
+}

--- a/cookbook/remote-backend/lib/main.dart
+++ b/cookbook/remote-backend/lib/main.dart
@@ -1,0 +1,41 @@
+/// remote-backend recipe — minimal Stack provisioning a GCS bucket to hold
+/// Terraform state. Apply with local backend (Stage 0); migrate this bucket's
+/// own state into GCS via `terraform init -migrate-state`; then other recipes
+/// (e.g. single-project-app) can be retargeted at this bucket via a
+/// `backend "gcs" { bucket = "...", prefix = "..." }` declaration in their
+/// `tf-out/terraform.tf`.
+///
+/// Pattern demonstrated: **introduce remote state to a previously local Stack**.
+/// Includes versioning + uniform bucket-level access suitable for a
+/// long-lived terraform state container.
+library;
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/provider.dart';
+import 'package:terradart_google/storage.dart';
+
+final class RemoteBackendStack extends Stack {
+  RemoteBackendStack({
+    required this.projectId,
+    required this.bucketName,
+  }) : super(
+          providers: [
+            GoogleProvider(project: projectId, region: 'asia-northeast1'),
+          ],
+          backend: const LocalBackend(),
+        ) {
+    add(GoogleStorageBucket(
+      localName: 'tfstate',
+      name: TfArg.literal(bucketName),
+      location: TfArg.literal('asia-northeast1'),
+      uniformBucketLevelAccess: TfArg.literal(true),
+      versioning: StorageBucketVersioning(enabled: TfArg.literal(true)),
+      // forceDestroy: false is the default; explicit here for clarity.
+      // State buckets are long-lived; destroy must be a deliberate action.
+      forceDestroy: TfArg.literal(false),
+    ));
+  }
+
+  final String projectId;
+  final String bucketName;
+}

--- a/cookbook/remote-backend/pubspec.yaml
+++ b/cookbook/remote-backend/pubspec.yaml
@@ -1,0 +1,18 @@
+name: remote_backend
+description: terradart cookbook recipe — GCS remote backend for Terraform state. Stage 0 bootstrap (creates the state bucket with local backend, then migrates its own state to GCS), demonstrates the canonical "introduce remote state" workflow.
+homepage: https://github.com/nozomi-koborinai/terradart/tree/main/cookbook/remote-backend
+repository: https://github.com/nozomi-koborinai/terradart
+publish_to: none
+version: 0.1.0
+
+environment:
+  sdk: ^3.6.0
+
+resolution: workspace
+
+dependencies:
+  terradart_core: ^0.21.0
+  terradart_google: ^0.21.0
+
+dev_dependencies:
+  lints: ^6.0.0

--- a/cookbook/single-project-app/FRICTIONS.md
+++ b/cookbook/single-project-app/FRICTIONS.md
@@ -1,0 +1,290 @@
+# Friction log
+
+Findings from dogfooding terradart against the coffee-shop recipe. Each entry was a candidate for the v0.9 polish wave (sub-project A of the v0.9 design).
+
+**v0.9 status:** Issues terradart#52-#57 are resolved in terradart v0.9.0 (link TBD post-tag). This recipe has been migrated to the v0.9 surface on branch `migrate/v0.9`.
+
+## Entry template
+
+```markdown
+### <short title>
+
+**Context:** which tier / which terraform command / which env.
+
+**Friction:** what was unexpected — symptom + observed behavior.
+
+**Proposed fix:** rename / add abstraction / docs update / etc. (feeds into A wave scope).
+
+**Tracked:** terradart#XXX (added after issue is filed).
+```
+
+## D1a (local backend)
+
+### Fresh GCP projects miss compute + servicenetworking; Tier 1 plan assumption wrong
+
+**Context:** D1a Tier 2 `terraform apply` against a fresh `terradart-validate` project (no manual gcloud commands run beforehand).
+
+**Friction:** `Error 403: Compute Engine API has not been used in project terradart-validate ... SERVICE_DISABLED`. The dogfood plan listed only 6 APIs in Tier 1 (run / sql / pubsub / monitoring / secret / iam) and assumed compute + servicenetworking are pre-enabled. On a freshly-created GCP project (which is exactly what `terradart-validate` is), they aren't — Compute Engine has historically been auto-enabled for billing-linked legacy projects, but newly-created ones since ~2023 require explicit enablement.
+
+A subtler observation: terradart doesn't help the user discover this dependency. Importing `package:terradart_google/compute.dart` and adding `GoogleComputeNetwork` does NOT tell the dev "you need `google_project_service` for `compute.googleapis.com` first". They only learn from a runtime `terraform apply` error.
+
+**Proposed fix:** in v0.9 polish wave, ship a curated "API enablement helper": `Apis.required(barrels: [compute, service_networking, cloud_sql, ...])` that emits the necessary `google_project_service` set based on which terradart barrels the Stack imports / uses. This would prevent recipe authors from misconfiguring Tier 1.
+
+**Tracked:** terradart#57. **Status:** Resolved in terradart v0.9.0 (link TBD post-tag).
+
+### Backend block requires handwritten terraform.tf
+
+**Context:** D1a tier 1 setup — synth produces `tf-out/main.tf.json` but does not emit a `terraform { backend "local" {} }` block.
+
+**Friction:** terradart_core v0.8.0-dev exposes `StackBackend` + `GcsBackend` (via `setBackend(...)` on `Stack`), but ships no `LocalBackend` implementation. Consumers wanting a local backend must hand-author `tf-out/terraform.tf` alongside the synthesized JSON, and force-add it past the `cookbook/*/tf-out/` gitignore (`git add -f`).
+
+**Proposed fix:** add `LocalBackend` to `terradart_core` in sub-project A (lives next to existing `GcsBackend` in `src/backends.dart`); export from `terradart_core.dart`. Then `stack.setBackend(const LocalBackend())` would emit `terraform.backend.local: {}` in `main.tf.json` and the handwritten file disappears.
+
+**Tracked:** terradart#52. **Status:** Resolved in terradart v0.9.0 (link TBD post-tag).
+
+### `Stack.synth` is abstract — every quickstart re-implements file-write boilerplate
+
+**Context:** D1a tier 1 setup — needed to override `synth({required String outDir})` in `CoffeeShopStack` to call `StackSynth.synth(this)`, then `Directory(outDir).create(recursive: true)`, then `File('$outDir/main.tf.json').writeAsString(...)` with `dart:convert`'s `JsonEncoder.withIndent('  ')`.
+
+**Friction:** `Stack.synth` is declared abstract (`packages/terradart_core/lib/src/stack.dart:192`), so every consumer copies the same 6-line boilerplate. Also forces every consumer to alias `dart:convert` (e.g. `import 'dart:convert' as dart_convert;`) because `terradart_core.dart` exports its own `JsonEncoder` class, shadowing `dart:convert`'s.
+
+**Proposed fix:** provide a concrete default `synth` on `Stack` that writes `main.tf.json` (and the `*.app.dart` constants file when present) under `outDir`. Subclasses can still override for custom side effects, but the 80% case becomes a no-boilerplate call. Rename the internal `JsonEncoder` export to `TfJsonEncoder` to avoid shadowing `dart:convert`.
+
+**Tracked:** terradart#56. **Status:** Resolved in terradart v0.9.0 (link TBD post-tag).
+
+### Synth emits `terraform.required_version` & `required_providers`, duplicating handwritten `terraform.tf`
+
+**Context:** D1a tier 1 setup — handwritten `tf-out/terraform.tf` declares `required_version = ">= 1.5"` and the `hashicorp/google ~> 7.0` provider block; synth-emitted `main.tf.json` re-declares both (synth pins `required_version` to `">= 1.11.0"` and the provider block to `hashicorp/google ~> 7.0`).
+
+**Friction:** Terraform merges duplicate declarations and the stricter `required_version` wins (`>= 1.11.0`), so the handwritten `>= 1.5` is silently ignored — confusing for users who think they control the floor. The duplicated `required_providers` block is harmless but visually noisy.
+
+**Proposed fix:** if a `LocalBackend` abstraction lands (see first entry above), the handwritten `terraform.tf` disappears entirely and this becomes moot. Until then, document in the cookbook README that `terraform.tf`'s `required_version` is overridden by the synth-emitted `>= 1.11.0` value (or let users override via `stack.setRequiredVersion(...)`).
+
+**Tracked:** terradart#52. **Status:** Resolved in terradart v0.9.0 (link TBD post-tag).
+
+### terradart hardcodes `required_version: ">= 1.11.0"`; older terraform users hard-blocked
+
+**Context:** D1a first `terraform init` against synth output `tf-out/main.tf.json` on the user's laptop.
+
+**Friction:** `Error: Unsupported Terraform Core version ... This configuration does not support Terraform version 1.5.7.` terradart_core v0.8.0-dev emits `"required_version": ">= 1.11.0"` unconditionally inside the synth output's `terraform` block. Consumers on terraform < 1.11 are hard-blocked — they cannot even read the plan without upgrading.
+
+terraform 1.11 was released 2025-02; it's reasonable to require recent versions, but: (a) the constraint should be configurable per Stack so library users can target older clusters; (b) the cookbook README incorrectly stated "Terraform 1.5+", which surfaced as a confusing blocker; (c) this is a stricter constraint than the cookbook recipe's `pubspec.yaml` advertises.
+
+**Proposed fix:** in sub-project A (v0.9 polish wave), expose `Stack.terraformVersionConstraint` (or similar field) that defaults to a sensible permissive value like `">= 1.5"` and lets advanced users tighten it. The handwritten `terraform.tf` constraint should then take precedence (or terradart should not emit `required_version` at all when consumer provides their own `terraform.tf`).
+
+**Workaround for D1a:** `brew upgrade hashicorp/tap/terraform` to get >= 1.11. Cookbook README updated to say "Terraform 1.11+" until v0.9 polish lands.
+
+**Tracked:** terradart#52 (rolled in alongside the broader `terraform.tf` elimination workstream). **Status:** Resolved in terradart v0.9.0 (link TBD post-tag).
+
+### `google_project_service` "created" signal lags actual API usability by 30-60s
+
+**Context:** D1a Tier 2 second apply attempt (after Fix "Add compute + servicenetworking to Tier 1").
+
+**Friction:** `terraform apply` created `google_project_service.api_compute` and `api_servicenetworking` in 1m46s, then immediately tried `google_compute_network.coffee_vpc` — and hit `Error 403: Compute Engine API has not been used ... SERVICE_DISABLED`. The API was "created" per Terraform's view, but GCP backend propagation hadn't completed. Re-running `terraform apply` 1-2 minutes later succeeded (3 resources in ~1m19s).
+
+This is a well-known Terraform / google provider issue but it surfaces sharply in fresh-project dogfood because every API enable is on the critical path. Common workaround: insert a `time_sleep` resource between `google_project_service` completion and dependent resources.
+
+**Proposed fix:** in v0.9 polish wave, optionally have terradart's hypothetical `Apis.required(...)` helper (see prior friction) wrap dependent resources behind a `time_sleep` of 30-60s. Alternatively (less invasive): emit a doc comment / barrel-level guidance pointing at the `time_sleep` pattern.
+
+**Workaround used:** re-run `terraform apply` — Terraform's `google_compute_network` errored cleanly, no partial state.
+
+**Tracked:** terradart#57. **Status:** Resolved in terradart v0.9.0 (link TBD post-tag).
+
+### Tier 3 API surface deviates from plan-author guesses — naming conventions worth a doc pass
+
+**Context:** D1a Tier 3 implementation — wiring `GoogleSqlDatabaseInstance` + `GoogleSecretManagerSecret` per the Task 5 plan.
+
+**Friction:** the implementation plan was authored against guessed class names that did not match terradart_google v0.8.0-dev exports. Four discrepancies surfaced during Step 1 verification:
+
+1. **`SqlInstanceSettings` → `Settings`** (plain `Settings`, scoped under `cloud_sql.dart`). The naming is unprefixed even though it's specific to Cloud SQL — at the call site `Settings(...)` reads as ambiguous (Settings of what?). A consumer importing multiple barrels could plausibly hit a name collision.
+2. **`SqlIpConfiguration` → `IpConfiguration`** (same pattern — unprefixed nested-block helper).
+3. **`SecretReplication.automatic()` → `Replication.auto()`** (sealed factory; subclasses are `_AutoReplication` / `_UserManagedReplication`). The factory name `auto` is reasonable but the `SecretReplication` prefix the plan author guessed would have helped find it.
+4. **`GoogleSecretManagerSecret.idRef` → `.id`** (returns `TfRef<String>`, so functionally equivalent — just `id` not `idRef`).
+
+The cloud_sql quickstart at `examples/cloud_sql_quickstart/lib/main.dart` documents the correct names; reading that first prevented a compile failure. But without the quickstart, the natural first guess (resource-prefixed nested-block classes) is wrong.
+
+**Proposed fix:** in v0.9 polish wave, decide on a naming convention for nested-block helpers and apply it consistently across all barrels — either prefix every helper with the resource it belongs to (`SqlInstanceSettings` / `SqlIpConfiguration` / `SecretReplication`) for clarity, OR document that bare helpers (`Settings`, `IpConfiguration`, `Replication`) are scoped per barrel and recommend `import 'package:terradart_google/cloud_sql.dart' as cloud_sql;` show-style aliasing. Either resolution should propagate to `dart doc` pages and the cookbook README.
+
+A related sub-observation: `GoogleSecretManagerSecretVersion.secretData` is `@Deprecated` (per spec §10.4, prefer `secretDataWo` write-only API), so call sites need `// ignore: deprecated_member_use` until the cookbook recipe migrates to the write-only flow. The recipe stays on `secretData` for Tier 3 because Tier 4-6 haven't been written yet — once Cloud Run mounts the secret, switching to `secretDataWo` should be straightforward.
+
+**Workaround used:** consulted `~/.pub-cache/hosted/pub.dev/terradart_google-0.8.0-dev/lib/src/sql/` directly to discover the actual exports before writing call sites. Sensitive masking confirmed working: at synth time both `google_sql_user.password` and `google_secret_manager_secret_version.secret_data` are emitted as `""` in `main.tf.json` (verified via `jq` against `tf-out/main.tf.json`), so the literal `dbPassword` value does NOT leak into the synth output.
+
+**Tracked:** terradart#55. **Status:** Resolved in terradart v0.9.0 (link TBD post-tag).
+
+### CRITICAL — synth-time sensitive masking destroys apply for write-once secret fields
+
+**Context:** D1a Tier 3 `terraform apply` — first cycle after Tier 3 synth landed. `google_sql_database_instance.coffee_sql` (13m6s), `google_sql_database.coffee_db`, and `google_secret_manager_secret.db_password` (parent secret, 2s) all created successfully. Then `google_sql_user.coffee_user` and `google_secret_manager_secret_version.db_password_v1` failed.
+
+**Friction:** terradart_core v0.8.0-dev's synth pipeline masks any `TfArgLiteral` written to a field listed in the resource's `$sensitiveFields` set — replacing the literal with `""` empty string in `tf-out/main.tf.json` before terraform sees it. This is the same mechanism that prevents secrets from leaking into the synth output (see prior entry). But for fields that **must carry a non-empty value at apply time** (e.g. `google_sql_user.password` and `google_secret_manager_secret_version.secret_data`), the masking destroys the apply: terraform receives `password = ""` and the provider rejects it (`Error: googleapi: Error 400: Invalid request: missing required field`).
+
+Worse: the `Variable` / consumer-supplied interpolation API doesn't exist in v0.8.0-dev (`tf_ref.dart:16` reserves it for future), so the natural escape hatch — switch to `TfArg.variable(...)` and let `${var.db_password}` flow through unmasked — is unavailable. Users dogfooding Tier 3 hit a hard wall: the synth output's literal is silently destroyed and there's no obvious alternative in the public API.
+
+**Workaround applied:** swap `password` / `secretData` → `passwordWo` / `secretDataWo` (write-only variants). v0.8.0-dev's `$sensitiveFields` set does NOT include the `_wo` variants, so literal values pass through to terraform unmasked, go through the write-only attribute mechanism at apply (value flows to provider, never enters tfstate). Synth output now contains the literal `dbPassword` value in `tf-out/main.tf.json` — acceptable trade-off because `tf-out/` is gitignored AND the new attributes are the canonical idiom per `google_sql_user.dart:55-58` doc comments.
+
+**Proposed fix:** in v0.9 polish wave, two-part: (a) add `TfArg.variable(name)` (or equivalent) to `terradart_core` so consumers can route secrets through handwritten `variable` blocks when the resource's write-only API isn't ergonomic enough; (b) emit a clear synth-time diagnostic when a literal targets a masked field with no `_wo` alternative present — currently the masking is silent and the failure mode only surfaces at `terraform apply`. The `@Deprecated` annotation on `secretData` already nudges users toward `secretDataWo`; doing the same for `google_sql_user.password` would close the gap.
+
+**Tracked:** terradart#53. **Status:** Resolved in terradart v0.9.0 (link TBD post-tag).
+
+### Duplicate `required_providers` between synth output and handwritten terraform.tf hard-blocks init
+
+**Context:** D1a `terraform init` immediately after upgrading to terraform 1.11+ (fixing the previous required_version friction).
+
+**Friction:** `Error: Duplicate required providers configuration` — `tf-out/terraform.tf` (handwritten, see "Backend block requires handwritten terraform.tf" friction above) declared `required_providers { google = ... }` to align the version pin, but synth output's `main.tf.json` already declares the same block at `main.tf.json:4`. terraform treats them as duplicates and refuses to init. Workaround was to reduce `terraform.tf` to `terraform { backend "local" {} }` only — drop `required_version` and `required_providers` and let synth own those declarations.
+
+This is the same root cause as the "Backend abstraction missing" friction, but the day-2 symptom is sharper: consumers attempting to follow the Terraform community convention (declare versions in `terraform.tf` for source-of-truth visibility) actively break init.
+
+**Proposed fix:** same as Backend abstraction (v0.9 A.1): if `Stack.backend` is set, synth emits the full `terraform { ... }` block including backend; user never authors `terraform.tf`. Alternatively (transitional): synth could detect a sibling `terraform.tf` and skip emitting `required_*` fields when present, but this is fragile.
+
+**Tracked:** terradart#52. **Status:** Resolved in terradart v0.9.0 (link TBD post-tag).
+
+### Tier 4 — `GoogleServiceAccount` IAM-binding getter name is unguessable
+
+**Context:** D1a Tier 4 implementation — wiring `GoogleServiceAccount` + three `GoogleProjectIamMember` bindings + one `GoogleSecretManagerSecretIamMember` per the Task 6 plan.
+
+**Friction:** the implementation plan was authored against the guessed getter name `runSa.emailMember` (i.e. "the email formatted as an IAM member string"). The actual getter on `GoogleServiceAccount` is `.member` — bare, no `email` prefix. The dartdoc on the resource explicitly recommends `.member` over manual `'serviceAccount:' + email` concatenation, but the bare name `member` doesn't telegraph what it returns. The natural first guesses (`.emailMember`, `.memberRef`, `.iamMember`, `.principal`) all fail. A reader scanning `GoogleServiceAccount`'s public surface sees five getters — `id`, `email`, `name`, `uniqueId`, `member` — and `.member` looks like it could be "the service account's primary identity field" rather than "the pre-formatted IAM-binding string".
+
+**Proposed fix:** in v0.9 polish wave, rename `GoogleServiceAccount.member` → `GoogleServiceAccount.iamMember` (or `iamMemberRef`) to make the intent self-documenting at the call site. The current dartdoc is good ("pre-formatted `serviceAccount:<email>` string. **Use this for IAM bindings**"), but the getter name itself fights the doc. Bonus: the same naming convention should propagate to any other resource that emits a member-formatted attribute (e.g. workload identity pool providers, federated identities).
+
+**Workaround used:** consulted `~/.pub-cache/hosted/pub.dev/terradart_google-0.8.0-dev/lib/src/iam/google_service_account.dart` to discover the actual getter name before writing call sites.
+
+**Tracked:** terradart#55. **Status:** Resolved in terradart v0.9.0 (link TBD post-tag).
+
+### Tier 5 — Cloud Run v2 env-var helper shape diverges from natural guess; `locationRef` getter missing
+
+**Context:** D1a Tier 5 implementation — wiring `GoogleCloudRunV2Service` with 4 env vars (3 literal sourced from refs, 1 from Secret Manager) + `GoogleCloudRunV2ServiceIamMember` per the Task 7 plan.
+
+**Friction:** two distinct discrepancies surfaced while writing Tier 5 against terradart_google v0.8.0-dev's actual exports:
+
+1. **`EnvVar` is a wrapper, not the leaf type.** The Task 7 plan author's natural guess (informed by the synth-test pattern names already in our project memory) was a flat shape — `EnvVarFromLiteral(name: ..., value: ...)` / `EnvVarFromSecret(name: ..., secret: ..., version: ...)`. The actual API is `EnvVar(name: 'DB_INSTANCE', source: EnvVarFromLiteral(TfArg.literal('...')))` — i.e. `EnvVar` carries the name (plain `String`, not `TfArg<String>`) and dispatches to a sealed `EnvVarSource` (`EnvVarFromLiteral(value)` positional / `EnvVarFromSecret({secret, version})`) for the value source. This shape models the Terraform schema's `value` vs `value_source.secret_key_ref` exactly_one_of constraint at the type level, which is good — but the wrapper-vs-leaf layering isn't telegraphed by the export list (`EnvVar` / `EnvVarFromLiteral` / `EnvVarFromSecret` / `EnvVarSource` all sit at the same level in `cloud_run.dart`). A consumer scanning the exports could plausibly read `EnvVarFromLiteral` as a self-contained env var rather than a value source. The job-side helpers (`JobEnvVar` / `JobEnvVarFromLiteral` / etc.) repeat the exact same pattern in a parallel namespace.
+
+2. **`GoogleCloudRunV2Service` exposes `nameRef` but no `locationRef`.** The IAM member binding needs both `name` and `location` to identify the target service. The plan attempted `TfArg.ref(coffeeService.locationRef)` symmetrically with `nameRef`, but no such getter exists — the surface is `nameRef`, `id`, `uri`, `generation`, `latestReadyRevision`, `latestCreatedRevision`, `uid`, `etag` (zero location-related attrs). The workaround was to re-literal `'asia-northeast1'` for the IAM member's `location` field, which works but introduces a magic-string coupling between the service declaration and the binding — change the region in one place and you need to remember to change it in the other. A consumer following a "always wire via refs" hygiene rule (which terradart's overall design encourages) would expect this getter to exist.
+
+**Proposed fix:** in v0.9 polish wave, two adjustments:
+
+- **(a)** Consider flattening the env-var helper into a single leaf type per source, e.g. `EnvLiteral(name: 'DB_INSTANCE', value: TfArg.literal('...'))` and `EnvSecret(name: 'DB_PASSWORD', secret: TfArg.ref(...), version: 'latest')`. This loses the sealed-class dispatch benefit but the Terraform schema's `exactly_one_of` constraint is already enforced at the provider level — moving it into the type system buys correctness at the cost of an unintuitive shape. If the wrapper design stays, add a doc comment on `EnvVar` (and `JobEnvVar`) explicitly calling out "this is the name carrier; pick a source from `EnvVarSource`'s sealed family" — currently the dartdoc says "Set [source] to inject a value", which doesn't telegraph the dispatch idiom.
+
+- **(b)** Add `locationRef` (and possibly `projectRef`) as input-mirror getters on `GoogleCloudRunV2Service` (and other location-scoped resources) so the binding-companion pattern stays ref-based throughout. Even though Terraform doesn't expose `location` as a read attribute on these resources, the synthesizer could generate a getter that returns a `TfRef` to the local Terraform argument (`${google_cloud_run_v2_service.<local>.location}`) since the argument is required and thus always set. Alternatively: expose the resource's required input arguments via a uniform `inputs.location` / `inputs.region` mirror so consumers always have a ref-able handle without forcing the schema to materialize the attr at read time.
+
+**Workaround used:** (a) wrote env vars in the actual `EnvVar(name: ..., source: EnvVarFrom...())` shape after reading `~/.pub-cache/hosted/pub.dev/terradart_google-0.8.0-dev/lib/src/cloud_run/google_cloud_run_v2_service.dart:484-552` directly. (b) hard-coded `TfArg.literal('asia-northeast1')` for the IAM member's `location` instead of a ref.
+
+**Tracked:** terradart#55. **Status:** Resolved in terradart v0.9.0 (link TBD post-tag).
+
+### Tier 6 — Monitoring nested-block helpers are inconsistent about `TfArg` wrapping; enum names diverge from plan author guesses
+
+**Context:** D1a Tier 6 implementation — wiring `GooglePubsubTopic` + `GooglePubsubSubscription` (push to Cloud Run + OIDC token) + `GoogleMonitoringNotificationChannel` (email) + `GoogleMonitoringUptimeCheckConfig` + `GoogleMonitoringAlertPolicy` per the Task 8 plan.
+
+**Friction:** several discrepancies between the plan author's natural guesses and the actual v0.8.0-dev exports surfaced during Step 1 verification:
+
+1. **`MonitoringUptimeCheckMonitoredResource` and `MonitoringUptimeCheckHttpCheck` fields are plain Dart types, NOT `TfArg<T>`.** The plan was written assuming the typical terradart pattern of "every settable field is `TfArg<T>`" (which is the rule for `Resource` constructors). For nested-block helpers in the monitoring barrel, fields like `type` / `labels` / `port` / `path` / `useSsl` are plain `String` / `Map<String, String>` / `int` / `bool`. This is internally consistent inside the monitoring barrel but inconsistent with the project-wide "wire via `TfArg`" hygiene rule — a consumer who's been using `TfArg.literal(...)` everywhere will reach for it here and hit a static type error.
+
+2. **`Aggregation.perSeriesAligner` is `Aligner?`, NOT `TfArg<Aligner>?`.** Same inconsistency: `Aggregation.alignmentPeriod` is `TfArg<String>?` (TfArg-wrapped), but `perSeriesAligner` and `crossSeriesReducer` are bare enums. The plan attempted `TfArg.literal(Aligner.alignNextOlder)`; the actual API is `Aligner.nextOlder` (bare enum value, no TfArg wrapper).
+
+3. **Enum value names differ from plain-English guesses.** Plan guessed `Comparison.lessThan` and `Aligner.alignNextOlder`. Actual names are `Comparison.lt` (terse abbreviation) and `Aligner.nextOlder` (no `align` prefix — the prefix lives in the `terraformValue` `'ALIGN_NEXT_OLDER'`). Symmetry-of-naming reading would expect either both terse or both verbose.
+
+4. **`GooglePubsubSubscription.topic` requires `.id`, NOT `.nameRef`.** The plan attempted `TfArg.ref(orderTopic.nameRef)`. The actual provider expects the full resource path `projects/{project}/topics/{name}`, which is what `.id` returns. The dartdoc on `google_pubsub_subscription.dart` is explicit about this ("NOT `topic.nameRef`"), but the more general lesson is that consumers can't tell from the call site whether a given consumer field wants `.nameRef` vs `.id` — and the wrong choice produces a runtime apply error, not a synth-time signal.
+
+5. **`Aggregation` cannot be `const`-constructed when its fields use `TfArg.literal(...)`.** `TfArg.literal` is a static method, not a const constructor; `TfArgLiteral<T>(...)` is the const-constructible form. Mixing nested helpers (which often want `const`) with `TfArg.literal` argument calls silently breaks `const`-ness. The call site has to drop `const` on the outer collection literal.
+
+**Proposed fix:** in v0.9 polish wave, three adjustments:
+
+- **(a)** Decide on a uniform "wrap or not" policy for nested-block helpers across all barrels. Either every settable field is `TfArg<T>` (consistent with `Resource` constructors, requires more verbose call sites), OR nested helpers expose plain Dart types and document this contrast prominently. Halfway (some fields TfArg, some plain) confuses consumers.
+- **(b)** Audit enum names for length consistency. `Comparison.gt/ge/lt/le/eq/ne` (terse) vs `Aligner.nextOlder/percentile99/...` (verbose) reads inconsistent. Either go terse everywhere (`Comparison.lt` + `Aligner.no`) or verbose everywhere (`Comparison.lessThan` + `Aligner.nextOlder`).
+- **(c)** For ref-style fields where the consumer ambiguously expects `.nameRef` vs `.id`, add a type-level distinction (`TfRefName<T>` vs `TfRefId<T>`?) or at minimum a doc comment on the consumer field telling readers "expects `.id` not `.nameRef`" — currently only the producing resource's getter doc has this info.
+
+**Workaround used:** read `~/.pub-cache/hosted/pub.dev/terradart_google-0.8.0-dev/lib/src/monitoring/google_monitoring_alert_policy.dart` and `google_monitoring_uptime_check_config.dart` directly; adapted call sites to match the actual API (bare enums where required, plain Dart types where required, `.id` for the topic reference). Synth output verified end-to-end via `jq` against `tf-out/main.tf.json` — all 5 Tier 6 resources emit valid Terraform JSON.
+
+**Tracked:** terradart#55. **Status:** Resolved in terradart v0.9.0 (link TBD post-tag).
+
+### Cloud Run container image choice matters for IAM: only `cloudrun/container/hello` works without explicit grants
+
+**Context:** D1a Tier 5 `terraform apply` for `google_cloud_run_v2_service.coffee_service` using image `asia-northeast1-docker.pkg.dev/google-samples/containers/hello-app:1.0`.
+
+**Friction:** `Error 403: Permission 'artifactregistry.repositories.downloadArtifacts' denied on resource (or it may not exist).` The `google-samples` AR repository requires the Cloud Run service agent (`service-<project_number>@serverless-robot-prod.iam.gserviceaccount.com`) to have explicit `roles/artifactregistry.reader` on the `google-samples` project — which is not auto-granted. The image is "publicly visible" but not "publicly pullable by managed service agents".
+
+The canonical Cloud Run public sample is `us-docker.pkg.dev/cloudrun/container/hello` — Google grants every GCP user's Cloud Run service agent `downloadArtifacts` permission on the `cloudrun` project automatically. This is the recommended starter image in Cloud Run's own quickstart docs.
+
+**Proposed fix (this recipe):** swap to `us-docker.pkg.dev/cloudrun/container/hello`.
+
+**Proposed fix (v0.9 polish):** add doc-comment guidance on `GoogleCloudRunV2Service.template.containers[].image` pointing to the canonical public hello image. Optionally provide a `CloudRunSampleImages.helloPublic` constant that recipes can reference.
+
+**Tracked:** Documented in cookbook (no terradart code issue).
+
+### Cloud Run v2 service has `deletion_protection = true` provider default; recipe-author must explicitly disable
+
+**Context:** D1a closeout `terraform destroy` against the 24-resource stack on `terradart-validate`.
+
+**Friction:** `Error: cannot destroy service without setting deletion_protection=false and running terraform apply`. The recipe's Tier 5 builder (`buildCloudRunService`) did not specify `deletionProtection`, so the Terraform google provider's default of `true` applied silently. `terraform destroy` partially succeeded — Pub/Sub topics, subscriptions, IAM bindings, monitoring resources, and notification channels destroyed cleanly — but the Cloud Run service block halted the chain, leaving ~6 resources orphaned (SQL instance, Cloud Run service, SA, secret, VPC, global_address, service_networking_connection).
+
+To unblock destroy, the dev had to (a) add `deletionProtection: TfArg.literal(false)` to the builder, (b) re-run `terraform apply` to push the new value to the existing service, then (c) re-run `terraform destroy`. The dogfood already explicitly sets `deletionProtection: false` on `GoogleSqlDatabaseInstance` for the same reason — Cloud Run v2 was simply overlooked.
+
+**Proposed fix:** terradart's docs / quickstarts should consistently flag "sample / dogfood code should explicitly set `deletionProtection: false` on every resource that has the field" — Cloud Run v2, Cloud SQL, Secret Manager (when supported), GCS bucket, BigQuery dataset, etc. Optionally: add a `Stack.devMode` or `Stack.deletionProtectionDefault` flag that recipe authors flip once instead of repeating per resource.
+
+**Tracked:** terradart#54. **Status:** Resolved in terradart v0.9.0 (link TBD post-tag).
+
+### Cloud SQL producer-side peering lingers after instance destroy; service_networking_connection blocks destroy chain
+
+**Context:** D1a closeout `terraform destroy` AFTER `google_sql_database_instance.coffee_sql` had already been destroyed (~15-20 minutes earlier).
+
+**Friction:** `Error: Unable to remove Service Networking Connection ... Failed to delete connection; Producer services (e.g. CloudSQL, Cloud Memstore, etc.) are still using this connection.` GCP's Cloud SQL tenant project (`h9cb7f1a3a38477dap-tp`) was still holding the consumer-side peering reservation even though Cloud SQL itself was gone. This is a well-known Google Cloud behavior — producer-side cleanup can take hours.
+
+The destroy chain halts at this resource, leaving 3 downstream resources (PSA connection + global_address + VPC) in a stuck state.
+
+**Workaround applied:** force-delete the consumer-side VPC peering via the Compute Engine API directly:
+
+```bash
+gcloud compute networks peerings delete servicenetworking-googleapis-com \
+  --network=coffee-shop-vpc \
+  --project=terradart-validate \
+  --quiet
+```
+
+After this, `terraform destroy` refreshes its plan and treats the PSA connection as already gone (state sync at refresh time), then proceeds to destroy `google_compute_global_address` (12s) + `google_compute_network` (22s) cleanly.
+
+**Proposed fix:** This is a GCP / Terraform google provider issue, not a terradart code bug. But the cookbook recipe + terradart docs should call out this teardown pattern explicitly: "If you destroyed a Cloud SQL instance with PSA peering, expect `terraform destroy` of the surrounding network resources to hang on the service_networking_connection. The workaround is to force-delete the consumer-side peering via `gcloud compute networks peerings delete servicenetworking-googleapis-com --network=<vpc> --project=<project>` before retrying."
+
+Optional terradart enhancement: a `Stack.teardown()` helper that orchestrates Cloud-SQL-PSA-aware destroy ordering, or a doc-comment on `GoogleServiceNetworkingConnection` explaining the producer-side cleanup quirk.
+
+**Tracked:** Documented in cookbook (no terradart code issue — provider behavior).
+
+## D1b (GCS backend)
+
+(filled in during the D1b apply cycle.)
+
+## v0.11.0 dogfood
+
+### README claims a `coffee_service_uri` Terraform output that the Stack does not actually emit
+
+**Context:** v0.11.0 surface fresh-state apply against `terradart-validate`. Apply succeeded (28 resources, ~9 min including Cloud SQL). Followed the README smoke section verbatim:
+
+```bash
+SERVICE_URL=$(terraform output -raw coffee_service_uri)
+curl -i "$SERVICE_URL"
+```
+
+**Friction:** `terraform output` returns `No outputs found`. The recipe Stack does not call `addExport` for `coffee_service_uri`, and the synthesized `main.tf.json` has no `output` block. The README's smoke recipe is uncopypastable as-written.
+
+Workaround used during this dogfood: `SERVICE_URL=$(gcloud run services describe coffee-shop --project terradart-validate --region asia-northeast1 --format='value(status.url)')`. GET / and POST /order both returned HTTP 200 — endpoint is healthy, only the discovery path was broken.
+
+**Proposed fix:** either (a) add `addExport('coffee_service_uri', coffeeService.uri)` in `lib/service.dart` to make the README example accurate (preferred — this is the kind of typed export that v0.11.0 `setAppExportsOutputPath` is designed to surface), or (b) replace the README smoke section with the gcloud-based URL lookup. (a) is more in the spirit of the recipe (demonstrates the AppExport feature); (b) is a one-line README change. Either way, the README and Stack should agree.
+
+**Tracked:** Documented here for the next polish wave.
+
+### `service_networking_connection` destroy fails first time; PSA workaround in README still required
+
+**Context:** v0.11.0 surface `terraform destroy` after the apply above. 26 of 28 resources destroyed cleanly on the first pass; PSA connection + dependent VPC hung with `Error code 9: Producer services (e.g. CloudSQL, Cloud Memstore, etc.) are still using this connection.`
+
+**Friction:** Same behavior the README's "Teardown gotcha" section already documents. Cloud SQL is gone (tenant-side cleanup pending), but Terraform can't proceed with the consumer-side peering until GCP's tenant-side cleanup completes (can take hours).
+
+Applied the documented workaround verbatim:
+
+```bash
+gcloud compute networks peerings delete servicenetworking-googleapis-com \
+  --network=coffee-shop-vpc --project=terradart-validate --quiet
+terraform destroy -auto-approve
+```
+
+Retry destroyed the remaining 2 resources (VPC + PSA connection) in 11s. Total teardown clean.
+
+**Proposed fix:** none for terradart or the recipe — this is GCP provider behavior. The README's existing "Teardown gotcha" section is accurate and the workaround works. Reconfirmed under v0.11.0.
+
+**Tracked:** Pre-existing finding, reconfirmed.

--- a/cookbook/single-project-app/README.md
+++ b/cookbook/single-project-app/README.md
@@ -1,0 +1,105 @@
+> Part of the [TerraDart cookbook](../README.md). Library: [terradart](https://github.com/nozomi-koborinai/terradart).
+>
+> **Status:** Verified on terradart v0.11.0. See [FRICTIONS.md](./FRICTIONS.md) for dogfood findings.
+
+# single-project-app
+
+Pattern demonstrated: **single GCP project, end-to-end app surface**. Resources span Cloud Run (compute) + Cloud SQL (datastore) + Pub/Sub (messaging) + Monitoring (observability) + Secret Manager + IAM + Service Networking. Internal sample uses "coffee shop" naming (visit `lib/main.dart` for the actual resource names) but the recipe's identity is the PATTERN, not the imagined app domain. The dogfood session surfaced 13 friction entries (logged in FRICTIONS.md) that fed v0.9 polish issues on the terradart repo — see [`terradart#52`](https://github.com/nozomi-koborinai/terradart/issues/52) and adjacent.
+
+Webhook-driven coffee order tracker. Demonstrates terradart end-to-end with a real-world stack on Google Cloud.
+
+## Architecture
+
+- Cloud Run v2 service receives webhook POSTs at `/order`.
+- Cloud SQL (Postgres, private IP) persists orders.
+- Secret Manager stores the DB password.
+- Pub/Sub topic emits `order.created` events; a Pub/Sub push subscription invokes the same Cloud Run service.
+- Cloud Monitoring covers an uptime check + alert policy + email notification channel.
+
+~30 resources across 8 terradart barrels: `project`, `iam`, `service_networking`, `compute`, `cloud_sql`, `secret_manager`, `cloud_run`, `pubsub`, `monitoring`.
+
+## Required APIs
+
+The recipe enables the following APIs via `google_project_service` resources — you do not need to enable them manually first:
+
+- `compute.googleapis.com` (Compute Engine — VPC, addresses)
+- `iam.googleapis.com` (IAM)
+- `monitoring.googleapis.com` (Cloud Monitoring)
+- `pubsub.googleapis.com` (Pub/Sub)
+- `run.googleapis.com` (Cloud Run)
+- `secretmanager.googleapis.com` (Secret Manager)
+- `servicenetworking.googleapis.com` (Service Networking — Cloud SQL private peering)
+- `sqladmin.googleapis.com` (Cloud SQL)
+
+Storage is typically already enabled on a fresh GCP project. If any of the above are missing on first apply, `terraform plan` will surface a clear 403 error pointing to the missing API.
+
+## Cost notes
+
+This recipe provisions billable resources. Rough estimates if left running 24h in `asia-northeast1`:
+
+- Cloud SQL `db-f1-micro` (Postgres): ~$8-12 / day
+- Cloud Run v2 (min-instances=0, idle): negligible until traffic arrives
+- Reserved /16 private services range + VPC peering: free
+- Pub/Sub + Monitoring + Secret Manager: negligible at this volume
+
+**Always end your dogfood session with `terraform destroy`**. The recipe is structured so destroy fully cleans up — including the SQL instance (`deletion_protection = false` is explicit in the Stack).
+
+## Run
+
+Prerequisites: `gcloud auth application-default login` for an account with Owner on the target project. Terraform 1.11+ (terradart v0.9.0 synth hardcodes `required_version: ">= 1.11.0"` — required for write-only attribute support).
+
+```bash
+export GCP_PROJECT_ID=terradart-validate
+export DB_PASSWORD=$(openssl rand -base64 24)
+export ALERT_EMAIL=kobofender@gmail.com
+
+dart pub get
+dart run bin/infra.dart           # synth -> tf-out/main.tf.json
+
+cd tf-out
+terraform init
+terraform plan
+# DB_PASSWORD flows via terradart synth → `password_wo` write-only attribute (not stored in tfstate).
+terraform apply -auto-approve
+
+# Smoke test
+SERVICE_URL=$(terraform output -raw coffee_service_uri)
+curl -i "$SERVICE_URL"
+
+terraform destroy -auto-approve
+```
+
+### Teardown gotcha
+
+If your Cloud SQL instance used a private-services-access peering (this recipe does — via `service_networking_connection`), `terraform destroy` will partially succeed and then hang on the PSA connection with `Producer services (e.g. CloudSQL, Cloud Memstore, etc.) are still using this connection.` even though Cloud SQL itself is already gone. GCP's tenant-side cleanup can take hours.
+
+**Workaround**: force-delete the consumer-side peering, then retry destroy:
+
+```bash
+gcloud compute networks peerings delete servicenetworking-googleapis-com \
+  --network=coffee-shop-vpc \
+  --project=terradart-validate \
+  --quiet
+
+# Re-run terraform destroy — refresh detects PSA connection missing,
+# proceeds with VPC + global_address cleanup.
+terraform destroy -auto-approve
+```
+
+See [FRICTIONS.md](./FRICTIONS.md) for the full context. This is a GCP / Terraform google provider behavior, not a terradart bug.
+
+## v0.9 patterns
+
+This recipe uses the terradart v0.9.0 API surface. Key changes from v0.8.0-dev:
+
+- **`LocalBackend`** — `Stack(backend: const LocalBackend())` emits `terraform.backend.local: {}` in `main.tf.json`. The handwritten `tf-out/terraform.tf` is gone.
+- **`devMode: true`** — `Stack(devMode: true)` flips `deletion_protection: false` on Cloud Run, Cloud SQL, and Secret Manager at synth time. No more per-resource `deletionProtection: TfArg.literal(false)` calls in sample code.
+- **Concrete `synth()`** — `Stack.synth()` is now a concrete default that writes `tf-out/main.tf.json`. The `@override synth(...)` boilerplate and `dart:convert` import are gone from the Stack subclass.
+- **`TfArg.variable('name')`** — route secrets through Terraform variable blocks (`${var.db_password}`) instead of masking workarounds.
+- **`.iamMember` getter** — `GoogleServiceAccount.iamMember` (was `.member`) is self-documenting at IAM binding call sites.
+- **Service-prefixed helper classes** — `SqlDatabaseInstanceSettings`, `SqlDatabaseInstanceIpConfiguration`, `SecretManagerSecretReplication`, `CloudRunV2ServiceTemplate`, `CloudRunV2ServiceServiceContainer`, `CloudRunV2ServiceEnvVar`, `PubsubSubscriptionPushConfig`, `MonitoringUptimeCheckConfigMonitoredResource`, `MonitoringAlertPolicyAlertCondition`, etc. Prevents name collisions when importing multiple barrels.
+- **Enum name polish** — `Comparison.lessThan` (was `.lt`), `Aligner.alignNextOlder` (was `.nextOlder`).
+
+## D1b — GCS backend
+
+To switch to a GCS-backed state for the second dogfood phase, see [FRICTIONS.md](./FRICTIONS.md) and the `bin/bootstrap.dart` flow.

--- a/cookbook/single-project-app/analysis_options.yaml
+++ b/cookbook/single-project-app/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/cookbook/single-project-app/bin/infra.dart
+++ b/cookbook/single-project-app/bin/infra.dart
@@ -1,0 +1,33 @@
+/// Synth entry. `dart run bin/infra.dart` -> `tf-out/main.tf.json`.
+library;
+
+import 'dart:io';
+
+import 'package:single_project_app/main.dart';
+
+Future<void> main() async {
+  final projectId = Platform.environment['GCP_PROJECT_ID'];
+  if (projectId == null || projectId.isEmpty) {
+    stderr.writeln(
+        'error: set GCP_PROJECT_ID env var (target GCP project, e.g. terradart-validate)');
+    exit(64);
+  }
+  final dbPassword = Platform.environment['DB_PASSWORD'];
+  if (dbPassword == null || dbPassword.isEmpty) {
+    stderr.writeln('error: set DB_PASSWORD env var');
+    exit(64);
+  }
+  final alertEmail = Platform.environment['ALERT_EMAIL'];
+  if (alertEmail == null || alertEmail.isEmpty) {
+    stderr.writeln(
+        'error: set ALERT_EMAIL env var (notification channel destination)');
+    exit(64);
+  }
+  final stack = SingleProjectAppStack(
+    projectId: projectId,
+    dbPassword: dbPassword,
+    alertEmail: alertEmail,
+  );
+  await stack.writeTo('tf-out');
+  print('synthesized to tf-out/main.tf.json');
+}

--- a/cookbook/single-project-app/lib/apis.dart
+++ b/cookbook/single-project-app/lib/apis.dart
@@ -1,0 +1,50 @@
+/// Tier 1: API enablement.
+library;
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/project.dart';
+
+/// All 8 project_service activations the recipe requires.
+/// Caller adds them to its Stack via `for (final api in buildProjectServices()) add(api);`.
+List<GoogleProjectService> buildProjectServices() => [
+      GoogleProjectService(
+        localName: 'api_run',
+        service: TfArg.literal('run.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+      GoogleProjectService(
+        localName: 'api_sql',
+        service: TfArg.literal('sqladmin.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+      GoogleProjectService(
+        localName: 'api_pubsub',
+        service: TfArg.literal('pubsub.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+      GoogleProjectService(
+        localName: 'api_monitoring',
+        service: TfArg.literal('monitoring.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+      GoogleProjectService(
+        localName: 'api_secret',
+        service: TfArg.literal('secretmanager.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+      GoogleProjectService(
+        localName: 'api_iam',
+        service: TfArg.literal('iam.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+      GoogleProjectService(
+        localName: 'api_compute',
+        service: TfArg.literal('compute.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+      GoogleProjectService(
+        localName: 'api_servicenetworking',
+        service: TfArg.literal('servicenetworking.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+    ];

--- a/cookbook/single-project-app/lib/datastore.dart
+++ b/cookbook/single-project-app/lib/datastore.dart
@@ -1,0 +1,65 @@
+/// Tier 3: Datastore (private Cloud SQL) + Secret.
+library;
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/cloud_sql.dart';
+import 'package:terradart_google/compute.dart';
+import 'package:terradart_google/secret_manager.dart';
+import 'package:terradart_google/service_networking.dart';
+
+GoogleSqlDatabaseInstance buildSqlInstance({
+  required GoogleComputeNetwork vpc,
+  required GoogleServiceNetworkingConnection psaConnection,
+}) =>
+    GoogleSqlDatabaseInstance(
+      localName: 'coffee_sql',
+      name: TfArg.literal('coffee-shop-sql'),
+      databaseVersion: TfArg.literal(DatabaseVersion.postgres15),
+      region: TfArg.literal('asia-northeast1'),
+      deletionProtection: TfArg.literal(false),
+      settings: SqlDatabaseInstanceSettings(
+        tier: TfArg.literal('db-f1-micro'),
+        ipConfiguration: SqlDatabaseInstanceIpConfiguration(
+          ipv4Enabled: TfArg.literal(false),
+          privateNetwork: TfArg.ref(vpc.selfLink),
+        ),
+      ),
+      // SQL instance requires PSA peering active; declared via the typed
+      // ResourceDependency builder (terradart_core exposes a first-class
+      // `dependsOn: List<DependencyTarget>?` parameter).
+      dependsOn: [ResourceDependency(psaConnection)],
+    );
+
+GoogleSqlDatabase buildSqlDatabase(GoogleSqlDatabaseInstance sqlInstance) =>
+    GoogleSqlDatabase(
+      localName: 'coffee_db',
+      name: TfArg.literal('coffee_orders'),
+      instance: TfArg.ref(sqlInstance.nameRef),
+    );
+
+GoogleSqlUser buildSqlUser(
+        GoogleSqlDatabaseInstance sqlInstance, String dbPassword) =>
+    GoogleSqlUser(
+      localName: 'coffee_user',
+      name: TfArg.literal('coffee_app'),
+      instance: TfArg.ref(sqlInstance.nameRef),
+      passwordWo: TfArg.literal(dbPassword),
+      passwordWoVersion: TfArg.literal(1),
+    );
+
+GoogleSecretManagerSecret buildDbPasswordSecret() => GoogleSecretManagerSecret(
+      localName: 'db_password',
+      secretId: TfArg.literal('coffee-shop-db-password'),
+      replication: SecretManagerSecretReplication.auto(),
+    );
+
+GoogleSecretManagerSecretVersion buildDbPasswordSecretVersion(
+  GoogleSecretManagerSecret secret,
+  String dbPassword,
+) =>
+    GoogleSecretManagerSecretVersion(
+      localName: 'db_password_v1',
+      secret: TfArg.ref(secret.id),
+      secretDataWo: TfArg.literal(dbPassword),
+      secretDataWoVersion: TfArg.literal(1),
+    );

--- a/cookbook/single-project-app/lib/generated/single_project_app.app.dart
+++ b/cookbook/single-project-app/lib/generated/single_project_app.app.dart
@@ -1,0 +1,14 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// terradart synth output for stack: SingleProjectAppStack
+// dart format off
+// ignore_for_file: type=lint
+
+abstract final class SingleProjectAppStackExports {
+  SingleProjectAppStackExports._();
+
+  /// Cloud Run v2 service name. Matches the Terraform resource name.
+  static const String SERVICE_NAME = r'coffee-shop';
+
+  /// GCP region this recipe deploys into.
+  static const String REGION = r'asia-northeast1';
+}

--- a/cookbook/single-project-app/lib/iam.dart
+++ b/cookbook/single-project-app/lib/iam.dart
@@ -1,0 +1,48 @@
+/// Tier 4: IAM (service account + role bindings).
+library;
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/iam.dart';
+import 'package:terradart_google/secret_manager.dart';
+
+GoogleServiceAccount buildRunSa() => GoogleServiceAccount(
+      localName: 'run_sa',
+      accountId: TfArg.literal('coffee-run-sa'),
+      displayName: TfArg.literal('Coffee Shop Cloud Run SA'),
+    );
+
+List<GoogleProjectIamMember> buildProjectIamBindings({
+  required String projectId,
+  required GoogleServiceAccount runSa,
+}) =>
+    [
+      GoogleProjectIamMember(
+        localName: 'run_sa_sql_client',
+        project: TfArg.literal(projectId),
+        role: TfArg.literal('roles/cloudsql.client'),
+        member: TfArg.ref(runSa.iamMember),
+      ),
+      GoogleProjectIamMember(
+        localName: 'run_sa_log_writer',
+        project: TfArg.literal(projectId),
+        role: TfArg.literal('roles/logging.logWriter'),
+        member: TfArg.ref(runSa.iamMember),
+      ),
+      GoogleProjectIamMember(
+        localName: 'run_sa_monitoring_writer',
+        project: TfArg.literal(projectId),
+        role: TfArg.literal('roles/monitoring.metricWriter'),
+        member: TfArg.ref(runSa.iamMember),
+      ),
+    ];
+
+GoogleSecretManagerSecretIamMember buildSecretIamMember(
+  GoogleSecretManagerSecret dbPasswordSecret,
+  GoogleServiceAccount runSa,
+) =>
+    GoogleSecretManagerSecretIamMember(
+      localName: 'db_password_access',
+      secretId: TfArg.ref(dbPasswordSecret.id),
+      role: TfArg.literal('roles/secretmanager.secretAccessor'),
+      member: TfArg.ref(runSa.iamMember),
+    );

--- a/cookbook/single-project-app/lib/main.dart
+++ b/cookbook/single-project-app/lib/main.dart
@@ -1,0 +1,125 @@
+/// single-project-app recipe — webhook on Cloud Run with private Cloud SQL,
+/// Pub/Sub event ingestion, and Monitoring coverage. Single-GCP-project
+/// pattern: all resources live in one project, no cross-project IAM, local
+/// `tf-out/` working dir.
+///
+/// The Stack composition is split across per-service files (`apis.dart`,
+/// `network.dart`, `datastore.dart`, `iam.dart`, `service.dart`,
+/// `observability.dart`), each exposing pure builder functions that RETURN
+/// constructed resources. `main.dart` is the only place that calls
+/// `Stack.add(...)`, so the whole composition is visible at a glance.
+library;
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/provider.dart';
+
+import 'apis.dart';
+import 'datastore.dart';
+import 'iam.dart';
+import 'network.dart';
+import 'observability.dart';
+import 'service.dart';
+
+final class SingleProjectAppStack extends Stack {
+  SingleProjectAppStack({
+    required this.projectId,
+    required this.dbPassword,
+    required this.alertEmail,
+  }) : super(
+          providers: [
+            GoogleProvider(project: projectId, region: 'asia-northeast1'),
+          ],
+          backend: const LocalBackend(),
+          devMode: true,
+        ) {
+    // ===== Tier 1 — API enablement (8 services) ===========================
+    for (final api in buildProjectServices()) {
+      add(api);
+    }
+
+    // ===== Tier 2 — Network (VPC + PSA chain) =============================
+    final vpc = add(buildVpc());
+    add(buildPsaRange(vpc));
+    final psaConnection = add(buildPsaConnection(vpc));
+
+    // ===== Tier 3 — Datastore (Cloud SQL + Secret Manager) ================
+    final sqlInstance = add(buildSqlInstance(
+      vpc: vpc,
+      psaConnection: psaConnection,
+    ));
+    final sqlDatabase = add(buildSqlDatabase(sqlInstance));
+    add(buildSqlUser(sqlInstance, dbPassword));
+    final dbPasswordSecret = add(buildDbPasswordSecret());
+    add(buildDbPasswordSecretVersion(dbPasswordSecret, dbPassword));
+
+    // ===== Tier 4 — IAM (SA + role bindings + secret access) ==============
+    final runSa = add(buildRunSa());
+    for (final binding in buildProjectIamBindings(
+      projectId: projectId,
+      runSa: runSa,
+    )) {
+      add(binding);
+    }
+    add(buildSecretIamMember(dbPasswordSecret, runSa));
+
+    // ===== Tier 5 — Cloud Run v2 service ==================================
+    final coffeeService = add(buildCloudRunService(
+      runSa: runSa,
+      sqlInstance: sqlInstance,
+      sqlDatabase: sqlDatabase,
+      dbPasswordSecret: dbPasswordSecret,
+    ));
+    add(buildCloudRunInvoker(coffeeService));
+
+    // ===== Tier 6 — Pub/Sub + Monitoring ==================================
+    final orderTopic = add(buildOrderTopic());
+    add(buildOrderSubscription(
+      orderTopic: orderTopic,
+      coffeeService: coffeeService,
+      runSa: runSa,
+    ));
+    final emailChannel = add(buildEmailChannel(alertEmail));
+    add(buildUptimeCheck(coffeeService));
+    add(buildDownAlert(emailChannel));
+
+    // ===== AppExports — IaC ↔ application seam =============================
+    // `coffee_service_uri` is apply-time known (Cloud Run assigns the URL),
+    // so it surfaces as a Terraform output that the README's smoke recipe
+    // consumes via `terraform output -raw coffee_service_uri`.
+    //
+    // `SERVICE_NAME` and `REGION` are synth-time literals — `setAppExports`
+    // materialises them as `const` declarations in
+    // `lib/generated/single_project_app.app.dart`, giving any consumer that
+    // depends on this package typed (rename-safe) access without duplicating
+    // the string literals across the codebase.
+    addExport(
+      'coffee_service_uri',
+      ResourceIdExport(
+        coffeeService.uri,
+        emitTerraformOutput: true,
+        description:
+            'URL of the Cloud Run v2 service. Populated after terraform apply.',
+      ),
+    );
+    addExport(
+      'SERVICE_NAME',
+      StringExport(
+        'coffee-shop',
+        description:
+            'Cloud Run v2 service name. Matches the Terraform resource name.',
+      ),
+    );
+    addExport(
+      'REGION',
+      StringExport(
+        'asia-northeast1',
+        description: 'GCP region this recipe deploys into.',
+      ),
+    );
+    setAppExportsOutputPath('lib/generated/single_project_app.app.dart');
+  }
+
+  final String projectId;
+  final String dbPassword;
+  final String alertEmail;
+}

--- a/cookbook/single-project-app/lib/network.dart
+++ b/cookbook/single-project-app/lib/network.dart
@@ -1,0 +1,33 @@
+/// Tier 2: Network (VPC + private services peering).
+library;
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/compute.dart';
+import 'package:terradart_google/service_networking.dart';
+
+GoogleComputeNetwork buildVpc() => GoogleComputeNetwork(
+      localName: 'coffee_vpc',
+      name: TfArg.literal('coffee-shop-vpc'),
+      autoCreateSubnetworks: TfArg.literal(false),
+    );
+
+GoogleComputeGlobalAddress buildPsaRange(GoogleComputeNetwork vpc) =>
+    GoogleComputeGlobalAddress(
+      localName: 'psa_range',
+      name: TfArg.literal('coffee-shop-psa-range'),
+      addressType: TfArg.literal(GlobalAddressType.internal),
+      purpose: TfArg.literal(GlobalAddressPurpose.vpcPeering),
+      prefixLength: TfArg.literal(16),
+      network: TfArg.ref(vpc.selfLink),
+    );
+
+GoogleServiceNetworkingConnection buildPsaConnection(
+        GoogleComputeNetwork vpc) =>
+    GoogleServiceNetworkingConnection(
+      localName: 'psa',
+      network: TfArg.ref(vpc.selfLink),
+      service: TfArg.literal('servicenetworking.googleapis.com'),
+      reservedPeeringRanges: TfArg.literal([
+        '\${google_compute_global_address.psa_range.name}',
+      ]),
+    );

--- a/cookbook/single-project-app/lib/observability.dart
+++ b/cookbook/single-project-app/lib/observability.dart
@@ -1,0 +1,99 @@
+/// Tier 6: Pub/Sub eventing + Monitoring.
+library;
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/cloud_run.dart';
+import 'package:terradart_google/iam.dart';
+import 'package:terradart_google/monitoring.dart';
+import 'package:terradart_google/pubsub.dart';
+
+GooglePubsubTopic buildOrderTopic() => GooglePubsubTopic(
+      localName: 'orders_topic',
+      name: TfArg.literal('coffee-orders'),
+    );
+
+/// Push subscription invokes the Cloud Run service with an OIDC token signed
+/// for the runSa identity. The Cloud Run invoker IAM in Tier 5 was set to
+/// allUsers, so runSa is a valid invoker.
+///
+/// NOTE: `topic` must reference the topic's `.id` (full path
+/// `projects/{project}/topics/{name}`), NOT `.nameRef`. See the dartdoc on
+/// `google_pubsub_subscription.dart` — the provider expects the full resource
+/// path here.
+GooglePubsubSubscription buildOrderSubscription({
+  required GooglePubsubTopic orderTopic,
+  required GoogleCloudRunV2Service coffeeService,
+  required GoogleServiceAccount runSa,
+}) =>
+    GooglePubsubSubscription(
+      localName: 'orders_subscription',
+      name: TfArg.literal('coffee-orders-sub'),
+      topic: TfArg.ref(orderTopic.id),
+      pushConfig: PubsubSubscriptionPushConfig(
+        pushEndpoint: TfArg.ref(coffeeService.uri),
+        oidcToken: PubsubSubscriptionOidcToken(
+          serviceAccountEmail: TfArg.ref(runSa.email),
+        ),
+      ),
+    );
+
+GoogleMonitoringNotificationChannel buildEmailChannel(String alertEmail) =>
+    GoogleMonitoringNotificationChannel(
+      localName: 'email_channel',
+      displayName: TfArg.literal('Coffee Shop email'),
+      type: TfArg.literal('email'),
+      labels: TfArg.literal({'email_address': alertEmail}),
+    );
+
+GoogleMonitoringUptimeCheckConfig buildUptimeCheck(
+  GoogleCloudRunV2Service coffeeService,
+) =>
+    GoogleMonitoringUptimeCheckConfig(
+      localName: 'coffee_uptime',
+      displayName: TfArg.literal('Coffee Shop uptime'),
+      timeout: TfArg.literal('10s'),
+      period: TfArg.literal('60s'),
+      target: MonitoringUptimeCheckConfigMonitoredResource(
+        type: TfArg.literal('uptime_url'),
+        labels: {
+          'host':
+              '\${replace(replace(google_cloud_run_v2_service.coffee_service.uri, "https://", ""), "/", "")}',
+        },
+      ),
+      httpCheck: MonitoringUptimeCheckConfigHttpCheck(
+        path: TfArg.literal('/'),
+        port: TfArg.literal(443),
+        useSsl: TfArg.literal(true),
+      ),
+    );
+
+GoogleMonitoringAlertPolicy buildDownAlert(
+  GoogleMonitoringNotificationChannel emailChannel,
+) =>
+    GoogleMonitoringAlertPolicy(
+      localName: 'coffee_down',
+      displayName: TfArg.literal('Coffee Shop down'),
+      combiner: TfArg.literal(AlertCombiner.or),
+      conditions: [
+        MonitoringAlertPolicyAlertCondition(
+          displayName: TfArg.literal('uptime check failing'),
+          conditionThreshold: MonitoringAlertPolicyConditionThreshold(
+            filter: TfArg.literal(
+              'metric.type="monitoring.googleapis.com/uptime_check/check_passed" AND resource.type="uptime_url" AND metric.labels.check_id="\${google_monitoring_uptime_check_config.coffee_uptime.uptime_check_id}"',
+            ),
+            comparison: TfArg.literal(Comparison.lessThan),
+            thresholdValue: TfArg.literal(1),
+            duration: TfArg.literal('60s'),
+            aggregations: [
+              MonitoringAlertPolicyAggregation(
+                alignmentPeriod: TfArg.literal('60s'),
+                perSeriesAligner: Aligner.alignNextOlder,
+              ),
+            ],
+          ),
+        ),
+      ],
+      notificationChannels: TfArg.literal([
+        '\${google_monitoring_notification_channel.email_channel.name}',
+      ]),
+    );

--- a/cookbook/single-project-app/lib/service.dart
+++ b/cookbook/single-project-app/lib/service.dart
@@ -1,0 +1,72 @@
+/// Tier 5: Cloud Run v2 service.
+library;
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/cloud_run.dart';
+import 'package:terradart_google/cloud_sql.dart';
+import 'package:terradart_google/iam.dart';
+import 'package:terradart_google/secret_manager.dart';
+
+GoogleCloudRunV2Service buildCloudRunService({
+  required GoogleServiceAccount runSa,
+  required GoogleSqlDatabaseInstance sqlInstance,
+  required GoogleSqlDatabase sqlDatabase,
+  required GoogleSecretManagerSecret dbPasswordSecret,
+}) =>
+    GoogleCloudRunV2Service(
+      localName: 'coffee_service',
+      name: TfArg.literal('coffee-shop'),
+      location: TfArg.literal('asia-northeast1'),
+      ingress: TfArg.literal(Ingress.all),
+      deletionProtection: TfArg.literal(false),
+      template: CloudRunV2ServiceTemplate(
+        serviceAccount: TfArg.ref(runSa.email),
+        containers: [
+          CloudRunV2ServiceServiceContainer(
+            image: TfArg.literal(
+              'us-docker.pkg.dev/cloudrun/container/hello',
+            ),
+            env: [
+              CloudRunV2ServiceEnvVar(
+                name: TfArg.literal('DB_INSTANCE'),
+                source: CloudRunV2ServiceEnvVarFromLiteral(
+                  TfArg.ref(sqlInstance.connectionName),
+                ),
+              ),
+              CloudRunV2ServiceEnvVar(
+                name: TfArg.literal('DB_NAME'),
+                source: CloudRunV2ServiceEnvVarFromLiteral(
+                  TfArg.ref(sqlDatabase.nameRef),
+                ),
+              ),
+              CloudRunV2ServiceEnvVar(
+                name: TfArg.literal('DB_USER'),
+                source: CloudRunV2ServiceEnvVarFromLiteral(
+                  TfArg.literal('coffee_app'),
+                ),
+              ),
+              CloudRunV2ServiceEnvVar(
+                name: TfArg.literal('DB_PASSWORD'),
+                source: CloudRunV2ServiceEnvVarFromSecret(
+                  secret: TfArg.ref(dbPasswordSecret.id),
+                  version: TfArg.literal('latest'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+
+GoogleCloudRunV2ServiceIamMember buildCloudRunInvoker(
+  GoogleCloudRunV2Service coffeeService,
+) =>
+    GoogleCloudRunV2ServiceIamMember(
+      localName: 'coffee_invoker',
+      name: TfArg.ref(coffeeService.nameRef),
+      location: TfArg.literal('asia-northeast1'),
+      role: TfArg.literal('roles/run.invoker'),
+      // allUsers = public webhook. Acceptable for dogfood smoke; harden in
+      // production by replacing with the upstream Pub/Sub push SA or similar.
+      member: TfArg.literal('allUsers'),
+    );

--- a/cookbook/single-project-app/pubspec.yaml
+++ b/cookbook/single-project-app/pubspec.yaml
@@ -1,0 +1,18 @@
+name: single_project_app
+description: terradart cookbook recipe — single-project Cloud Run + Cloud SQL + Pub/Sub + Monitoring webhook stack. Sample uses "coffee shop" naming inside but the recipe pattern is "1 GCP project, end-to-end app surface".
+homepage: https://github.com/nozomi-koborinai/terradart/tree/main/cookbook/single-project-app
+repository: https://github.com/nozomi-koborinai/terradart
+publish_to: none
+version: 0.1.0
+
+environment:
+  sdk: ^3.6.0
+
+resolution: workspace
+
+dependencies:
+  terradart_core: ^0.21.0
+  terradart_google: ^0.21.0
+
+dev_dependencies:
+  lints: ^6.0.0

--- a/examples/firestore_document_quickstart/README.md
+++ b/examples/firestore_document_quickstart/README.md
@@ -7,7 +7,7 @@ the `FirestoreFields.encode` helper.
 
 For a more complete cookbook recipe (4 collections, 11 documents,
 composite index, daily backup schedule), see
-`terradart-cookbook/recipes/firestore-seeded-data/`.
+[`../../cookbook/firestore-seeded-data/`](../../cookbook/firestore-seeded-data/).
 
 ## Prerequisites
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  buffer:
+    dependency: transitive
+    description:
+      name: buffer
+      sha256: "389da2ec2c16283c8787e0adaede82b1842102f8c8aae2f49003a766c5c6b3d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
   build:
     dependency: transitive
     description:
@@ -49,6 +57,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.6"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  build_runner:
+    dependency: transitive
+    description:
+      name: build_runner
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -73,6 +105,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
   cli_config:
     dependency: transitive
     description:
@@ -185,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.2"
+  genkit_google_genai:
+    dependency: transitive
+    description:
+      name: genkit_google_genai
+      sha256: e5cb3a3764650d2ef05a8c0b33385e0deab2376d57046f1adaa2ba2c6d3ee8d9
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.7"
   genkit_mcp:
     dependency: transitive
     description:
@@ -193,6 +249,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.7"
+  genkit_shelf:
+    dependency: transitive
+    description:
+      name: genkit_shelf
+      sha256: "479e0839b2a22bbc25b6ab65b4c465a43a553cb87284727258f96190525d6fdd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.7"
+  genkit_vertex_auth:
+    dependency: transitive
+    description:
+      name: genkit_vertex_auth
+      sha256: "4407de7568bd3e901cd87401335aa680107f705ff9be2284204fe6afb0b164dd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.7"
+  genkit_vertexai:
+    dependency: transitive
+    description:
+      name: genkit_vertexai
+      sha256: "604cc22252f0bdc9448369209b1a62811b4bf67a4ddcb0e9de4618839d1969cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.7"
   glob:
     dependency: transitive
     description:
@@ -201,6 +281,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_cloud:
+    dependency: transitive
+    description:
+      name: google_cloud
+      sha256: b385e20726ef5315d302c5933bfb728103116c5be2d3d17094b01a82da538c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      sha256: "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+1"
+  googleapis_auth:
+    dependency: transitive
+    description:
+      name: googleapis_auth
+      sha256: "1417d8846663df5e7b77ca56591c5edd442c66ffc9c01ab036e138a21a148e86"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   http:
     dependency: "direct dev"
     description:
@@ -209,6 +321,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
+  http_methods:
+    dependency: transitive
+    description:
+      name: http_methods
+      sha256: "6bccce8f1ec7b5d701e7921dca35e202d425b57e317ba1a37f2638590e29e566"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -337,6 +457,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  postgres:
+    dependency: transitive
+    description:
+      name: postgres
+      sha256: "123de5cbadc56a7e8d9fa485c780b6b56940b4081f4c74f3a5578682757c299b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.12"
   protobuf:
     dependency: transitive
     description:
@@ -353,6 +481,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   quiver:
     dependency: transitive
     description:
@@ -393,6 +529,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  shelf_router:
+    dependency: transitive
+    description:
+      name: shelf_router
+      sha256: f5e5d492440a7fb165fe1e2e1a623f31f734d3370900070b2b1e0d0428d59864
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.4"
   shelf_static:
     dependency: transitive
     description:
@@ -457,6 +601,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,12 @@ workspace:
   - examples/vertex_ai_quickstart
   - examples/workflows_quickstart
   - examples/app_engine_quickstart
+  - cookbook/single-project-app
+  - cookbook/firestore-seeded-data
+  - cookbook/remote-backend
+  - cookbook/lunch-concierge/shared
+  - cookbook/lunch-concierge/server
+  - cookbook/lunch-concierge/infra
 dev_dependencies:
   args: any
   meta: any

--- a/website/src/content/docs/docs/architecture.mdx
+++ b/website/src/content/docs/docs/architecture.mdx
@@ -61,7 +61,7 @@ final class AppInfraStack extends Stack { /* ... */ }
 
 ## Provider integration
 
-[`terradart_google`](https://pub.dev/packages/terradart_google) ships a **curated** subset of the HashiCorp [`google`](https://registry.terraform.io/providers/hashicorp/google/latest) provider — typed factories for common services, expanded release by release. It does not wrap every resource block in the upstream provider yet. See [status](/docs/status/) and the [package README](https://pub.dev/packages/terradart_google) for what is available today; [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart-cookbook) add fuller stacks over time.
+[`terradart_google`](https://pub.dev/packages/terradart_google) ships a **curated** subset of the HashiCorp [`google`](https://registry.terraform.io/providers/hashicorp/google/latest) provider — typed factories for common services, expanded release by release. It does not wrap every resource block in the upstream provider yet. See [status](/docs/status/) and the [package README](https://pub.dev/packages/terradart_google) for what is available today; [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook) add fuller stacks over time.
 
 TerraDart depends on the Google Terraform provider via two upstream sources, both reconciled automatically on a weekly cadence.
 
@@ -104,7 +104,7 @@ Two export kinds cover most cases:
 
 Calling `setAppExportsOutputPath(...)` is what triggers the `.app.dart` emission. Exports whose values are only known after apply (for example `ResourceIdExport(topic.id)`) emit Terraform `output` blocks only; literal-resolvable exports (for example `ResourceIdExport(topic.nameRef)`) become typed Dart constants. Runnable pattern: [pubsub quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart) (`lib/subscriber_stub.dart`).
 
-A worked end-to-end example lives in the [terradart-cookbook `single-project-app` recipe](https://github.com/nozomi-koborinai/terradart-cookbook/tree/main/recipes/single-project-app), exporting `coffee_service_uri` (Terraform output), `SERVICE_NAME`, and `REGION` (Dart constants).
+A worked end-to-end example lives in the [cookbook `single-project-app` recipe](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook/single-project-app), exporting `coffee_service_uri` (Terraform output), `SERVICE_NAME`, and `REGION` (Dart constants).
 
 ## Non-goals
 

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -100,4 +100,4 @@ Rename `orders-prod` in the Stack without updating the subscriber and `dart anal
 - [Waves 23–24](/docs/waves/) — latest curated factories (v0.12.10)
 - [Migrating](/docs/migrating/) — read before bumping from `0.12.9`
 - [Status & versioning](/docs/status/) — pre-alpha vs beta vs 1.0
-- [Examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and [cookbook](https://github.com/nozomi-koborinai/terradart-cookbook) for fuller stacks
+- [Examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook) for fuller stacks

--- a/website/src/content/docs/docs/status.md
+++ b/website/src/content/docs/docs/status.md
@@ -48,7 +48,7 @@ We will label the project **beta** starting with **v0.15.0** when every **requir
 
 - [x] **`MIGRATING.md` / site migration guide** — [Migrating](/docs/migrating/) mirrors the `0.12.9 → 0.12.10` breaking changes; [MIGRATING.md on GitHub](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) remains canonical for older releases. *Two-minor depth across minors remains a beta quality bar for current and future minor releases.*
 - [ ] **External quickstart**: someone outside the core team completes the README path once; feedback captured in an issue or discussion.
-- [ ] **Real apply dogfood** via [terradart-cookbook](https://github.com/nozomi-koborinai/terradart-cookbook): at least one non-trivial recipe documents a successful `terraform apply`.
+- [ ] **Real apply dogfood** via the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook): at least one non-trivial recipe documents a successful `terraform apply`.
 - [ ] **`terradart-mcp`**: [Agent install](/docs/agent/install/) verified on a clean machine (Homebrew or release binary + five tools).
 - [ ] **1.0.0 criteria** drafted (what “stable” means for curated names and `terradart_core` API).
 

--- a/website/src/content/docs/docs/why-terradart.mdx
+++ b/website/src/content/docs/docs/why-terradart.mdx
@@ -96,7 +96,7 @@ HCL has provider schema types; CDKTF bindings are typed in TypeScript and other 
 
 ## Curated provider coverage
 
-[`terradart_google`](https://pub.dev/packages/terradart_google) does not wrap every resource in the upstream HashiCorp `google` provider. It ships **typed factories for a growing, battle-tested subset** — **206 curated resource factories + 1 data source** (210 catalog entries) on open expansion PRs. Recent additions are documented in [Waves 23–35](/docs/waves/); see also [status](/docs/status/) and [Architecture — Provider integration](/docs/architecture/#provider-integration). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart-cookbook) (both expanding). Upgrading from `0.12.9`? Read [Migrating](/docs/migrating/) first.
+[`terradart_google`](https://pub.dev/packages/terradart_google) does not wrap every resource in the upstream HashiCorp `google` provider. It ships **typed factories for a growing, battle-tested subset** — **206 curated resource factories + 1 data source** (210 catalog entries) on open expansion PRs. Recent additions are documented in [Waves 23–35](/docs/waves/); see also [status](/docs/status/) and [Architecture — Provider integration](/docs/architecture/#provider-integration). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook) (both expanding). Upgrading from `0.12.9`? Read [Migrating](/docs/migrating/) first.
 
 ## Non-goals
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move the existing TerraDart cookbook recipes into the main monorepo under `cookbook/` and wire them into the Dart workspace.
- Add `cookbook/lunch-concierge`, a full-stack demo recipe with Flutter Web, a Shelf/Genkit Vertex AI server, generated AppExport constants, Cloud Run sidecar, private Cloud SQL, VPC/PSA, IAM, and Artifact Registry infrastructure.
- Update docs and example links to point at the monorepo cookbook.

## Verification
- `dart pub get`
- `dart run build_runner build --delete-conflicting-outputs` in `cookbook/lunch-concierge/server`
- `dart format cookbook/lunch-concierge/client cookbook/lunch-concierge/server cookbook/lunch-concierge/infra cookbook/lunch-concierge/shared`
- `dart analyze cookbook/lunch-concierge/server cookbook/lunch-concierge/infra cookbook/lunch-concierge/shared cookbook/single-project-app cookbook/firestore-seeded-data cookbook/remote-backend`
- `GCP_PROJECT_ID=flutter-gakkai-10 IMAGE_URI=asia-northeast1-docker.pkg.dev/flutter-gakkai-10/lunch-concierge/app:demo INVOKER_EMAIL=demo@example.com dart run bin/infra.dart` in `cookbook/lunch-concierge/infra`
- `terraform init -backend=false && terraform validate` in `cookbook/lunch-concierge/infra/tf-out`
- `dart compile exe bin/server.dart -o /tmp/lunch_concierge_server` in `cookbook/lunch-concierge/server`
- `tool/agent_verify.sh` currently fails at the existing `check_override_enum_gaps` step with 26 enum gaps; earlier steps complete successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e83b1ee-fb3a-4549-8826-cf7caa0f462d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e83b1ee-fb3a-4549-8826-cf7caa0f462d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

