### PR TITLE
chore(release): v0.22.0 — Waves 76–77

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to file. terradart is **pre-alpha** on
-        **0.21.x** today (beta planned from v0.17.0). Single-maintainer;
+        **0.22.x** today (beta planned from v0.17.0). Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         **PII note**: synthesized `.tf.json`, error output, and schema excerpts

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to file. terradart is **pre-alpha** on
-        **0.21.x** today (beta planned from v0.17.0). Single-maintainer;
+        **0.22.x** today (beta planned from v0.17.0). Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         Feature requests are welcome — no timeline promises, but they help

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to ask. terradart is **pre-alpha** on
-        **0.21.x** today (beta planned from v0.17.0). Single-maintainer;
+        **0.22.x** today (beta planned from v0.17.0). Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         Docs: https://terradart.dev/docs/getting-started/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to terradart are documented here. The format follows [Keep a
 
 Per-package changelogs live alongside each package and are the system of record for `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_agent`, and `terradart_coverage` — this top-level file summarises cross-cutting milestones.
 
+## [0.22.0] - 2026-06-30
+
+Lockstep release across the workspace. **No breaking changes** vs `0.21.0`.
+
+### Added
+
+- **`terradart_google`** — Wave 76 (OS Config + Binary Authorization VM compliance): **5** curated factories — `google_os_config_os_policy_assignment`, `google_os_config_patch_deployment`, `google_binary_authorization_policy`, `google_binary_authorization_attestor`, `google_binary_authorization_attestor_iam_member`. New `os_config` and `binary_authorization` service barrels.
+- **`terradart_google`** — Wave 77 (API security): **3** curated factories — `google_apikeys_key`, `google_recaptcha_enterprise_key`, `google_network_management_connectivity_test`. New `apikeys` and `recaptcha` service barrels; connectivity test on the existing `network` barrel. Catalog grows to **380 curated resource factories + 1 data source** (381 entries; 65 service barrels).
+- **Examples** — new [`vm_compliance_quickstart`](examples/vm_compliance_quickstart/) (Wave 76) and [`api_security_quickstart`](examples/api_security_quickstart/) (Wave 77).
+
+### Changed
+
+- **Agent guide** — remove co-authorship commit policy from `AGENTS.md`; simplify `tool/agent_commit.sh`.
+
 ## [0.21.0] - 2026-06-28
 
 Lockstep release across the workspace. **No breaking changes** vs `0.20.0`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing to terradart
 
