### PR TITLE
chore(coverage): align analysis_options with the other packages

### DIFF
--- a/packages/terradart_coverage/analysis_options.yaml
+++ b/packages/terradart_coverage/analysis_options.yaml
@@ -1,1 +1,15 @@
 include: package:lints/recommended.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+  errors:
+    invalid_use_of_internal_member: error
+
+linter:
+  rules:
+    - prefer_final_locals
+    - require_trailing_commas
+    - sort_constructors_first

--- a/packages/terradart_coverage/lib/src/tf_json_parser.dart
+++ b/packages/terradart_coverage/lib/src/tf_json_parser.dart
@@ -22,7 +22,7 @@ ParseOutcome parseShowJson(Map<String, dynamic> json) {
 }
 
 void _walk(
-  Map module,
+  Map<dynamic, dynamic> module,
   String modulePath,
   List<TfReference> refs,
   List<String> unparseable,

--- a/packages/terradart_coverage/test/cli_test.dart
+++ b/packages/terradart_coverage/test/cli_test.dart
@@ -23,7 +23,7 @@ void main() {
     ]);
     expect(result.exitCode, 0, reason: result.stderr.toString());
     final decoded = jsonDecode(result.stdout as String);
-    expect(decoded['summary'], isA<Map>());
+    expect(decoded['summary'], isA<Map<String, dynamic>>());
   });
 
   test('CLI exits non-zero on non-JSON input', () async {

--- a/packages/terradart_coverage/test/config_parser_test.dart
+++ b/packages/terradart_coverage/test/config_parser_test.dart
@@ -91,10 +91,13 @@ void main() {
       File('${tmp.path}/main.tf.json').writeAsStringSync(
         jsonEncode({
           'resource': {
-            'google_pubsub_topic': {'a': {}, 'b': {}},
+            'google_pubsub_topic': {
+              'a': <String, Object?>{},
+              'b': <String, Object?>{},
+            },
           },
           'data': {
-            'google_project': {'p': {}},
+            'google_project': {'p': <String, Object?>{}},
           },
         }),
       );

--- a/packages/terradart_coverage/test/report_render_test.dart
+++ b/packages/terradart_coverage/test/report_render_test.dart
@@ -43,7 +43,7 @@ void main() {
   test('reportToJsonMap returns same structure as json render', () {
     final sample = _sample();
     final m = reportToJsonMap(sample);
-    expect(m['summary'], isA<Map>());
+    expect(m['summary'], isA<Map<String, Object?>>());
     expect((m['summary'] as Map)['distinctTypes'], 1);
     expect(
       m.keys,


### PR DESCRIPTION
## Summary

A Dart-conventions audit (lints/recommended + strict trio + `dart fix --dry-run` across the workspace) came back clean everywhere except one gap: `terradart_coverage`'s `analysis_options.yaml` was a bare `include: package:lints/recommended.yaml` — no `strict-casts` / `strict-inference` / `strict-raw-types` and none of the shared extra lints. It is the youngest package (#161), so this reads as a scaffold omission rather than a decision.

## Changes

- Adopt the core/agent shape: strict trio + `invalid_use_of_internal_member: error` + `prefer_final_locals` / `require_trailing_commas` / `sort_constructors_first`.
- Strictness surfaced six raw/under-inferred `Map` sites; typed them explicitly:
  - `lib/src/tf_json_parser.dart` — raw `Map` param → `Map<dynamic, dynamic>` (matches the dynamic JSON walk it performs)
  - tests — untyped empty map literals → `<String, Object?>{}`; `isA<Map>()` matchers → `isA<Map<String, dynamic>>()` / `isA<Map<String, Object?>>()`

## Verification

- `dart analyze packages/terradart_coverage --fatal-infos --fatal-warnings` — No issues found
- `dart test` — 34/34 green
- `dart format` check — clean; `dart fix --dry-run` — Nothing to fix