### PR TITLE
test(google): wire-precision tests for flagship sealed families + agent edge cases

### DIFF
--- a/packages/terradart_agent/test/tools/get_resource_schema_test.dart
+++ b/packages/terradart_agent/test/tools/get_resource_schema_test.dart
@@ -15,4 +15,22 @@ void main() {
     expect(r.found, isFalse);
     expect(r.suggestions, contains('google_pubsub_topic'));
   });
+
+  test('a far-off name returns no noisy suggestions', () {
+    final r = getResourceSchema(terradartCatalog, 'aws_s3_bucket');
+    expect(r.found, isFalse);
+    expect(
+      r.suggestions,
+      isEmpty,
+      reason:
+          'nothing within edit distance 3 — suggesting anything '
+          'would be noise for the calling agent',
+    );
+  });
+
+  test('empty input returns not-found with no suggestions', () {
+    final r = getResourceSchema(terradartCatalog, '');
+    expect(r.found, isFalse);
+    expect(r.suggestions, isEmpty);
+  });
 }

--- a/packages/terradart_google/test/bigquery/google_bigquery_dataset_access_test.dart
+++ b/packages/terradart_google/test/bigquery/google_bigquery_dataset_access_test.dart
@@ -1,0 +1,133 @@
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/bigquery.dart';
+import 'package:test/test.dart';
+
+/// Wire-precision tests for the 8-variant `BigqueryDatasetAccess` sealed
+/// hierarchy (the README's flagship exactly-one-of example).
+///
+/// Gate 6 asserts each variant encodes something well-formed; these tests
+/// pin the exact principal key per variant and that no sibling principal
+/// key leaks into another variant's encoding.
+void main() {
+  const principalKeys = {
+    'user_by_email',
+    'group_by_email',
+    'special_group',
+    'domain',
+    'iam_member',
+    'view',
+    'dataset',
+    'routine',
+  };
+
+  group('BigqueryDatasetAccess principal variants', () {
+    test('each scalar-principal variant encodes its own key + role only', () {
+      final variants = <String, BigqueryDatasetAccess>{
+        'user_by_email': BigqueryDatasetAccessUserByEmail(
+          userByEmail: TfArg.literal('alice@example.com'),
+          role: TfArg.literal('READER'),
+        ),
+        'group_by_email': BigqueryDatasetAccessGroupByEmail(
+          groupByEmail: TfArg.literal('data-eng@example.com'),
+          role: TfArg.literal('READER'),
+        ),
+        'special_group': BigqueryDatasetAccessSpecialGroup(
+          specialGroup: TfArg.literal('projectOwners'),
+          role: TfArg.literal('OWNER'),
+        ),
+        'domain': BigqueryDatasetAccessDomain(
+          domain: TfArg.literal('example.com'),
+          role: TfArg.literal('READER'),
+        ),
+        'iam_member': BigqueryDatasetAccessIamMember(
+          iamMember: TfArg.literal(
+            'serviceAccount:sa@p.iam.gserviceaccount.com',
+          ),
+          role: TfArg.literal('READER'),
+        ),
+      };
+      for (final entry in variants.entries) {
+        final encoded = entry.value.encode();
+        expect(
+          encoded.keys.toSet(),
+          equals({entry.key, 'role'}),
+          reason: '${entry.value.runtimeType} must emit only '
+              '${entry.key} + role',
+        );
+        final leaked =
+            principalKeys.difference({entry.key}).where(encoded.containsKey);
+        expect(
+          leaked,
+          isEmpty,
+          reason: '${entry.value.runtimeType} leaked sibling principal '
+              'key(s): $leaked',
+        );
+      }
+    });
+
+    test('view nests a fully-qualified table reference', () {
+      final access = BigqueryDatasetAccessView(
+        view: BigqueryDatasetDatasetView(
+          projectId: TfArg.literal('p'),
+          datasetId: TfArg.literal('analytics'),
+          tableId: TfArg.literal('daily_view'),
+        ),
+      );
+      expect(
+        access.encode(),
+        equals({
+          'view': [
+            {
+              'project_id': 'p',
+              'dataset_id': 'analytics',
+              'table_id': 'daily_view',
+            },
+          ],
+        }),
+      );
+    });
+
+    test('dataset nests a dataset reference + target_types', () {
+      final access = BigqueryDatasetAccessDataset(
+        dataset: BigqueryDatasetDatasetAccessChild(
+          dataset: BigqueryDatasetDatasetReference(
+            projectId: TfArg.literal('p'),
+            datasetId: TfArg.literal('shared'),
+          ),
+          targetTypes: [TfArg.literal('VIEWS')],
+        ),
+      );
+      expect(
+        access.encode(),
+        equals({
+          'dataset': [
+            {
+              'dataset': [
+                {'project_id': 'p', 'dataset_id': 'shared'},
+              ],
+              'target_types': ['VIEWS'],
+            },
+          ],
+        }),
+      );
+    });
+
+    test('routine nests a routine reference and needs no role', () {
+      final access = BigqueryDatasetAccessRoutine(
+        routine: BigqueryDatasetDatasetRoutineRef(
+          projectId: TfArg.literal('p'),
+          datasetId: TfArg.literal('lib'),
+          routineId: TfArg.literal('cleanse'),
+        ),
+      );
+      final encoded = access.encode();
+      expect(encoded.keys.toList(), equals(['routine']));
+      expect(
+        encoded['routine'],
+        equals([
+          {'project_id': 'p', 'dataset_id': 'lib', 'routine_id': 'cleanse'},
+        ]),
+      );
+    });
+  });
+}

