### PR TITLE
chore(codegen): A1 enum migration — member-level probe + flip the 8 exact candidates

### DIFF
--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_app_engine_firewall_rule.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_app_engine_firewall_rule.yaml
@@ -1,6 +1,7 @@
 outputDir: app
 deriveClassDoc: true
 deriveOutputGetters: true
+deriveEnums: true
 
 paramOrder:
   - priority
@@ -12,15 +13,3 @@ paramOrder:
 
 dartTypeOverrides:
   action: AppEngineFirewallRuleAction
-
-prelude: |
-  /// `action` on `google_app_engine_firewall_rule`.
-  enum AppEngineFirewallRuleAction implements TerraformEnum {
-    unspecifiedAction('UNSPECIFIED_ACTION'),
-    allow('ALLOW'),
-    deny('DENY');
-
-    const AppEngineFirewallRuleAction(this.terraformValue);
-    @override
-    final String terraformValue;
-  }

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_certificate_manager_dns_authorization.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_certificate_manager_dns_authorization.yaml
@@ -2,6 +2,7 @@ outputDir: certificate_manager
 
 deriveClassDoc: true
 deriveOutputGetters: true
+deriveEnums: true
 
 paramOrder:
   - name
@@ -32,15 +33,3 @@ curatedDoc: |-
   ///   domain: TfArg.literal('app.example.com'),
   /// );
   /// ```
-
-prelude: |
-  /// `type` — DNS authorization record strategy. When unset the API
-  /// picks `FIXED_RECORD` for global resources.
-  enum CertificateManagerDnsAuthorizationType implements TerraformEnum {
-    fixedRecord('FIXED_RECORD'),
-    perProjectRecord('PER_PROJECT_RECORD');
-
-    const CertificateManagerDnsAuthorizationType(this.terraformValue);
-    @override
-    final String terraformValue;
-  }

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_network_security_address_group.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_network_security_address_group.yaml
@@ -1,23 +1,10 @@
 outputDir: network
 deriveClassDoc: true
 deriveOutputGetters: true
+deriveEnums: true
 
 dartTypeOverrides:
   type: NetworkSecurityAddressGroupType
-
-prelude: |
-  /// IP-version a [GoogleNetworkSecurityAddressGroup] holds.
-  enum NetworkSecurityAddressGroupType implements TerraformEnum {
-    /// IPv4 addresses / CIDR ranges.
-    ipv4('IPV4'),
-
-    /// IPv6 addresses / CIDR ranges.
-    ipv6('IPV6');
-
-    const NetworkSecurityAddressGroupType(this.terraformValue);
-    @override
-    final String terraformValue;
-  }
 
 paramOrder:
   - name

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_parameter_manager_parameter.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_parameter_manager_parameter.yaml
@@ -1,27 +1,10 @@
 outputDir: parameter_manager
 deriveClassDoc: true
 deriveOutputGetters: true
+deriveEnums: true
 
 dartTypeOverrides:
   format: ParameterManagerParameterFormat
-
-prelude: |
-  /// Payload format of a [GoogleParameterManagerParameter] — controls how
-  /// Parameter Manager validates and renders the parameter's data.
-  enum ParameterManagerParameterFormat implements TerraformEnum {
-    /// Opaque bytes (no validation).
-    unformatted('UNFORMATTED'),
-
-    /// YAML-validated payload.
-    yaml('YAML'),
-
-    /// JSON-validated payload.
-    json('JSON');
-
-    const ParameterManagerParameterFormat(this.terraformValue);
-    @override
-    final String terraformValue;
-  }
 
 paramOrder:
   - parameter_id

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_parameter_manager_regional_parameter.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_parameter_manager_regional_parameter.yaml
@@ -1,26 +1,10 @@
 outputDir: parameter_manager
 deriveClassDoc: true
 deriveOutputGetters: true
+deriveEnums: true
 
 dartTypeOverrides:
   format: ParameterManagerRegionalParameterFormat