-Thanks for taking time to look at this. terradart is a **pre-alpha** single-maintainer project (0.21.x today; [beta planned at v0.17.0](https://terradart.dev/docs/status/#beta-readiness-checklist)). Contributions are welcome on a best-effort basis.
+Thanks for taking time to look at this. terradart is a **pre-alpha** single-maintainer project (0.22.x today; [beta planned at v0.17.0](https://terradart.dev/docs/status/#beta-readiness-checklist)). Contributions are welcome on a best-effort basis.
 
 ## What kind of contribution?
 
 terradart ships one consumer surface:
 
-- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**380 curated resource factories + 1 data source** as of 0.21.x). Bug fixes, tests, and doc improvements welcome. New resources land via `terradart wrap` overrides — open an issue first to discuss scope.
+- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**380 curated resource factories + 1 data source** as of 0.22.x). Bug fixes, tests, and doc improvements welcome. New resources land via `terradart wrap` overrides — open an issue first to discuss scope.
 
-Within a **minor** line (`^0.21.x`), we aim to avoid breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (stricter from v0.17.0 beta — see [status](https://terradart.dev/docs/status/)).
+Within a **minor** line (`^0.22.x`), we aim to avoid breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (stricter from v0.17.0 beta — see [status](https://terradart.dev/docs/status/)).
 
 Bug reports / questions / feature requests: pick a template when [opening an issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 >
 > Google Cloud infrastructure as real Dart code — typed, refactor-safe, drop-in for `terraform apply`.
 
-**Pre-alpha** — no SemVer guarantees until v1.0.0. Pin `^0.21.x`, read [`MIGRATING.md`](MIGRATING.md) before bumping, and see [status on terradart.dev](https://terradart.dev/docs/status/).
+**Pre-alpha** — no SemVer guarantees until v1.0.0. Pin `^0.22.x`, read [`MIGRATING.md`](MIGRATING.md) before bumping, and see [status on terradart.dev](https://terradart.dev/docs/status/).
 
 <!-- identity -->
 [![pub: terradart_core](https://img.shields.io/pub/v/terradart_core.svg?label=pub%3A%20core)](https://pub.dev/packages/terradart_core)
@@ -202,8 +202,8 @@ GoogleCloudRunV2Service(
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.21.x
-  terradart_google: ^0.21.x
+  terradart_core: ^0.22.x
+  terradart_google: ^0.22.x
 ```
 
 ```bash
@@ -309,7 +309,7 @@ Application platform & operations
 
 ## Status
 
-**Pre-alpha**, pre-1.0 (0.21.x). No SemVer guarantees until v1.0.0; pin `^0.21.x` and read [`MIGRATING.md`](MIGRATING.md) before every minor bump. Beta is planned from **v0.15.0** once [readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met. Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
+**Pre-alpha**, pre-1.0 (0.22.x). No SemVer guarantees until v1.0.0; pin `^0.22.x` and read [`MIGRATING.md`](MIGRATING.md) before every minor bump. Beta is planned from **v0.15.0** once [readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met. Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
 
 ## Schema-bump automation (Plan 5.E)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,13 +31,13 @@ What does **not** count:
 
 ## Supported versions
 
-Pin dependencies with `^0.21.x` on [pub.dev](https://pub.dev/packages/terradart_core) today.
+Pin dependencies with `^0.22.x` on [pub.dev](https://pub.dev/packages/terradart_core) today.
 
 | Version | Status | Security fixes |
 |---|---|---|
-| **0.21.x** (pre-alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
-| **0.11.x and older** | Unsupported | Upgrade to 0.21.x; see [MIGRATING.md](MIGRATING.md) |
-| **0.21.x** (beta, planned) | Best-effort with clearer minor-boundary policy | See [status on terradart.dev](https://terradart.dev/docs/status/) |
+| **0.22.x** (pre-alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
+| **0.11.x and older** | Unsupported | Upgrade to 0.22.x; see [MIGRATING.md](MIGRATING.md) |
+| **0.22.x** (beta, planned) | Best-effort with clearer minor-boundary policy | See [status on terradart.dev](https://terradart.dev/docs/status/) |
 
 ## Disclosure policy
 

--- a/cookbook/firestore-seeded-data/pubspec.yaml
+++ b/cookbook/firestore-seeded-data/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/lunch-concierge/infra/pubspec.yaml
+++ b/cookbook/lunch-concierge/infra/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/remote-backend/pubspec.yaml
+++ b/cookbook/remote-backend/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/single-project-app/pubspec.yaml
+++ b/cookbook/single-project-app/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/access_context_quickstart/pubspec.yaml
+++ b/examples/access_context_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/api_security_quickstart/pubspec.yaml
+++ b/examples/api_security_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/apigee_quickstart/pubspec.yaml
+++ b/examples/apigee_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/app_engine_quickstart/pubspec.yaml
+++ b/examples/app_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/biglake_quickstart/pubspec.yaml
+++ b/examples/biglake_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_quickstart/pubspec.yaml
+++ b/examples/bigquery_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigtable_quickstart/pubspec.yaml
+++ b/examples/bigtable_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/chronicle_quickstart/pubspec.yaml
+++ b/examples/chronicle_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_build_quickstart/pubspec.yaml
+++ b/examples/cloud_build_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_functions_quickstart/pubspec.yaml
+++ b/examples/cloud_functions_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_quickstart/pubspec.yaml
+++ b/examples/cloud_run_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_scheduler_quickstart/pubspec.yaml
+++ b/examples/cloud_scheduler_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_sql_quickstart/pubspec.yaml
+++ b/examples/cloud_sql_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_tasks_quickstart/pubspec.yaml
+++ b/examples/cloud_tasks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/clouddeploy_quickstart/pubspec.yaml
+++ b/examples/clouddeploy_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_lb_quickstart/pubspec.yaml
+++ b/examples/compute_lb_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_quickstart/pubspec.yaml
+++ b/examples/compute_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_route_quickstart/pubspec.yaml
+++ b/examples/compute_route_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/config_deployment_quickstart/pubspec.yaml
+++ b/examples/config_deployment_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataplex_quickstart/pubspec.yaml
+++ b/examples/dataplex_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_quickstart/pubspec.yaml
+++ b/examples/dialogflow_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/discovery_engine_quickstart/pubspec.yaml
+++ b/examples/discovery_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dns_quickstart/pubspec.yaml
+++ b/examples/dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/document_ai_quickstart/pubspec.yaml
+++ b/examples/document_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/eventarc_quickstart/pubspec.yaml
+++ b/examples/eventarc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/filestore_quickstart/pubspec.yaml
+++ b/examples/filestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_check_quickstart/pubspec.yaml
+++ b/examples/firebase_app_check_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_hosting_quickstart/pubspec.yaml
+++ b/examples/firebase_app_hosting_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_data_connect_quickstart/pubspec.yaml
+++ b/examples/firebase_data_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_remote_config_quickstart/pubspec.yaml
+++ b/examples/firebase_remote_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_document_quickstart/pubspec.yaml
+++ b/examples/firestore_document_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_quickstart/pubspec.yaml
+++ b/examples/firestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gemini_quickstart/pubspec.yaml
+++ b/examples/gemini_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_hub_quickstart/pubspec.yaml
+++ b/examples/gke_hub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_quickstart/pubspec.yaml
+++ b/examples/gke_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/healthcare_quickstart/pubspec.yaml
+++ b/examples/healthcare_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iam_quickstart/pubspec.yaml
+++ b/examples/iam_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_quickstart/pubspec.yaml
+++ b/examples/kms_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/license_manager_quickstart/pubspec.yaml
+++ b/examples/license_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/migration_center_quickstart/pubspec.yaml
+++ b/examples/migration_center_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/monitoring_quickstart/pubspec.yaml
+++ b/examples/monitoring_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_connectivity_quickstart/pubspec.yaml
+++ b/examples/network_connectivity_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_lists_quickstart/pubspec.yaml
+++ b/examples/network_security_lists_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_ull_quickstart/pubspec.yaml
+++ b/examples/network_security_ull_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/observability_quickstart/pubspec.yaml
+++ b/examples/observability_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ops_quickstart/pubspec.yaml
+++ b/examples/ops_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_autonomous_database_quickstart/pubspec.yaml
+++ b/examples/oracle_autonomous_database_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_db_system_quickstart/pubspec.yaml
+++ b/examples/oracle_db_system_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_exadata_quickstart/pubspec.yaml
+++ b/examples/oracle_exadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_goldengate_quickstart/pubspec.yaml
+++ b/examples/oracle_goldengate_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/parameter_manager_quickstart/pubspec.yaml
+++ b/examples/parameter_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/pubsub_quickstart/pubspec.yaml
+++ b/examples/pubsub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/secret_manager_quickstart/pubspec.yaml
+++ b/examples/secret_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/service_directory_quickstart/pubspec.yaml
+++ b/examples/service_directory_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_quickstart/pubspec.yaml
+++ b/examples/storage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/tags_quickstart/pubspec.yaml
+++ b/examples/tags_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vertex_ai_quickstart/pubspec.yaml
+++ b/examples/vertex_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vm_compliance_quickstart/pubspec.yaml
+++ b/examples/vm_compliance_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/workflows_quickstart/pubspec.yaml
+++ b/examples/workflows_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/terradart_agent/CHANGELOG.md
+++ b/packages/terradart_agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.22.0 - 2026-06-30
+
+Lockstep release for Waves 76–77 (`terradart_google` OS Config, Binary Authorization, API Keys, reCAPTCHA, connectivity test). Catalog: **381 entries** (380 curated resource factories + 1 data source) across **65 service barrels**. No MCP protocol or tool changes.
+
 ## 0.21.0 - 2026-06-28
 
 Lockstep release for Wave 74 (`terradart_google` Dataplex lake operations). Catalog: **348 entries** (347 curated resource factories + 1 data source) across **60 service barrels**. No MCP protocol or tool changes.

--- a/packages/terradart_agent/lib/src/version.dart
+++ b/packages/terradart_agent/lib/src/version.dart
@@ -1,4 +1,4 @@
 /// The terradart-mcp binary version, kept in lockstep with pubspec.yaml's
 /// `version:` field by `tool/bump_version.sh`. The lockstep is guarded by
 /// test/version_test.dart so the two can never silently drift.
-const String packageVersion = '0.21.0';
+const String packageVersion = '0.22.0';

--- a/packages/terradart_agent/pubspec.yaml
+++ b/packages/terradart_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_agent
 description: terradart-mcp — MCP server exposing the curated GCP factory catalog of TerraDart.
-version: 0.21.0
+version: 0.22.0
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -16,9 +16,9 @@ executables:
   terradart-mcp: terradart_mcp
 
 dependencies:
-  terradart_core: ^0.21.0
-  terradart_google: ^0.21.0
-  terradart_coverage: ^0.21.0
+  terradart_core: ^0.22.0
+  terradart_google: ^0.22.0
+  terradart_coverage: ^0.22.0
   genkit: ^0.13.2
   genkit_mcp: ^0.1.7
   schemantic: ^0.1.3

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.22.0 - 2026-06-30
+
+Lockstep release for Waves 76–77. Agent guide: co-authorship commit policy removed from `AGENTS.md`.
+
 ## 0.21.0 - 2026-06-28
 
 Lockstep release for Wave 74. Apply-smoke test 13 (cost-comment gate) and `tool/apply_cost_comment_debt.yaml`.

--- a/packages/terradart_codegen/README.md
+++ b/packages/terradart_codegen/README.md
@@ -15,7 +15,7 @@ End users depend on [`terradart_google`](https://pub.dev/packages/terradart_goog
 Activate on the same minor line as your workspace when working on the repo:
 
 ```bash
-dart pub global activate terradart_codegen ^0.21.x
+dart pub global activate terradart_codegen ^0.22.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_codegen) for the latest patch.

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart maintainer tooling — parses Terraform provider schema JSON and Magic Modules YAML and emits curated factory wrappers via terradart wrap. Ships the terradart CLI.
-version: 0.21.0
+version: 0.22.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -33,7 +33,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.21.0
+  terradart_core: ^0.22.0
 
 dev_dependencies:
   http: ^1.0.0

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.22.0 - 2026-06-30
+
+Lockstep release for Waves 76–77. No API changes in `terradart_core`.
+
 ## 0.21.0 - 2026-06-28
 
 Lockstep release for Wave 74. No API changes in `terradart_core`.

--- a/packages/terradart_core/README.md
+++ b/packages/terradart_core/README.md
@@ -36,7 +36,7 @@ enum RoutingMode implements TerraformEnum {
 
 ```yaml
 dependencies:
-  terradart_core: ^0.21.x
+  terradart_core: ^0.22.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch. Read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before minor bumps.

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.21.0
+version: 0.22.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_coverage/CHANGELOG.md
+++ b/packages/terradart_coverage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.22.0 - 2026-06-30
+
+Lockstep release for Waves 76–77. No API changes in `terradart_coverage`.
+
 ## 0.21.0 - 2026-06-28
 
 Lockstep release for Wave 74. No API changes in `terradart_coverage`.

--- a/packages/terradart_coverage/pubspec.yaml
+++ b/packages/terradart_coverage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_coverage
 description: Read-only Terraform coverage checker — reports how much of a Terraform config is covered by curated terradart_google factories.
-version: 0.21.0
+version: 0.22.0
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -15,7 +15,7 @@ executables:
   terradart-coverage: terradart_coverage
 
 dependencies:
-  terradart_google: ^0.21.0
+  terradart_google: ^0.22.0
   args: ^2.5.0
 
 dev_dependencies:

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.22.0 - 2026-06-30
+
+Lockstep release. **No breaking changes** vs `0.21.0`.
+
+### Added
+
+- Wave 76 — OS Config + Binary Authorization (5 factories): OS policy assignment, patch deployment, project policy, attestor, attestor IAM member. New `os_config` and `binary_authorization` barrels.
+- Wave 77 — API security (3 factories): API Keys key, reCAPTCHA Enterprise key, Network Management connectivity test. New `apikeys` and `recaptcha` barrels. Catalog: **380 curated resource factories + 1 data source** (381 entries; 65 service barrels).
+- [`vm_compliance_quickstart`](../../examples/vm_compliance_quickstart/) and [`api_security_quickstart`](../../examples/api_security_quickstart/).
+
 ## 0.21.0 - 2026-06-28
 
 Lockstep release. **No breaking changes** vs `0.20.0`.

--- a/packages/terradart_google/README.md
+++ b/packages/terradart_google/README.md
@@ -16,8 +16,8 @@ Runtime primitives (`Stack`, `TfArg`, `writeTo`) live in [`terradart_core`](http
 
 ```yaml
 dependencies:
-  terradart_core: ^0.21.x
-  terradart_google: ^0.21.x
+  terradart_core: ^0.22.x
+  terradart_google: ^0.22.x
 ```
 
 ## Usage example

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: Curated factory wrappers for Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.
-version: 0.21.0
+version: 0.22.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -22,11 +22,11 @@ false_secrets:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.21.0
+  terradart_core: ^0.22.0
   meta: ^1.15.0
 
 dev_dependencies:
-  terradart_codegen: ^0.21.0
+  terradart_codegen: ^0.22.0
   path: ^1.9.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -3,7 +3,7 @@ title: Getting Started
 description: Install TerraDart and generate your first *.tf.json from a Stack.
 ---
 
-This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.21.x** line. TerraDart is **pre-alpha** until [beta gates](/docs/status/#beta-readiness-checklist) are complete (planned label: **v0.17.0**).
+This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.22.x** line. TerraDart is **pre-alpha** until [beta gates](/docs/status/#beta-readiness-checklist) are complete (planned label: **v0.17.0**).
 
 ## Prerequisites
 
@@ -16,8 +16,8 @@ This guide matches the [README quickstart](https://github.com/nozomi-koborinai/t
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.21.x
-  terradart_google: ^0.21.x
+  terradart_core: ^0.22.x
+  terradart_google: ^0.22.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch, then run:

--- a/website/src/content/docs/docs/waves.md
+++ b/website/src/content/docs/docs/waves.md
@@ -1,6 +1,6 @@
 ---
 title: Waves 23–41
-description: Curated google_* factories shipped through Wave 74 (v0.12.10–v0.21.0) with example stack pointers.
+description: Curated google_* factories shipped through Wave 77 (v0.12.10–v0.22.0) with example stack pointers.
 ---
 
 ## v0.12.10 — Waves 23–24


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lockstep **0.22.0** release for Waves 76–77 (merged in #237). **No breaking changes** vs `0.21.0`.

## Highlights

- **`terradart_google` catalog:** **380 curated resource factories + 1 data source** (**381 entries**; **65 service barrels**)
- **8 new curated factories** across OS Config, Binary Authorization, API Keys, reCAPTCHA, and Network Management
- **New examples:** [`vm_compliance_quickstart`](examples/vm_compliance_quickstart/), [`api_security_quickstart`](examples/api_security_quickstart/)

## Wave 76 — OS Config + Binary Authorization (`os_config`, `binary_authorization`)

| Terraform type | Dart factory |
| --- | --- |
| `google_os_config_os_policy_assignment` | `GoogleOsConfigOsPolicyAssignment` |
| `google_os_config_patch_deployment` | `GoogleOsConfigPatchDeployment` |
| `google_binary_authorization_policy` | `GoogleBinaryAuthorizationPolicy` |
| `google_binary_authorization_attestor` | `GoogleBinaryAuthorizationAttestor` |
| `google_binary_authorization_attestor_iam_member` | `GoogleBinaryAuthorizationAttestorIamMember` |

## Wave 77 — API security (`apikeys`, `recaptcha`, `network`)

| Terraform type | Dart factory |
| --- | --- |
| `google_apikeys_key` | `GoogleApikeysKey` |
| `google_recaptcha_enterprise_key` | `GoogleRecaptchaEnterpriseKey` |
| `google_network_management_connectivity_test` | `GoogleNetworkManagementConnectivityTest` |

## Upgrade

```yaml
dependencies:
  terradart_core: ^0.22.0
  terradart_google: ^0.22.0
```

## Verification

- `tool/bump_version.sh 0.22.0` (examples, cookbook, docs carets)
- `tool/agent_verify.sh` — green locally

## Post-merge (maintainer)

- Tag `v0.22.0` → pub.dev publish workflow
- GitHub release notes per [`terradart-ship-wave`](.agents/skills/terradart-ship-wave/SKILL.md)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1858-23c5-7d13-a0c8-09656ddb0dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1858-23c5-7d13-a0c8-09656ddb0dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

