### PR TITLE
feat(codegen): deriveNestedTypes gate — typed nested helpers from provider schema (dark)

### DIFF
--- a/packages/terradart_codegen/lib/src/cli/wrap_command.dart
+++ b/packages/terradart_codegen/lib/src/cli/wrap_command.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
 
@@ -210,7 +211,22 @@ class WrapCommand extends Command<int> {
     // `sensitiveFields` / `constructorParams` are computed from the SAME
     // helpers the wrapper emitter uses (zero drift by construction).
     final catalogEntries = <CatalogEntryData>[];
-    final resourceEmitter = WrapperEmitter(overrides: loaded.resources);
+    // `deriveNestedTypes` needs the RAW schema.json `block` shape
+    // (`block_types` / `nesting_mode` / `min_items`, ...), which `baseIr`
+    // above no longer carries once `SchemaJsonParser` has flattened it into
+    // the IR. Decoding schema.json a second time only when at least one
+    // loaded override actually sets the gate keeps today's (dark) run
+    // exactly as cheap as before this gate existed — every committed
+    // override currently leaves `deriveNestedTypes` at its `false` default.
+    final needsRawSchemas =
+        loaded.resources.values.any((o) => o.deriveNestedTypes);
+    final rawResourceSchemas = needsRawSchemas
+        ? _rawResourceBlocks(schemaSrc)
+        : const <String, Map<String, dynamic>>{};
+    final resourceEmitter = WrapperEmitter(
+      overrides: loaded.resources,
+      rawResourceSchemas: rawResourceSchemas,
+    );
     final dataSourceEmitter =
         DataSourceWrapperEmitter(overrides: loaded.dataSources);
     // Layer 2 emit output is unformatted; match the WrapperEmitter /
@@ -415,4 +431,25 @@ class WrapCommand extends Command<int> {
     stderr.writeln('\nRun `terradart wrap` to regenerate.');
     return CliExitCodes.dataError;
   }
+}
+
+/// Decodes [schemaJson]'s raw `resource_schemas` entries down to just their
+/// `block` map, keyed by Terraform type — the shape
+/// `collectNestedTypes`/`WrapperEmitter.rawResourceSchemas` need for the
+/// `deriveNestedTypes` gate. Mirrors the navigation path
+/// `SchemaJsonParser.parseString` itself uses
+/// (`provider_schemas` -> the single provider body -> `resource_schemas`),
+/// just stopping one level short of IR construction so `block_types` /
+/// `nesting_mode` survive.
+Map<String, Map<String, dynamic>> _rawResourceBlocks(String schemaJson) {
+  final root = jsonDecode(schemaJson) as Map<String, dynamic>;
+  final schemas = (root['provider_schemas'] as Map).cast<String, dynamic>();
+  final providerBody = (schemas.values.single as Map).cast<String, dynamic>();
+  final resourceSchemas =
+      (providerBody['resource_schemas'] as Map?)?.cast<String, dynamic>() ??
+          const {};
+  return {
+    for (final entry in resourceSchemas.entries)
+      entry.key: ((entry.value as Map)['block'] as Map).cast<String, dynamic>(),
+  };
 }

--- a/packages/terradart_codegen/lib/src/codegen/enum_value_parser.dart
+++ b/packages/terradart_codegen/lib/src/codegen/enum_value_parser.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+/// Parses schema descriptions that document a finite value set.
+List<String>? parseEnumValuesFromDescription(String? description) {
+  if (description == null) return null;
+
+  final bracket = RegExp(r'Possible values:\s*(\[[^\]]+\])');
+  final m = bracket.firstMatch(description);
+  if (m != null) {
+    try {
+      final vals = jsonDecode(m.group(1)!.replaceAll("'", '"')) as List;
+      final strings = vals.cast<String>();
+      return strings.length >= 2 ? strings : null;
+    } on FormatException {
+      // fall through
+    }
+  }
+
+  // `Valid values are: "PAGELESS", "PAGINATED".`
+  final validAre = RegExp(
+    r'Valid values are:\s*([^.]+)\.',
+    caseSensitive: false,
+  );
+  final vm = validAre.firstMatch(description);
+  if (vm != null) {
+    final quoted = RegExp(r'"([^"]+)"')
+        .allMatches(vm.group(1)!)
+        .map((m) => m.group(1)!)
+        .toList();
+    if (quoted.length >= 2) return quoted;
+  }
+
+  // `Possible values: JOB_TYPE_UNSPECIFIED, PIPELINE, QUERY`
+  final loose = RegExp(r'Possible values:\s*([A-Z0-9_,\s]+)');
+  final lm = loose.firstMatch(description);
+  if (lm != null) {
+    final vals = lm
+        .group(1)!
+        .split(',')
+        .map((v) => v.trim())
+        .where((v) => v.isNotEmpty)
+        .toList();
+    if (vals.length >= 2) return vals;
+  }
+
+  return null;
+}