-
-prelude: |
-  /// Payload format of a [GoogleParameterManagerRegionalParameter].
-  enum ParameterManagerRegionalParameterFormat implements TerraformEnum {
-    /// Opaque bytes (no validation).
-    unformatted('UNFORMATTED'),
-
-    /// YAML-validated payload.
-    yaml('YAML'),
-
-    /// JSON-validated payload.
-    json('JSON');
-
-    const ParameterManagerRegionalParameterFormat(this.terraformValue);
-    @override
-    final String terraformValue;
-  }
 
 paramOrder:
   - parameter_id

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_spanner_instance.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_spanner_instance.yaml
@@ -2,6 +2,7 @@ outputDir: spanner
 
 deriveClassDoc: true
 deriveOutputGetters: true
+deriveEnums: true
 
 paramOrder:
   - config
@@ -35,16 +36,3 @@ curatedDoc: |-
   ///   numNodes: TfArg.literal(1),
   /// );
   /// ```
-
-prelude: |
-  /// `edition` — Spanner edition / capability tier.
-  enum SpannerInstanceEdition implements TerraformEnum {
-    editionUnspecified('EDITION_UNSPECIFIED'),
-    standard('STANDARD'),
-    enterprise('ENTERPRISE'),
-    enterprisePlus('ENTERPRISE_PLUS');
-
-    const SpannerInstanceEdition(this.terraformValue);
-    @override
-    final String terraformValue;
-  }

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_storage_hmac_key.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_storage_hmac_key.yaml
@@ -1,19 +1,10 @@
 outputDir: storage
 deriveClassDoc: true
 deriveOutputGetters: true
+deriveEnums: true
 
 dartTypeOverrides:
   state: StorageHmacKeyState
-
-prelude: |
-  enum StorageHmacKeyState implements TerraformEnum {
-    active('ACTIVE'),
-    inactive('INACTIVE');
-
-    const StorageHmacKeyState(this.terraformValue);
-    @override
-    final String terraformValue;
-  }
 
 paramOrder:
   - service_account_email

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_tags_tag_key.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml/google_tags_tag_key.yaml
@@ -1,24 +1,10 @@
 outputDir: tags
 deriveClassDoc: true
 deriveOutputGetters: true
+deriveEnums: true
 
 dartTypeOverrides:
   purpose: TagsTagKeyPurpose
-
-prelude: |
-  /// Purpose of a [GoogleTagsTagKey] — when set, the key (and its values)
-  /// drives a specific Google Cloud feature rather than free-form labelling.
-  enum TagsTagKeyPurpose implements TerraformEnum {
-    /// Tag values are usable in VPC firewall rules as network tags.
-    gceFirewall('GCE_FIREWALL'),
-
-    /// Tag values participate in data-governance policies.
-    dataGovernance('DATA_GOVERNANCE');
-
-    const TagsTagKeyPurpose(this.terraformValue);
-    @override
-    final String terraformValue;
-  }
 
 paramOrder:
   - short_name

