### PR TITLE
chore: sweep small staleness (stack doc, MIGRATING heading, RELEASE sample)

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -27,7 +27,7 @@ connectionTrackingPolicy:
 
 If you did not set `connection_tracking_policy`, no change is needed.
 
-## 0.12.20 → next release
+## 0.12.20 → 0.13.0
 
 **Breaking changes** — API-enablement collapse, time-wrapper relocation, and
 removal of the unimplemented provider-aliasing surface.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Checklist
 
-terradart bumps 5 packages in lockstep: `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_agent`, and `terradart_coverage`. All 5 share the same version (e.g. `0.15.0`). The pub.dev publish workflow currently publishes the 3 hosted packages: `terradart_core`, `terradart_codegen`, and `terradart_google`.
+terradart bumps 5 packages in lockstep: `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_agent`, and `terradart_coverage`. All 5 share the same version. The pub.dev publish workflow currently publishes the 3 hosted packages: `terradart_core`, `terradart_codegen`, and `terradart_google`.
 
 ## Pre-flight (local)
 

--- a/packages/terradart_core/lib/src/stack.dart
+++ b/packages/terradart_core/lib/src/stack.dart
@@ -80,10 +80,9 @@ abstract base class Stack {
   /// When true, synth-time injection flips `deletion_protection` to
   /// `false` on any registered resource whose
   /// `Resource.supportsDeletionProtection` is true and that did not
-  /// explicitly set the field. (The capability getter is added in the
-  /// next commit.) Intended for dogfood / sample apps; production
-  /// stacks leave this false (the provider default of `true` then
-  /// applies).
+  /// explicitly set the field. Intended for dogfood / sample apps;
+  /// production stacks leave this false (the provider default of
+  /// `true` then applies).
   final bool devMode;
 
   final List<StackProvider> _providers;


### PR DESCRIPTION
## Summary

Three small staleness fixes found during the 2026-07-02 repo-wide audit:

- **stack.dart** — drop the "(The capability getter is added in the next commit.)" aside from the `devMode` doc; `Resource.supportsDeletionProtection` has existed since the same release, so the parenthetical was review narration that outlived its PR.
- **MIGRATING.md** — resolve the "`0.12.20 → next release`" heading to the release those breaking changes actually shipped in (**0.13.0**: `Apis.enable` collapse, time-wrapper relocation, provider-aliasing removal).
- **RELEASE.md** — drop the version example from the lockstep sentence so the process doc carries no number that can go stale.

## Deliberately not included (audited, deferred)

- `StackProvider.toTfJson()` back-compat shim removal — it is public API, so removal is a breaking change needing a MIGRATING section; zero-harm one-liner, better bundled into the next breaking minor's pre-1.0 API cleanup.
- The 18 remaining `classDocComment` overrides (firebase_app_check / firebase_app_hosting / iam) — each is 28–60 lines of artisanal doc (variant-selection guides, external links) requiring curatedDoc distillation, i.e. a de-fatten doc-wave of its own, not a sweep item.

## Verification

- terradart_core suite — 196 tests green
- `dart analyze --fatal-infos --fatal-warnings` / `dart format` — clean
- `dart tool/check_docs_consistency.dart` — OK