--- a/packages/terradart_codegen/lib/src/codegen/naming.dart
+++ b/packages/terradart_codegen/lib/src/codegen/naming.dart
@@ -64,7 +64,7 @@ EnumName enumName({
   // schema_settings.encoding) — short and distinctive.
   final leaf = fieldPath.split('.').last;
   final leafPascal = snakeToPascal(leaf);
-  final dartMembers = [for (final m in members) _screamingToCamel(m)];
+  final dartMembers = [for (final m in members) screamingToCamel(m)];
   return EnumName(
     dartName: '$shortResourcePascal$leafPascal',
     dartMembers: dartMembers,
@@ -73,7 +73,62 @@ EnumName enumName({
   );
 }
 
-String _screamingToCamel(String screaming) {
+/// SCREAMING_SNAKE_CASE → camelCase, e.g. `AUTOMATIC` → `automatic`,
+/// `ENCODING_UNSPECIFIED` → `encodingUnspecified`.
+///
+/// Guarantees a legal Dart identifier: on the rare occasion a raw value's
+/// camelCase rendering collides with a word Dart reserves outright
+/// (`default`, `in`, ...), a `Case` suffix is appended — the same
+/// mechanical fallback `ValidValuesEmitter` uses for the MM-derived
+/// `enum_values` path (`wrap_promote/valid_values_emitter.dart`). Every
+/// *known* collision in this codebase has so far been hand-named per field
+/// instead (e.g. `defaultMode` in
+/// `wrapper_overrides/yaml/google_compute_router.yaml`, `overrideStrategy`
+/// in `wrapper_overrides/yaml/google_app_engine_domain_mapping.yaml`) — this
+/// generic fallback only exists so a not-yet-reviewed derived enum can never
+/// fail to compile; a real hit is worth a human pass at a more fitting name.
+String screamingToCamel(String screaming) {
   final parts = screaming.toLowerCase().split('_');
-  return snakeToCamel(parts.join('_'));
+  final camel = snakeToCamel(parts.join('_'));
+  return _dartReservedWords.contains(camel) ? '${camel}Case' : camel;
 }
+
+/// Dart's fully-reserved words: illegal as an identifier in *any* context.
+/// Deliberately narrower than "reserved words + built-in identifiers" (e.g.
+/// `abstract`, `late`, `static` are legal identifiers in Dart) — this set
+/// only guards against the words that would otherwise fail to parse.
+const Set<String> _dartReservedWords = {
+  'assert',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'default',
+  'do',
+  'else',
+  'enum',
+  'extends',
+  'false',
+  'final',
+  'finally',
+  'for',
+  'if',
+  'in',
+  'is',
+  'new',
+  'null',
+  'rethrow',
+  'return',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'var',
+  'void',
+  'while',
+  'with',
+};

--- a/packages/terradart_codegen/lib/src/codegen/naming.dart
+++ b/packages/terradart_codegen/lib/src/codegen/naming.dart
@@ -43,6 +43,24 @@ class EnumName {
   });
 }
 
+/// Strips the `google_` provider prefix (if present) from [terraformType],
+/// then converts the remainder to PascalCase — e.g.
+/// `google_app_engine_domain_mapping` → `AppEngineDomainMapping`.
+///
+/// This is the shared "short resource name" both [enumName] (top-level
+/// derived enum names, e.g. `PubsubTopicEncoding` rather than
+/// `GooglePubsubTopicEncoding`) and the `deriveNestedTypes` collector wiring
+/// in `wrapper_emitter.dart` (nested-type class name prefixes, e.g.
+/// `AppEngineDomainMappingSslSettings`) build their generated names from —
+/// dropping the prefix keeps generated names readable in user code.
+String shortResourcePascal(String terraformType) {
+  const providerPrefix = 'google_';
+  final short = terraformType.startsWith(providerPrefix)
+      ? terraformType.substring(providerPrefix.length)
+      : terraformType;
+  return snakeToPascal(short);
+}
+
 /// Enum name = `<ResourceShortName><FieldNamePascal>`, e.g.
 /// `google_pubsub_topic` + `schema_settings.encoding` →
 /// `PubsubTopicEncoding`.
@@ -53,20 +71,13 @@ EnumName enumName({
   required String fieldPath,
   required List<String> members,
 }) {
-  // Drop the `google_` provider prefix when synthesising enum names so they
-  // read naturally in user code (`PubsubTopicEncoding`, not
-  // `GooglePubsubTopicSchemaSettingsEncoding`).
-  final shortResource = resourceType.startsWith('google_')
-      ? resourceType.substring(7)
-      : resourceType;
-  final shortResourcePascal = snakeToPascal(shortResource);
   // Use the **leaf** field name for the enum suffix (encoding, not
   // schema_settings.encoding) — short and distinctive.
   final leaf = fieldPath.split('.').last;
   final leafPascal = snakeToPascal(leaf);
   final dartMembers = [for (final m in members) screamingToCamel(m)];
   return EnumName(
-    dartName: '$shortResourcePascal$leafPascal',
+    dartName: '${shortResourcePascal(resourceType)}$leafPascal',
     dartMembers: dartMembers,
     rawValues: List<String>.from(members),
     fieldPath: fieldPath,

--- a/packages/terradart_codegen/lib/src/codegen/nested_types/nested_type_collector.dart
+++ b/packages/terradart_codegen/lib/src/codegen/nested_types/nested_type_collector.dart
@@ -5,7 +5,8 @@ import '../naming.dart';
 ///
 /// [dartType] is the *inner* type only (e.g. `'String'`, an enum class
 /// name, `'Map<String, String>'`) — the emitter (Task 3) wraps it in
-/// `TfArg<...>` and applies nullability from [required].
+/// `TfArg<...>` (or `List<TfArg<...>>`-shaped when [repeated]) and applies
+/// nullability from [required].
 final class NestedAttrSpec {
   final String tfName;
   final String dartName;
@@ -13,12 +14,22 @@ final class NestedAttrSpec {
   final bool required;
   final List<String>? enumValues;
 
+  /// Whether the underlying schema type is a `list`/`set` of [dartType]
+  /// rather than a bare scalar. Currently only ever `true` for a
+  /// list-of-enum-string attribute (`["list", "string"]` with a
+  /// `Possible values: [...]` description) — every other repeated shape
+  /// (a plain list of strings, a list of objects, ...) has no clean
+  /// per-element [dartType] to repeat, so it stays `false` and falls back
+  /// to an opaque [dartType] instead (see `_scalarDartType`).
+  final bool repeated;
+
   const NestedAttrSpec({
     required this.tfName,
     required this.dartName,
     required this.dartType,
     required this.required,
     this.enumValues,
+    this.repeated = false,
   });
 }
 
@@ -103,8 +114,7 @@ _ChildScan _scanChildren(
   required Set<String> customSlotKeys,
   required Set<String> excludedPaths,
 }) {
-  final blockTypes =
-      (block['block_types'] as Map?)?.cast<String, dynamic>() ?? const {};
+  final blockTypes = _optionalMap(block['block_types'], context: 'block_types');
   final children = <NestedBlockSpec>[];
   final excludedChildTfNames = <String>[];
   for (final entry in blockTypes.entries) {
@@ -119,7 +129,7 @@ _ChildScan _scanChildren(
 
     children.add(_buildSpec(
       tfName,
-      (entry.value as Map).cast<String, dynamic>(),
+      _requireMap(entry.value, context: 'block_types.$tfName'),
       path: childPath,
       resourcePrefix: resourcePrefix,
       customSlotKeys: customSlotKeys,
@@ -149,8 +159,10 @@ NestedBlockSpec _buildSpec(
   final minItems = (nestedBlockBody['min_items'] as num?)?.toInt();
   final className = resourcePrefix + path.map(snakeToPascal).join();
 
-  final block =
-      (nestedBlockBody['block'] as Map?)?.cast<String, dynamic>() ?? const {};
+  final block = _optionalMap(
+    nestedBlockBody['block'],
+    context: '$tfName.block',
+  );
   final scan = _scanChildren(
     block,
     path: path,
@@ -175,12 +187,11 @@ List<NestedAttrSpec> _collectAttrs(
   Map<String, dynamic> block, {
   required String className,
 }) {
-  final attributes =
-      (block['attributes'] as Map?)?.cast<String, dynamic>() ?? const {};
+  final attributes = _optionalMap(block['attributes'], context: 'attributes');
   final out = <NestedAttrSpec>[];
   for (final entry in attributes.entries) {
     final tfName = entry.key;
-    final body = (entry.value as Map).cast<String, dynamic>();
+    final body = _requireMap(entry.value, context: 'attributes.$tfName');
 
     final isComputed = body['computed'] == true;
     final isOptional = body['optional'] == true;
@@ -190,32 +201,98 @@ List<NestedAttrSpec> _collectAttrs(
 
     final enumValues =
         parseEnumValuesFromDescription(body['description'] as String?);
-    final dartType = enumValues != null
-        ? '$className${snakeToPascal(tfName)}'
-        : _scalarDartType(body['type']);
+    final typeInfo = _attrTypeInfo(
+      rawType: body['type'],
+      enumValues: enumValues,
+      className: className,
+      tfName: tfName,
+    );
 
     out.add(NestedAttrSpec(
       tfName: tfName,
       dartName: snakeToCamel(tfName),
-      dartType: dartType,
+      dartType: typeInfo.dartType,
       required: isRequired,
-      enumValues: enumValues,
+      enumValues: typeInfo.enumValues,
+      repeated: typeInfo.repeated,
     ));
   }
   return out;
 }
 
-/// Maps a raw schema-json attribute `type` to a dartType string.
+typedef _AttrTypeInfo = ({
+  String dartType,
+  bool repeated,
+  List<String>? enumValues,
+});
+
+/// Decides an attribute's [NestedAttrSpec] shape, gating enum detection on
+/// the RAW schema type rather than on `enumValues` alone.
+///
+/// A description matching `parseEnumValuesFromDescription` only produces an
+/// enum-typed [NestedAttrSpec] when the underlying type is one this
+/// collector can actually represent as an enum:
+/// - a bare `"string"` -> a scalar enum (`repeated: false`).
+/// - `["list", "string"]` / `["set", "string"]` -> a *repeated* enum
+///   (`repeated: true`) — e.g. `patch_config.windows_update.classifications`
+///   (`google_os_config_patch_deployment`) and
+///   `basic.conditions.device_policy.allowed_device_management_levels` /
+///   `allowed_encryption_statuses` (`google_access_context_manager_access_level`),
+///   3 of the 56 NESTED_THIN sites.
+///
+/// Any other shape — including a plain `["list", "string"]` with NO enum
+/// description, or an enum-shaped description on some other type entirely —
+/// ignores `enumValues` and falls back to [_scalarDartType]'s conservative
+/// mapping. This keeps `dartType`/`enumValues`/`repeated` mutually
+/// consistent: a scalar `dartType` never means "actually a list", and
+/// `enumValues` is only ever non-null when `dartType` really does name an
+/// enum class.
+_AttrTypeInfo _attrTypeInfo({
+  required Object? rawType,
+  required List<String>? enumValues,
+  required String className,
+  required String tfName,
+}) {
+  if (enumValues != null) {
+    if (rawType == 'string') {
+      return (
+        dartType: '$className${snakeToPascal(tfName)}',
+        repeated: false,
+        enumValues: enumValues,
+      );
+    }
+    if (_isListOrSetOfString(rawType)) {
+      return (
+        dartType: '$className${snakeToPascal(tfName)}',
+        repeated: true,
+        enumValues: enumValues,
+      );
+    }
+  }
+  return (
+    dartType: _scalarDartType(rawType),
+    repeated: false,
+    enumValues: null
+  );
+}
+
+bool _isListOrSetOfString(Object? rawType) =>
+    rawType is List &&
+    rawType.length == 2 &&
+    (rawType[0] == 'list' || rawType[0] == 'set') &&
+    rawType[1] == 'string';
+
+/// Maps a raw schema-json attribute `type` to a dartType string, for shapes
+/// [_attrTypeInfo] didn't already resolve as an enum.
 ///
 /// Scalars map cleanly (`"string"`->`String`, `"bool"`->`bool`,
 /// `"number"`->`num`, `"dynamic"`->`Object?`), as does a map-of-scalar
 /// (`["map", "string"]`->`Map<String, String>`). Everything else — a list
 /// or set of *anything* (including a plain list of primitives), a bare
 /// object type, a tuple, or a map of a non-scalar — has no single clean
-/// representation in [NestedAttrSpec] (there is no derived
-/// `List<EnumClass>` or nested-class-inside-a-list shape here), so it
-/// conservatively falls back to a `Map<String, dynamic>` /
-/// `List<Object?>`-style dartType. Genuinely unrecognized shapes throw,
+/// representation in [NestedAttrSpec] (no derived nested-class-inside-a-list
+/// shape here), so it conservatively falls back to a `Map<String, dynamic>`
+/// / `List<Object?>`-style dartType. Genuinely unrecognized shapes throw,
 /// matching `_type_decoder.dart`'s fail-fast convention for malformed
 /// schema input.
 String _scalarDartType(Object? rawType) {
@@ -254,4 +331,19 @@ String _scalarDartType(Object? rawType) {
     }
   }
   throw FormatException('Cannot map attribute type: $rawType');
+}
+
+/// Casts a required JSON-object value, failing loudly (not with a bare
+/// `TypeError`) when the schema doesn't shape up as expected.
+Map<String, dynamic> _requireMap(Object? value, {required String context}) {
+  if (value is Map) return value.cast<String, dynamic>();
+  throw FormatException('Expected a JSON object at $context, got: $value');
+}
+
+/// Like [_requireMap], but `null` (the key absent entirely) is a valid
+/// "nothing here" case that resolves to an empty map — schema-json omits
+/// `attributes`/`block_types` entirely on blocks that have none.
+Map<String, dynamic> _optionalMap(Object? value, {required String context}) {
+  if (value == null) return const {};
+  return _requireMap(value, context: context);
 }

--- a/packages/terradart_codegen/lib/src/codegen/nested_types/nested_type_collector.dart
+++ b/packages/terradart_codegen/lib/src/codegen/nested_types/nested_type_collector.dart
@@ -1,0 +1,257 @@
+import '../enum_value_parser.dart';
+import '../naming.dart';
+
+/// One attribute surfaced on a derived nested-type helper class.
+///
+/// [dartType] is the *inner* type only (e.g. `'String'`, an enum class
+/// name, `'Map<String, String>'`) — the emitter (Task 3) wraps it in
+/// `TfArg<...>` and applies nullability from [required].
+final class NestedAttrSpec {
+  final String tfName;
+  final String dartName;
+  final String dartType;
+  final bool required;
+  final List<String>? enumValues;
+
+  const NestedAttrSpec({
+    required this.tfName,
+    required this.dartName,
+    required this.dartType,
+    required this.required,
+    this.enumValues,
+  });
+}
+
+/// One `block_types` entry, collected recursively from the provider-schema
+/// JSON down to (but not through) customSlot- or exclude-covered subtrees.
+final class NestedBlockSpec {
+  final String tfName;
+  final List<String> path;
+  final String className;
+  final bool repeated;
+  final bool required;
+  final List<NestedAttrSpec> attrs;
+  final List<NestedBlockSpec> children;
+  final List<String> excludedChildTfNames;
+
+  const NestedBlockSpec({
+    required this.tfName,
+    required this.path,
+    required this.className,
+    required this.repeated,
+    required this.required,
+    required this.attrs,
+    required this.children,
+    required this.excludedChildTfNames,
+  });
+}
+
+/// Recursively collects [NestedBlockSpec]s from [resourceBlock]'s
+/// `block_types`, for the `deriveNestedTypes` codegen gate.
+///
+/// Pure: consumes the already-decoded provider-schema JSON block map, does
+/// no I/O, and never mutates its inputs. [resourcePrefix] (e.g.
+/// `'AppEngineDomainMapping'` for `google_app_engine_domain_mapping`) is
+/// derived by the caller — see `naming.dart`'s `snakeToPascal`.
+///
+/// Filtering, applied uniformly at every recursion depth:
+/// - A block whose bare Terraform name is in [customSlotKeys] is skipped
+///   entirely — no trace anywhere in the result. The hand-written
+///   customSlot already owns that whole subtree (mirrors
+///   `check_override_enum_gaps.dart`'s `_customSlotCoversBlock`; checking
+///   the bare name at every depth reproduces its "any ancestor" semantics
+///   for free, because a skipped node's children are never visited).
+/// - A block named `timeouts` is skipped entirely — Terraform's SDK-level
+///   meta-argument, not a user-facing input (same rule as
+///   `constructor_params.dart`'s `skipNestedBlock`).
+/// - A block whose dotted path from the resource root (e.g.
+///   `'basic.conditions'`) is in [excludedPaths] is recorded by its bare
+///   name in its parent's [NestedBlockSpec.excludedChildTfNames] and not
+///   descended into; the wrapper emitter renders it as a passthrough
+///   `TfArg<Map<String, dynamic>>?` instead of a derived class. A
+///   root-level exclusion has no parent spec to record into, so it is
+///   simply absent from the returned list (root-level slot selection is
+///   already the constructor's `paramOrder`'s job, not this collector's).
+List<NestedBlockSpec> collectNestedTypes({
+  required Map<String, dynamic> resourceBlock,
+  required String resourcePrefix,
+  required Set<String> customSlotKeys,
+  required Set<String> excludedPaths,
+}) {
+  final scan = _scanChildren(
+    resourceBlock,
+    path: const [],
+    resourcePrefix: resourcePrefix,
+    customSlotKeys: customSlotKeys,
+    excludedPaths: excludedPaths,
+  );
+  return scan.children;
+}
+
+typedef _ChildScan = ({
+  List<NestedBlockSpec> children,
+  List<String> excludedChildTfNames,
+});
+
+/// Scans one block's `block_types` map, returning the child specs that
+/// survive filtering plus the bare names of children dropped because their
+/// dotted path is in `excludedPaths`.
+_ChildScan _scanChildren(
+  Map<String, dynamic> block, {
+  required List<String> path,
+  required String resourcePrefix,
+  required Set<String> customSlotKeys,
+  required Set<String> excludedPaths,
+}) {
+  final blockTypes =
+      (block['block_types'] as Map?)?.cast<String, dynamic>() ?? const {};
+  final children = <NestedBlockSpec>[];
+  final excludedChildTfNames = <String>[];
+  for (final entry in blockTypes.entries) {
+    final tfName = entry.key;
+    if (customSlotKeys.contains(tfName) || tfName == 'timeouts') continue;
+
+    final childPath = [...path, tfName];
+    if (excludedPaths.contains(childPath.join('.'))) {
+      excludedChildTfNames.add(tfName);
+      continue;
+    }
+
+    children.add(_buildSpec(
+      tfName,
+      (entry.value as Map).cast<String, dynamic>(),
+      path: childPath,
+      resourcePrefix: resourcePrefix,
+      customSlotKeys: customSlotKeys,
+      excludedPaths: excludedPaths,
+    ));
+  }
+  return (children: children, excludedChildTfNames: excludedChildTfNames);
+}
+
+const _knownNestingModes = {'single', 'list', 'set', 'map', 'group'};
+
+NestedBlockSpec _buildSpec(
+  String tfName,
+  Map<String, dynamic> nestedBlockBody, {
+  required List<String> path,
+  required String resourcePrefix,
+  required Set<String> customSlotKeys,
+  required Set<String> excludedPaths,
+}) {
+  final nestingMode = nestedBlockBody['nesting_mode'];
+  if (nestingMode is! String || !_knownNestingModes.contains(nestingMode)) {
+    throw FormatException(
+      'Unknown nesting_mode: $nestingMode for nested block $tfName',
+    );
+  }
+  final maxItems = (nestedBlockBody['max_items'] as num?)?.toInt();
+  final minItems = (nestedBlockBody['min_items'] as num?)?.toInt();
+  final className = resourcePrefix + path.map(snakeToPascal).join();
+
+  final block =
+      (nestedBlockBody['block'] as Map?)?.cast<String, dynamic>() ?? const {};
+  final scan = _scanChildren(
+    block,
+    path: path,
+    resourcePrefix: resourcePrefix,
+    customSlotKeys: customSlotKeys,
+    excludedPaths: excludedPaths,
+  );
+
+  return NestedBlockSpec(
+    tfName: tfName,
+    path: path,
+    className: className,
+    repeated: (nestingMode == 'list' || nestingMode == 'set') && maxItems != 1,
+    required: (minItems ?? 0) >= 1,
+    attrs: _collectAttrs(block, className: className),
+    children: scan.children,
+    excludedChildTfNames: scan.excludedChildTfNames,
+  );
+}
+
+List<NestedAttrSpec> _collectAttrs(
+  Map<String, dynamic> block, {
+  required String className,
+}) {
+  final attributes =
+      (block['attributes'] as Map?)?.cast<String, dynamic>() ?? const {};
+  final out = <NestedAttrSpec>[];
+  for (final entry in attributes.entries) {
+    final tfName = entry.key;
+    final body = (entry.value as Map).cast<String, dynamic>();
+
+    final isComputed = body['computed'] == true;
+    final isOptional = body['optional'] == true;
+    final isRequired = body['required'] == true;
+    final computedOnly = isComputed && !isOptional && !isRequired;
+    if (computedOnly) continue;
+
+    final enumValues =
+        parseEnumValuesFromDescription(body['description'] as String?);
+    final dartType = enumValues != null
+        ? '$className${snakeToPascal(tfName)}'
+        : _scalarDartType(body['type']);
+
+    out.add(NestedAttrSpec(
+      tfName: tfName,
+      dartName: snakeToCamel(tfName),
+      dartType: dartType,
+      required: isRequired,
+      enumValues: enumValues,
+    ));
+  }
+  return out;
+}
+
+/// Maps a raw schema-json attribute `type` to a dartType string.
+///
+/// Scalars map cleanly (`"string"`->`String`, `"bool"`->`bool`,
+/// `"number"`->`num`, `"dynamic"`->`Object?`), as does a map-of-scalar
+/// (`["map", "string"]`->`Map<String, String>`). Everything else — a list
+/// or set of *anything* (including a plain list of primitives), a bare
+/// object type, a tuple, or a map of a non-scalar — has no single clean
+/// representation in [NestedAttrSpec] (there is no derived
+/// `List<EnumClass>` or nested-class-inside-a-list shape here), so it
+/// conservatively falls back to a `Map<String, dynamic>` /
+/// `List<Object?>`-style dartType. Genuinely unrecognized shapes throw,
+/// matching `_type_decoder.dart`'s fail-fast convention for malformed
+/// schema input.
+String _scalarDartType(Object? rawType) {
+  if (rawType is String) {
+    return switch (rawType) {
+      'string' => 'String',
+      'bool' => 'bool',
+      'number' => 'num',
+      'dynamic' => 'Object?',
+      _ => throw FormatException('Unknown primitive attribute type: $rawType'),
+    };
+  }
+  if (rawType is List && rawType.isNotEmpty) {
+    final ctor = rawType.first;
+    switch (ctor) {
+      case 'map':
+        final valueType = rawType.length > 1 ? rawType[1] : null;
+        if (valueType is String) {
+          return switch (valueType) {
+            'string' => 'Map<String, String>',
+            'bool' => 'Map<String, bool>',
+            'number' => 'Map<String, num>',
+            _ => 'Map<String, dynamic>',
+          };
+        }
+        return 'Map<String, dynamic>';
+      case 'list':
+      case 'set':
+        return 'List<Object?>';
+      case 'object':
+        return 'Map<String, dynamic>';
+      case 'tuple':
+        return 'List<Object?>';
+      default:
+        throw FormatException('Unknown attribute type constructor: $ctor');
+    }
+  }
+  throw FormatException('Cannot map attribute type: $rawType');
+}

--- a/packages/terradart_codegen/lib/src/codegen/nested_types/nested_type_emitter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/nested_types/nested_type_emitter.dart
@@ -1,0 +1,254 @@
+import '../naming.dart';
+import 'nested_type_collector.dart';
+
+/// Renders the Dart source for a resource's derived nested-block helper
+/// classes and their attribute enums — the render half of the
+/// `deriveNestedTypes` gate, matching the `@immutable` helper-class idiom
+/// hand-written `wrapper_overrides/` preludes have used until now (e.g.
+/// `wrapper_overrides/yaml/google_apigee_datastore.yaml`).
+///
+/// Pure string templating, no I/O. Like every other emitter in this package
+/// (see `WrapperEmitter.emit`), the returned source is **unformatted** —
+/// callers splice it into the surrounding wrapper file and run
+/// `dart_style.DartFormatter` once, over the whole file. It assumes that
+/// file already imports `package:meta/meta.dart` (`@immutable`) and
+/// `package:terradart_core/terradart_core.dart` (`TfArg`, `TerraformEnum`);
+/// no import directives are emitted here.
+///
+/// Ordering is depth-first over [specs] — each spec's own class, then its
+/// attribute enums, then its children (recursively), before moving to the
+/// next sibling — with alphabetical-by-Terraform-name tie-breaking at every
+/// sibling level (root [specs], each block's enum-bearing attrs, each
+/// block's children). This makes the output depend only on the *set* of
+/// specs, never the order the caller happened to list them in, mirroring
+/// `constructor_params.dart`'s "IR-natural order... alphabetical" guarantee
+/// for top-level attributes.
+String renderNestedTypes(
+  List<NestedBlockSpec> specs, {
+  required String resourceTerraformType,
+}) {
+  final buf = StringBuffer();
+  var first = true;
+  for (final spec in _byTfName(specs, (NestedBlockSpec s) => s.tfName)) {
+    if (!first) buf.writeln();
+    first = false;
+    buf.write(_renderBlockTree(spec, resourceTerraformType));
+  }
+  return buf.toString();
+}
+
+/// The Dart type of the constructor parameter a resource (or an ancestor
+/// nested class) uses to hold [s] — a bare class reference, never
+/// `TfArg`-wrapped, because a whole nested block has no Terraform "computed
+/// reference" form the way a leaf attribute does (only the *scalar/enum
+/// attributes inside it* can be individually computed-or-literal). Always
+/// nullable; a caller rendering a `required` slot strips the trailing `?`
+/// itself — mirrors [NestedAttrSpec.dartType], which is likewise the inner
+/// type only, with nullability layered on by whoever renders the field.
+String nestedParamType(NestedBlockSpec s) => '${_bareNestedType(s)}?';
+
+String _bareNestedType(NestedBlockSpec s) =>
+    s.repeated ? 'List<${s.className}>' : s.className;
+
+/// Renders one block's own class, then its attribute enums, then recurses
+/// depth-first into its children — the full subtree [spec] roots, as a
+/// sequence of top-level declarations separated by single blank lines.
+String _renderBlockTree(NestedBlockSpec spec, String resourceTerraformType) {
+  final buf = StringBuffer()..write(_renderClass(spec, resourceTerraformType));
+
+  final enumAttrs = _byTfName(
+    spec.attrs.where((a) => a.enumValues != null),
+    (NestedAttrSpec a) => a.tfName,
+  );
+  for (final attr in enumAttrs) {
+    buf
+      ..writeln()
+      ..write(_renderEnum(attr));
+  }
+
+  for (final child
+      in _byTfName(spec.children, (NestedBlockSpec s) => s.tfName)) {
+    buf
+      ..writeln()
+      ..write(_renderBlockTree(child, resourceTerraformType));
+  }
+
+  return buf.toString();
+}
+
+/// Renders [spec]'s own `@immutable` helper class: doc comment, constructor,
+/// fields, `encode()`. Field order is: [spec]'s attributes first
+/// (alphabetical by Terraform name), then its block-type children — both
+/// derived nested classes and opaque [NestedBlockSpec.excludedChildTfNames]
+/// passthroughs, merged into one alphabetical-by-Terraform-name group —
+/// mirroring `constructor_params.dart`'s "attributes first, then nested
+/// blocks" grouping for top-level wrapper constructors.
+String _renderClass(NestedBlockSpec spec, String resourceTerraformType) {
+  final plans = _fieldPlans(spec);
+  final blockPath = spec.path.join('.');
+
+  final buf = StringBuffer()
+    ..writeln('/// Typed helper for the `$blockPath` block of')
+    ..writeln('/// `$resourceTerraformType` (derived from provider schema).')
+    ..writeln('@immutable')
+    ..writeln('final class ${spec.className} {');
+  if (plans.isEmpty) {
+    // `{}` is not a valid (empty) named-parameter clause in Dart — unlike
+    // an empty `()`, the braces require at least one parameter — so a
+    // block with no attrs/children/excluded children gets a bare `()`
+    // constructor instead of the usual `({...})` shape.
+    buf.writeln('  const ${spec.className}();');
+  } else {
+    buf.writeln('  const ${spec.className}({');
+    for (final p in plans) {
+      buf.writeln('    ${p.ctorParam}');
+    }
+    buf.writeln('  });');
+  }
+  buf.writeln();
+
+  for (final p in plans) {
+    buf
+      ..writeln('  ${p.fieldDecl}')
+      ..writeln();
+  }
+
+  buf.writeln('  Map<String, Object?> encode() => {');
+  for (final p in plans) {
+    buf.writeln('    ${p.encodeEntry}');
+  }
+  buf
+    ..writeln('  };')
+    ..writeln('}');
+
+  return buf.toString();
+}
+
+/// Renders the free-standing `TerraformEnum` declaration for one
+/// enum-carrying attribute. Member names reuse [screamingToCamel] (shared
+/// with the top-level `deriveEnums` path via `naming.dart`'s `enumName`) —
+/// never re-implemented here, including its reserved-word fallback.
+String _renderEnum(NestedAttrSpec attr) {
+  final values = attr.enumValues!;
+  final buf = StringBuffer()
+    ..writeln(
+        '/// `${attr.tfName}` — derived from the provider schema description.')
+    ..writeln('enum ${attr.dartType} implements TerraformEnum {');
+  for (var i = 0; i < values.length; i++) {
+    final isLast = i == values.length - 1;
+    final member = screamingToCamel(values[i]);
+    buf.writeln("  $member('${values[i]}')${isLast ? ';' : ','}");
+  }
+  buf
+    ..writeln()
+    ..writeln('  const ${attr.dartType}(this.terraformValue);')
+    ..writeln('  @override')
+    ..writeln('  final String terraformValue;')
+    ..writeln('}');
+  return buf.toString();
+}
+
+/// One class member's rendering, in its three call sites (constructor
+/// parameter, field declaration, `encode()` map entry) — computed together
+/// so the required/optional and repeated/scalar axes are handled exactly
+/// once (see [_plan]) instead of re-derived at each call site.
+typedef _FieldPlan = ({String ctorParam, String fieldDecl, String encodeEntry});
+
+/// [spec]'s own class members, in render order: attrs first, then
+/// block-type children (derived + excluded, merged), each group
+/// alphabetical by Terraform name.
+List<_FieldPlan> _fieldPlans(NestedBlockSpec spec) {
+  final plans = <_FieldPlan>[
+    for (final attr in _byTfName(spec.attrs, (NestedAttrSpec a) => a.tfName))
+      _planAttr(attr),
+  ];
+
+  final blockChildren = <({String tfName, _FieldPlan plan})>[
+    for (final child in spec.children)
+      (tfName: child.tfName, plan: _planChild(child)),
+    for (final excluded in spec.excludedChildTfNames)
+      (tfName: excluded, plan: _planExcludedChild(excluded)),
+  ]..sort((a, b) => a.tfName.compareTo(b.tfName));
+  plans.addAll(blockChildren.map((e) => e.plan));
+
+  return plans;
+}
+
+_FieldPlan _planAttr(NestedAttrSpec attr) => _plan(
+      dartName: attr.dartName,
+      tfName: attr.tfName,
+      elementType: attr.dartType,
+      required: attr.required,
+      repeated: attr.repeated,
+      wrapInTfArg: true,
+    );
+
+/// A derived nested child renders as a bare (non-`TfArg`) class reference —
+/// see [nestedParamType] — and encodes via its own `.encode()`.
+_FieldPlan _planChild(NestedBlockSpec child) => _plan(
+      dartName: snakeToCamel(child.tfName),
+      tfName: child.tfName,
+      elementType: child.className,
+      required: child.required,
+      repeated: child.repeated,
+      wrapInTfArg: false,
+    );
+
+/// An excluded child (its subtree wasn't collected — see
+/// [NestedBlockSpec.excludedChildTfNames]) renders as an opaque, always
+/// -optional `TfArg<Map<String, dynamic>>?` passthrough: the collector
+/// deliberately discards its nesting mode / required-ness, so this is the
+/// conservative shape that fits any of them.
+_FieldPlan _planExcludedChild(String tfName) => _plan(
+      dartName: snakeToCamel(tfName),
+      tfName: tfName,
+      elementType: 'Map<String, dynamic>',
+      required: false,
+      repeated: false,
+      wrapInTfArg: true,
+    );
+
+/// The one place the required/optional and repeated/scalar axes resolve
+/// into a constructor parameter, field declaration, and `encode()` entry.
+///
+/// [wrapInTfArg] selects between the two attribute shapes this emitter
+/// ever produces: a leaf attribute (`TfArg<elementType>`, encoded via
+/// `.toTfJson()`) or a nested-block reference (bare `elementType`, encoded
+/// via `.encode()`).
+_FieldPlan _plan({
+  required String dartName,
+  required String tfName,
+  required String elementType,
+  required bool required,
+  required bool repeated,
+  required bool wrapInTfArg,
+}) {
+  final accessor = wrapInTfArg ? '.toTfJson()' : '.encode()';
+  final elementDartType = wrapInTfArg ? 'TfArg<$elementType>' : elementType;
+  final bareFieldType = repeated ? 'List<$elementDartType>' : elementDartType;
+  final fieldType = required ? bareFieldType : '$bareFieldType?';
+
+  final ctorParam = required ? 'required this.$dartName,' : 'this.$dartName,';
+  final fieldDecl = 'final $fieldType $dartName;';
+
+  final String valueExpr;
+  if (repeated) {
+    final source = required ? dartName : '$dartName!';
+    valueExpr = '[for (final e in $source) e$accessor]';
+  } else {
+    final target = required ? dartName : '$dartName!';
+    valueExpr = '$target$accessor';
+  }
+  final entry = "'$tfName': $valueExpr,";
+  final encodeEntry = required ? entry : 'if ($dartName != null) $entry';
+
+  return (ctorParam: ctorParam, fieldDecl: fieldDecl, encodeEntry: encodeEntry);
+}
+
+/// Sorts a defensive copy of [items] by [tfName], ascending. Every
+/// sibling-ordering decision in this file goes through here so the output
+/// never depends on the caller's own list order.
+List<T> _byTfName<T>(Iterable<T> items, String Function(T) tfName) {
+  final list = items.toList()..sort((a, b) => tfName(a).compareTo(tfName(b)));
+  return list;
+}

--- a/packages/terradart_codegen/lib/src/codegen/override_linter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/override_linter.dart
@@ -69,6 +69,22 @@ List<LintViolation> lintOverride(
     ));
   }
 
+  // Belt-and-suspenders alongside the loader's eager FormatException (see
+  // `yaml_loader.dart`'s `nestedTypeExcludes requires deriveNestedTypes`
+  // check): the loader can never actually produce this shape from yaml, but
+  // an override built some other way (a test, a future non-yaml source)
+  // could still combine the two fields incorrectly.
+  if (override.nestedTypeExcludes != null && !override.deriveNestedTypes) {
+    violations.add(LintViolation(
+      tfType: tfType,
+      rule: 'nested-excludes-without-derive',
+      detail: 'nestedTypeExcludes is set but deriveNestedTypes is false. '
+          'nestedTypeExcludes only has an effect inside the deriveNestedTypes '
+          'codegen gate, so it is dead config. Set deriveNestedTypes: true or '
+          'remove nestedTypeExcludes.',
+    ));
+  }
+
   violations.addAll(lintDeadCustomSlots(tfType, override));
 
   violations.addAll(

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_emitter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_emitter.dart
@@ -7,6 +7,8 @@ import 'doc_comment_builder.dart';
 import 'enum_emitter.dart';
 import 'getter_emitter.dart';
 import 'naming.dart';
+import 'nested_types/nested_type_collector.dart';
+import 'nested_types/nested_type_emitter.dart';
 import 'sensitive_set_emitter.dart';
 import 'wrapper_overrides/wrapper_override.dart';
 
@@ -44,9 +46,20 @@ import 'wrapper_overrides/wrapper_override.dart';
 ///   const from `.schema.dart`.
 /// - The `sensitiveFields` getter references the new file-private const.
 class WrapperEmitter {
-  WrapperEmitter({required this.overrides});
+  WrapperEmitter({required this.overrides, this.rawResourceSchemas = const {}});
 
   final Map<String, WrapperOverride> overrides;
+
+  /// Raw provider-schema JSON `block` maps, keyed by Terraform type — the
+  /// shape `collectNestedTypes` consumes (`block_types` / `nesting_mode` /
+  /// `min_items`, etc.), which the parsed [ResourceDef] IR no longer carries
+  /// once `SchemaJsonParser` has flattened it into [Attribute] /
+  /// [NestedBlockDef]. Only consulted when an override sets
+  /// `deriveNestedTypes: true`; `wrap_command.dart` builds this lazily (only
+  /// decoding schema.json a second time when at least one loaded override
+  /// needs it), so callers that never flip the gate — every committed
+  /// override today — can omit this entirely.
+  final Map<String, Map<String, dynamic>> rawResourceSchemas;
 
   /// Emits the wrapper file source.
   ///
@@ -70,6 +83,11 @@ class WrapperEmitter {
     final override = overrides[def.terraformType];
     final requiredOverrides =
         (override?.requiredParams ?? const <String>[]).toSet();
+    // Hoisted ahead of its historical position (immediately before the
+    // constructor section) because the `deriveNestedTypes` gate below needs
+    // `customSlotKeys` before it renders the prelude section — customSlots
+    // itself doesn't depend on anything emitted in between.
+    final customSlots = override?.customSlots ?? const <String, CustomSlot>{};
 
     // Imports. `extraImports` is emitted FIRST so that `package:meta` (the
     // common case for hand-written helper classes that decorate themselves
@@ -145,6 +163,33 @@ class WrapperEmitter {
       buf.writeln();
     }
 
+    // `deriveNestedTypes` gate: derive a typed `@immutable` helper class
+    // (plus any attribute `TerraformEnum`s) for each of this resource's
+    // TOP-LEVEL nested blocks from the RAW provider-schema JSON —
+    // `collectNestedTypes` needs `block_types` / `nesting_mode` / etc., which
+    // the parsed IR no longer carries. `customSlots.keys` marks subtrees the
+    // hand-written override already owns (the collector skips them
+    // entirely, at any depth); `nestedTypeExcludes` marks additional
+    // subtrees left as the generic passthrough. Dark by construction: no
+    // committed override sets `deriveNestedTypes`, so `nestedTypeSpecs` is
+    // always `const []` today and this whole block is a no-op.
+    final nestedTypeSpecs = (override?.deriveNestedTypes ?? false)
+        ? collectNestedTypes(
+            resourceBlock: _requireRawSchema(def.terraformType),
+            resourcePrefix: shortResourcePascal(def.terraformType),
+            customSlotKeys: customSlots.keys.toSet(),
+            excludedPaths:
+                (override?.nestedTypeExcludes ?? const <String>[]).toSet(),
+          )
+        : const <NestedBlockSpec>[];
+    if (nestedTypeSpecs.isNotEmpty) {
+      buf.write(renderNestedTypes(
+        nestedTypeSpecs,
+        resourceTerraformType: def.terraformType,
+      ));
+      buf.writeln();
+    }
+
     // Class-level doc comment. Phase A4: derived deterministically from the
     // IR when `deriveClassDoc: true` — `Factory wrapper for <type>`, then the
     // resource summary rewrapped from `ResourceDef.description` (merged from
@@ -176,7 +221,6 @@ class WrapperEmitter {
     // `http_target` / `app_engine_http_target` blocks.
     final paramOrder = orderedConstructorParams(def, override?.paramOrder);
     final argMapOrder = override?.argMapOrder ?? paramOrder;
-    final customSlots = override?.customSlots ?? const <String, CustomSlot>{};
     final dartTypeOverrides =
         override?.dartTypeOverrides ?? const <String, String>{};
     final deprecations = override?.deprecatedParams ?? const <String, String>{};
@@ -190,6 +234,18 @@ class WrapperEmitter {
     for (final entry in customSlots.entries) {
       paramsByName[entry.key] = entry.value.paramDeclaration;
       argMapByName[entry.key] = entry.value.argMapEntry;
+    }
+    // Replace the generic passthrough for every TOP-LEVEL `deriveNestedTypes`
+    // spec with its typed rendering. Keys never collide with the customSlots
+    // loop above: `collectNestedTypes` skips any subtree rooted at a
+    // `customSlots` key entirely (see `customSlotKeys` above), so a spec can
+    // never share a `tfName` with a customSlot entry.
+    for (final spec in nestedTypeSpecs) {
+      final isRequired =
+          spec.required || requiredOverrides.contains(spec.tfName);
+      final slot = _nestedTypeSlot(spec, isRequired: isRequired);
+      paramsByName[spec.tfName] = slot.param;
+      argMapByName[spec.tfName] = slot.argMapEntry;
     }
 
     buf.writeln('  $pascal({');
@@ -408,5 +464,59 @@ class WrapperEmitter {
       return "'$snakeName': $camel,";
     }
     return "if ($camel != null) '$snakeName': $camel,";
+  }
+
+  /// Builds the constructor-param and argMap-entry snippets for one
+  /// TOP-LEVEL `deriveNestedTypes` spec, replacing [_nestedBlockParam] /
+  /// [_argMapEntry]'s generic `TfArg<Map<String, dynamic>>?` passthrough for
+  /// that slot.
+  ///
+  /// Mirrors the hand-written idiom [CustomSlot]'s doc comment describes
+  /// (e.g. `google_pubsub_subscription.bigquery_config`): the constructor
+  /// exposes a bare (non-`TfArg`) helper-class reference —
+  /// [nestedParamType]'s shape, required-ness stripped per its own
+  /// documented contract ("a caller rendering a required slot strips the
+  /// trailing `?` itself") — and the argMap entry wraps its `.encode()`
+  /// output in `TfArg.literal(...)` so it satisfies `Resource.argMap`'s
+  /// `Map<String, TfArg<dynamic>?>` contract.
+  ({String param, String argMapEntry}) _nestedTypeSlot(
+    NestedBlockSpec spec, {
+    required bool isRequired,
+  }) {
+    final dartName = snakeToCamel(spec.tfName);
+    final nullableType = nestedParamType(spec);
+    final bareType = nullableType.substring(0, nullableType.length - 1);
+    final param =
+        isRequired ? 'required $bareType $dartName' : '$nullableType $dartName';
+
+    final String encodeExpr;
+    if (spec.repeated) {
+      encodeExpr = isRequired
+          ? '[for (final e in $dartName) e.encode()]'
+          : '[for (final e in $dartName!) e.encode()]';
+    } else {
+      encodeExpr = isRequired ? '$dartName.encode()' : '$dartName!.encode()';
+    }
+    final entry = "'${spec.tfName}': TfArg.literal($encodeExpr),";
+    final argMapEntry = isRequired ? entry : 'if ($dartName != null) $entry';
+    return (param: param, argMapEntry: argMapEntry);
+  }
+
+  /// Looks up [terraformType]'s raw provider-schema `block` map in
+  /// [rawResourceSchemas], failing loudly when it's missing — this only
+  /// happens when a caller sets `deriveNestedTypes: true` without also
+  /// supplying the matching raw schema (a wiring bug, not a data problem;
+  /// `wrap_command.dart` always supplies it once any loaded override needs
+  /// it).
+  Map<String, dynamic> _requireRawSchema(String terraformType) {
+    final raw = rawResourceSchemas[terraformType];
+    if (raw == null) {
+      throw StateError(
+        'WrapperEmitter: deriveNestedTypes is set for "$terraformType" but '
+        'no raw provider-schema block was supplied (rawResourceSchemas has '
+        'no entry for this type).',
+      );
+    }
+    return raw;
   }
 }

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/wrapper_override.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/wrapper_override.dart
@@ -218,6 +218,37 @@ final class WrapperOverride {
   /// `null` means "no curated doc fragment".
   final String? curatedDoc;
 
+  /// `deriveNestedTypes` migration gate. When `true`, the emitter derives a
+  /// typed `@immutable` helper class (plus any attribute `TerraformEnum`s)
+  /// for each of this resource's TOP-LEVEL nested blocks from the provider
+  /// schema — see `nested_types/nested_type_collector.dart` and
+  /// `nested_type_emitter.dart` — replacing the generic
+  /// `TfArg<Map<String, dynamic>>?` passthrough the IR would otherwise
+  /// produce for that slot. A block already covered by a [customSlots] entry
+  /// is left untouched (the collector skips any subtree rooted at a
+  /// customSlot key). Defaults to `false` so un-migrated resources are
+  /// unaffected — mirrors [deriveEnums] / [deriveOutputGetters] / [deriveClassDoc].
+  final bool deriveNestedTypes;
+
+  /// Dotted provider-schema block paths (e.g. `'basic.conditions'`) to
+  /// exclude from [deriveNestedTypes] derivation, relative to the resource
+  /// root. An excluded block (and everything under it) is rendered as the
+  /// generic `TfArg<Map<String, dynamic>>?` passthrough instead of a derived
+  /// class — use this for a subtree that still needs hand-curation (e.g. a
+  /// shape the collector cannot represent, or one earmarked for a future
+  /// customSlot). A TOP-LEVEL path (no dot) simply omits that slot from
+  /// derivation entirely; the constructor still emits it via the ordinary
+  /// `paramOrder`-driven passthrough.
+  ///
+  /// Only meaningful when [deriveNestedTypes] is `true` — the loader rejects
+  /// a yaml file that sets this without the gate (`FormatException` at load
+  /// time), and `lintOverride`'s `nested-excludes-without-derive` rule flags
+  /// the same condition for an override constructed some other way.
+  ///
+  /// `null` means "derive every nested block reachable from the resource
+  /// root" (subject only to the [customSlots] skip).
+  final List<String>? nestedTypeExcludes;
+
   /// Snake-case slot name → custom constructor / argMap snippets.
   ///
   /// Two use cases:
@@ -298,6 +329,8 @@ final class WrapperOverride {
     this.deriveOutputGetters = false,
     this.deriveClassDoc = false,
     this.curatedDoc,
+    this.deriveNestedTypes = false,
+    this.nestedTypeExcludes,
   });
 }
 

--- a/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml_loader.dart
+++ b/packages/terradart_codegen/lib/src/codegen/wrapper_overrides/yaml_loader.dart
@@ -45,9 +45,11 @@ class LoadedOverrides {
 ///
 /// Validation:
 /// - File names must match `^[a-z][a-z0-9_]*$`.
-/// - Top-level keys must be in the allowed set (15 axes — 11 wrapper axes
+/// - Top-level keys must be in the allowed set (20 axes — 16 wrapper axes
 ///   plus the 4 Phase 4.1 axes: `kind`, `outputDir`, `schemaStubBodyMode`,
 ///   `fileLeadingComment`).
+/// - `nestedTypeExcludes` requires `deriveNestedTypes: true` (checked eagerly,
+///   like the `argMapOrder`-must-permute-`paramOrder` rule below).
 /// - `List<String>` fields must not be empty and entries must be strings.
 /// - `Map<String, String>` fields' values must be strings.
 /// - `customSlots[x].paramDeclaration` and `customSlots[x].argMapEntry`
@@ -80,6 +82,8 @@ class YamlOverrideLoader {
     'deriveClassDoc',
     'curatedDoc',
     'customSlots',
+    'deriveNestedTypes',
+    'nestedTypeExcludes',
     // 4 Phase 4.1 axes (kind dispatch + emitter routing).
     'kind',
     'outputDir',
@@ -236,6 +240,21 @@ class YamlOverrideLoader {
         );
       }
     }
+    final deriveNestedTypes =
+        _readBool(yaml, 'deriveNestedTypes', filePath) ?? false;
+    final nestedTypeExcludes =
+        _readStringList(yaml, 'nestedTypeExcludes', filePath);
+    if (nestedTypeExcludes != null && !deriveNestedTypes) {
+      // Mirrors the retired-`classDocComment` style above: fail loudly at
+      // load time instead of silently accepting dead config the emitter
+      // would never consult (`nestedTypeExcludes` only has an effect inside
+      // the `deriveNestedTypes` codegen gate).
+      throw FormatException(
+        '$filePath: nestedTypeExcludes requires deriveNestedTypes: true. Set '
+        '`deriveNestedTypes: true` on this override, or remove '
+        '`nestedTypeExcludes`.',
+      );
+    }
     final kind = _parseKind(yaml, filePath, errors);
     if (kind == null) return null;
     final outputDir = _parseOutputDir(yaml, filePath, errors);
@@ -315,6 +334,8 @@ class YamlOverrideLoader {
       deriveClassDoc: _readBool(yaml, 'deriveClassDoc', filePath) ?? false,
       curatedDoc: _readString(yaml, 'curatedDoc', filePath),
       customSlots: _readCustomSlots(yaml, filePath),
+      deriveNestedTypes: deriveNestedTypes,
+      nestedTypeExcludes: nestedTypeExcludes,
     );
   }
 

--- a/packages/terradart_codegen/test/cli/wrap_command_test.dart
+++ b/packages/terradart_codegen/test/cli/wrap_command_test.dart
@@ -1,9 +1,17 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:dart_style/dart_style.dart';
 import 'package:path/path.dart' as p;
 import 'package:terradart_codegen/src/cli/cli_runner.dart';
 import 'package:terradart_codegen/src/cli/exit_codes.dart';
+import 'package:terradart_codegen/src/codegen/barrels/barrel_emitter.dart';
+import 'package:terradart_codegen/src/codegen/barrels/barrel_manifest.dart';
+import 'package:terradart_codegen/src/codegen/catalog_entry_builder.dart';
+import 'package:terradart_codegen/src/codegen/wrapper_emitter.dart';
+import 'package:terradart_codegen/src/codegen/wrapper_overrides/yaml_loader.dart';
+import 'package:terradart_codegen/src/parser/schema_parser.dart';
 import 'package:test/test.dart';
 
 /// Barrels are written one level above `--output` (`lib/` beside `lib/src`),
@@ -521,6 +529,176 @@ void main() {
       }
     });
   });
+
+  group('WrapCommand deriveNestedTypes (dark launch)', () {
+    // Unlike every other test in this file, this one does NOT go through
+    // `buildCliRunner().run(['wrap', ...])`: `WrapCommand` resolves its
+    // override registry from the PACKAGE's own committed
+    // `lib/src/codegen/wrapper_overrides/yaml/` directory
+    // (`Isolate.resolvePackageUri` in `wrap_command.dart`), not from
+    // `--source` — there is no CLI flag to point it at a temp override
+    // directory instead. Flipping a real committed yaml (even temporarily,
+    // even restored in a `finally`) would violate the dark-launch
+    // requirement this whole PR exists to satisfy, and risks bleeding into
+    // any other test file that loads the same production directory
+    // concurrently. So this test drives the same building blocks
+    // `WrapCommand.run()` composes — `YamlOverrideLoader` ->
+    // `SchemaJsonParser` -> `WrapperEmitter` -> `DartFormatter` ->
+    // `buildCatalogEntry` -> `buildBarrelFiles` — directly, against a
+    // throwaway temp override, the same way `barrel_derivation_test.dart`
+    // exercises `buildBarrelFiles` without going through the CLI at all.
+    //
+    // The dark-launch invariant for the COMMITTED tree (byte-identical
+    // `wrap --check`) is proved by the untouched `WrapCommand --check`
+    // group above, which stays green throughout this change.
+    test(
+        'a temp deriveNestedTypes:true override derives a typed nested '
+        'class, narrows the ctor param, and flows into the catalog + a '
+        'barrel', () async {
+      const terraformType = 'google_app_engine_domain_mapping';
+      final tmpOverrideDir =
+          await Directory.systemTemp.createTemp('phase4_nested_types_');
+      try {
+        // Minimal override: only the two slots this test cares about.
+        // `paramOrder` may be a subset — slots it omits are simply not
+        // emitted (see `WrapperOverride.paramOrder`'s doc) — so dropping
+        // `override_strategy` / `deletion_policy` / `project` here (present
+        // in the real committed yaml) is deliberate, not an oversight: it
+        // keeps this reproduction minimal and free of the unrelated
+        // hand-written `override_strategy` enum idiom.
+        await File(p.join(tmpOverrideDir.path, '$terraformType.yaml'))
+            .writeAsString('''
+outputDir: app
+deriveNestedTypes: true
+paramOrder:
+  - domain_name
+  - ssl_settings
+''');
+        final loaded =
+            YamlOverrideLoader(rootDir: tmpOverrideDir.path).load().resources;
+        expect(loaded.keys, [terraformType]);
+
+        final schemaSrc = File(
+          p.join('test', 'fixtures', 'wrap', 'source', 'schema.json'),
+        ).readAsStringSync();
+        final ir = const SchemaJsonParser().parseString(schemaSrc);
+        final def = ir.resources[terraformType]!;
+
+        final emitter = WrapperEmitter(
+          overrides: loaded,
+          rawResourceSchemas: {
+            terraformType: _rawBlockOf(schemaSrc, terraformType),
+          },
+        );
+        final raw = emitter.emit(def, providerSource: 'hashicorp/google');
+        final formatter = DartFormatter(
+          languageVersion: DartFormatter.latestLanguageVersion,
+        );
+        final formatted = formatter.format(raw);
+
+        // The derived helper class + its attribute enum are emitted as
+        // top-level declarations. Their internal shape is byte-pinned by
+        // Task 3's emitter tests; here we only need to confirm the wiring
+        // actually reaches them.
+        expect(
+          formatted,
+          contains('final class AppEngineDomainMappingSslSettings {'),
+        );
+        // The class name is long enough that dart_style wraps `implements
+        // TerraformEnum {` onto its own line (83 columns unwrapped), so the
+        // two fragments are checked independently rather than as one
+        // contiguous string — same wrap-tolerance convention Task 3's tests
+        // use elsewhere in this campaign.
+        expect(
+          formatted,
+          contains('enum AppEngineDomainMappingSslSettingsSslManagementType'),
+        );
+        expect(formatted, contains('implements TerraformEnum {'));
+
+        // The constructor param narrows from the generic
+        // `TfArg<Map<String, dynamic>>? sslSettings` passthrough to the
+        // typed, bare (non-`TfArg`) class reference. `ssl_settings` is
+        // schema-optional (nesting_mode: list, max_items: 1, no min_items),
+        // so it stays nullable / un-`required`.
+        expect(
+          formatted,
+          contains('AppEngineDomainMappingSslSettings? sslSettings'),
+        );
+        expect(
+          formatted,
+          isNot(contains('TfArg<Map<String, dynamic>>? sslSettings')),
+        );
+
+        // The argMap entry wraps the typed helper's own `.encode()` in
+        // `TfArg.literal(...)` — matching the hand-written customSlot idiom
+        // (e.g. `google_pubsub_subscription.yaml`'s `bigquery_config`) —
+        // guarded since the slot is optional.
+        expect(formatted, contains('if (sslSettings != null)'));
+        expect(formatted, contains('TfArg.literal(sslSettings!.encode())'));
+
+        // Catalog: `nestedTypes` is scanned from this SAME formatted source
+        // (`catalog_entry_builder.dart`'s `scanNestedTypes`) — there is no
+        // separate registration list to wire up or keep in sync.
+        final entry = buildCatalogEntry(
+          tfType: terraformType,
+          override: loaded[terraformType]!,
+          def: def,
+          kind: 'resource',
+          emittedSource: formatted,
+        );
+        expect(
+          entry.nestedTypes,
+          containsAll([
+            'AppEngineDomainMappingSslSettings',
+            'AppEngineDomainMappingSslSettingsSslManagementType',
+          ]),
+        );
+
+        // Barrels: `buildBarrelFiles` merges `className` + `nestedTypes`
+        // into one sorted `show` set per barrel (`barrel_emitter.dart`).
+        // Confirm the derived names reach a barrel's export line, using a
+        // minimal synthetic manifest (mirrors `barrel_derivation_test.dart`)
+        // rather than the full 66-barrel production manifest, which needs a
+        // catalog entry for every declared barrel.
+        final barrelFiles = buildBarrelFiles(
+          entries: [entry],
+          manifest: const BarrelManifest(
+            umbrellaDoc: '/// Umbrella.',
+            umbrellaExtraExports: [],
+            barrels: {'app': BarrelSpec(doc: '/// App Engine.')},
+          ),
+        );
+        expect(
+          barrelFiles['app'],
+          contains('AppEngineDomainMappingSslSettings'),
+        );
+        expect(
+          barrelFiles['app'],
+          contains('AppEngineDomainMappingSslSettingsSslManagementType'),
+        );
+      } finally {
+        await tmpOverrideDir.delete(recursive: true);
+      }
+    });
+  });
+}
+
+/// Loads `resource_schemas[terraformType].block` straight from an
+/// already-read schema.json string — the raw shape `collectNestedTypes` (via
+/// `WrapperEmitter.rawResourceSchemas`) needs. Mirrors
+/// `nested_type_collector_test.dart`'s `_blockOf` helper and
+/// `wrap_command.dart`'s own private `_rawResourceBlocks`.
+Map<String, dynamic> _rawBlockOf(String schemaJson, String terraformType) {
+  final decoded = jsonDecode(schemaJson) as Map<String, dynamic>;
+  final providerSchemas =
+      (decoded['provider_schemas'] as Map).cast<String, dynamic>();
+  final providerBody =
+      (providerSchemas.values.single as Map).cast<String, dynamic>();
+  final resourceSchemas =
+      (providerBody['resource_schemas'] as Map).cast<String, dynamic>();
+  final resource =
+      (resourceSchemas[terraformType] as Map).cast<String, dynamic>();
+  return (resource['block'] as Map).cast<String, dynamic>();
 }
 
 /// Minimal [Stdout] stand-in that appends every `write*` call to a

--- a/packages/terradart_codegen/test/codegen/enum_value_parser_test.dart
+++ b/packages/terradart_codegen/test/codegen/enum_value_parser_test.dart
@@ -1,0 +1,31 @@
+import 'package:terradart_codegen/src/codegen/enum_value_parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('bracket JSON-ish list', () {
+    expect(
+      parseEnumValuesFromDescription(
+        'Mode. Possible values: ["BASIC", "ADVANCED"]',
+      ),
+      ['BASIC', 'ADVANCED'],
+    );
+  });
+  test('valid-values-are quoted prose', () {
+    expect(
+      parseEnumValuesFromDescription(
+          'Valid values are: "PAGELESS", "PAGINATED".'),
+      ['PAGELESS', 'PAGINATED'],
+    );
+  });
+  test('bare screaming list', () {
+    expect(
+      parseEnumValuesFromDescription(
+          'Possible values: JOB_TYPE_UNSPECIFIED, PIPELINE, QUERY'),
+      ['JOB_TYPE_UNSPECIFIED', 'PIPELINE', 'QUERY'],
+    );
+  });
+  test('null and <2 values reject', () {
+    expect(parseEnumValuesFromDescription(null), isNull);
+    expect(parseEnumValuesFromDescription('Possible values: ["ONLY"]'), isNull);
+  });
+}

--- a/packages/terradart_codegen/test/codegen/naming_test.dart
+++ b/packages/terradart_codegen/test/codegen/naming_test.dart
@@ -24,6 +24,16 @@ void main() {
       expect(nestedAbstractClassName('schema_settings'), r'$SchemaSettings');
     });
 
+    test('shortResourcePascal strips the google_ prefix then PascalCases', () {
+      expect(shortResourcePascal('google_app_engine_domain_mapping'),
+          'AppEngineDomainMapping');
+    });
+
+    test('shortResourcePascal leaves a non-google_ type untouched (Pascal)',
+        () {
+      expect(shortResourcePascal('foo_bar'), 'FooBar');
+    });
+
     test('enumName builds Pascal name and screaming-snake to camel members',
         () {
       final e = enumName(

--- a/packages/terradart_codegen/test/codegen/naming_test.dart
+++ b/packages/terradart_codegen/test/codegen/naming_test.dart
@@ -39,5 +39,24 @@ void main() {
       expect(
           resourceFileName('google_pubsub_topic'), 'google_pubsub_topic.dart');
     });
+
+    test('screamingToCamel converts without collision', () {
+      expect(screamingToCamel('AUTOMATIC'), 'automatic');
+      expect(screamingToCamel('ENCODING_UNSPECIFIED'), 'encodingUnspecified');
+    });
+
+    test('screamingToCamel appends Case on a reserved-word collision', () {
+      expect(screamingToCamel('DEFAULT'), 'defaultCase');
+      expect(screamingToCamel('IN'), 'inCase');
+    });
+
+    test('enumName carries the reserved-word-safe member through', () {
+      final e = enumName(
+        resourceType: 'google_compute_router',
+        fieldPath: 'advertise_mode',
+        members: const ['DEFAULT', 'CUSTOM'],
+      );
+      expect(e.dartMembers, ['defaultCase', 'custom']);
+    });
   });
 }

