### PR TITLE
ci(cookbook): fix lunch deploy workflow

### DIFF
--- a/.github/workflows/lunch-concierge-deploy.yml
+++ b/.github/workflows/lunch-concierge-deploy.yml
@@ -3,16 +3,20 @@ name: Lunch Concierge Deploy
 on:
   workflow_dispatch:
     inputs:
+      operation:
+        description: Terraform operation.
+        required: true
+        default: plan
+        type: choice
+        options:
+          - plan
+          - apply
+          - destroy
       image_tag:
         description: Container image tag to build and deploy.
         required: true
         default: demo
         type: string
-      apply:
-        description: Apply Terraform changes and push the container image.
-        required: true
-        default: false
-        type: boolean
 
 concurrency:
   group: lunch-concierge-deploy
@@ -34,7 +38,7 @@ env:
 
 jobs:
   deploy:
-    name: plan/apply Lunch Concierge
+    name: ${{ inputs.operation }} Lunch Concierge
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -75,33 +79,54 @@ jobs:
           TF_STATE_PREFIX: ${{ env.TF_STATE_PREFIX }}
         run: dart run bin/infra.dart
 
-      - name: Terraform validate and plan
+      - name: Terraform init and validate
         working-directory: cookbook/lunch-concierge/infra/tf-out
         run: |
           terraform init
           terraform validate
-          terraform plan -out=tfplan
 
-      - name: Import Artifact Registry repository
-        if: inputs.apply
+      - name: Import Artifact Registry repository if present
+        if: inputs.operation == 'apply' || inputs.operation == 'destroy'
         working-directory: cookbook/lunch-concierge/infra/tf-out
         run: |
           if ! terraform state show google_artifact_registry_repository.app_images >/dev/null 2>&1; then
-            terraform import \
-              google_artifact_registry_repository.app_images \
-              "projects/${PROJECT_ID}/locations/${REGION}/repositories/lunch-concierge"
+            if gcloud artifacts repositories describe lunch-concierge \
+              --project="$PROJECT_ID" \
+              --location="$REGION" >/dev/null 2>&1; then
+              terraform import \
+                google_artifact_registry_repository.app_images \
+                "projects/${PROJECT_ID}/locations/${REGION}/repositories/lunch-concierge"
+            fi
           fi
 
+      - name: Terraform plan
+        if: inputs.operation == 'plan'
+        working-directory: cookbook/lunch-concierge/infra/tf-out
+        run: terraform plan -out=tfplan
+
       - name: Build and push image
-        if: inputs.apply
+        if: inputs.operation == 'apply'
         run: |
           gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
           docker build -f cookbook/lunch-concierge/server/Dockerfile -t "$IMAGE_URI" .
           docker push "$IMAGE_URI"
 
       - name: Terraform apply
-        if: inputs.apply
+        if: inputs.operation == 'apply'
         working-directory: cookbook/lunch-concierge/infra/tf-out
         run: |
           terraform plan -out=tfplan
           terraform apply -auto-approve tfplan
+
+      - name: Delete demo image before destroy
+        if: inputs.operation == 'destroy'
+        run: |
+          gcloud artifacts docker images delete "$IMAGE_URI" \
+            --project="$PROJECT_ID" \
+            --delete-tags \
+            --quiet || true
+
+      - name: Terraform destroy
+        if: inputs.operation == 'destroy'
+        working-directory: cookbook/lunch-concierge/infra/tf-out
+        run: terraform destroy -auto-approve

--- a/cookbook/lunch-concierge/server/Dockerfile
+++ b/cookbook/lunch-concierge/server/Dockerfile
@@ -5,19 +5,23 @@ FROM ghcr.io/cirruslabs/flutter:stable AS client_builder
 WORKDIR /src/cookbook/lunch-concierge/client
 COPY cookbook/lunch-concierge/client/pubspec.yaml ./
 COPY cookbook/lunch-concierge/shared ../shared
+RUN sed -i '/^resolution: workspace$/d' ../shared/pubspec.yaml
 RUN flutter pub get
 COPY cookbook/lunch-concierge/client ./
 RUN flutter build web --release
 
 FROM dart:stable AS server_builder
-WORKDIR /src
-COPY pubspec.yaml pubspec.lock ./
-COPY packages ./packages
-COPY cookbook ./cookbook
-RUN dart pub get
+WORKDIR /src/cookbook/lunch-concierge
+COPY cookbook/lunch-concierge/shared ./shared
+RUN sed -i '/^resolution: workspace$/d' shared/pubspec.yaml
 WORKDIR /src/cookbook/lunch-concierge/shared
+RUN dart pub get
 RUN dart run build_runner build --delete-conflicting-outputs
+WORKDIR /src/cookbook/lunch-concierge
+COPY cookbook/lunch-concierge/server ./server
+RUN sed -i '/^resolution: workspace$/d' server/pubspec.yaml
 WORKDIR /src/cookbook/lunch-concierge/server
+RUN dart pub get
 RUN dart compile exe bin/server.dart -o /out/server
 
 FROM debian:bookworm-slim AS runtime


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace the boolean deploy input with `operation: plan | apply | destroy` in the Lunch Concierge workflow.
- Add a destroy path that best-effort deletes the demo image before `terraform destroy`.
- Import an existing Artifact Registry repository before apply/destroy if it is not already in Terraform state.
- Fix the Lunch Concierge Dockerfile to resolve only the client/server/shared packages instead of the full monorepo workspace.

## Verification
- `tool/check_cookbook.sh`
- `git diff --check`

## Notes
- Docker is not installed in the agent environment, so the Dockerfile fix is expected to be validated by the Lunch Concierge deploy workflow build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

