### PR TITLE
ci(cookbook): import bootstrapped artifact registry

### DIFF
--- a/.github/workflows/lunch-concierge-deploy.yml
+++ b/.github/workflows/lunch-concierge-deploy.yml
@@ -82,10 +82,15 @@ jobs:
           terraform validate
           terraform plan -out=tfplan
 
-      - name: Create Artifact Registry repository
+      - name: Import Artifact Registry repository
         if: inputs.apply
         working-directory: cookbook/lunch-concierge/infra/tf-out
-        run: terraform apply -auto-approve -target=google_artifact_registry_repository.app_images
+        run: |
+          if ! terraform state show google_artifact_registry_repository.app_images >/dev/null 2>&1; then
+            terraform import \
+              google_artifact_registry_repository.app_images \
+              "projects/${PROJECT_ID}/locations/${REGION}/repositories/lunch-concierge"
+          fi
 
       - name: Build and push image
         if: inputs.apply


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update the Lunch Concierge deploy workflow to import the pre-created Artifact Registry repository into Terraform state before build/push.
- Keep the repository defined in TerraDart while allowing the manually bootstrapped repository to be reconciled by IaC.

## Verification
- `tool/check_cookbook.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