--- a/packages/terradart_codegen/test/codegen/nested_types/nested_type_collector_test.dart
+++ b/packages/terradart_codegen/test/codegen/nested_types/nested_type_collector_test.dart
@@ -1,0 +1,177 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:terradart_codegen/src/codegen/naming.dart';
+import 'package:terradart_codegen/src/codegen/nested_types/nested_type_collector.dart';
+import 'package:test/test.dart';
+
+const _schemaPath = 'test/fixtures/wrap/source/schema.json';
+
+/// Loads `resource_schemas[terraformType].block` as a raw decoded JSON map
+/// (the shape [collectNestedTypes] consumes), straight from the pinned
+/// provider-schema fixture — no IR parsing involved.
+Map<String, dynamic> _blockOf(String terraformType) {
+  final decoded =
+      jsonDecode(File(_schemaPath).readAsStringSync()) as Map<String, dynamic>;
+  final providerSchemas =
+      (decoded['provider_schemas'] as Map).cast<String, dynamic>();
+  final providerBody =
+      (providerSchemas.values.single as Map).cast<String, dynamic>();
+  final resourceSchemas =
+      (providerBody['resource_schemas'] as Map).cast<String, dynamic>();
+  final resource =
+      (resourceSchemas[terraformType] as Map).cast<String, dynamic>();
+  return (resource['block'] as Map).cast<String, dynamic>();
+}
+
+/// `google_app_engine_domain_mapping` -> `AppEngineDomainMapping`.
+///
+/// The collector takes `resourcePrefix` as caller-supplied, so this mirrors
+/// what the real caller (the Task 4 wrapper-emitter wiring) will do: strip
+/// the `google_` provider prefix, then reuse naming.dart's existing public
+/// snake->Pascal helper rather than writing a new one here.
+String _resourcePrefixOf(String terraformType) {
+  const providerPrefix = 'google_';
+  final short = terraformType.startsWith(providerPrefix)
+      ? terraformType.substring(providerPrefix.length)
+      : terraformType;
+  return snakeToPascal(short);
+}
+
+void main() {
+  test(
+      'google_app_engine_domain_mapping: ssl_settings becomes the only '
+      'nested spec (timeouts filtered, computed-only attr dropped, enum '
+      'detected)', () {
+    const terraformType = 'google_app_engine_domain_mapping';
+    final specs = collectNestedTypes(
+      resourceBlock: _blockOf(terraformType),
+      resourcePrefix: _resourcePrefixOf(terraformType),
+      customSlotKeys: const {},
+      excludedPaths: const {},
+    );
+
+    // Only `ssl_settings` should survive — the schema's other block_type,
+    // `timeouts`, is Terraform SDK metadata and is never a derivable spec.
+    expect(specs, hasLength(1));
+    final sslSettings = specs.single;
+    expect(sslSettings.tfName, 'ssl_settings');
+    expect(sslSettings.path, ['ssl_settings']);
+    expect(sslSettings.className, 'AppEngineDomainMappingSslSettings');
+    // nesting_mode: list, max_items: 1 -> not a repeated collection.
+    expect(sslSettings.repeated, isFalse);
+    // no min_items -> the block itself is optional.
+    expect(sslSettings.required, isFalse);
+    expect(sslSettings.children, isEmpty);
+    expect(sslSettings.excludedChildTfNames, isEmpty);
+
+    final sslManagementType =
+        sslSettings.attrs.firstWhere((a) => a.tfName == 'ssl_management_type');
+    expect(sslManagementType.dartName, 'sslManagementType');
+    expect(sslManagementType.required, isTrue);
+    expect(sslManagementType.enumValues, ['AUTOMATIC', 'MANUAL']);
+    expect(
+      sslManagementType.dartType,
+      'AppEngineDomainMappingSslSettingsSslManagementType',
+    );
+
+    final certificateId =
+        sslSettings.attrs.firstWhere((a) => a.tfName == 'certificate_id');
+    expect(certificateId.dartName, 'certificateId');
+    // optional + computed -> kept, not required.
+    expect(certificateId.required, isFalse);
+    expect(certificateId.enumValues, isNull);
+    expect(certificateId.dartType, 'String');
+
+    // pending_managed_certificate_id is computed-only (computed, neither
+    // optional nor required) and must be dropped entirely.
+    expect(
+      sslSettings.attrs
+          .any((a) => a.tfName == 'pending_managed_certificate_id'),
+      isFalse,
+    );
+  });
+
+  test(
+      'google_access_context_manager_access_level: excludedPaths records '
+      'the child by name without descending, customSlot keys hide the '
+      'whole subtree, and a max_items-less list block is repeated', () {
+    const terraformType = 'google_access_context_manager_access_level';
+    final block = _blockOf(terraformType);
+    final resourcePrefix = _resourcePrefixOf(terraformType);
+
+    final specs = collectNestedTypes(
+      resourceBlock: block,
+      resourcePrefix: resourcePrefix,
+      customSlotKeys: const {},
+      excludedPaths: const {'basic.conditions'},
+    );
+
+    final basic = specs.firstWhere((s) => s.tfName == 'basic');
+    expect(basic.path, ['basic']);
+    expect(basic.className, 'AccessContextManagerAccessLevelBasic');
+    // `basic.conditions` is excluded: recorded by name on the parent...
+    expect(basic.excludedChildTfNames, ['conditions']);
+    // ...and NOT present as a child spec (the subtree is not descended).
+    expect(basic.children.any((c) => c.tfName == 'conditions'), isFalse);
+
+    // Re-run unrestricted (no excludedPaths) to pin `repeated` on the same
+    // real block: `conditions` is nesting_mode list with min_items: 1 and
+    // no max_items, so it is both required and repeated.
+    final unrestricted = collectNestedTypes(
+      resourceBlock: block,
+      resourcePrefix: resourcePrefix,
+      customSlotKeys: const {},
+      excludedPaths: const {},
+    );
+    final unrestrictedBasic =
+        unrestricted.firstWhere((s) => s.tfName == 'basic');
+    // `basic` carries both its own attribute (combining_function) AND a
+    // nested block (conditions) — the recursion must produce both from the
+    // same block map, not just one or the other.
+    expect(
+      unrestrictedBasic.attrs.any((a) => a.tfName == 'combining_function'),
+      isTrue,
+    );
+    final conditions =
+        unrestrictedBasic.children.firstWhere((c) => c.tfName == 'conditions');
+    expect(conditions.repeated, isTrue);
+    expect(conditions.required, isTrue);
+
+    // customSlot keys hide the whole subtree: no trace anywhere (contrast
+    // with excludedPaths above, which still records the bare name) — tested
+    // at the ROOT ('basic', a top-level block_types entry)...
+    final withCustomSlot = collectNestedTypes(
+      resourceBlock: block,
+      resourcePrefix: resourcePrefix,
+      customSlotKeys: const {'basic'},
+      excludedPaths: const {},
+    );
+    expect(withCustomSlot.any((s) => s.tfName == 'basic'), isFalse);
+    // ...and an unrelated sibling block is unaffected by the customSlot skip.
+    expect(withCustomSlot.any((s) => s.tfName == 'custom'), isTrue);
+
+    // ...and NESTED ('conditions', a child two levels down): `basic` itself
+    // must still be collected (with its own attrs intact), but with
+    // `conditions` entirely gone from both `children` AND
+    // `excludedChildTfNames` — true invisibility, unlike excludedPaths.
+    final withNestedCustomSlot = collectNestedTypes(
+      resourceBlock: block,
+      resourcePrefix: resourcePrefix,
+      customSlotKeys: const {'conditions'},
+      excludedPaths: const {},
+    );
+    final basicWithNestedCustomSlot =
+        withNestedCustomSlot.firstWhere((s) => s.tfName == 'basic');
+    expect(
+      basicWithNestedCustomSlot.attrs
+          .any((a) => a.tfName == 'combining_function'),
+      isTrue,
+    );
+    expect(
+      basicWithNestedCustomSlot.children.any((c) => c.tfName == 'conditions'),
+      isFalse,
+    );
+    expect(basicWithNestedCustomSlot.excludedChildTfNames, isEmpty);
+  });
+}

