### PR TITLE
ci(cookbook): support lunch concierge deploy state

### DIFF
--- a/.github/workflows/lunch-concierge-deploy.yml
+++ b/.github/workflows/lunch-concierge-deploy.yml
@@ -1,0 +1,102 @@
+name: Lunch Concierge Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Container image tag to build and deploy.
+        required: true
+        default: demo
+        type: string
+      apply:
+        description: Apply Terraform changes and push the container image.
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: lunch-concierge-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  REGION: asia-northeast1
+  PROJECT_ID: ${{ secrets.LUNCH_PROJECT_ID }}
+  PROJECT_NUMBER: ${{ secrets.LUNCH_PROJECT_NUMBER }}
+  TF_STATE_BUCKET: ${{ secrets.LUNCH_TF_STATE_BUCKET }}
+  TF_STATE_PREFIX: ${{ secrets.LUNCH_TF_STATE_PREFIX }}
+  WIF_PROVIDER: ${{ secrets.LUNCH_WIF_PROVIDER }}
+  DEPLOYER_SERVICE_ACCOUNT: ${{ secrets.LUNCH_DEPLOYER_SERVICE_ACCOUNT }}
+  INVOKER_EMAIL: ${{ secrets.LUNCH_INVOKER_EMAIL }}
+
+jobs:
+  deploy:
+    name: plan/apply Lunch Concierge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "1.15.2"
+
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.DEPLOYER_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      - run: dart pub get
+
+      - name: Resolve deployment inputs
+        run: |
+          image_uri="${REGION}-docker.pkg.dev/${PROJECT_ID}/lunch-concierge/app:${{ inputs.image_tag }}"
+          echo "IMAGE_URI=$image_uri" >> "$GITHUB_ENV"
+
+      - name: Generate server schemas
+        working-directory: cookbook/lunch-concierge/server
+        run: dart run build_runner build
+
+      - name: Synth Terraform JSON
+        working-directory: cookbook/lunch-concierge/infra
+        env:
+          GCP_PROJECT_ID: ${{ env.PROJECT_ID }}
+          IMAGE_URI: ${{ env.IMAGE_URI }}
+          INVOKER_EMAIL: ${{ env.INVOKER_EMAIL }}
+          TF_STATE_BUCKET: ${{ env.TF_STATE_BUCKET }}
+          TF_STATE_PREFIX: ${{ env.TF_STATE_PREFIX }}
+        run: dart run bin/infra.dart
+
+      - name: Terraform validate and plan
+        working-directory: cookbook/lunch-concierge/infra/tf-out
+        run: |
+          terraform init
+          terraform validate
+          terraform plan -out=tfplan
+
+      - name: Create Artifact Registry repository
+        if: inputs.apply
+        working-directory: cookbook/lunch-concierge/infra/tf-out
+        run: terraform apply -auto-approve -target=google_artifact_registry_repository.app_images
+
+      - name: Build and push image
+        if: inputs.apply
+        run: |
+          gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+          docker build -f cookbook/lunch-concierge/server/Dockerfile -t "$IMAGE_URI" .
+          docker push "$IMAGE_URI"
+
+      - name: Terraform apply
+        if: inputs.apply
+        working-directory: cookbook/lunch-concierge/infra/tf-out
+        run: |
+          terraform plan -out=tfplan
+          terraform apply -auto-approve tfplan

--- a/cookbook/lunch-concierge/README.md
+++ b/cookbook/lunch-concierge/README.md
@@ -29,9 +29,9 @@ Cloud SQL PostgreSQL
   - IAM DB authentication
 ```
 
-TerraDart defines the Artifact Registry repository, Cloud Run service, Cloud
-SQL instance/database/IAM user, VPC, Private Service Access, IAM grants, API
-enablement, and generated app exports.
+TerraDart defines the Cloud Run service, Cloud SQL instance/database/IAM user,
+VPC, Private Service Access, IAM grants, API enablement, and generated app
+exports. The Artifact Registry repository is a one-time bootstrap prerequisite.
 
 ## Layout
 
@@ -65,9 +65,6 @@ dart run build_runner build --delete-conflicting-outputs
 
 cd ../infra
 dart run bin/infra.dart
-cd tf-out
-terraform init
-terraform apply -target=google_artifact_registry_repository.app_images
 
 cd ../../../..
 gcloud auth configure-docker "$REGION-docker.pkg.dev"
@@ -75,11 +72,13 @@ docker build -f cookbook/lunch-concierge/server/Dockerfile -t "$IMAGE_URI" .
 docker push "$IMAGE_URI"
 
 cd cookbook/lunch-concierge/infra/tf-out
+terraform init
 terraform apply
 ```
 