--- a/packages/terradart_google/test/cloud_run/google_cloud_run_v2_service_sealed_test.dart
+++ b/packages/terradart_google/test/cloud_run/google_cloud_run_v2_service_sealed_test.dart
@@ -1,0 +1,102 @@
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/cloud_run.dart';
+import 'package:test/test.dart';
+
+/// Wire-precision tests for the Cloud Run v2 sealed families.
+///
+/// Gate 6 (test/synth/encode_round_trip_test.dart) asserts every sealed
+/// member encodes something well-formed; these tests pin the exact wire
+/// shape and — the part Gate 6 cannot see — exactly-one-of exclusivity:
+/// a variant must not leak its siblings' keys.
+void main() {
+  group('CloudRunV2ServiceEnvVarSource', () {
+    test('FromLiteral encodes env.value and nothing else', () {
+      final env = CloudRunV2ServiceEnvVar(
+        name: TfArg.literal('LOG_LEVEL'),
+        source: CloudRunV2ServiceEnvVarFromLiteral(TfArg.literal('info')),
+      );
+      expect(env.toArgMap(), equals({'name': 'LOG_LEVEL', 'value': 'info'}));
+    });
+
+    test('FromSecret encodes value_source.secret_key_ref and no value', () {
+      final env = CloudRunV2ServiceEnvVar(
+        name: TfArg.literal('DB_PASSWORD'),
+        source: CloudRunV2ServiceEnvVarFromSecret(
+          secret: TfArg.literal('db-pwd'),
+          version: TfArg.literal('latest'),
+        ),
+      );
+      expect(
+        env.toArgMap(),
+        equals({
+          'name': 'DB_PASSWORD',
+          'value_source': [
+            {
+              'secret_key_ref': [
+                {'secret': 'db-pwd', 'version': 'latest'},
+              ],
+            },
+          ],
+        }),
+      );
+    });
+
+    test('null source emits the name alone', () {
+      final env = CloudRunV2ServiceEnvVar(name: TfArg.literal('EMPTY'));
+      expect(env.toArgMap(), equals({'name': 'EMPTY'}));
+    });
+  });
+
+  group('CloudRunV2ServiceVolumeSource', () {
+    test('every variant encodes exactly its own block key', () {
+      final variants = <String, CloudRunV2ServiceVolumeSource>{
+        'secret': CloudRunV2ServiceVolumeSecret(secret: TfArg.literal('s')),
+        'cloud_sql_instance': CloudRunV2ServiceCloudSqlVolume(
+          instances: TfArg.literal(['p:r:i']),
+        ),
+        'empty_dir': CloudRunV2ServiceEmptyDirVolume(
+          sizeLimit: TfArg.literal('500Mi'),
+        ),
+        'gcs': CloudRunV2ServiceGcsVolume(bucket: TfArg.literal('assets')),
+        'nfs': CloudRunV2ServiceNfsVolume(
+          server: TfArg.literal('10.0.0.2'),
+          path: TfArg.literal('/exports'),
+        ),
+      };
+      for (final entry in variants.entries) {
+        expect(
+          entry.value.encode().keys.toList(),
+          equals([entry.key]),
+          reason: '${entry.value.runtimeType} must emit only ${entry.key}',
+        );
+      }
+    });
+
+    test('secret volume maps items to path/version/mode', () {
+      final volume = CloudRunV2ServiceVolumeSecret(
+        secret: TfArg.literal('certs'),
+        defaultMode: TfArg.literal(292),
+        items: [
+          CloudRunV2ServiceSecretVolumeItem(
+            path: TfArg.literal('tls.crt'),
+            version: TfArg.literal('3'),
+          ),
+        ],
+      );
+      expect(
+        volume.encode(),
+        equals({
+          'secret': [
+            {
+              'secret': 'certs',
+              'default_mode': 292,
+              'items': [
+                {'path': 'tls.crt', 'version': '3'},
+              ],
+            },
+          ],
+        }),
+      );
+    });
+  });
+}