--- a/packages/terradart_codegen/test/codegen/nested_types/nested_type_collector_test.dart
+++ b/packages/terradart_codegen/test/codegen/nested_types/nested_type_collector_test.dart
@@ -174,4 +174,112 @@ void main() {
     );
     expect(basicWithNestedCustomSlot.excludedChildTfNames, isEmpty);
   });
+
+  test(
+      'google_os_config_patch_deployment: a list(string) attr with an enum '
+      'description becomes a first-class repeated enum, not a scalar one', () {
+    const terraformType = 'google_os_config_patch_deployment';
+    final specs = collectNestedTypes(
+      resourceBlock: _blockOf(terraformType),
+      resourcePrefix: _resourcePrefixOf(terraformType),
+      customSlotKeys: const {},
+      excludedPaths: const {},
+    );
+
+    final patchConfig = specs.firstWhere((s) => s.tfName == 'patch_config');
+    final windowsUpdate =
+        patchConfig.children.firstWhere((c) => c.tfName == 'windows_update');
+    expect(windowsUpdate.path, ['patch_config', 'windows_update']);
+    expect(
+      windowsUpdate.className,
+      'OsConfigPatchDeploymentPatchConfigWindowsUpdate',
+    );
+
+    // `classifications` is `["list", "string"]` with a "Possible values:
+    // [...]" description — schema type AND description agree it's a
+    // repeated enum, so it must render as one (not a self-contradictory
+    // scalar enum dartType on a list-typed field).
+    final classifications =
+        windowsUpdate.attrs.firstWhere((a) => a.tfName == 'classifications');
+    expect(classifications.dartName, 'classifications');
+    expect(classifications.required, isFalse);
+    expect(classifications.repeated, isTrue);
+    expect(classifications.enumValues, [
+      'CRITICAL',
+      'SECURITY',
+      'DEFINITION',
+      'DRIVER',
+      'FEATURE_PACK',
+      'SERVICE_PACK',
+      'TOOL',
+      'UPDATE_ROLLUP',
+      'UPDATE',
+    ]);
+    expect(
+      classifications.dartType,
+      'OsConfigPatchDeploymentPatchConfigWindowsUpdateClassifications',
+    );
+  });
+
+  test(
+      'google_access_context_manager_access_level: both device_policy '
+      'allow-lists become repeated enums when the conditions subtree is '
+      'not excluded', () {
+    const terraformType = 'google_access_context_manager_access_level';
+    final specs = collectNestedTypes(
+      resourceBlock: _blockOf(terraformType),
+      resourcePrefix: _resourcePrefixOf(terraformType),
+      customSlotKeys: const {},
+      excludedPaths: const {},
+    );
+
+    final basic = specs.firstWhere((s) => s.tfName == 'basic');
+    final conditions =
+        basic.children.firstWhere((c) => c.tfName == 'conditions');
+    final devicePolicy =
+        conditions.children.firstWhere((c) => c.tfName == 'device_policy');
+    expect(
+      devicePolicy.className,
+      'AccessContextManagerAccessLevelBasicConditionsDevicePolicy',
+    );
+
+    final managementLevels = devicePolicy.attrs
+        .firstWhere((a) => a.tfName == 'allowed_device_management_levels');
+    expect(managementLevels.repeated, isTrue);
+    expect(managementLevels.enumValues, [
+      'MANAGEMENT_UNSPECIFIED',
+      'NONE',
+      'BASIC',
+      'COMPLETE',
+    ]);
+    expect(
+      managementLevels.dartType,
+      'AccessContextManagerAccessLevelBasicConditionsDevicePolicy'
+      'AllowedDeviceManagementLevels',
+    );
+
+    final encryptionStatuses = devicePolicy.attrs
+        .firstWhere((a) => a.tfName == 'allowed_encryption_statuses');
+    expect(encryptionStatuses.repeated, isTrue);
+    expect(encryptionStatuses.enumValues, [
+      'ENCRYPTION_UNSPECIFIED',
+      'ENCRYPTION_UNSUPPORTED',
+      'UNENCRYPTED',
+      'ENCRYPTED',
+    ]);
+    expect(
+      encryptionStatuses.dartType,
+      'AccessContextManagerAccessLevelBasicConditionsDevicePolicy'
+      'AllowedEncryptionStatuses',
+    );
+
+    // A plain list(string) with NO enum description must still fall back
+    // to the conservative shape, not be swept up by the new repeated-enum
+    // branch.
+    final ipSubnetworks =
+        conditions.attrs.firstWhere((a) => a.tfName == 'ip_subnetworks');
+    expect(ipSubnetworks.repeated, isFalse);
+    expect(ipSubnetworks.enumValues, isNull);
+    expect(ipSubnetworks.dartType, 'List<Object?>');
+  });
 }

