### PR TITLE
ci(cookbook): create docker output directory

### DIFF
--- a/cookbook/lunch-concierge/server/Dockerfile
+++ b/cookbook/lunch-concierge/server/Dockerfile
@@ -18,6 +18,7 @@ COPY cookbook/lunch-concierge/server ./server
 RUN sed -i '/^resolution: workspace$/d' server/pubspec.yaml
 WORKDIR /src/cookbook/lunch-concierge/server
 RUN dart pub get
+RUN mkdir -p /out
 RUN dart compile exe bin/server.dart -o /out/server
 
 FROM debian:bookworm-slim AS runtime


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Create `/out` before compiling the Lunch Concierge server binary in the Docker build.
- Fixes the deploy workflow failure where `dart compile exe -o /out/server` failed because `/out` did not exist.

## Verification
- `tool/check_cookbook.sh`
- `git diff --check`

## Notes
- Docker is not installed in the agent environment, so the Dockerfile fix is expected to be validated by the Lunch Concierge deploy workflow build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

