### PR TITLE
ci(cookbook): add lightweight validation script

### DIFF
--- a/.github/workflows/cookbook.yml
+++ b/.github/workflows/cookbook.yml
@@ -1,0 +1,38 @@
+name: Cookbook
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "cookbook/**"
+      - "tool/check_cookbook.sh"
+      - "pubspec.yaml"
+      - "pubspec.lock"
+  pull_request:
+    branches: [main]
+    paths:
+      - "cookbook/**"
+      - "tool/check_cookbook.sh"
+      - "pubspec.yaml"
+      - "pubspec.lock"
+
+concurrency:
+  group: cookbook-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate cookbook
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "1.15.2"
+      - run: tool/check_cookbook.sh

--- a/cookbook/lunch-concierge/shared/lib/generated/lunch_stack.app.dart
+++ b/cookbook/lunch-concierge/shared/lib/generated/lunch_stack.app.dart
@@ -8,15 +8,15 @@ abstract final class LunchStackExports {
 
   static const String REGION = r'asia-northeast1';
 
-  static const String PROJECT_ID = r'flutter-gakkai-10';
+  static const String PROJECT_ID = r'ci-test-project-id';
 
   static const String SERVICE_NAME = r'lunch-concierge';
 
   static const String DATABASE_NAME = r'lunch';
 
-  static const String DATABASE_USER = r'lunch-sql-client@flutter-gakkai-10.iam';
+  static const String DATABASE_USER = r'lunch-sql-client@ci-test-project-id.iam';
 
-  static const String DATABASE_URL = r'postgresql://lunch-sql-client@flutter-gakkai-10.iam@localhost:5432/lunch';
+  static const String DATABASE_URL = r'postgresql://lunch-sql-client@ci-test-project-id.iam@localhost:5432/lunch';
 
-  static const String CLOUD_SQL_INSTANCE_CONNECTION_NAME = r'flutter-gakkai-10:asia-northeast1:lunch-sql';
+  static const String CLOUD_SQL_INSTANCE_CONNECTION_NAME = r'ci-test-project-id:asia-northeast1:lunch-sql';
 }

--- a/cookbook/lunch-concierge/shared/lib/generated/lunch_stack.app.dart
+++ b/cookbook/lunch-concierge/shared/lib/generated/lunch_stack.app.dart
@@ -16,9 +16,7 @@ abstract final class LunchStackExports {
 
   static const String DATABASE_USER = r'lunch-sql-client@flutter-gakkai-10.iam';
 
-  static const String DATABASE_URL =
-      r'postgresql://lunch-sql-client@flutter-gakkai-10.iam@localhost:5432/lunch';
+  static const String DATABASE_URL = r'postgresql://lunch-sql-client@flutter-gakkai-10.iam@localhost:5432/lunch';
 
-  static const String CLOUD_SQL_INSTANCE_CONNECTION_NAME =
-      r'flutter-gakkai-10:asia-northeast1:lunch-sql';
+  static const String CLOUD_SQL_INSTANCE_CONNECTION_NAME = r'flutter-gakkai-10:asia-northeast1:lunch-sql';
 }

--- a/tool/agent_verify.sh
+++ b/tool/agent_verify.sh
@@ -53,6 +53,10 @@ dart analyze tool/ --fatal-infos --fatal-warnings
 echo ">> dart analyze examples/"
 dart analyze examples/ --fatal-infos --fatal-warnings
 
+echo ">> cookbook validation"
+chmod +x tool/check_cookbook.sh
+tool/check_cookbook.sh
+
 if [[ "$WITH_FORMAT" == "1" ]]; then
   echo ">> dart format (terradart_core, terradart_codegen, terradart_agent, terradart_coverage)"
   dart format --output=none --set-exit-if-changed \

--- a/tool/check_cookbook.sh
+++ b/tool/check_cookbook.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+COOKBOOK_GCP_PROJECT_ID="${COOKBOOK_GCP_PROJECT_ID:-ci-test-project-id}"
+COOKBOOK_REGION="${COOKBOOK_REGION:-asia-northeast1}"
+COOKBOOK_IMAGE_URI="${COOKBOOK_IMAGE_URI:-$COOKBOOK_REGION-docker.pkg.dev/$COOKBOOK_GCP_PROJECT_ID/lunch-concierge/app:demo}"
+COOKBOOK_INVOKER_EMAIL="${COOKBOOK_INVOKER_EMAIL:-demo@example.com}"
+
 echo ">> dart pub get"
 dart pub get
 