--- a/packages/terradart_codegen/test/codegen/nested_types/nested_type_emitter_test.dart
+++ b/packages/terradart_codegen/test/codegen/nested_types/nested_type_emitter_test.dart
@@ -172,6 +172,52 @@ enum AppEngineDomainMappingSslSettingsSslManagementType implements TerraformEnum
       expect(formatted, contains('this.certificateId,'));
       expect(formatted, contains('final TfArg<String>? certificateId;'));
     });
+
+    test(
+        'google_access_context_manager_access_level: basic.conditions is '
+        'both required AND repeated (Task 3 carry-over — untested combo, '
+        'real data)', () {
+      const terraformType = 'google_access_context_manager_access_level';
+      final specs = collectNestedTypes(
+        resourceBlock: _blockOf(terraformType),
+        resourcePrefix: _resourcePrefixOf(terraformType),
+        customSlotKeys: const {},
+        excludedPaths: const {},
+      );
+
+      final formatted = _fmt(renderNestedTypes(
+        specs,
+        resourceTerraformType: terraformType,
+      ));
+
+      // `conditions` (nesting_mode: list, min_items: 1, no max_items) is a
+      // CHILD of `basic`, so it renders as a bare (non-`TfArg`) class
+      // reference encoded via `.encode()` — required means non-nullable
+      // field + unconditional entry + no `!`; repeated means `List<...>` +
+      // a `[for (final e in ...) e.encode()]` comprehension with no `!`
+      // guard on the iterable either (required, so it can't be null).
+      expect(formatted, contains('required this.conditions'));
+      expect(
+        formatted,
+        contains(
+          'final List<AccessContextManagerAccessLevelBasicConditions> '
+          'conditions;',
+        ),
+      );
+      expect(
+        formatted,
+        contains("'conditions': [for (final e in conditions) e.encode()],"),
+      );
+      expect(formatted, isNot(contains('conditions!')));
+      expect(formatted, isNot(contains('if (conditions != null)')));
+      // Depth-first: the child's own class is rendered too.
+      expect(
+        formatted,
+        contains(
+          'final class AccessContextManagerAccessLevelBasicConditions {',
+        ),
+      );
+    });
   });
 
   group('renderNestedTypes: additional shape rules', () {

--- a/packages/terradart_codegen/test/codegen/nested_types/nested_type_emitter_test.dart
+++ b/packages/terradart_codegen/test/codegen/nested_types/nested_type_emitter_test.dart
@@ -1,0 +1,511 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_style/dart_style.dart';
+import 'package:terradart_codegen/src/codegen/naming.dart';
+import 'package:terradart_codegen/src/codegen/nested_types/nested_type_collector.dart';
+import 'package:terradart_codegen/src/codegen/nested_types/nested_type_emitter.dart';
+import 'package:test/test.dart';
+
+/// The exact `dart_style` configuration `terradart wrap` formats generated
+/// files with (`wrap_command.dart`) — comparisons below run BOTH the
+/// emitter's raw output and the hand-written expected source through this
+/// same formatter, so the test pins the format-stable *contract* rather
+/// than the emitter's own (irrelevant) internal whitespace choices.
+final _formatter =
+    DartFormatter(languageVersion: DartFormatter.latestLanguageVersion);
+
+String _fmt(String source) => _formatter.format(source);
+
+const _schemaPath = 'test/fixtures/wrap/source/schema.json';
+
+/// Loads `resource_schemas[terraformType].block` straight from the pinned
+/// provider-schema fixture, mirroring `nested_type_collector_test.dart`.
+Map<String, dynamic> _blockOf(String terraformType) {
+  final decoded =
+      jsonDecode(File(_schemaPath).readAsStringSync()) as Map<String, dynamic>;
+  final providerSchemas =
+      (decoded['provider_schemas'] as Map).cast<String, dynamic>();
+  final providerBody =
+      (providerSchemas.values.single as Map).cast<String, dynamic>();
+  final resourceSchemas =
+      (providerBody['resource_schemas'] as Map).cast<String, dynamic>();
+  final resource =
+      (resourceSchemas[terraformType] as Map).cast<String, dynamic>();
+  return (resource['block'] as Map).cast<String, dynamic>();
+}
+
+String _resourcePrefixOf(String terraformType) {
+  const providerPrefix = 'google_';
+  final short = terraformType.startsWith(providerPrefix)
+      ? terraformType.substring(providerPrefix.length)
+      : terraformType;
+  return snakeToPascal(short);
+}
+
+void main() {
+  group(
+      'renderNestedTypes: byte-pinned idiom (google_app_engine_domain_mapping.ssl_settings)',
+      () {
+    // NOTE on `sslManagementType.required`: the brief's pinned idiom text
+    // renders `sslManagementType` as optional. The REAL provider schema
+    // (test/fixtures/wrap/source/schema.json) actually marks
+    // `ssl_management_type` `"required": true` — confirmed by the already
+    // -committed, already-green `nested_type_collector_test.dart`
+    // ("ssl_management_type" test expects `.required, isTrue`). This test
+    // deliberately hand-constructs `required: false` to match the brief's
+    // literal pinned text byte-for-byte (the point of this test is pinning
+    // the FORMAT/idiom, not replaying this one resource's real schema). The
+    // group below ("real collector output") separately renders the ACTUAL
+    // collector output for this resource and confirms the required-attr
+    // shape kicks in correctly for the real `required: true` data.
+    test('matches the hand-written helper idiom byte-for-byte (post-format)',
+        () {
+      final certificateId = const NestedAttrSpec(
+        tfName: 'certificate_id',
+        dartName: 'certificateId',
+        dartType: 'String',
+        required: false,
+      );
+      final sslManagementType = const NestedAttrSpec(
+        tfName: 'ssl_management_type',
+        dartName: 'sslManagementType',
+        dartType: 'AppEngineDomainMappingSslSettingsSslManagementType',
+        required: false,
+        enumValues: ['AUTOMATIC', 'MANUAL'],
+      );
+      final sslSettings = NestedBlockSpec(
+        tfName: 'ssl_settings',
+        path: const ['ssl_settings'],
+        className: 'AppEngineDomainMappingSslSettings',
+        repeated: false,
+        required: false,
+        // Deliberately reversed vs. tfName-alphabetical order, to prove
+        // renderNestedTypes re-sorts attrs itself rather than trusting
+        // caller-supplied order.
+        attrs: [sslManagementType, certificateId],
+        children: const [],
+        excludedChildTfNames: const [],
+      );
+
+      final actual = renderNestedTypes(
+        [sslSettings],
+        resourceTerraformType: 'google_app_engine_domain_mapping',
+      );
+
+      const expected = '''
+/// Typed helper for the `ssl_settings` block of
+/// `google_app_engine_domain_mapping` (derived from provider schema).
+@immutable
+final class AppEngineDomainMappingSslSettings {
+  const AppEngineDomainMappingSslSettings({
+    this.certificateId,
+    this.sslManagementType,
+  });
+
+  final TfArg<String>? certificateId;
+
+  final TfArg<AppEngineDomainMappingSslSettingsSslManagementType>?
+      sslManagementType;
+
+  Map<String, Object?> encode() => {
+        if (certificateId != null) 'certificate_id': certificateId!.toTfJson(),
+        if (sslManagementType != null)
+          'ssl_management_type': sslManagementType!.toTfJson(),
+      };
+}
+
+/// `ssl_management_type` — derived from the provider schema description.
+enum AppEngineDomainMappingSslSettingsSslManagementType implements TerraformEnum {
+  automatic('AUTOMATIC'),
+  manual('MANUAL');
+
+  const AppEngineDomainMappingSslSettingsSslManagementType(this.terraformValue);
+  @override
+  final String terraformValue;
+}
+''';
+
+      expect(_fmt(actual), _fmt(expected));
+    });
+  });
+
+  group('renderNestedTypes: real collector output', () {
+    test('ssl_management_type renders as required (real schema: required=true)',
+        () {
+      const terraformType = 'google_app_engine_domain_mapping';
+      final specs = collectNestedTypes(
+        resourceBlock: _blockOf(terraformType),
+        resourcePrefix: _resourcePrefixOf(terraformType),
+        customSlotKeys: const {},
+        excludedPaths: const {},
+      );
+
+      final formatted = _fmt(renderNestedTypes(
+        specs,
+        resourceTerraformType: terraformType,
+      ));
+
+      // required attr: `required this.x`, non-nullable field, unconditional
+      // encode entry (no `if (x != null)` guard, no `!` before the call).
+      // Fragments are checked independently, not as one contiguous string,
+      // because the class name is long enough that dart_style wraps the
+      // field declaration across lines (same reason the main idiom test
+      // above shows `sslManagementType`'s own field split in two).
+      expect(formatted, contains('required this.sslManagementType'));
+      expect(
+        formatted,
+        contains('TfArg<AppEngineDomainMappingSslSettingsSslManagementType>'),
+      );
+      expect(
+        formatted,
+        matches(RegExp(r'TfArg<\w+SslManagementType>\s+sslManagementType;')),
+      );
+      expect(
+        formatted,
+        contains("'ssl_management_type': sslManagementType.toTfJson(),"),
+      );
+      expect(formatted, isNot(contains('sslManagementType!.toTfJson()')));
+      expect(formatted, isNot(contains('if (sslManagementType != null)')));
+
+      // certificate_id stays optional (schema: optional + computed).
+      expect(formatted, contains('this.certificateId,'));
+      expect(formatted, contains('final TfArg<String>? certificateId;'));
+    });
+  });
+
+  group('renderNestedTypes: additional shape rules', () {
+    test(
+        'a repeated child block renders as List<Child>? and encodes via .encode()',
+        () {
+      final conditions = const NestedBlockSpec(
+        tfName: 'conditions',
+        path: ['basic', 'conditions'],
+        className: 'AccessLevelBasicConditions',
+        repeated: true,
+        required: false,
+        attrs: [],
+        children: [],
+        excludedChildTfNames: [],
+      );
+      final basic = NestedBlockSpec(
+        tfName: 'basic',
+        path: const ['basic'],
+        className: 'AccessLevelBasic',
+        repeated: false,
+        required: false,
+        attrs: const [],
+        children: [conditions],
+        excludedChildTfNames: const [],
+      );
+
+      final formatted = _fmt(renderNestedTypes(
+        [basic],
+        resourceTerraformType: 'google_access_context_manager_access_level',
+      ));
+
+      expect(
+        formatted,
+        contains('final List<AccessLevelBasicConditions>? conditions;'),
+      );
+      expect(formatted, contains('if (conditions != null)'));
+      expect(
+        formatted,
+        contains(
+          "'conditions': [for (final e in conditions!) e.encode()],",
+        ),
+      );
+      // Depth-first: the child's own class is rendered too.
+      expect(
+        formatted,
+        contains('final class AccessLevelBasicConditions {'),
+      );
+    });
+
+    test(
+        'a required attr renders required this.x, non-nullable field, unconditional entry',
+        () {
+      final requiredAttr = const NestedAttrSpec(
+        tfName: 'display_name',
+        dartName: 'displayName',
+        dartType: 'String',
+        required: true,
+      );
+      final spec = NestedBlockSpec(
+        tfName: 'thing',
+        path: const ['thing'],
+        className: 'FooThing',
+        repeated: false,
+        required: false,
+        attrs: [requiredAttr],
+        children: const [],
+        excludedChildTfNames: const [],
+      );
+
+      final formatted = _fmt(renderNestedTypes(
+        [spec],
+        resourceTerraformType: 'google_foo',
+      ));
+
+      // A single named param collapses onto one line under dart_style (no
+      // trailing comma) — assert on the parameter text itself, not on a
+      // trailing comma that only appears when the line is long enough to
+      // force a multi-line parameter list.
+      expect(formatted, contains('required this.displayName'));
+      expect(formatted, contains('final TfArg<String> displayName;'));
+      // Same collapse-to-one-line caveat as the constructor param above: a
+      // lone map entry that fits on one line loses its trailing comma too.
+      expect(
+        formatted,
+        contains("'display_name': displayName.toTfJson()"),
+      );
+      expect(formatted, isNot(contains('displayName!.toTfJson()')));
+      expect(formatted, isNot(contains('if (displayName != null)')));
+    });
+
+    test(
+        'an excludedChildTfNames entry renders a TfArg<Map<String, dynamic>>? passthrough',
+        () {
+      final spec = const NestedBlockSpec(
+        tfName: 'thing',
+        path: ['thing'],
+        className: 'FooThing',
+        repeated: false,
+        required: false,
+        attrs: [],
+        children: [],
+        excludedChildTfNames: ['device_policy'],
+      );
+
+      final formatted = _fmt(renderNestedTypes(
+        [spec],
+        resourceTerraformType: 'google_foo',
+      ));
+
+      expect(
+        formatted,
+        contains('final TfArg<Map<String, dynamic>>? devicePolicy;'),
+      );
+      expect(
+        formatted,
+        contains(
+          "if (devicePolicy != null) 'device_policy': devicePolicy!.toTfJson(),",
+        ),
+      );
+    });
+
+    test(
+        'a repeated enum attribute renders List<TfArg<EnumClass>>? and encodes each element',
+        () {
+      final repeatedEnumAttr = const NestedAttrSpec(
+        tfName: 'allowed_statuses',
+        dartName: 'allowedStatuses',
+        dartType: 'FooThingAllowedStatuses',
+        required: false,
+        enumValues: ['ESSENTIAL', 'FULL'],
+        repeated: true,
+      );
+      final spec = NestedBlockSpec(
+        tfName: 'thing',
+        path: const ['thing'],
+        className: 'FooThing',
+        repeated: false,
+        required: false,
+        attrs: [repeatedEnumAttr],
+        children: const [],
+        excludedChildTfNames: const [],
+      );
+
+      final formatted = _fmt(renderNestedTypes(
+        [spec],
+        resourceTerraformType: 'google_foo',
+      ));
+
+      expect(
+        formatted,
+        contains(
+            'final List<TfArg<FooThingAllowedStatuses>>? allowedStatuses;'),
+      );
+      expect(formatted, contains('if (allowedStatuses != null)'));
+      expect(
+        formatted,
+        contains(
+          "'allowed_statuses': [for (final e in allowedStatuses!) e.toTfJson()],",
+        ),
+      );
+      expect(
+        formatted,
+        contains('enum FooThingAllowedStatuses implements TerraformEnum {'),
+      );
+      expect(formatted, contains("essential('ESSENTIAL'),"));
+      expect(formatted, contains("full('FULL');"));
+    });
+
+    test(
+        'field order: attrs (alphabetical) first, then block-type children '
+        '— derived and excluded merged (alphabetical) — second', () {
+      final zzzAttr = const NestedAttrSpec(
+        tfName: 'zzz_attr',
+        dartName: 'zzzAttr',
+        dartType: 'String',
+        required: false,
+      );
+      final aaaAttr = const NestedAttrSpec(
+        tfName: 'aaa_attr',
+        dartName: 'aaaAttr',
+        dartType: 'String',
+        required: false,
+      );
+      final mmmChild = const NestedBlockSpec(
+        tfName: 'mmm_child',
+        path: ['thing', 'mmm_child'],
+        className: 'FooThingMmmChild',
+        repeated: false,
+        required: false,
+        attrs: [],
+        children: [],
+        excludedChildTfNames: [],
+      );
+      final spec = NestedBlockSpec(
+        tfName: 'thing',
+        path: const ['thing'],
+        className: 'FooThing',
+        repeated: false,
+        required: false,
+        // Deliberately unsorted, and deliberately interleaving attrs with
+        // the child, to prove the two-group rule below isn't an accident
+        // of input order.
+        attrs: [zzzAttr, aaaAttr],
+        children: [mmmChild],
+        excludedChildTfNames: const ['bbb_excluded'],
+      );
+
+      final formatted = _fmt(renderNestedTypes(
+        [spec],
+        resourceTerraformType: 'google_foo',
+      ));
+
+      final aaaIdx = formatted.indexOf('aaaAttr');
+      final zzzIdx = formatted.indexOf('zzzAttr');
+      final bbbIdx = formatted.indexOf('bbbExcluded');
+      final mmmIdx = formatted.indexOf('mmmChild');
+      expect([aaaIdx, zzzIdx, bbbIdx, mmmIdx], everyElement(greaterThan(-1)));
+      // Group 1 (attrs, alphabetical): aaa_attr before zzz_attr.
+      expect(aaaIdx, lessThan(zzzIdx));
+      // Group 2 (block-type children, alphabetical, derived+excluded
+      // merged): bbb_excluded before mmm_child — and the whole group comes
+      // after every attr.
+      expect(zzzIdx, lessThan(bbbIdx));
+      expect(bbbIdx, lessThan(mmmIdx));
+    });
+  });
+
+  group('renderNestedTypes: determinism', () {
+    test('same specs produce identical output on repeated calls', () {
+      final a = const NestedBlockSpec(
+        tfName: 'aaa',
+        path: ['aaa'],
+        className: 'FooAaa',
+        repeated: false,
+        required: false,
+        attrs: [],
+        children: [],
+        excludedChildTfNames: [],
+      );
+      final b = const NestedBlockSpec(
+        tfName: 'bbb',
+        path: ['bbb'],
+        className: 'FooBbb',
+        repeated: false,
+        required: false,
+        attrs: [],
+        children: [],
+        excludedChildTfNames: [],
+      );
+
+      final first =
+          renderNestedTypes([a, b], resourceTerraformType: 'google_foo');
+      final second =
+          renderNestedTypes([a, b], resourceTerraformType: 'google_foo');
+      expect(first, second);
+    });
+
+    test('output is stable across input list-order permutations', () {
+      final a = const NestedBlockSpec(
+        tfName: 'aaa',
+        path: ['aaa'],
+        className: 'FooAaa',
+        repeated: false,
+        required: false,
+        attrs: [],
+        children: [],
+        excludedChildTfNames: [],
+      );
+      final b = const NestedBlockSpec(
+        tfName: 'bbb',
+        path: ['bbb'],
+        className: 'FooBbb',
+        repeated: false,
+        required: false,
+        attrs: [],
+        children: [],
+        excludedChildTfNames: [],
+      );
+      final c = const NestedBlockSpec(
+        tfName: 'ccc',
+        path: ['ccc'],
+        className: 'FooCcc',
+        repeated: false,
+        required: false,
+        attrs: [],
+        children: [],
+        excludedChildTfNames: [],
+      );
+
+      final canonical =
+          renderNestedTypes([a, b, c], resourceTerraformType: 'google_foo');
+      for (final permuted in [
+        [a, c, b],
+        [b, a, c],
+        [b, c, a],
+        [c, a, b],
+        [c, b, a],
+      ]) {
+        expect(
+          renderNestedTypes(permuted, resourceTerraformType: 'google_foo'),
+          canonical,
+        );
+      }
+    });
+  });
+
+  group('nestedParamType', () {
+    test('single block -> "ClassName?"', () {
+      final spec = const NestedBlockSpec(
+        tfName: 'ssl_settings',
+        path: ['ssl_settings'],
+        className: 'AppEngineDomainMappingSslSettings',
+        repeated: false,
+        required: false,
+        attrs: [],
+        children: [],
+        excludedChildTfNames: [],
+      );
+      expect(nestedParamType(spec), 'AppEngineDomainMappingSslSettings?');
+    });
+
+    test('repeated block -> "List<ClassName>?"', () {
+      final spec = const NestedBlockSpec(
+        tfName: 'conditions',
+        path: ['basic', 'conditions'],
+        className: 'AccessLevelBasicConditions',
+        repeated: true,
+        required: false,
+        attrs: [],
+        children: [],
+        excludedChildTfNames: [],
+      );
+      expect(nestedParamType(spec), 'List<AccessLevelBasicConditions>?');
+    });
+  });
+}

--- a/packages/terradart_codegen/test/codegen/override_linter_test.dart
+++ b/packages/terradart_codegen/test/codegen/override_linter_test.dart
@@ -272,6 +272,33 @@ void main() {
       );
       expect(lintOverride('google_x', o), isEmpty);
     });
