### PR TITLE
fix(cookbook): disable SSL for proxy Postgres connection

### DIFF
--- a/cookbook/lunch-concierge/server/lib/db.dart
+++ b/cookbook/lunch-concierge/server/lib/db.dart
@@ -28,6 +28,7 @@ final class LunchHistoryRepository {
           database: LunchStackExports.DATABASE_NAME,
           username: LunchStackExports.DATABASE_USER,
         ),
+        settings: const ConnectionSettings(sslMode: SslMode.disable),
       ),
     );
     stderr.writeln('postgres connection opened; ensuring schema');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Set `ConnectionSettings(sslMode: SslMode.disable)` for the Lunch Concierge PostgreSQL client.
- Cloud SQL Auth Proxy terminates the secure Cloud SQL connection and exposes a local plaintext PostgreSQL socket, so the Dart client must not require SSL on `127.0.0.1:5432`.

## Evidence
- Cloud Run logs showed repeated `Server does not support SSL, but it was required (default configuration). To disable secure connections, use ConnectionSettings(sslMode: SslMode.disable)` errors.

## Verification
- `tool/check_cookbook.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-912ad323-9a3d-4d9a-ab5e-cabeb1420592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