-The targeted first apply creates the Artifact Registry repository so the image
-can be pushed. The second apply creates or updates the rest of the stack.
+Create the `lunch-concierge` Docker repository in Artifact Registry before this
+flow. The repository is bootstrap infrastructure that stores the image consumed
+by the Terraform-managed Cloud Run service.
 
 ## Boundary contract
 

--- a/cookbook/lunch-concierge/README.md
+++ b/cookbook/lunch-concierge/README.md
@@ -52,11 +52,11 @@ build uses a Flutter builder image for the client stage.
 From the repository root:
 
 ```bash
-export GCP_PROJECT_ID=flutter-gakkai-10
+export GCP_PROJECT_ID="<your-gcp-project-id>"
 export REGION=asia-northeast1
 export IMAGE_URI="$REGION-docker.pkg.dev/$GCP_PROJECT_ID/lunch-concierge/app:demo"
-export INVOKER_EMAIL="you@example.com"
-export TF_STATE_BUCKET=flutter-gakkai-10-tfstate
+export INVOKER_EMAIL="<your-google-account@example.com>"
+export TF_STATE_BUCKET="$GCP_PROJECT_ID-tfstate"
 export TF_STATE_PREFIX=lunch-concierge
 
 dart pub get

--- a/cookbook/lunch-concierge/README.md
+++ b/cookbook/lunch-concierge/README.md
@@ -29,9 +29,9 @@ Cloud SQL PostgreSQL
   - IAM DB authentication
 ```
 
-TerraDart defines the Cloud Run service, Cloud SQL instance/database/IAM user,
-VPC, Private Service Access, IAM grants, API enablement, and generated app
-exports. The Artifact Registry repository is a one-time bootstrap prerequisite.
+TerraDart defines the Artifact Registry repository, Cloud Run service, Cloud
+SQL instance/database/IAM user, VPC, Private Service Access, IAM grants, API
+enablement, and generated app exports.
 
 ## Layout
 
@@ -65,6 +65,9 @@ dart run build_runner build --delete-conflicting-outputs
 
 cd ../infra
 dart run bin/infra.dart
+cd tf-out
+terraform init
+terraform apply -target=google_artifact_registry_repository.app_images
 
 cd ../../../..
 gcloud auth configure-docker "$REGION-docker.pkg.dev"
@@ -72,13 +75,11 @@ docker build -f cookbook/lunch-concierge/server/Dockerfile -t "$IMAGE_URI" .
 docker push "$IMAGE_URI"
 
 cd cookbook/lunch-concierge/infra/tf-out