+
+    test(
+        'flags nestedTypeExcludes without deriveNestedTypes as dead config '
+        '(belt-and-suspenders for the loader-level FormatException)', () {
+      const o = WrapperOverride(
+        outputDir: 'x',
+        nestedTypeExcludes: ['basic.conditions'],
+      );
+      final violations = lintOverride('google_x', o);
+      expect(violations, hasLength(1));
+      expect(violations.single.rule, 'nested-excludes-without-derive');
+      expect(violations.single.detail, contains('nestedTypeExcludes'));
+    });
+
+    test('clean: deriveNestedTypes + nestedTypeExcludes', () {
+      const o = WrapperOverride(
+        outputDir: 'x',
+        deriveNestedTypes: true,
+        nestedTypeExcludes: ['basic.conditions'],
+      );
+      expect(lintOverride('google_x', o), isEmpty);
+    });
+
+    test('clean: deriveNestedTypes true with no excludes', () {
+      const o = WrapperOverride(outputDir: 'x', deriveNestedTypes: true);
+      expect(lintOverride('google_x', o), isEmpty);
+    });
   });
 
   group('lintOverrides', () {

--- a/packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart
+++ b/packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart
@@ -35,6 +35,8 @@ void main() {
         expect(override.deriveOutputGetters, isFalse);
         expect(override.deriveClassDoc, isFalse);
         expect(override.curatedDoc, isNull);
+        expect(override.deriveNestedTypes, isFalse);
+        expect(override.nestedTypeExcludes, isNull);
       });
 
       test('derive_enums_on -> deriveEnums true', () {
@@ -70,6 +72,29 @@ void main() {
         // the single `///` line with no leading separator or trailing `\n`.
         expect(o.curatedDoc, equals('/// Curated example block.'));
         expect(o.outputDir, 'test_out');
+      });
+
+      test('derive_nested_types_on -> deriveNestedTypes true', () {
+        final loader = YamlOverrideLoader(
+          rootDir: 'test/fixtures/semantic_hints_loader/happy',
+        );
+        final result = loader.load().resources;
+        final o = result['derive_nested_types_on']!;
+        expect(o.deriveNestedTypes, isTrue);
+        expect(o.nestedTypeExcludes, isNull);
+        expect(o.outputDir, 'test_out');
+      });
+
+      test(
+          'nested_type_excludes_only -> deriveNestedTypes + nestedTypeExcludes '
+          'round-trip', () {
+        final loader = YamlOverrideLoader(
+          rootDir: 'test/fixtures/semantic_hints_loader/happy',
+        );
+        final result = loader.load().resources;
+        final o = result['nested_type_excludes_only']!;
+        expect(o.deriveNestedTypes, isTrue);
+        expect(o.nestedTypeExcludes, equals(['basic.conditions', 'foo.bar']));
       });
 
       test('param_order_only -> only paramOrder set', () {
@@ -187,8 +212,8 @@ void main() {
       });
 
       test(
-          'full_axis -> all axes set (Plan 5.X: 10 axes, schemaStubComment retired)',
-          () {
+          'full_axis -> all axes set (schemaStubComment retired; '
+          'deriveNestedTypes + nestedTypeExcludes added)', () {
         final loader = YamlOverrideLoader(
           rootDir: 'test/fixtures/semantic_hints_loader/happy',
         );
@@ -206,6 +231,8 @@ void main() {
           o.customSlots!['s']!.paramDeclaration,
           equals('required Bar b'),
         );
+        expect(o.deriveNestedTypes, isTrue);
+        expect(o.nestedTypeExcludes, equals(['basic.conditions']));
       });
     });
 
@@ -337,6 +364,21 @@ schemaStubComment: |-
           loader.load,
           throwsFormatExceptionWith(
             '"deriveOutputGetters" must be a boolean (true or false)',
+          ),
+        );
+      });
+
+      test(
+          'nestedTypeExcludes without deriveNestedTypes -> FormatException '
+          '(mirrors the classDocComment retirement style)', () {
+        final loader = YamlOverrideLoader(
+          rootDir: 'test/fixtures/semantic_hints_loader/failure/'
+              'nested_type_excludes_without_derive',
+        );
+        expect(
+          loader.load,
+          throwsFormatExceptionWith(
+            'nestedTypeExcludes requires deriveNestedTypes',
           ),
         );
       });

