### PR TITLE
fix(cookbook): correct lunch Cloud SQL IAM user

### DIFF
--- a/cookbook/lunch-concierge/infra/lib/src/cloud_run.dart
+++ b/cookbook/lunch-concierge/infra/lib/src/cloud_run.dart
@@ -88,7 +88,12 @@ GoogleCloudRunV2Service addCloudRunService({
         ResourceDependency(vertexApi),
         ResourceDependency(network.subnet),
         ResourceDependency(database.sql),
+        ResourceDependency(database.database),
+        ResourceDependency(database.sqlUser),
         ResourceDependency(identity.serviceAccount),
+        ResourceDependency(identity.cloudSqlClientGrant),
+        ResourceDependency(identity.instanceUserGrant),
+        ResourceDependency(identity.vertexUserGrant),
       ],
     ),
   );

--- a/cookbook/lunch-concierge/infra/lib/src/database.dart
+++ b/cookbook/lunch-concierge/infra/lib/src/database.dart
@@ -8,12 +8,16 @@ import 'runtime_identity.dart';
 final class LunchDatabase {
   const LunchDatabase({
     required this.sql,
+    required this.database,
+    required this.sqlUser,
     required this.databaseUser,
     required this.databaseUrl,
     required this.instanceConnectionName,
   });
 
   final GoogleSqlDatabaseInstance sql;
+  final GoogleSqlDatabase database;
+  final GoogleSqlUser sqlUser;
   final String databaseUser;
   final String databaseUrl;
   final String instanceConnectionName;
@@ -54,7 +58,7 @@ LunchDatabase addDatabase({
     ),
   );
 
-  stack.add(
+  final database = stack.add(
     GoogleSqlDatabase(
       localName: 'lunch',
       instance: TfArg.ref(sql.nameRef),
@@ -63,14 +67,12 @@ LunchDatabase addDatabase({
     ),
   );
 
-  final sqlIamUserName =
-      '$sqlClientAccountId@$projectId.iam.gserviceaccount.com';
   final databaseUser = '$sqlClientAccountId@$projectId.iam';
-  stack.add(
+  final sqlUser = stack.add(
     GoogleSqlUser(
       localName: 'sql_client',
       instance: TfArg.ref(sql.nameRef),
-      name: TfArg.literal(sqlIamUserName),
+      name: TfArg.literal(databaseUser),
       type: TfArg.literal(SqlUserType.cloudIamServiceAccount),
       dependsOn: [
         ResourceDependency(sql),
@@ -81,6 +83,8 @@ LunchDatabase addDatabase({
 
   return LunchDatabase(
     sql: sql,
+    database: database,
+    sqlUser: sqlUser,
     databaseUser: databaseUser,
     databaseUrl: 'postgresql://$databaseUser@localhost:5432/$databaseName',
     instanceConnectionName: '$projectId:$region:$sqlInstanceName',

--- a/cookbook/lunch-concierge/infra/lib/src/runtime_identity.dart
+++ b/cookbook/lunch-concierge/infra/lib/src/runtime_identity.dart
@@ -5,9 +5,17 @@ import 'package:terradart_google/project.dart';
 import 'constants.dart';
 
 final class LunchRuntimeIdentity {
-  const LunchRuntimeIdentity({required this.serviceAccount});
+  const LunchRuntimeIdentity({
+    required this.serviceAccount,
+    required this.cloudSqlClientGrant,
+    required this.instanceUserGrant,
+    required this.vertexUserGrant,
+  });
 
   final GoogleServiceAccount serviceAccount;
+  final GoogleProjectIamMember cloudSqlClientGrant;
+  final GoogleProjectIamMember instanceUserGrant;
+  final GoogleProjectIamMember vertexUserGrant;
 }
 
 LunchRuntimeIdentity addRuntimeIdentity({
@@ -23,7 +31,7 @@ LunchRuntimeIdentity addRuntimeIdentity({
     ),
   );
 
-  stack.add(
+  final cloudSqlClientGrant = stack.add(
     GoogleProjectIamMember(
       localName: 'sql_client_cloudsql_client',
       project: TfArg.literal(projectId),
@@ -33,7 +41,7 @@ LunchRuntimeIdentity addRuntimeIdentity({
     ),
   );
 
-  stack.add(
+  final instanceUserGrant = stack.add(
     GoogleProjectIamMember(
       localName: 'sql_client_instance_user',
       project: TfArg.literal(projectId),
@@ -43,7 +51,7 @@ LunchRuntimeIdentity addRuntimeIdentity({
     ),
   );
 
-  stack.add(
+  final vertexUserGrant = stack.add(
     GoogleProjectIamMember(
       localName: 'sql_client_vertex_user',
       project: TfArg.literal(projectId),
@@ -56,5 +64,10 @@ LunchRuntimeIdentity addRuntimeIdentity({
     ),
   );
 
-  return LunchRuntimeIdentity(serviceAccount: serviceAccount);
+  return LunchRuntimeIdentity(
+    serviceAccount: serviceAccount,
+    cloudSqlClientGrant: cloudSqlClientGrant,
+    instanceUserGrant: instanceUserGrant,
+    vertexUserGrant: vertexUserGrant,
+  );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Use the Cloud SQL IAM database username without the `.gserviceaccount.com` suffix for the Lunch Concierge service account user.
- Return SQL database/user and runtime IAM grant resources from helper modules.
- Make the Cloud Run service depend on database, SQL IAM user, and runtime IAM grants so the app starts after its database identity is ready.

## Verification
- `tool/check_cookbook.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