--- a/packages/terradart_codegen/test/convergence/enum_derivation_probe_test.dart
+++ b/packages/terradart_codegen/test/convergence/enum_derivation_probe_test.dart
@@ -1,0 +1,276 @@
+@Tags(['convergence'])
+library;
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:terradart_codegen/src/codegen/naming.dart';
+import 'package:terradart_codegen/src/codegen/wrapper_overrides/_registry.dart';
+import 'package:terradart_codegen/src/codegen/wrapper_overrides/yaml_loader.dart';
+import 'package:terradart_codegen/src/ir/resource_def.dart';
+import 'package:terradart_codegen/src/parser/ir_merger.dart';
+import 'package:terradart_codegen/src/parser/mm_yaml_parser.dart';
+import 'package:terradart_codegen/src/parser/schema_parser.dart';
+import 'package:test/test.dart';
+
+/// Enum-derivation probe (A1 migration, Phase 1).
+///
+/// The de-fatten discovery tracer compares hand-written prelude enums to
+/// IR-derivable enums BY NAME ONLY — the documented blind spot that hid the
+/// `bigquery_routine` constant drift. This probe goes member-level: for every
+/// hand-written `enum X implements TerraformEnum` it compares the derived
+/// enum's Dart member names AND raw `terraformValue` strings, then classifies:
+///
+/// - DERIVABLE_EXACT  — name + members + raw values all match; flipping
+///   `deriveEnums: true` and deleting the hand enum changes only doc comments
+///   (the accepted A1 trade-off). These are the migration candidates.
+/// - MEMBER_DRIFT     — same name, different members/values. Flipping would
+///   change public API → stays ③ frozen.
+/// - NAME_DRIFT       — a derived enum carries the same raw values under a
+///   different Dart name (hand-curated rename) → stays ③ frozen.
+/// - NOT_DERIVABLE    — no top-level IR enumValues back this enum (nested
+///   block enum, or the schema stores the field as free-form string) —
+///   outside A1's scope by design.
+///
+/// This is a REPORT test: it always passes (modulo reconciliation) and
+/// prints/writes the classification so a migration wave can be scoped from
+/// data instead of guesses.
+
+const _overrideRoot = 'lib/src/codegen/wrapper_overrides/yaml';
+const _schemaPath = 'test/fixtures/wrap/source/schema.json';
+const _mmDir = 'test/fixtures/wrap/source/mm';
+
+typedef _Setup = ({
+  Map<String, ResourceDef> resources,
+  LoadedOverrides loaded,
+});
+
+_Setup _setup() {
+  final schemaSrc = File(_schemaPath).readAsStringSync();
+  final baseIr = const SchemaJsonParser().parseString(schemaSrc);
+
+  final mm = <String, MmResourceOverrides>{};
+  final mmDirRef = Directory(_mmDir);
+  if (mmDirRef.existsSync()) {
+    for (final file in mmDirRef.listSync().whereType<File>().where(
+          (f) => f.path.endsWith('.yaml'),
+        )) {
+      final key = p.basenameWithoutExtension(file.path);
+      mm[key] = const MmYamlParser().parseString(file.readAsStringSync());
+    }
+  }
+
+  final ir =
+      mm.isEmpty ? baseIr : const IrMerger().merge(base: baseIr, overrides: mm);
+  final loaded = loadWrapperOverrides(rootDir: _overrideRoot);
+  return (resources: ir.resources, loaded: loaded);
+}
+
+typedef _HandEnum = ({
+  String name,
+  List<String> members,
+  List<String> raws,
+  String block,
+});
+
+/// Extracts every `enum X implements TerraformEnum { ... }` declaration from
+/// [prelude] with its member names and raw values. Anchoring on
+/// `implements TerraformEnum` matches the discovery tracer (ADR-0016: every
+/// hand-written prelude enum implements it).
+List<_HandEnum> _extractHandEnums(String prelude) {
+  final out = <_HandEnum>[];
+  final decl = RegExp(r'\benum (\w+)\s+implements\s+TerraformEnum\s*\{');
+  for (final m in decl.allMatches(prelude)) {
+    var depth = 1;
+    var i = m.end;
+    while (i < prelude.length && depth > 0) {
+      final ch = prelude[i];
+      if (ch == '{') depth++;
+      if (ch == '}') depth--;
+      i++;
+    }
+    final block = prelude.substring(m.start, i);
+    final members = <String>[];
+    final raws = <String>[];
+    for (final c in RegExp(r"^\s*(\w+)\('([^']*)'\)\s*[,;]", multiLine: true)
+        .allMatches(block)) {
+      members.add(c.group(1)!);
+      raws.add(c.group(2)!);
+    }
+    out.add((name: m.group(1)!, members: members, raws: raws, block: block));
+  }
+  return out;
+}
+
+/// True when [prelude] contains nothing but its enum declarations, their
+/// `///` doc comments, and whitespace — i.e. deleting the enums empties it.
+bool _isEnumOnly(String prelude, List<_HandEnum> enums) {
+  var rest = prelude;
+  for (final e in enums) {
+    rest = rest.replaceFirst(e.block, '');
+  }
+  return rest
+      .split('\n')
+      .every((line) => line.trim().isEmpty || line.trim().startsWith('///'));
+}
+
+/// Derived top-level enums for [def], keyed by Dart enum name — exactly the
+/// set the `deriveEnums: true` gate would emit (WrapperEmitter A1 branch).
+Map<String, EnumName> _derivedEnums(ResourceDef def) {
+  final out = <String, EnumName>{};
+  for (final a in def.root.attributes) {
+    final values = a.constraints.enumValues;
+    if (values == null || values.isEmpty) continue;
+    final en = enumName(
+      resourceType: def.terraformType,
+      fieldPath: a.name,
+      members: values,
+    );
+    out[en.dartName] = en;
+  }
+  return out;
+}
+
+bool _sameList(List<String> a, List<String> b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}
+
+void main() {
+  test('enum derivation probe: member-level classification report', () {
+    final result = _setup();
+
+    const classes = [
+      'DERIVABLE_EXACT',
+      'MEMBER_DRIFT',
+      'NAME_DRIFT',
+      'NOT_DERIVABLE',
+    ];
+    final totals = {for (final c in classes) c: 0};
+    final rows = <String>[
+      [
+        'type',
+        'deriveEnums',
+        'preludeShape',
+        'handEnums',
+        'exact',
+        'memberDrift',
+        'nameDrift',
+        'notDerivable',
+        'detail',
+      ].join('\t'),
+    ];
+    final flipCandidates = <String>[];
+    final gateOnWithHandEnums = <String>[];
+    var withHandEnums = 0;
+    var handEnumTotal = 0;
+    var skipped = 0;
+
+    for (final entry in result.loaded.all.entries) {
+      final type = entry.key;
+      final override = entry.value;
+      final prelude = override.prelude;
+      if (prelude == null) continue;
+      final handEnums = _extractHandEnums(prelude);
+      if (handEnums.isEmpty) continue;
+
+      final def = result.resources[type];
+      if (def == null) {
+        skipped++;
+        continue;
+      }
+      withHandEnums++;
+      handEnumTotal += handEnums.length;
+
+      final derived = _derivedEnums(def);
+      final byClass = {for (final c in classes) c: <String>[]};
+      for (final hand in handEnums) {
+        final d = derived[hand.name];
+        final String cls;
+        if (d != null) {
+          cls = _sameList(d.dartMembers, hand.members) &&
+                  _sameList(d.rawValues, hand.raws)
+              ? 'DERIVABLE_EXACT'
+              : 'MEMBER_DRIFT';
+        } else {
+          final rawSet = hand.raws.toSet();
+          final renamed = derived.values.any(
+            (e) =>
+                e.rawValues.toSet().containsAll(rawSet) &&
+                rawSet.containsAll(e.rawValues.toSet()),
+          );
+          cls = renamed ? 'NAME_DRIFT' : 'NOT_DERIVABLE';
+        }
+        byClass[cls]!.add(hand.name);
+        totals[cls] = totals[cls]! + 1;
+      }
+
+      final enumOnly = _isEnumOnly(prelude, handEnums);
+      final shape = enumOnly ? 'enum-only' : 'mixed';
+      final allExact = byClass['DERIVABLE_EXACT']!.length == handEnums.length;
+      if (enumOnly && allExact && !override.deriveEnums) {
+        flipCandidates.add(type);
+      }
+      if (override.deriveEnums) {
+        const label = {
+          'DERIVABLE_EXACT': 'E',
+          'MEMBER_DRIFT': 'M',
+          'NAME_DRIFT': 'N',
+          'NOT_DERIVABLE': 'X',
+        };
+        gateOnWithHandEnums.add(
+          '$type (${classes.map((c) => '${byClass[c]!.length}${label[c]}').join('/')})',
+        );
+      }
+
+      rows.add([
+        type,
+        override.deriveEnums.toString(),
+        shape,
+        handEnums.length.toString(),
+        byClass['DERIVABLE_EXACT']!.length.toString(),
+        byClass['MEMBER_DRIFT']!.length.toString(),
+        byClass['NAME_DRIFT']!.length.toString(),
+        byClass['NOT_DERIVABLE']!.length.toString(),
+        classes
+            .where((c) => byClass[c]!.isNotEmpty && c != 'DERIVABLE_EXACT')
+            .map((c) => '$c:${(byClass[c]!..sort()).join(",")}')
+            .join(' '),
+      ].join('\t'));
+    }
+
+    final tsvPath =
+        p.join(Directory.systemTemp.path, 'enum_derivation_probe.tsv');
+    File(tsvPath).writeAsStringSync(rows.join('\n'));
+
+    // ignore: avoid_print
+    print([
+      'ENUM DERIVATION PROBE:',
+      'files-with-hand-enums=$withHandEnums (skipped-no-schema=$skipped)',
+      'hand-enums=$handEnumTotal',
+      ...classes.map((c) => '$c=${totals[c]}'),
+      'flip-candidates(enum-only+all-exact+gate-off)='
+          '${flipCandidates.length}',
+      'gate-on-with-hand-enums=${gateOnWithHandEnums.length}',
+      'report=$tsvPath',
+    ].join(' '));
+    if (flipCandidates.isNotEmpty) {
+      // ignore: avoid_print
+      print('FLIP CANDIDATES: ${(flipCandidates..sort()).join(', ')}');
+    }
+    if (gateOnWithHandEnums.isNotEmpty) {
+      // ignore: avoid_print
+      print('GATE-ON WITH HAND ENUMS (E=exact/M=member-drift/N=name-drift/'
+          'X=not-derivable): ${(gateOnWithHandEnums..sort()).join('; ')}');
+    }
+
+    expect(
+      totals.values.fold<int>(0, (a, b) => a + b),
+      equals(handEnumTotal),
+      reason: 'every hand enum must land in exactly one class',
+    );
+  });
+}