-terraform init
 terraform apply
 ```
 
-Create the `lunch-concierge` Docker repository in Artifact Registry before this
-flow. The repository is bootstrap infrastructure that stores the image consumed
-by the Terraform-managed Cloud Run service.
+The targeted first apply creates the Artifact Registry repository so the image
+can be pushed. The second apply creates or updates the rest of the stack.
 
 ## Boundary contract
 

--- a/cookbook/lunch-concierge/README.md
+++ b/cookbook/lunch-concierge/README.md
@@ -56,6 +56,8 @@ export GCP_PROJECT_ID=flutter-gakkai-10
 export REGION=asia-northeast1
 export IMAGE_URI="$REGION-docker.pkg.dev/$GCP_PROJECT_ID/lunch-concierge/app:demo"
 export INVOKER_EMAIL="you@example.com"
+export TF_STATE_BUCKET=flutter-gakkai-10-tfstate
+export TF_STATE_PREFIX=lunch-concierge
 
 dart pub get
 cd cookbook/lunch-concierge/server

--- a/cookbook/lunch-concierge/infra/bin/infra.dart
+++ b/cookbook/lunch-concierge/infra/bin/infra.dart
@@ -8,6 +8,7 @@ library;
 
 import 'dart:io';
 
+import 'package:terradart_core/terradart_core.dart';
 import 'package:lunch_concierge_infra/lunch_concierge_stack.dart';
 
 Future<void> main() async {
@@ -20,6 +21,15 @@ Future<void> main() async {
     imageUri: imageUri,
     invokerEmail: invokerEmail,
   );
+  final stateBucket = Platform.environment['TF_STATE_BUCKET'];
+  if (stateBucket != null && stateBucket.isNotEmpty) {
+    stack.setBackend(
+      GcsBackend(
+        bucket: stateBucket,
+        prefix: Platform.environment['TF_STATE_PREFIX'] ?? 'lunch-concierge',
+      ),
+    );
+  }
   await stack.writeTo('tf-out');
   stdout.writeln('synthesized to tf-out/main.tf.json');
 }

--- a/cookbook/lunch-concierge/infra/lib/lunch_concierge_stack.dart
+++ b/cookbook/lunch-concierge/infra/lib/lunch_concierge_stack.dart
@@ -5,7 +5,6 @@
 library;
 
 import 'package:terradart_core/terradart_core.dart';
-import 'package:terradart_google/artifact_registry.dart';
 import 'package:terradart_google/cloud_run.dart';
 import 'package:terradart_google/cloud_sql.dart';
 import 'package:terradart_google/compute.dart';
@@ -17,7 +16,6 @@ import 'package:terradart_google/time.dart';
 
 const _region = 'asia-northeast1';
 const _serviceName = 'lunch-concierge';
-const _repositoryId = 'lunch-concierge';
 const _vpcName = 'lunch-vpc';
 const _subnetName = 'lunch-subnet';
 const _subnetCidr = '10.10.0.0/24';
@@ -42,7 +40,6 @@ final class LunchStack extends Stack {
     final apiDeps = Apis.enable(
       this,
       barrels: [
-        Barrels.artifactRegistry,
         Barrels.cloudRun,
         Barrels.compute,
         Barrels.serviceNetworking,
@@ -55,17 +52,6 @@ final class LunchStack extends Stack {
         localName: 'api_aiplatform',
         service: TfArg.literal('aiplatform.googleapis.com'),
         disableOnDestroy: TfArg.literal(false),
-      ),
-    );
-
-    add(
-      GoogleArtifactRegistryRepository(
-        localName: 'app_images',
-        repositoryId: TfArg.literal(_repositoryId),
-        format: TfArg.literal('DOCKER'),
-        location: TfArg.literal(_region),
-        description: TfArg.literal('Lunch Concierge demo container images'),
-        dependsOn: apiDeps,
       ),
     );
 

--- a/cookbook/lunch-concierge/infra/lib/lunch_concierge_stack.dart
+++ b/cookbook/lunch-concierge/infra/lib/lunch_concierge_stack.dart
@@ -5,6 +5,7 @@
 library;
 
 import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/artifact_registry.dart';
 import 'package:terradart_google/cloud_run.dart';
 import 'package:terradart_google/cloud_sql.dart';
 import 'package:terradart_google/compute.dart';
@@ -16,6 +17,7 @@ import 'package:terradart_google/time.dart';
 
 const _region = 'asia-northeast1';
 const _serviceName = 'lunch-concierge';
+const _repositoryId = 'lunch-concierge';
 const _vpcName = 'lunch-vpc';
 const _subnetName = 'lunch-subnet';
 const _subnetCidr = '10.10.0.0/24';
@@ -40,6 +42,7 @@ final class LunchStack extends Stack {
     final apiDeps = Apis.enable(
       this,
       barrels: [
+        Barrels.artifactRegistry,
         Barrels.cloudRun,
         Barrels.compute,
         Barrels.serviceNetworking,
@@ -52,6 +55,17 @@ final class LunchStack extends Stack {
         localName: 'api_aiplatform',
         service: TfArg.literal('aiplatform.googleapis.com'),
         disableOnDestroy: TfArg.literal(false),
+      ),
+    );
+
+    add(
+      GoogleArtifactRegistryRepository(
+        localName: 'app_images',
+        repositoryId: TfArg.literal(_repositoryId),
+        format: TfArg.literal('DOCKER'),
+        location: TfArg.literal(_region),
+        description: TfArg.literal('Lunch Concierge demo container images'),
+        dependsOn: apiDeps,
       ),
     );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add optional `TF_STATE_BUCKET` / `TF_STATE_PREFIX` handling to the Lunch Concierge infra synth entrypoint so deploy CI can use a GCS backend.
- Document the state backend environment variables in the Lunch Concierge cookbook deploy flow.
- Add a manual `Lunch Concierge Deploy` workflow that authenticates via GitHub OIDC/WIF, plans by default, and applies/builds/pushes only when `apply=true`.
- Keep Artifact Registry repository definition in TerraDart so manually bootstrapped repositories are reconciled by IaC.

## Verification
- `tool/check_cookbook.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

