### PR TITLE
docs: declare alpha — change policy in force now, beta gated on external validation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to file. terradart is **pre-alpha** on
+        Thanks for taking the time to file. terradart is **alpha** on
         **0.22.x** today. Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to file. terradart is **pre-alpha** on
+        Thanks for taking the time to file. terradart is **alpha** on
         **0.22.x** today. Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to ask. terradart is **pre-alpha** on
+        Thanks for taking the time to ask. terradart is **alpha** on
         **0.22.x** today. Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to terradart
 
-Thanks for taking time to look at this. terradart is a **pre-alpha** single-maintainer project (0.22.x today; [beta readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met, label timing under consideration). Contributions are welcome on a best-effort basis.
+Thanks for taking time to look at this. terradart is an **alpha** single-maintainer project (0.22.x today; breaking changes land only on minor bumps — beta needs external validation, see the [path to beta](https://terradart.dev/docs/status/#path-to-beta)). Contributions are welcome on a best-effort basis.
 
 ## What kind of contribution?
 
@@ -8,7 +8,7 @@ terradart ships one consumer surface:
 
 - **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**380 curated resource factories + 1 data source** as of 0.22.x). Bug fixes, tests, and doc improvements welcome. New resources land via `terradart wrap` overrides — open an issue first to discuss scope.
 
-Within a **minor** line (`^0.22.x`), we aim to avoid breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (stricter once beta is declared — see [status](https://terradart.dev/docs/status/)).
+Within a **minor** line (`^0.22.x`), no breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (the alpha change policy — see [status](https://terradart.dev/docs/status/)).
 
 Bug reports / questions / feature requests: pick a template when [opening an issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
 
@@ -68,7 +68,7 @@ Before opening a PR:
 
 ## Review cadence
 
-terradart is a single-maintainer project (pre-alpha). Issue triage and PR
+terradart is a single-maintainer project (alpha). Issue triage and PR
 review are best-effort — expect a few weeks of latency, not a defined SLA.
 If a PR sits untouched for 30 days, ping with a comment.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 >
 > Google Cloud infrastructure as real Dart code — typed, refactor-safe, drop-in for `terraform apply`.
 
-**Pre-alpha** — no SemVer guarantees until v1.0.0. Pin `^0.22.x`, read [`MIGRATING.md`](MIGRATING.md) before bumping, and see [status on terradart.dev](https://terradart.dev/docs/status/).
+**Alpha** — no SemVer until v1.0.0, but breaking changes land only on **minor** bumps. Pin `^0.22.x`, read [`MIGRATING.md`](MIGRATING.md) before minor bumps, and see [status on terradart.dev](https://terradart.dev/docs/status/).
 
 <!-- identity -->
 [![pub: terradart_core](https://img.shields.io/pub/v/terradart_core.svg?label=pub%3A%20core)](https://pub.dev/packages/terradart_core)
@@ -216,7 +216,7 @@ Runnable end-to-end:  [`examples/pubsub_quickstart/`](examples/pubsub_quickstart
 
 ## terradart-mcp
 
-**Pre-alpha.** [`terradart-mcp`](packages/terradart_agent/) is an MCP server that exposes the curated factory **catalog** to coding agents (Claude Code, Cursor, Claude Desktop). Five read-only tools — `list_barrels`, `list_resources`, `get_resource_schema`, `get_quickstart`, and `check_coverage` — help agents author correct Dart without guessing factory names. It does **not** run Terraform or touch GCP.
+**Alpha.** [`terradart-mcp`](packages/terradart_agent/) is an MCP server that exposes the curated factory **catalog** to coding agents (Claude Code, Cursor, Claude Desktop). Five read-only tools — `list_barrels`, `list_resources`, `get_resource_schema`, `get_quickstart`, and `check_coverage` — help agents author correct Dart without guessing factory names. It does **not** run Terraform or touch GCP.
 
 ```sh
 brew install nozomi-koborinai/tap/terradart-mcp
@@ -298,18 +298,18 @@ Application platform & operations
 | Dart authoring | ✅ | ❌ | ❌ (TS / Py / Java / Go) | ❌ (TS / Py / Go / etc.) |
 | Type-safe handoff to your app | ✅ (compile-time) | ❌ (`terraform output` + parse) | ❌ (no Dart) | ❌ (no Dart) |
 | Drop-in for `terraform apply` | ✅ (emits `*.tf.json`) | ✅ (native) | ✅ | ⚠️ (different state model) |
-| Project status | Pre-alpha | Mature | **Archived Dec 2025** | Active |
+| Project status | Alpha | Mature | **Archived Dec 2025** | Active |
 
 ## Non-goals
 
 - **Not a Terraform replacement.** TerraDart synthesizes JSON; `terraform plan / apply` runs as before. State stays where you already keep it.
 - **Not a multi-cloud tool yet.** Google provider only. AWS / Azure may follow if the curated surface stabilizes — no promise.
-- **Not a constructs framework.** Composite abstractions are out of scope for the pre-alpha cycle.
+- **Not a constructs framework.** Composite abstractions are out of scope for the pre-1.0 cycle.
 - **Not module-block support.** Compose Terraform modules in HCL alongside TerraDart-generated `*.tf.json` — both feed the same `terraform apply`.
 
 ## Status
 
-**Pre-alpha**, pre-1.0 (0.22.x). No SemVer guarantees until v1.0.0; pin `^0.22.x` and read [`MIGRATING.md`](MIGRATING.md) before every minor bump. The [beta readiness gates](https://terradart.dev/docs/status/#beta-readiness-checklist) are met; the beta label timing is under consideration. Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
+**Alpha**, pre-1.0 (0.22.x). No SemVer until v1.0.0, but breaking changes land only on **minor** bumps, always documented in [`MIGRATING.md`](MIGRATING.md); pin `^0.22.x` and take patches freely. Beta needs external validation — see the [path to beta](https://terradart.dev/docs/status/#path-to-beta). Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
 
 ## Schema-bump automation (Plan 5.E)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,13 +35,13 @@ Pin dependencies with `^0.22.x` on [pub.dev](https://pub.dev/packages/terradart_
 
 | Version | Status | Security fixes |
 |---|---|---|
-| **0.22.x** (pre-alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
+| **0.22.x** (alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
 | **0.11.x and older** | Unsupported | Upgrade to 0.22.x; see [MIGRATING.md](MIGRATING.md) |
 | Future beta line (TBD) | Best-effort with clearer minor-boundary policy | See [status on terradart.dev](https://terradart.dev/docs/status/) |
 
 ## Disclosure policy
 
-**Best-effort, target 90 days** from confirmed-report to public advisory. As a single-maintainer pre-alpha project, we cannot guarantee this window — straightforward fixes typically ship within 30 days; fixes requiring upstream changes (provider schema, Dart SDK) may exceed 90 days. Reporters will be kept informed of timeline shifts on the embargoed advisory thread.
+**Best-effort, target 90 days** from confirmed-report to public advisory. As a single-maintainer alpha project, we cannot guarantee this window — straightforward fixes typically ship within 30 days; fixes requiring upstream changes (provider schema, Dart SDK) may exceed 90 days. Reporters will be kept informed of timeline shifts on the embargoed advisory thread.
 
 CVE IDs are requested via GitHub's CNA on advisory publication.
 

--- a/packages/terradart_agent/README.md
+++ b/packages/terradart_agent/README.md
@@ -8,7 +8,7 @@ Built on [`genkit`](https://pub.dev/packages/genkit) + [`genkit_mcp`](https://pu
 
 ## Status
 
-**Pre-alpha** — same expectations as the rest of TerraDart (pin versions, read release notes). The server is read-only catalog metadata; it does not run `terraform`, touch GCP, or apply infrastructure.
+**Alpha** — same expectations as the rest of TerraDart (pin versions, read release notes). The server is read-only catalog metadata; it does not run `terraform`, touch GCP, or apply infrastructure.
 
 ## Install
 

--- a/packages/terradart_coverage/README.md
+++ b/packages/terradart_coverage/README.md
@@ -8,7 +8,7 @@ It matches Terraform type strings against the static catalog compiled into [`ter
 
 ## Status
 
-**Pre-alpha** — same expectations as the rest of TerraDart (pin versions, read release notes). The tool is read-only: it reads source files and reports. It never runs Terraform, touches a backend, or modifies anything.
+**Alpha** — same expectations as the rest of TerraDart (pin versions, read release notes). The tool is read-only: it reads source files and reports. It never runs Terraform, touches a backend, or modifies anything.
 
 ## Install
 

--- a/tool/bump_version.sh
+++ b/tool/bump_version.sh
@@ -22,9 +22,9 @@
 #   - packages/terradart_google/README.md         (pubspec sample carets)
 #   - packages/terradart_codegen/README.md        (`dart pub global activate` caret)
 #   - website/src/content/docs/docs/getting-started.md  (pubspec sample caret note + version line)
-#   - .github/ISSUE_TEMPLATE/bug.yml              (pre-alpha banner version)
-#   - .github/ISSUE_TEMPLATE/feature.yml          (pre-alpha banner version)
-#   - .github/ISSUE_TEMPLATE/question.yml         (pre-alpha banner version)
+#   - .github/ISSUE_TEMPLATE/bug.yml              (alpha banner version)
+#   - .github/ISSUE_TEMPLATE/feature.yml          (alpha banner version)
+#   - .github/ISSUE_TEMPLATE/question.yml         (alpha banner version)
 #
 # What it does NOT touch (write these by hand after the bump):
 #   - CHANGELOG.md (root + per-package) — release notes are prose
@@ -205,8 +205,8 @@ for tpl in .github/ISSUE_TEMPLATE/bug.yml \
   fi
 done
 
-# `.x`-style minor carets + pre-alpha banner. The pubspec samples in the
-# READMEs and the website getting-started page, plus the README pre-alpha
+# `.x`-style minor carets + alpha banner. The pubspec samples in the
+# READMEs and the website getting-started page, plus the README alpha
 # banner, use the ^X.Y.x minor form — distinct from the ^X.Y.Z full-semver
 # samples handled above, which is why those passes leave them untouched. Sweep
 # them in one pass so the docs-consistency check (which expects ^X.Y.x) stays

--- a/website/src/content/docs/docs/architecture.mdx
+++ b/website/src/content/docs/docs/architecture.mdx
@@ -110,7 +110,7 @@ A worked end-to-end example lives in the [cookbook `single-project-app` recipe](
 
 - Not a Terraform replacement — state and apply stay in Terraform.
 - Not multi-cloud yet — the Google provider only.
-- Not a constructs framework in the pre-alpha cycle.
+- Not a constructs framework in the pre-1.0 cycle.
 - Not module-block support — compose Terraform modules in HCL alongside TerraDart-generated `*.tf.json`; both feed the same `terraform apply`.
 
 See [README — Non-goals](https://github.com/nozomi-koborinai/terradart#non-goals) for the canonical list.

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -3,7 +3,7 @@ title: Getting Started
 description: Install TerraDart and generate your first *.tf.json from a Stack.
 ---
 
-This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.22.x** line. TerraDart is **pre-alpha**; the [beta gates](/docs/status/#beta-readiness-checklist) are met and the label timing is under consideration — see [Status & versioning](/docs/status/).
+This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.22.x** line. TerraDart is **alpha** — breaking changes land only on **minor** bumps; see [Status & versioning](/docs/status/) for the change policy and the [path to beta](/docs/status/#path-to-beta).
 
 ## Prerequisites
 
@@ -99,5 +99,5 @@ Rename `orders-prod` in the Stack without updating the subscriber and `dart anal
 - [Architecture](/docs/architecture/) — `synth()`, `writeTo()`, curated coverage
 - [Curated factory waves](/docs/waves/) — factory history and example pointers
 - [Migrating](/docs/migrating/) — read before every minor bump
-- [Status & versioning](/docs/status/) — pre-alpha vs beta vs 1.0
+- [Status & versioning](/docs/status/) — alpha vs beta vs 1.0
 - [Examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook) for fuller stacks

--- a/website/src/content/docs/docs/index.md
+++ b/website/src/content/docs/docs/index.md
@@ -14,9 +14,9 @@ Guides track the **0.22.x** line on pub.dev. The repo [README](https://github.co
 - [Architecture](/docs/architecture/) — generate `*.tf.json`, `synth()` / `writeTo()`, AppExport
 - [Curated factory waves](/docs/waves/) — factory history and example pointers
 - [Migrating](/docs/migrating/) — breaking-change guides for minor bumps
-- [Status & versioning](/docs/status/) — pre-alpha, beta readiness, 1.0
+- [Status & versioning](/docs/status/) — alpha, path to beta, 1.0
 
 ## For AI assistants
 
-- [terradart-mcp](/docs/agent/) — MCP catalog server for coding agents (pre-alpha)
+- [terradart-mcp](/docs/agent/) — MCP catalog server for coding agents (alpha)
 - [llms.txt](/llms.txt) — condensed site map for LLM crawlers

--- a/website/src/content/docs/docs/migrating.md
+++ b/website/src/content/docs/docs/migrating.md
@@ -133,5 +133,5 @@ Earlier breaking changes (WIF provider sealed `trustSource`, `terradart codegen`
 ## Next steps
 
 - [Waves 23–24](/docs/waves/) — new factories and example stacks
-- [Status & versioning](/docs/status/) — pre-alpha expectations and beta policy
+- [Status & versioning](/docs/status/) — alpha expectations and change policy
 - [Examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) — updated quickstarts exercising the new APIs

--- a/website/src/content/docs/docs/status.md
+++ b/website/src/content/docs/docs/status.md
@@ -1,58 +1,59 @@
 ---
 title: Status & versioning
-description: Pre-alpha expectations, beta readiness, and how TerraDart versions releases.
+description: Alpha expectations, the path to beta, and how TerraDart versions releases.
 ---
 
-TerraDart is **pre-alpha** on the **0.22.x** line today. The [beta readiness](#beta-readiness-checklist) required gates are complete; labeling the project **beta** is now a deliberate timing decision under consideration (together with the eventual 1.0 timeline). The beta label will apply from a future release, not retroactively on earlier 0.x lines.
+TerraDart is **alpha** on the **0.22.x** line today. Alpha means the maintainer-side quality gates are all done (see [Alpha gates](#alpha-gates-complete)) and the [change policy](#change-policy-from-alpha-onward) below is in force; what still separates alpha from **beta** is external validation — see [Path to beta](#path-to-beta).
 
-There are no SemVer guarantees until **v1.0.0**. Pin with `^0.22.x` and read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before every **minor** bump. Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch.
+There are no SemVer guarantees until **v1.0.0**, but breaking changes land only on **minor** bumps: pin with `^0.22.x`, take patch releases freely, and read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before every minor bump. Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch.
 
 ## Release phases
 
 | Phase | Version line | What we promise |
 | --- | --- | --- |
-| **Pre-alpha** | 0.22.x (current) | Breaking changes may land in any 0.x release until beta policy applies. |
-| **Beta** | TBD (gates met; timing under consideration) | Trustworthy onboarding on terradart.dev and GitHub. **No breaking changes within a minor** (`^0.N.x`); breaking changes only on minor bumps, always documented in `MIGRATING.md`. Not SemVer-frozen until 1.0.0. |
+| **Alpha** | 0.22.x (current) | Maintainer-side gates are done (docs, CI, real-apply coverage). **No breaking changes within a minor** (`^0.N.x`); breaking changes only on minor bumps, always documented in `MIGRATING.md`. Not SemVer until 1.0.0. |
+| **Beta** | TBD (needs external validation) | The same change policy, proven against real external usage — see [Path to beta](#path-to-beta). |
 | **1.0.0** | TBD | Stable SemVer for `terradart_core`, `terradart_google`, and `terradart_codegen`. |
 
-## What to expect today (pre-alpha)
+## What to expect today (alpha)
 
-- Surface and emitted Terraform JSON may change between releases, especially across **minor** bumps.
+- Breaking changes to the public Dart API or the emitted Terraform JSON land only on **minor** bumps, each with a [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) section; patch releases within `^0.N.x` are safe to take.
 - Use hosted `^0.22.x` carets on [pub.dev](https://pub.dev/packages/terradart_core) — not legacy `0.x.y-dev` pre-release tags.
 - Only the **curated** `terradart_google` surface is supported for users; non-curated resources require a curation request.
 
-## Beta change policy (applies once beta is declared)
-
-When we declare beta:
+## Change policy (from alpha onward)
 
 - **Patch releases** (`0.N.x` → `0.N.y`): no intentional breaking changes to `terradart_core` / `terradart_google` public APIs.
 - **Minor releases** (`0.N.x` → `0.M.x`): breaking changes allowed only with a `MIGRATING.md` section for the previous minor.
 - **Curated factory additions** continue (additive waves); renaming or removing curated factories still counts as breaking.
 
-## Beta readiness checklist
+## Alpha gates (complete)
 
-Every **required** item below is done, so beta is no longer blocked on readiness — declaring it is a maintainer timing decision, and the label will take effect from a future release when made.
-
-### Required (all must be ✅ before the beta label)
+Alpha required every item below; all are done. (This list was the former "beta readiness checklist" — beta is now gated on [external validation](#path-to-beta) instead.)
 
 - [x] **Getting Started** on terradart.dev matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart); no “Coming soon” placeholders on Status or Getting Started.
 - [x] **`tool/check_docs_consistency`** runs in CI and passes (workspace + examples caret minor, catalog count, key meta docs). Workflow: [`.github/workflows/docs-consistency.yml`](https://github.com/nozomi-koborinai/terradart/blob/main/.github/workflows/docs-consistency.yml).
 - [x] **`tool/smoke_quickstart.sh`** runs in CI and passes (`pubsub_quickstart`: pub get → synth → analyze including export consumer stub).
 - [x] **Examples matrix** on `main` stays green (per-example synth + `terraform validate` on `tf-out/`).
 - [x] **Boundary demo**: [pubsub_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart) documents `addExport` / generated `.app.dart` and includes a subscriber stub that `dart analyze` accepts.
-- [x] **Meta docs aligned** with the current minor: CONTRIBUTING, SECURITY, issue templates, package READMEs, and root README agree on pre-alpha/beta wording, `^0.N.x` pins, and **380 curated resource factories + 1 data source** (381 catalog entries).
+- [x] **Meta docs aligned** with the current minor: CONTRIBUTING, SECURITY, issue templates, package READMEs, and root README agree on alpha/beta wording, `^0.N.x` pins, and **380 curated resource factories + 1 data source** (381 catalog entries).
 - [x] **Full example coverage**: `tool/example_debt.yaml` is empty — all catalog entries appear in at least one quickstart synth (`check_docs_consistency.dart`).
-- [x] **Beta change policy** published on this page (see [Beta change policy](#beta-change-policy-applies-once-beta-is-declared)).
+- [x] **Change policy** published on this page (see [Change policy](#change-policy-from-alpha-onward)) and in force from alpha.
 
-### Optional (does not block beta)
+## Path to beta
 
-- [x] **`MIGRATING.md` / site migration guide** — [Migrating](/docs/migrating/) mirrors the `0.12.9 → 0.12.10` breaking changes; [MIGRATING.md on GitHub](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) remains canonical for older releases. *Two-minor depth across minors remains a beta quality bar for current and future minor releases.*
+Beta is the alpha change policy **proven against real external usage**. We will label the project beta when:
+
 - [ ] **External quickstart**: someone outside the core team completes the README path once; feedback captured in an issue or discussion.
 - [ ] **Real apply dogfood** via the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook): at least one non-trivial recipe documents a successful `terraform apply`.
 - [ ] **`terradart-mcp`**: [Agent install](/docs/agent/install/) verified on a clean machine (Homebrew or release binary + five tools).
+
+Toward **1.0.0** (does not block beta):
+
+- [x] **`MIGRATING.md` / site migration guide** — [Migrating](/docs/migrating/) mirrors the `0.12.9 → 0.12.10` breaking changes; [MIGRATING.md on GitHub](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) remains canonical for older releases. *Two-minor depth across minors remains a quality bar for current and future minor releases.*
 - [ ] **1.0.0 criteria** drafted (what “stable” means for curated names and `terradart_core` API).
 
-## What beta does *not* mean
+## What alpha does *not* mean
 
 - **Not** a freeze on new curated factories.
 - **Not** [constructs / composite frameworks](https://github.com/nozomi-koborinai/terradart#non-goals).

--- a/website/src/content/docs/docs/why-terradart.mdx
+++ b/website/src/content/docs/docs/why-terradart.mdx
@@ -82,7 +82,7 @@ TerraDart fits teams already centered on **Dart**, already running **Terraform**
 | Dart authoring | Yes | No | No | No |
 | Drop-in for `terraform apply` | Yes | Yes | Yes | Different model |
 | Curated Dart factories for GCP | Yes | No | No | No |
-| Project status | Pre-alpha | Mature | Archived 2025 | Active |
+| Project status | Alpha | Mature | Archived 2025 | Active |
 
 HCL has provider schema types; CDKTF bindings are typed in TypeScript and other languages. TerraDart's difference is **Dart-native authoring** without replacing your Terraform execution pipeline.
 
@@ -102,11 +102,11 @@ HCL has provider schema types; CDKTF bindings are typed in TypeScript and other 
 
 - Not a Terraform replacement — state and apply stay in Terraform.
 - Not multi-cloud yet — the Google provider only.
-- Not a constructs framework in the pre-alpha cycle.
+- Not a constructs framework in the pre-1.0 cycle.
 - Not module-block support — compose Terraform modules in HCL alongside TerraDart-generated `*.tf.json`; both feed the same `terraform apply`.
 
 ## Next steps
 
 - [Architecture](/docs/architecture/) — `synth()` / `writeTo()`, provider integration, AppExport
 - [Getting Started](/docs/getting-started/) — install and first `*.tf.json` output (in progress)
-- [Status](/docs/status/) — pre-alpha expectations
+- [Status](/docs/status/) — alpha expectations


### PR DESCRIPTION
## Summary

TerraDart has called itself **pre-alpha** while every maintainer-side readiness gate is done and the 0.14+ release history already honors "breaking only on minor bumps, always with MIGRATING coverage". The label undersold the actual state; what is genuinely missing is not readiness but **external usage**. This PR renames the phase to what is true.

## The new phase model

- **Alpha (0.22.x, now)** — the former beta change policy applies **from alpha onward**: no breaking changes within a minor; breaking changes only on minor bumps, each with a `MIGRATING.md` section. The queued breaking work (`toTfJson` shim removal, the `enum_gap_debt.yaml` narrowings) ships in 0.23.0 — a minor bump, fully inside this promise.
- **Beta (TBD)** — the same policy **proven against real external usage**. The former Optional gates become the explicit *Path to beta*: an external quickstart completion, a real-apply cookbook record, and a clean-machine `terradart-mcp` install. "1.0.0 criteria drafted" stays a 1.0-side item.

## Changes

- **status.md** restructured: Release phases / What to expect today (alpha) / Change policy (from alpha onward) / Alpha gates (complete) / **Path to beta** / What alpha does *not* mean.
- README (banner, mcp section, comparison table, Status section), CONTRIBUTING, SECURITY (support table + disclosure), the three issue templates, `terradart_agent` + `terradart_coverage` READMEs, and the website pages (getting-started, index, why-terradart, architecture, migrating) all follow.
- The "pre-alpha cycle" non-goal phrasing becomes "pre-1.0 cycle" so it cannot go stale on the next phase change.
- `bump_version.sh` comments follow (no behavioral change; the version-rewrite patterns are label-independent).

## Verification

- `dart tool/check_docs_consistency.dart` — OK
- `tool/agent_verify.sh --quick` — OK (~20s; first field use of the new quick tier)
- Zero `pre-alpha` mentions remain outside CHANGELOG history