### PR TITLE
fix(ci): use SCHEMA_BUMP_PAT for schema-bump PR creation

### DIFF
--- a/.github/workflows/schema-bump.yml
+++ b/.github/workflows/schema-bump.yml
@@ -222,8 +222,15 @@ jobs:
       - name: Create branch + commit + PR
         if: steps.skip_check.outputs.skip != 'true' && github.event.inputs.dry_run != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN can push branches but cannot open PRs when the repo blocks
+          # "GitHub Actions creating/approving pull requests". Use a fine-grained PAT
+          # stored as SCHEMA_BUMP_PAT (contents + pull-requests write).
+          GH_TOKEN: ${{ secrets.SCHEMA_BUMP_PAT }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::SCHEMA_BUMP_PAT secret is missing. Add a fine-grained PAT with contents and pull-requests write so schema-bump can open PRs."
+            exit 1
+          fi
           today=$(date -u +%Y-%m-%d)
           branch="chore/schema-bump-$today"
           git config user.name "github-actions[bot]"

--- a/README.md
+++ b/README.md
@@ -334,6 +334,11 @@ to report, no PR is created.
 **Ad-hoc trigger:** workflow_dispatch on the Actions tab (with `dry_run`
 input for detection-only runs).
 
+**Repo secret:** `SCHEMA_BUMP_PAT` — a fine-grained PAT with **Contents**
+and **Pull requests** write access. The default `GITHUB_TOKEN` can push the
+bump branch but cannot open the PR when the repository blocks Actions from
+creating pull requests.
+
 **Why not Renovate for terraform-provider-google?** Renovate has no
 auto-detection path with our repo shape (no `.tf` or `.terraform-version`
 file). The schema-bump workflow is the single source of truth for provider


### PR DESCRIPTION
## Summary

- Use `SCHEMA_BUMP_PAT` instead of `GITHUB_TOKEN` in the schema-bump PR creation step
- Fail fast with a clear error when the secret is missing
- Document the secret requirement in README

## Background

Since 2026-06-28, the weekly `schema-bump` workflow succeeded through branch push but failed at `gh pr create` with:

> GitHub Actions is not permitted to create or approve pull requests

The default `GITHUB_TOKEN` can push the bump branch, but this repository blocks Actions from opening pull requests. That left `chore/schema-bump-2026-06-28` on the remote with no PR.

`SCHEMA_BUMP_PAT` was already configured in repo secrets (added 2026-06-22); this PR wires the workflow to use it and documents the requirement.

## Post-merge (maintainer)

1. Confirm `SCHEMA_BUMP_PAT` is still valid (fine-grained PAT with **Contents** and **Pull requests** write)
2. Run **Actions → schema-bump → Run workflow** (`dry_run: false`) to generate a fresh bump PR

Note: the orphan `chore/schema-bump-2026-06-28` branch was already deleted from the remote.

## Test plan

- [x] After merge, `workflow_dispatch` on schema-bump completes through PR creation — verified via [run 28526352917](https://github.com/nozomi-koborinai/terradart/actions/runs/28526352917) → [PR #244](https://github.com/nozomi-koborinai/terradart/pull/244)
- [x] If `SCHEMA_BUMP_PAT` were removed, the PR step fails with the explicit missing-secret error — verified by the deployed guard in `.github/workflows/schema-bump.yml` and a local empty-`GH_TOKEN` simulation of the same shell check