--- a/packages/terradart_codegen/test/fixtures/semantic_hints_loader/failure/nested_type_excludes_without_derive/x.yaml
+++ b/packages/terradart_codegen/test/fixtures/semantic_hints_loader/failure/nested_type_excludes_without_derive/x.yaml
@@ -1,0 +1,3 @@
+outputDir: x
+nestedTypeExcludes:
+  - basic.conditions

--- a/packages/terradart_codegen/test/fixtures/semantic_hints_loader/happy/derive_nested_types_on.yaml
+++ b/packages/terradart_codegen/test/fixtures/semantic_hints_loader/happy/derive_nested_types_on.yaml
@@ -1,0 +1,2 @@
+outputDir: test_out
+deriveNestedTypes: true

--- a/packages/terradart_codegen/test/fixtures/semantic_hints_loader/happy/full_axis.yaml
+++ b/packages/terradart_codegen/test/fixtures/semantic_hints_loader/happy/full_axis.yaml
@@ -21,3 +21,6 @@ customSlots:
   s:
     paramDeclaration: 'required Bar b'
     argMapEntry: 's: TfArg.literal(b.encode()),'
+deriveNestedTypes: true
+nestedTypeExcludes:
+  - basic.conditions

--- a/packages/terradart_codegen/test/fixtures/semantic_hints_loader/happy/nested_type_excludes_only.yaml
+++ b/packages/terradart_codegen/test/fixtures/semantic_hints_loader/happy/nested_type_excludes_only.yaml
@@ -1,0 +1,5 @@
+outputDir: test_out
+deriveNestedTypes: true
+nestedTypeExcludes:
+  - basic.conditions
+  - foo.bar

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -86,3 +86,5 @@ dev_dependencies:
   yaml: any
   terradart_google:
     path: packages/terradart_google