--- a/packages/terradart_google/lib/spanner.dart
+++ b/packages/terradart_google/lib/spanner.dart
@@ -5,4 +5,9 @@ library;
 export 'src/spanner/google_spanner_database.dart'
     show GoogleSpannerDatabase, SpannerDatabaseDialect;
 export 'src/spanner/google_spanner_instance.dart'
-    show GoogleSpannerInstance, SpannerInstanceEdition;
+    show
+        GoogleSpannerInstance,
+        SpannerInstanceDefaultBackupScheduleType,
+        SpannerInstanceEdition,
+        SpannerInstanceInstanceType,
+        SpannerInstanceState;

--- a/packages/terradart_google/lib/src/_catalog.g.dart
+++ b/packages/terradart_google/lib/src/_catalog.g.dart
@@ -9252,7 +9252,12 @@ const List<CatalogEntry> terradartCatalog = <CatalogEntry>[
       'edition',
       'labels',
     ],
-    nestedTypes: <String>['SpannerInstanceEdition'],
+    nestedTypes: <String>[
+      'SpannerInstanceDefaultBackupScheduleType',
+      'SpannerInstanceEdition',
+      'SpannerInstanceInstanceType',
+      'SpannerInstanceState',
+    ],
     sensitiveFields: <String>[],
     docComment:
         'Factory wrapper for `google_spanner_instance`.\n\nAn isolated set of Cloud Spanner resources on which databases can be hosted.\n\nCloud Spanner instance — horizontally scalable relational database.\n\nRequired identity:\n- [localName]: Terraform local name.\n- [config]: instance configuration name (e.g. `regional-asia-northeast1`).\n- [displayName]: user-visible label.\n\nSet exactly one of [numNodes] or [processingUnits] for capacity.\n\nEnable `spanner.googleapis.com` via [GoogleProjectService] before apply.\n\nExample:\n```dart\nGoogleSpannerInstance(\n  localName: \'app\',\n  config: TfArg.literal(\'regional-asia-northeast1\'),\n  displayName: TfArg.literal(\'App Spanner\'),\n  numNodes: TfArg.literal(1),\n);\n```',

