### PR TITLE
ci(cookbook): use checked-in lunch schemas in docker build

### DIFF
--- a/cookbook/lunch-concierge/server/Dockerfile
+++ b/cookbook/lunch-concierge/server/Dockerfile
@@ -14,10 +14,6 @@ FROM dart:stable AS server_builder
 WORKDIR /src/cookbook/lunch-concierge
 COPY cookbook/lunch-concierge/shared ./shared
 RUN sed -i '/^resolution: workspace$/d' shared/pubspec.yaml
-WORKDIR /src/cookbook/lunch-concierge/shared
-RUN dart pub get
-RUN dart run build_runner build --delete-conflicting-outputs
-WORKDIR /src/cookbook/lunch-concierge
 COPY cookbook/lunch-concierge/server ./server
 RUN sed -i '/^resolution: workspace$/d' server/pubspec.yaml
 WORKDIR /src/cookbook/lunch-concierge/server


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Simplify the Lunch Concierge Docker server build to use checked-in shared schema outputs instead of regenerating schemas inside the image build.
- Avoid the Docker-only failure where `server` compilation cannot see `shared/lib/schema.g.dart`.

## Verification
- `tool/check_cookbook.sh`

## Notes
- Docker is not installed in the agent environment, so the Dockerfile fix is expected to be validated by the Lunch Concierge deploy workflow build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

