### PR TITLE
fix(cookbook): start lunch server before database init

### DIFF
--- a/cookbook/lunch-concierge/server/lib/db.dart
+++ b/cookbook/lunch-concierge/server/lib/db.dart
@@ -6,11 +6,15 @@ import 'package:lunch_concierge_shared/schema.dart';
 import 'package:postgres/postgres.dart';
 
 final class LunchHistoryRepository {
-  LunchHistoryRepository(this._connection);
+  LunchHistoryRepository();
 
-  final Connection _connection;
+  Future<Connection>? _readyConnection;
 
-  static Future<LunchHistoryRepository> connect() async {
+  Future<Connection> _connection() {
+    return _readyConnection ??= _openAndPrepare();
+  }
+
+  Future<Connection> _openAndPrepare() async {
     final connection = await _withRetry(
       () => Connection.open(
         Endpoint(
@@ -21,13 +25,12 @@ final class LunchHistoryRepository {
         ),
       ),
     );
-    final repository = LunchHistoryRepository(connection);
-    await repository.ensureSchema();
-    return repository;
+    await _ensureSchema(connection);
+    return connection;
   }
 
-  Future<void> ensureSchema() async {
-    await _connection.execute('''
+  Future<void> _ensureSchema(Connection connection) async {
+    await connection.execute('''
       create table if not exists lunch_suggestions (
         id bigserial primary key,
         area text not null,
@@ -40,7 +43,8 @@ final class LunchHistoryRepository {
   }
 
   Future<void> save(LunchRequest request, LunchResponse response) async {
-    await _connection.execute(
+    final connection = await _connection();
+    await connection.execute(
       Sql.named('''
         insert into lunch_suggestions
           (area, mood, budget_yen, suggestion_json)

--- a/cookbook/lunch-concierge/server/lib/lunch_flow.dart
+++ b/cookbook/lunch-concierge/server/lib/lunch_flow.dart
@@ -13,7 +13,7 @@ final class LunchFlowBundle {
 }
 
 Future<LunchFlowBundle> createLunchFlow() async {
-  final repository = await LunchHistoryRepository.connect();
+  final repository = LunchHistoryRepository();
   final ai = Genkit(
     plugins: [
       vertexAI(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Make the Lunch Concierge server create its Genkit flow without opening Cloud SQL during process startup.
- Lazily open and prepare the PostgreSQL connection on the first history save, preserving retry behavior.
- This lets Cloud Run satisfy the PORT=8080 startup requirement before the Cloud SQL Auth Proxy / IAM DB connection is used.

## Verification
- `tool/check_cookbook.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