--- a/packages/terradart_google/lib/src/app/google_app_engine_firewall_rule.dart
+++ b/packages/terradart_google/lib/src/app/google_app_engine_firewall_rule.dart
@@ -6,7 +6,7 @@ import 'package:terradart_core/terradart_core.dart';
 /// Sensitive field paths for `google_app_engine_firewall_rule`.
 const Set<String> _googleAppEngineFirewallRuleSensitive = <String>{};
 
-/// `action` on `google_app_engine_firewall_rule`.
+/// App Engine Firewall Rule enum for `action`.
 enum AppEngineFirewallRuleAction implements TerraformEnum {
   unspecifiedAction('UNSPECIFIED_ACTION'),
   allow('ALLOW'),

--- a/packages/terradart_google/lib/src/certificate_manager/google_certificate_manager_dns_authorization.dart
+++ b/packages/terradart_google/lib/src/certificate_manager/google_certificate_manager_dns_authorization.dart
@@ -7,8 +7,7 @@ import 'package:terradart_core/terradart_core.dart';
 const Set<String> _googleCertificateManagerDnsAuthorizationSensitive =
     <String>{};
 
-/// `type` — DNS authorization record strategy. When unset the API
-/// picks `FIXED_RECORD` for global resources.
+/// Certificate Manager Dns Authorization enum for `type`.
 enum CertificateManagerDnsAuthorizationType implements TerraformEnum {
   fixedRecord('FIXED_RECORD'),
   perProjectRecord('PER_PROJECT_RECORD');

--- a/packages/terradart_google/lib/src/network/google_network_security_address_group.dart
+++ b/packages/terradart_google/lib/src/network/google_network_security_address_group.dart
@@ -6,12 +6,9 @@ import 'package:terradart_core/terradart_core.dart';
 /// Sensitive field paths for `google_network_security_address_group`.
 const Set<String> _googleNetworkSecurityAddressGroupSensitive = <String>{};
 
-/// IP-version a [GoogleNetworkSecurityAddressGroup] holds.
+/// Network Security Address Group enum for `type`.
 enum NetworkSecurityAddressGroupType implements TerraformEnum {
-  /// IPv4 addresses / CIDR ranges.
   ipv4('IPV4'),
-
-  /// IPv6 addresses / CIDR ranges.
   ipv6('IPV6');
 
   const NetworkSecurityAddressGroupType(this.terraformValue);

--- a/packages/terradart_google/lib/src/parameter_manager/google_parameter_manager_parameter.dart
+++ b/packages/terradart_google/lib/src/parameter_manager/google_parameter_manager_parameter.dart
@@ -6,16 +6,10 @@ import 'package:terradart_core/terradart_core.dart';
 /// Sensitive field paths for `google_parameter_manager_parameter`.
 const Set<String> _googleParameterManagerParameterSensitive = <String>{};
 
-/// Payload format of a [GoogleParameterManagerParameter] — controls how
-/// Parameter Manager validates and renders the parameter's data.
+/// Parameter Manager Parameter enum for `format`.
 enum ParameterManagerParameterFormat implements TerraformEnum {
-  /// Opaque bytes (no validation).
   unformatted('UNFORMATTED'),
-
-  /// YAML-validated payload.
   yaml('YAML'),
-
-  /// JSON-validated payload.
   json('JSON');
 
   const ParameterManagerParameterFormat(this.terraformValue);

--- a/packages/terradart_google/lib/src/parameter_manager/google_parameter_manager_regional_parameter.dart
+++ b/packages/terradart_google/lib/src/parameter_manager/google_parameter_manager_regional_parameter.dart
@@ -7,15 +7,10 @@ import 'package:terradart_core/terradart_core.dart';
 const Set<String> _googleParameterManagerRegionalParameterSensitive =
     <String>{};
 
-/// Payload format of a [GoogleParameterManagerRegionalParameter].
+/// Parameter Manager Regional Parameter enum for `format`.
 enum ParameterManagerRegionalParameterFormat implements TerraformEnum {
-  /// Opaque bytes (no validation).
   unformatted('UNFORMATTED'),
-
-  /// YAML-validated payload.
   yaml('YAML'),
-
-  /// JSON-validated payload.
   json('JSON');
 
   const ParameterManagerRegionalParameterFormat(this.terraformValue);

--- a/packages/terradart_google/lib/src/spanner/google_spanner_instance.dart
+++ b/packages/terradart_google/lib/src/spanner/google_spanner_instance.dart
@@ -6,7 +6,17 @@ import 'package:terradart_core/terradart_core.dart';
 /// Sensitive field paths for `google_spanner_instance`.
 const Set<String> _googleSpannerInstanceSensitive = <String>{};
 
-/// `edition` — Spanner edition / capability tier.
+/// Spanner Instance Default Backup Schedule enum for `default_backup_schedule_type`.
+enum SpannerInstanceDefaultBackupScheduleType implements TerraformEnum {
+  none('NONE'),
+  automatic('AUTOMATIC');
+
+  const SpannerInstanceDefaultBackupScheduleType(this.terraformValue);
+  @override
+  final String terraformValue;
+}
+
+/// Spanner Instance enum for `edition`.
 enum SpannerInstanceEdition implements TerraformEnum {
   editionUnspecified('EDITION_UNSPECIFIED'),
   standard('STANDARD'),
@@ -14,6 +24,26 @@ enum SpannerInstanceEdition implements TerraformEnum {
   enterprisePlus('ENTERPRISE_PLUS');
 
   const SpannerInstanceEdition(this.terraformValue);
+  @override
+  final String terraformValue;
+}
+
+/// Spanner Instance Instance enum for `instance_type`.
+enum SpannerInstanceInstanceType implements TerraformEnum {
+  provisioned('PROVISIONED'),
+  freeInstance('FREE_INSTANCE');
+
+  const SpannerInstanceInstanceType(this.terraformValue);
+  @override
+  final String terraformValue;
+}
+
+/// Spanner Instance enum for `state`.
+enum SpannerInstanceState implements TerraformEnum {
+  ready('READY'),
+  creating('CREATING');
+
+  const SpannerInstanceState(this.terraformValue);
   @override
   final String terraformValue;
 }

--- a/packages/terradart_google/lib/src/storage/google_storage_hmac_key.dart
+++ b/packages/terradart_google/lib/src/storage/google_storage_hmac_key.dart
@@ -6,6 +6,7 @@ import 'package:terradart_core/terradart_core.dart';
 /// Sensitive field paths for `google_storage_hmac_key`.
 const Set<String> _googleStorageHmacKeySensitive = <String>{'secret'};
 
+/// Storage Hmac Key enum for `state`.
 enum StorageHmacKeyState implements TerraformEnum {
   active('ACTIVE'),
   inactive('INACTIVE');

--- a/packages/terradart_google/lib/src/tags/google_tags_tag_key.dart
+++ b/packages/terradart_google/lib/src/tags/google_tags_tag_key.dart
@@ -6,13 +6,9 @@ import 'package:terradart_core/terradart_core.dart';
 /// Sensitive field paths for `google_tags_tag_key`.
 const Set<String> _googleTagsTagKeySensitive = <String>{};
 
-/// Purpose of a [GoogleTagsTagKey] — when set, the key (and its values)
-/// drives a specific Google Cloud feature rather than free-form labelling.
+/// Tags Tag Key enum for `purpose`.
 enum TagsTagKeyPurpose implements TerraformEnum {
-  /// Tag values are usable in VPC firewall rules as network tags.
   gceFirewall('GCE_FIREWALL'),
-
-  /// Tag values participate in data-governance policies.
   dataGovernance('DATA_GOVERNANCE');
 
   const TagsTagKeyPurpose(this.terraformValue);


### PR DESCRIPTION
## Summary

The de-fatten discovery tracer compared hand-written prelude enums to IR-derivable enums **by name only** — the documented blind spot that hid the `bigquery_routine` constant drift. This PR adds a member-level probe (a permanent convergence test comparing enum names, Dart member names, AND raw `terraformValue` strings), then executes the migration it justifies.

## Probe result (pre-flip): 414 hand enums across 150 overrides

| class | count | meaning |
|---|---|---|
| DERIVABLE_EXACT | 25 | name+members+values match; flip changes docs only |
| MEMBER_DRIFT | 13 | public API differs → stays frozen |
| NAME_DRIFT | 75 | curated rename (same values) → stays frozen |
| NOT_DERIVABLE | 301 | nested-block enums / no schema enumValues — outside the A1 top-level gate by design |

Flip candidates (enum-only prelude + all enums exact + gate off): **8 files**. The 11 `deriveEnums: true` overrides still carrying hand enums are all non-derivable nested complements — **zero dead config**.

## Flip (phase 2)

The 8 candidates migrate to `deriveEnums: true` with the hand prelude deleted; `dartTypeOverrides` keeps binding each enum to its constructor param. After `terradart wrap`:

- 7 of 8 wrappers change **only enum doc comments** (the accepted A1 trade-off).
- `google_spanner_instance` additionally gains **3 additive enums** the schema already documents (`SpannerInstanceDefaultBackupScheduleType`, `SpannerInstanceInstanceType`, `SpannerInstanceState`) — `deriveEnums` emits every top-level `enumValues` attribute, not just the previously hand-typed one. Existing API untouched; `_catalog.g.dart` nestedTypes follows.

Post-flip probe: **flip-candidates=0**; hand enums 414 → 406. The remaining 17 exact enums sit in mixed preludes whose siblings are drifted — the all-or-nothing gate cannot take them without emitting duplicate-purpose enums, so they stay frozen. With that, the A1 migration is complete on evidence rather than backlog.

## Verification

- `terradart wrap --check` — all 382 files match
- `terradart lint-override` — 381 overrides clean
- codegen suite (418 tests incl. the probe) + terradart_google suite — green
- `dart analyze` / `dart format --set-exit-if-changed` — clean
- `check_override_enum_gaps --strict-nested` — unchanged (2 pre-existing NESTED_THIN advisories)