### PR TITLE
chore(cookbook): log lunch database retry failures

### DIFF
--- a/cookbook/lunch-concierge/server/lib/db.dart
+++ b/cookbook/lunch-concierge/server/lib/db.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:lunch_concierge_shared/generated/lunch_stack.app.dart';
 import 'package:lunch_concierge_shared/schema.dart';
@@ -15,6 +16,10 @@ final class LunchHistoryRepository {
   }
 
   Future<Connection> _openAndPrepare() async {
+    stderr.writeln(
+      'opening postgres connection to 127.0.0.1:5432/'
+      '${LunchStackExports.DATABASE_NAME} as ${LunchStackExports.DATABASE_USER}',
+    );
     final connection = await _withRetry(
       () => Connection.open(
         Endpoint(
@@ -25,7 +30,9 @@ final class LunchHistoryRepository {
         ),
       ),
     );
+    stderr.writeln('postgres connection opened; ensuring schema');
     await _ensureSchema(connection);
+    stderr.writeln('postgres schema ready');
     return connection;
   }
 
@@ -74,9 +81,11 @@ Future<T> _withRetry<T>(
     } catch (error, stackTrace) {
       lastError = error;
       lastStackTrace = stackTrace;
+      stderr.writeln('operation attempt $attempt/$maxAttempts failed: $error');
       if (attempt == maxAttempts) break;
       await Future<void>.delayed(delay);
     }
   }
+  stderr.writeln('operation failed after $maxAttempts attempts');
   Error.throwWithStackTrace(lastError!, lastStackTrace!);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Log Lunch Concierge PostgreSQL connection attempts, schema preparation, retry failures, and final retry exhaustion to stderr.
- This is diagnostic instrumentation for the current `/api/lunch` 500s where Cloud Run request logs show only a generic server error.

## Verification
- `tool/check_cookbook.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

