### PR TITLE
docs: resolve release-phase contradictions and gate stale version prose

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to file. terradart is **pre-alpha** on
-        **0.22.x** today (beta planned from v0.17.0). Single-maintainer;
+        **0.22.x** today. Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         **PII note**: synthesized `.tf.json`, error output, and schema excerpts

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to file. terradart is **pre-alpha** on
-        **0.22.x** today (beta planned from v0.17.0). Single-maintainer;
+        **0.22.x** today. Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         Feature requests are welcome — no timeline promises, but they help

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to ask. terradart is **pre-alpha** on
-        **0.22.x** today (beta planned from v0.17.0). Single-maintainer;
+        **0.22.x** today. Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         Docs: https://terradart.dev/docs/getting-started/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to terradart
 
-Thanks for taking time to look at this. terradart is a **pre-alpha** single-maintainer project (0.22.x today; [beta planned at v0.17.0](https://terradart.dev/docs/status/#beta-readiness-checklist)). Contributions are welcome on a best-effort basis.
+Thanks for taking time to look at this. terradart is a **pre-alpha** single-maintainer project (0.22.x today; [beta readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met, label timing under consideration). Contributions are welcome on a best-effort basis.
 
 ## What kind of contribution?
 
@@ -8,7 +8,7 @@ terradart ships one consumer surface:
 
 - **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**380 curated resource factories + 1 data source** as of 0.22.x). Bug fixes, tests, and doc improvements welcome. New resources land via `terradart wrap` overrides — open an issue first to discuss scope.
 
-Within a **minor** line (`^0.22.x`), we aim to avoid breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (stricter from v0.17.0 beta — see [status](https://terradart.dev/docs/status/)).
+Within a **minor** line (`^0.22.x`), we aim to avoid breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (stricter once beta is declared — see [status](https://terradart.dev/docs/status/)).
 
 Bug reports / questions / feature requests: pick a template when [opening an issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Application platform & operations
 
 ## Status
 
-**Pre-alpha**, pre-1.0 (0.22.x). No SemVer guarantees until v1.0.0; pin `^0.22.x` and read [`MIGRATING.md`](MIGRATING.md) before every minor bump. Beta is planned from **v0.15.0** once [readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met. Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
+**Pre-alpha**, pre-1.0 (0.22.x). No SemVer guarantees until v1.0.0; pin `^0.22.x` and read [`MIGRATING.md`](MIGRATING.md) before every minor bump. The [beta readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met; the beta label timing is under consideration. Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
 
 ## Schema-bump automation (Plan 5.E)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,7 @@ Pin dependencies with `^0.22.x` on [pub.dev](https://pub.dev/packages/terradart_
 |---|---|---|
 | **0.22.x** (pre-alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
 | **0.11.x and older** | Unsupported | Upgrade to 0.22.x; see [MIGRATING.md](MIGRATING.md) |
-| **0.22.x** (beta, planned) | Best-effort with clearer minor-boundary policy | See [status on terradart.dev](https://terradart.dev/docs/status/) |
+| Future beta line (TBD) | Best-effort with clearer minor-boundary policy | See [status on terradart.dev](https://terradart.dev/docs/status/) |
 
 ## Disclosure policy
 

--- a/tool/bump_version.sh
+++ b/tool/bump_version.sh
@@ -150,18 +150,17 @@ OLD_MINOR_RE="$(printf '%s' "$OLD_MINOR" | sed 's/[.]/\\./g')"
 #     Pattern set per file (only the version token is replaced; surrounding
 #     text is left intact so prose stays correct):
 #
-#   CONTRIBUTING.md  — "X.Y.x today", "^X.Y.x" caret, "vX.Y.0 beta" labels
+#   CONTRIBUTING.md  — "X.Y.x today" + "^X.Y.x" caret
 #   SECURITY.md      — "^X.Y.x" pin + table rows "**X.Y.x**"
 #   package READMEs  — pubspec/activate caret samples (same pattern as above)
-#   getting-started  — "**X.Y.x** line" + "vX.Y.0" planned-label
-#   ISSUE_TEMPLATE   — "**X.Y.x** today" + "vX.Y.0" planned-label in markdown value
+#   website pages    — "**X.Y.x** line" + "^X.Y.x" pins + "X.Y.x (current)"
+#   ISSUE_TEMPLATE   — "**X.Y.x** today" in markdown value
 echo "  Additional doc/template files:"
 
 # CONTRIBUTING.md: replace ^X.Y.x and "X.Y.x today" and "vX.Y.0 beta" labels.
 if [ -f CONTRIBUTING.md ]; then
   sed_inplace "s#\\^${OLD_MINOR_RE}\\.x#^${NEW_MINOR}.x#g" CONTRIBUTING.md
   sed_inplace "s#${OLD_MINOR_RE}\\.x today#${NEW_MINOR}.x today#g" CONTRIBUTING.md
-  sed_inplace "s#v${OLD_MINOR_RE}\\.0#v${NEW_MINOR}.0#g" CONTRIBUTING.md
   echo "    - CONTRIBUTING.md"
 fi
 
@@ -184,21 +183,24 @@ for pkg_readme in packages/terradart_core/README.md \
   fi
 done
 
-# website/getting-started.md: "**X.Y.x** line" and "vX.Y.0" planned-label.
-GSTART="website/src/content/docs/docs/getting-started.md"
-if [ -f "$GSTART" ]; then
-  sed_inplace "s#\\*\\*${OLD_MINOR_RE}\\.x\\*\\* line#**${NEW_MINOR}.x** line#g" "$GSTART"
-  sed_inplace "s#v${OLD_MINOR_RE}\\.0#v${NEW_MINOR}.0#g" "$GSTART"
-  echo "    - $GSTART"
-fi
+# website pages: "**X.Y.x** line", "^X.Y.x" pins, "X.Y.x (current)" phase row.
+for site_md in website/src/content/docs/docs/getting-started.md \
+               website/src/content/docs/docs/index.md \
+               website/src/content/docs/docs/status.md; do
+  if [ -f "$site_md" ]; then
+    sed_inplace "s#\\*\\*${OLD_MINOR_RE}\\.x\\*\\* line#**${NEW_MINOR}.x** line#g" "$site_md"
+    sed_inplace "s#\\^${OLD_MINOR_RE}\\.x#^${NEW_MINOR}.x#g" "$site_md"
+    sed_inplace "s#${OLD_MINOR_RE}\\.x \\(current\\)#${NEW_MINOR}.x (current)#g" "$site_md"
+    echo "    - $site_md"
+  fi
+done
 
-# ISSUE_TEMPLATE ymls: "**X.Y.x** today" and "vX.Y.0" planned-label.
+# ISSUE_TEMPLATE ymls: "**X.Y.x** today".
 for tpl in .github/ISSUE_TEMPLATE/bug.yml \
            .github/ISSUE_TEMPLATE/feature.yml \
            .github/ISSUE_TEMPLATE/question.yml; do
   if [ -f "$tpl" ]; then
     sed_inplace "s#\\*\\*${OLD_MINOR_RE}\\.x\\*\\* today#**${NEW_MINOR}.x** today#g" "$tpl"
-    sed_inplace "s#v${OLD_MINOR_RE}\\.0#v${NEW_MINOR}.0#g" "$tpl"
     echo "    - $tpl"
   fi
 done

--- a/tool/check_docs_consistency.dart
+++ b/tool/check_docs_consistency.dart
@@ -56,6 +56,26 @@ Future<void> main() async {
   );
   _checkPhrase(
     errors,
+    'website/src/content/docs/docs/why-terradart.mdx',
+    '$curatedFactoryCount curated resource factories + 1 data source',
+    '($catalogEntryCount catalog entries)',
+  );
+  // Version-line freshness: any `0.NN.x` token in these user-facing pages must
+  // match the current workspace minor. Pages that intentionally reference old
+  // lines (MIGRATING, waves history, SECURITY's unsupported-versions table)
+  // are exempt.
+  for (final page in [
+    'README.md',
+    'CONTRIBUTING.md',
+    'website/src/content/docs/docs/index.md',
+    'website/src/content/docs/docs/status.md',
+    'website/src/content/docs/docs/getting-started.md',
+    'website/src/content/docs/docs/why-terradart.mdx',
+  ]) {
+    _checkNoStaleVersionLine(errors, minor, page);
+  }
+  _checkPhrase(
+    errors,
     'website/src/content/docs/docs/agent/index.md',
     agentCatalogEntriesPhrase,
     agentResourceFactoriesPhrase,
@@ -148,6 +168,24 @@ void _checkPhrase(
   for (final p in [phrase, phrase2, phrase3]) {
     if (p != null && !text.contains(p)) {
       errors.add('$path: expected phrase "$p"');
+    }
+  }
+}
+
+void _checkNoStaleVersionLine(List<String> errors, int minor, String path) {
+  final file = File(path);
+  if (!file.existsSync()) {
+    errors.add('Missing file: $path');
+    return;
+  }
+  final text = file.readAsStringSync();
+  final reported = <String>{};
+  for (final match in RegExp(r'\b0\.(\d+)\.x\b').allMatches(text)) {
+    final found = int.parse(match.group(1)!);
+    if (found != minor && reported.add('0.$found.x')) {
+      errors.add(
+        '$path: stale version line "0.$found.x" (current minor is 0.$minor.x)',
+      );
     }
   }
 }

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -3,7 +3,7 @@ title: Getting Started
 description: Install TerraDart and generate your first *.tf.json from a Stack.
 ---
 
-This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.22.x** line. TerraDart is **pre-alpha** until [beta gates](/docs/status/#beta-readiness-checklist) are complete (planned label: **v0.17.0**).
+This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.22.x** line. TerraDart is **pre-alpha**; the [beta gates](/docs/status/#beta-readiness-checklist) are met and the label timing is under consideration — see [Status & versioning](/docs/status/).
 
 ## Prerequisites
 
@@ -97,7 +97,7 @@ Rename `orders-prod` in the Stack without updating the subscriber and `dart anal
 
 - [Why TerraDart](/docs/why-terradart/) — motivation and comparisons
 - [Architecture](/docs/architecture/) — `synth()`, `writeTo()`, curated coverage
-- [Waves 23–24](/docs/waves/) — latest curated factories (v0.12.10)
-- [Migrating](/docs/migrating/) — read before bumping from `0.12.9`
+- [Curated factory waves](/docs/waves/) — factory history and example pointers
+- [Migrating](/docs/migrating/) — read before every minor bump
 - [Status & versioning](/docs/status/) — pre-alpha vs beta vs 1.0
 - [Examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook) for fuller stacks

--- a/website/src/content/docs/docs/index.md
+++ b/website/src/content/docs/docs/index.md
@@ -5,16 +5,16 @@ description: Guides for TerraDart — type-safe Google Cloud IaC for Dart.
 
 Welcome to the TerraDart docs.
 
-Guides track the **0.16.x** line on pub.dev. The repo [README](https://github.com/nozomi-koborinai/terradart/blob/main/README.md) and [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) stay the deepest references; this site mirrors onboarding and release expectations.
+Guides track the **0.22.x** line on pub.dev. The repo [README](https://github.com/nozomi-koborinai/terradart/blob/main/README.md) and [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) stay the deepest references; this site mirrors onboarding and release expectations.
 
 ## Guides
 
 - [Getting Started](/docs/getting-started/) — install, first `*.tf.json`, boundary export
 - [Why TerraDart](/docs/why-terradart/) — motivation, comparison, and curated coverage
 - [Architecture](/docs/architecture/) — generate `*.tf.json`, `synth()` / `writeTo()`, AppExport
-- [Waves 23–41](/docs/waves/) — curated factory waves and example pointers
-- [Migrating](/docs/migrating/) — upgrade from 0.12.9 (enum / nested-helper breaking changes)
-- [Status & versioning](/docs/status/) — pre-alpha, beta readiness (from v0.15.0), 1.0
+- [Curated factory waves](/docs/waves/) — factory history and example pointers
+- [Migrating](/docs/migrating/) — breaking-change guides for minor bumps
+- [Status & versioning](/docs/status/) — pre-alpha, beta readiness, 1.0
 
 ## For AI assistants
 

--- a/website/src/content/docs/docs/status.md
+++ b/website/src/content/docs/docs/status.md
@@ -3,25 +3,25 @@ title: Status & versioning
 description: Pre-alpha expectations, beta readiness, and how TerraDart versions releases.
 ---
 
-TerraDart is **pre-alpha** on the **0.16.x** line today. We remain pre-alpha until the [beta readiness](#beta-readiness-checklist) required gates are all complete; we plan to label the project **beta** starting with **v0.15.0**, not retroactively on earlier 0.x lines.
+TerraDart is **pre-alpha** on the **0.22.x** line today. The [beta readiness](#beta-readiness-checklist) required gates are complete; labeling the project **beta** is now a deliberate timing decision under consideration (together with the eventual 1.0 timeline). The beta label will apply from a future release, not retroactively on earlier 0.x lines.
 
-There are no SemVer guarantees until **v1.0.0**. Pin with `^0.16.x` and read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before every **minor** bump. Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch.
+There are no SemVer guarantees until **v1.0.0**. Pin with `^0.22.x` and read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before every **minor** bump. Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch.
 
 ## Release phases
 
 | Phase | Version line | What we promise |
 | --- | --- | --- |
-| **Pre-alpha** | 0.16.x (current) | Docs and automation are catching up. Breaking changes may land in any 0.x release until beta policy applies. |
-| **Beta** | from **0.15.0** (planned) | Trustworthy onboarding on terradart.dev and GitHub. **No breaking changes within a minor** (`^0.N.x`); breaking changes only on minor bumps, always documented in `MIGRATING.md`. Not SemVer-frozen until 1.0.0. |
+| **Pre-alpha** | 0.22.x (current) | Breaking changes may land in any 0.x release until beta policy applies. |
+| **Beta** | TBD (gates met; timing under consideration) | Trustworthy onboarding on terradart.dev and GitHub. **No breaking changes within a minor** (`^0.N.x`); breaking changes only on minor bumps, always documented in `MIGRATING.md`. Not SemVer-frozen until 1.0.0. |
 | **1.0.0** | TBD | Stable SemVer for `terradart_core`, `terradart_google`, and `terradart_codegen`. |
 
 ## What to expect today (pre-alpha)
 
 - Surface and emitted Terraform JSON may change between releases, especially across **minor** bumps.
-- Use hosted `^0.16.x` carets on [pub.dev](https://pub.dev/packages/terradart_core) — not legacy `0.x.y-dev` pre-release tags.
+- Use hosted `^0.22.x` carets on [pub.dev](https://pub.dev/packages/terradart_core) — not legacy `0.x.y-dev` pre-release tags.
 - Only the **curated** `terradart_google` surface is supported for users; non-curated resources require a curation request.
 
-## Beta change policy (applies from v0.15.0)
+## Beta change policy (applies once beta is declared)
 
 When we declare beta:
 
@@ -31,9 +31,9 @@ When we declare beta:
 
 ## Beta readiness checklist
 
-We will label the project **beta** starting with **v0.15.0** when every **required** item below is done.
+Every **required** item below is done, so beta is no longer blocked on readiness — declaring it is a maintainer timing decision, and the label will take effect from a future release when made.
 
-### Required (all must be ✅ before v0.15.0)
+### Required (all must be ✅ before the beta label)
 
 - [x] **Getting Started** on terradart.dev matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart); no “Coming soon” placeholders on Status or Getting Started.
 - [x] **`tool/check_docs_consistency`** runs in CI and passes (workspace + examples caret minor, catalog count, key meta docs). Workflow: [`.github/workflows/docs-consistency.yml`](https://github.com/nozomi-koborinai/terradart/blob/main/.github/workflows/docs-consistency.yml).
@@ -42,7 +42,7 @@ We will label the project **beta** starting with **v0.15.0** when every **requir
 - [x] **Boundary demo**: [pubsub_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart) documents `addExport` / generated `.app.dart` and includes a subscriber stub that `dart analyze` accepts.
 - [x] **Meta docs aligned** with the current minor: CONTRIBUTING, SECURITY, issue templates, package READMEs, and root README agree on pre-alpha/beta wording, `^0.N.x` pins, and **380 curated resource factories + 1 data source** (381 catalog entries).
 - [x] **Full example coverage**: `tool/example_debt.yaml` is empty — all catalog entries appear in at least one quickstart synth (`check_docs_consistency.dart`).
-- [x] **Beta change policy** published on this page (see [Beta change policy](#beta-change-policy-applies-from-v0150)).
+- [x] **Beta change policy** published on this page (see [Beta change policy](#beta-change-policy-applies-once-beta-is-declared)).
 
 ### Optional (does not block beta)
 

--- a/website/src/content/docs/docs/waves.md
+++ b/website/src/content/docs/docs/waves.md
@@ -1,6 +1,6 @@
 ---
-title: Waves 23–41
-description: Curated google_* factories shipped through Wave 77 (v0.12.10–v0.22.0) with example stack pointers.
+title: Curated factory waves
+description: Curated google_* factory waves from Wave 23 onward, with example stack pointers.
 ---
 
 ## v0.12.10 — Waves 23–24

--- a/website/src/content/docs/docs/why-terradart.mdx
+++ b/website/src/content/docs/docs/why-terradart.mdx
@@ -96,7 +96,7 @@ HCL has provider schema types; CDKTF bindings are typed in TypeScript and other 
 
 ## Curated provider coverage
 
-[`terradart_google`](https://pub.dev/packages/terradart_google) does not wrap every resource in the upstream HashiCorp `google` provider. It ships **typed factories for a growing, battle-tested subset** — **206 curated resource factories + 1 data source** (210 catalog entries) on open expansion PRs. Recent additions are documented in [Waves 23–35](/docs/waves/); see also [status](/docs/status/) and [Architecture — Provider integration](/docs/architecture/#provider-integration). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook) (both expanding). Upgrading from `0.12.9`? Read [Migrating](/docs/migrating/) first.
+[`terradart_google`](https://pub.dev/packages/terradart_google) does not wrap every resource in the upstream HashiCorp `google` provider. It ships **typed factories for a growing, battle-tested subset** — **380 curated resource factories + 1 data source** (381 catalog entries). Recent additions are documented in [Curated factory waves](/docs/waves/); see also [status](/docs/status/) and [Architecture — Provider integration](/docs/architecture/#provider-integration). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook) (both expanding). Upgrading across minors? Read [Migrating](/docs/migrating/) first.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

The public docs contradicted the release state: the status page said the project is on the **0.16.x** line and promised a beta label **starting with v0.15.0** (getting-started said **v0.17.0**), while the workspace is at **0.22.0** with every required beta gate checked. The "why TerraDart" page still advertised **206 curated resource factories (210 catalog entries)** against an actual **380 + 1 data source (381 entries)**.

The project stays **pre-alpha** (maintainer decision). Docs now state the actual position — beta readiness gates are met, the label timing is under consideration — without promising a version that the next release bump can silently outdate.

## Changes

- **status.md** — current line 0.22.x; Beta phase row `TBD (gates met; timing under consideration)`; the change-policy and checklist headings are no longer bound to a version; anchor reference updated.
- **README / CONTRIBUTING / SECURITY / issue templates** — drop `beta planned from vX.Y.0` phrasing. SECURITY's support table had degraded into two identical `0.22.x` rows (pre-alpha *and* beta) via blanket version bumps; the beta row is now `Future beta line (TBD)`.
- **why-terradart.mdx** — catalog counts 206/210 → 380/381; wave-range link and the `0.12.9` upgrade note generalized.
- **waves.md** — title unpinned from a wave range (it was stuck at "23–41" while the content reaches Wave 77); index/getting-started links follow.
- **tool/check_docs_consistency.dart** — why-terradart.mdx joins the catalog-count check; a new stale-version-line check fails any `0.NN.x` token that does not match the current workspace minor across the six user-facing pages (MIGRATING, waves history, and SECURITY's unsupported-versions table stay exempt).
- **tool/bump_version.sh** — rewrites index.md/status.md version lines on release alongside getting-started; drops the `vX.Y.0 planned-label` rewrites — they were the mechanism that kept re-promising beta one release ahead.

## Verification

- `dart tool/check_docs_consistency.dart` — OK (59/59 quickstart synth + `terraform validate`, new checks green)
- `dart analyze tool/` — no issues
- `bash -n tool/bump_version.sh` — OK