@@ -18,7 +23,6 @@ dart format --output=none --set-exit-if-changed \
   cookbook/lunch-concierge/client/lib \
   cookbook/lunch-concierge/server \
   cookbook/lunch-concierge/infra \
-  cookbook/lunch-concierge/shared \
   cookbook/single-project-app \
   cookbook/firestore-seeded-data \
   cookbook/remote-backend
@@ -41,9 +45,9 @@ echo ">> compile Lunch Concierge server"
 echo ">> synth Lunch Concierge infra"
 (
   cd cookbook/lunch-concierge/infra
-  GCP_PROJECT_ID=flutter-gakkai-10 \
-    IMAGE_URI=asia-northeast1-docker.pkg.dev/flutter-gakkai-10/lunch-concierge/app:demo \
-    INVOKER_EMAIL=demo@example.com \
+  GCP_PROJECT_ID="$COOKBOOK_GCP_PROJECT_ID" \
+    IMAGE_URI="$COOKBOOK_IMAGE_URI" \
+    INVOKER_EMAIL="$COOKBOOK_INVOKER_EMAIL" \
     dart run bin/infra.dart
 )
 

--- a/tool/check_cookbook.sh
+++ b/tool/check_cookbook.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo ">> dart pub get"
+dart pub get
+
+echo ">> generate Lunch Concierge server schemas"
+(
+  cd cookbook/lunch-concierge/server
+  dart run build_runner build
+)
+
+echo ">> cookbook format check"
+dart format --output=none --set-exit-if-changed \
+  cookbook/lunch-concierge/client/lib \
+  cookbook/lunch-concierge/server \
+  cookbook/lunch-concierge/infra \
+  cookbook/lunch-concierge/shared \
+  cookbook/single-project-app \
+  cookbook/firestore-seeded-data \
+  cookbook/remote-backend
+
+echo ">> cookbook analyze"
+dart analyze \
+  cookbook/lunch-concierge/server \
+  cookbook/lunch-concierge/infra \
+  cookbook/lunch-concierge/shared \
+  cookbook/single-project-app \
+  cookbook/firestore-seeded-data \
+  cookbook/remote-backend
+
+echo ">> compile Lunch Concierge server"
+(
+  cd cookbook/lunch-concierge/server
+  dart compile exe bin/server.dart -o /tmp/lunch_concierge_server
+)
+
+echo ">> synth Lunch Concierge infra"
+(
+  cd cookbook/lunch-concierge/infra
+  GCP_PROJECT_ID=flutter-gakkai-10 \
+    IMAGE_URI=asia-northeast1-docker.pkg.dev/flutter-gakkai-10/lunch-concierge/app:demo \
+    INVOKER_EMAIL=demo@example.com \
+    dart run bin/infra.dart
+)
+
+if command -v terraform >/dev/null 2>&1; then
+  echo ">> terraform validate Lunch Concierge infra"
+  (
+    cd cookbook/lunch-concierge/infra/tf-out
+    terraform init -backend=false
+    terraform validate
+  )
+else
+  echo ">> terraform not found; skipping terraform validate"
+fi


### PR DESCRIPTION
## Summary
- Add `tool/check_cookbook.sh` to validate cookbook Dart packages, Lunch Concierge schema generation, server compilation, infra synth, and Terraform validation without GCP credentials.
- Parameterize cookbook validation inputs via `COOKBOOK_GCP_PROJECT_ID`, `COOKBOOK_REGION`, `COOKBOOK_IMAGE_URI`, and `COOKBOOK_INVOKER_EMAIL`; defaults use non-real CI placeholders.
- Wire the cookbook validation script into `tool/agent_verify.sh` so local/agent verification covers cookbook recipes.
- Add `.github/workflows/cookbook.yml` so cookbook changes run the lightweight validation automatically in GitHub Actions.

## Verification
- `tool/check_cookbook.sh`