--- a/packages/terradart_google/test/compute/google_compute_health_check_protocol_test.dart
+++ b/packages/terradart_google/test/compute/google_compute_health_check_protocol_test.dart
@@ -1,0 +1,87 @@
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/compute.dart';
+import 'package:test/test.dart';
+
+/// Wire-precision tests for the unified health-check protocol sealed type:
+/// six per-protocol config blocks whose exactly-one-of constraint the
+/// resource enforces at the type level (a single `protocol` parameter).
+///
+/// Gate 6 asserts each config encodes something well-formed; these tests
+/// pin the block-key mapping and that the resource embeds exactly one
+/// `*_health_check` block.
+void main() {
+  test('each protocol variant maps to exactly its own block key', () {
+    final variants = <String, ({ComputeHealthCheckProtocol config, int port})>{
+      'http_health_check': (
+        config: ComputeHealthCheckHttpHealthCheckConfig(
+          port: TfArg.literal(80),
+        ),
+        port: 80,
+      ),
+      'https_health_check': (
+        config: ComputeHealthCheckHttpsHealthCheckConfig(
+          port: TfArg.literal(443),
+        ),
+        port: 443,
+      ),
+      'http2_health_check': (
+        config: ComputeHealthCheckHttp2HealthCheckConfig(
+          port: TfArg.literal(8443),
+        ),
+        port: 8443,
+      ),
+      'tcp_health_check': (
+        config: ComputeHealthCheckTcpHealthCheckConfig(
+          port: TfArg.literal(5432),
+        ),
+        port: 5432,
+      ),
+      'ssl_health_check': (
+        config: ComputeHealthCheckSslHealthCheckConfig(
+          port: TfArg.literal(636),
+        ),
+        port: 636,
+      ),
+      'grpc_health_check': (
+        config: ComputeHealthCheckGrpcHealthCheckConfig(
+          port: TfArg.literal(50051),
+        ),
+        port: 50051,
+      ),
+    };
+    for (final entry in variants.entries) {
+      expect(
+        entry.value.config.blockKey,
+        equals(entry.key),
+        reason: '${entry.value.config.runtimeType} blockKey',
+      );
+      expect(
+        entry.value.config.encode(),
+        equals([
+          {'port': entry.value.port},
+        ]),
+        reason: '${entry.value.config.runtimeType} minimal encode',
+      );
+    }
+  });
+
+  test('resource embeds exactly one *_health_check block', () {
+    final hc = GoogleComputeHealthCheck(
+      localName: 'web',
+      name: TfArg.literal('web-hc'),
+      protocol: ComputeHealthCheckHttpHealthCheckConfig(
+        requestPath: TfArg.literal('/healthz'),
+        port: TfArg.literal(8080),
+      ),
+    );
+    final protocolKeys =
+        hc.argMap.keys.where((k) => k.endsWith('_health_check')).toList();
+    expect(protocolKeys, equals(['http_health_check']));
+    expect(
+      hc.argMap['http_health_check']!.toTfJson(),
+      equals([
+        {'request_path': '/healthz', 'port': 8080},
+      ]),
+    );
+  });
+}