+  terradart_codegen:
+    path: packages/terradart_codegen

--- a/tool/check_override_enum_gaps.dart
+++ b/tool/check_override_enum_gaps.dart
@@ -17,6 +17,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:terradart_codegen/src/codegen/enum_value_parser.dart';
 import 'package:yaml/yaml.dart';
 
 final _root = Directory.current.path == '/workspace'
@@ -72,52 +73,6 @@ bool _isThin(Map<String, dynamic> ov) {
     'classDocComment',
   };
   return !ov.keys.any(rich.contains);
-}
-
-/// Parses schema descriptions that document a finite value set.
-List<String>? _parseEnumValues(String? desc) {
-  if (desc == null) return null;
-
-  final bracket = RegExp(r'Possible values:\s*(\[[^\]]+\])');
-  final m = bracket.firstMatch(desc);
-  if (m != null) {
-    try {
-      final vals = jsonDecode(m.group(1)!.replaceAll("'", '"')) as List;
-      final strings = vals.cast<String>();
-      return strings.length >= 2 ? strings : null;
-    } on FormatException {
-      // fall through
-    }
-  }
-
-  // `Valid values are: "PAGELESS", "PAGINATED".`
-  final validAre = RegExp(
-    r'Valid values are:\s*([^.]+)\.',
-    caseSensitive: false,
-  );
-  final vm = validAre.firstMatch(desc);
-  if (vm != null) {
-    final quoted = RegExp(r'"([^"]+)"')
-        .allMatches(vm.group(1)!)
-        .map((m) => m.group(1)!)
-        .toList();
-    if (quoted.length >= 2) return quoted;
-  }
-
-  // `Possible values: JOB_TYPE_UNSPECIFIED, PIPELINE, QUERY`
-  final loose = RegExp(r'Possible values:\s*([A-Z0-9_,\s]+)');
-  final lm = loose.firstMatch(desc);
-  if (lm != null) {
-    final vals = lm
-        .group(1)!
-        .split(',')
-        .map((v) => v.trim())
-        .where((v) => v.isNotEmpty)
-        .toList();
-    if (vals.length >= 2) return vals;
-  }
-
-  return null;
 }
 
 String _camel(String snake) {
@@ -214,7 +169,9 @@ List<_NestedEnumSite> _collectNestedEnumSites(Map<String, dynamic> block) {
       for (final attrEntry in attrs.entries) {
         final meta = Map<String, dynamic>.from(attrEntry.value as Map);
         if (meta['computed'] == true) continue;
-        final vals = _parseEnumValues(meta['description'] as String?);
+        final vals = parseEnumValuesFromDescription(
+          meta['description'] as String?,
+        );
         if (vals == null) continue;
         sites.add((blockPath: nextPath, attr: attrEntry.key, values: vals));
       }
@@ -256,7 +213,9 @@ void main(List<String> args) {
       final meta = Map<String, dynamic>.from(entry.value as Map);
       if (meta['computed'] == true) continue;
 
-      final vals = _parseEnumValues(meta['description'] as String?);
+      final vals = parseEnumValuesFromDescription(
+        meta['description'] as String?,
+      );
       if (vals == null) continue;
 
       final camel = _camel(attr);


### PR DESCRIPTION
## Summary

Mechanism PR (1 of 3) for the nested-type campaign: a new override gate `deriveNestedTypes: true` that generates typed helper classes for nested blocks — fields typed from the schema, enum-documented attrs as typed enums (incl. first-class list-of-enum), `encode()` for the argMap — replacing raw `TfArg<Map<String, dynamic>>` params. **This PR lands DARK**: no override sets the gate, and `wrap --check` is 449/449 byte-identical.

The flip across the 19 NESTED_THIN resources + MIGRATING is PR 2 (the 0.24.0 breaking body); the release bump is PR 3.

## Components

- **`enum_value_parser.dart`** — the three description→enum-values patterns moved verbatim out of `check_override_enum_gaps.dart`, which now imports it (single source: the checker and the emitter see identically). Gaps invariant unchanged: 56 advisories.
- **`nested_types/nested_type_collector.dart`** — pure schema→`NestedBlockSpec` tree walk: computed-only dropped, customSlot-covered subtrees skipped (proven equivalent to the checker's ancestor scan), `nestedTypeExcludes` honored, `timeouts` filtered (mirrors `constructor_params.dart`). Enum detection is **type-gated**: bare string → scalar enum; `["list"|"set","string"]` + enum description → repeated enum (a review round caught the original short-circuit that would have mislabeled the 3 real list-of-enum sites).
- **`nested_types/nested_type_emitter.dart`** — pure renderer matching the hand-written helper idiom byte-for-byte post-format (`@immutable final class`, const ctor, `encode()` with null-guarded entries; repeated enums as `List<TfArg<E>>`). Deterministic across input permutations. `naming.dart`'s screaming→camel helper made public with a reserved-word `Case`-suffix fallback (same mechanism as `ValidValuesEmitter`; proven inert for all 114 currently-derived enum values).
- **Wiring** — loader (`deriveNestedTypes` / `nestedTypeExcludes`, excludes-without-gate fails at load), lint rule `nested-excludes-without-derive`, `WrapperEmitter` integration behind the gate (lazy raw-schema decode only when some override flips; ctor default keeps all ~40 call sites unchanged). Generated classes ride the existing catalog `scanNestedTypes` scan into barrels for free.

## Verification

- Dark launch: `wrap --check` **449/449 byte-identical** on the committed tree; structural inertness reviewed at four levels (gate boolean, empty-list short-circuits, lazy decode, ctor default)
- 454 codegen tests green (+24 new across parser/collector/emitter/loader/lint/wrap-level); FULL `tool/agent_verify.sh` OK
- Per-task reviews: 4/4 approved (one Critical caught and fixed in the collector's enum type-gating)