### PR TITLE
fix(cookbook): remove Cloud SQL proxy startup probe

### DIFF
--- a/cookbook/lunch-concierge/infra/lib/src/cloud_run.dart
+++ b/cookbook/lunch-concierge/infra/lib/src/cloud_run.dart
@@ -44,7 +44,6 @@ GoogleCloudRunV2Service addCloudRunService({
           CloudRunV2ServiceServiceContainer(
             name: TfArg.literal('app'),
             image: TfArg.literal(imageUri),
-            dependsOn: TfArg.literal(['cloud-sql-proxy']),
             ports: const CloudRunV2ServiceContainerPort(
               containerPort: TfArgLiteral(8080),
             ),
@@ -63,13 +62,6 @@ GoogleCloudRunV2Service addCloudRunService({
               '--auto-iam-authn',
               database.instanceConnectionName,
             ]),
-            startupProbe: const CloudRunV2ServiceStartupProbe(
-              tcpSocket: CloudRunV2ServiceTcpSocketAction(
-                port: TfArgLiteral(5432),
-              ),
-              periodSeconds: TfArgLiteral(2),
-              failureThreshold: TfArgLiteral(30),
-            ),
             resources: CloudRunV2ServiceContainerResources(
               limits: TfArg.literal({'cpu': '0.5', 'memory': '256Mi'}),
               cpuIdle: TfArg.literal(false),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove the Cloud Run app container startup ordering dependency on the Cloud SQL Auth Proxy sidecar.
- Remove the Cloud SQL Auth Proxy TCP startup probe that was failing with `DEADLINE_EXCEEDED` despite the proxy logging that it was listening.
- Keep DB connection retry lazy in the app path so Cloud Run can satisfy the PORT=8080 readiness check independently of the sidecar probe.

## Evidence
- Cloud Run logs showed `STARTUP TCP probe failed 30 times consecutively for container "cloud-sql-proxy" on port 5432`, while the proxy had already logged `Listening on 127.0.0.1:5432`.

## Verification
- `tool/check_cookbook.sh`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