--- a/packages/terradart_google/test/storage/google_storage_bucket_object_test.dart
+++ b/packages/terradart_google/test/storage/google_storage_bucket_object_test.dart
@@ -1,0 +1,96 @@
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/provider.dart';
+import 'package:terradart_google/storage.dart';
+import 'package:test/test.dart';
+
+import '../_helpers.dart';
+
+/// Behavior tests for the `source` | `content` sealed payload on
+/// `google_storage_bucket_object`, including the part only a synth pass
+/// can show: `content` is provider-Sensitive, so a literal must fail
+/// fast (SensitiveLiteralError) instead of silently landing in state.
+void main() {
+  group('StorageBucketObjectBucketObjectContent', () {
+    test('FromSource encodes under source only', () {
+      final body = StorageBucketObjectBucketObjectFromSource(
+        source: TfArg.literal('./config.json'),
+      );
+      expect(body.blockKey, equals('source'));
+      expect(body.encode(), equals({'source': './config.json'}));
+    });
+
+    test('FromContent encodes under content only', () {
+      final body = StorageBucketObjectBucketObjectFromContent(
+        content: TfArg.variable('seed_content'),
+      );
+      expect(body.blockKey, equals('content'));
+      expect(body.encode(), equals({'content': r'${var.seed_content}'}));
+    });
+
+    test('resource argMap carries exactly the chosen payload key', () {
+      final object = GoogleStorageBucketObject(
+        localName: 'conf',
+        bucket: TfArg.literal('assets'),
+        name: TfArg.literal('config.json'),
+        body: StorageBucketObjectBucketObjectFromSource(
+          source: TfArg.literal('./config.json'),
+        ),
+      );
+      expect(object.argMap.containsKey('source'), isTrue);
+      expect(object.argMap.containsKey('content'), isFalse);
+    });
+  });
+
+  group('content sensitivity at synth time', () {
+    test('sensitiveFields pins content and the CMEK key', () {
+      final object = GoogleStorageBucketObject(
+        localName: 'conf',
+        bucket: TfArg.literal('assets'),
+        name: TfArg.literal('config.json'),
+        body: StorageBucketObjectBucketObjectFromSource(
+          source: TfArg.literal('./config.json'),
+        ),
+      );
+      expect(
+        object.sensitiveFields,
+        containsAll(<String>{
+          'content',
+          'customer_encryption.encryption_key',
+        }),
+      );
+    });
+
+    test('a literal content fails synth with SensitiveLiteralError', () {
+      final stack = TestStack(providers: [const GoogleProvider(project: 'p')]);
+      stack.add(
+        GoogleStorageBucketObject(
+          localName: 'seed',
+          bucket: TfArg.literal('assets'),
+          name: TfArg.literal('seed.json'),
+          body: StorageBucketObjectBucketObjectFromContent(
+            content: TfArg.literal('{"k":1}'),
+          ),
+        ),
+      );
+      expect(() => stack.synth(), throwsA(isA<SensitiveLiteralError>()));
+    });
+
+    test('a variable content synths to a var reference', () {
+      final stack = TestStack(providers: [const GoogleProvider(project: 'p')]);
+      stack.add(
+        GoogleStorageBucketObject(
+          localName: 'seed',
+          bucket: TfArg.literal('assets'),
+          name: TfArg.literal('seed.json'),
+          body: StorageBucketObjectBucketObjectFromContent(
+            content: TfArg.variable('seed_content'),
+          ),
+        ),
+      );
+      final tfJson = stack.synth().tfJson;
+      final resource = ((tfJson['resource']
+          as Map)['google_storage_bucket_object'] as Map)['seed'] as Map;
+      expect(resource['content'], equals(r'${var.seed_content}'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Behavior tests covered ~13 of 380 resources, while past real bugs clustered in the hand-written override axes (sealed exactly-one-of encoders, customSlots, sensitiveFields). Gate 6 (`test/synth/encode_round_trip_test.dart`) asserts every sealed member encodes *something* well-formed, but compares structure only — it cannot see wrong nesting, sibling-key leaks, or sensitive handling. This PR adds wire-precision tests for the four flagship sealed families the README advertises, plus two agent edge cases.

## Changes

- **cloud_run** — `EnvVarFromLiteral` vs `EnvVarFromSecret` exact shapes (`value` vs `value_source.secret_key_ref`), null-source behavior, all 5 volume variants emit exactly their own block key, secret-volume `items` mapping.
- **bigquery** — all 8 `BigqueryDatasetAccess` variants: scalar principals emit their key + `role` with zero sibling-key leak; `view`/`dataset`/`routine` nest their references exactly.
- **compute** — 6 health-check protocol configs map to their block key; the resource embeds **exactly one** `*_health_check` block.
- **storage** — `source` | `content` payload exclusivity; content sensitivity enforced through a real synth pass (literal → `SensitiveLiteralError` fail-fast, `TfArg.variable` → `${var.*}` reference) — guarding the historical write-once-secret apply breakage class directly.
- **terradart_agent** — `get_resource_schema` suggestion cutoff: far-off names (`aws_s3_bucket`) and empty input return **no** suggestions instead of junk matches. (`check_coverage` error paths were already covered by existing tests — no duplication added.)

## Verification

- terradart_google suite → **403 tests green** (+17)
- terradart_agent suite → **17 tests green** (+2)
- `dart analyze --fatal-infos --fatal-warnings` / `dart format` — clean