### PR TITLE
fix(tool): wave ledger admits the counts-forced files; PR-creation guidance

### DIFF
--- a/.cursor/agents/wave-shipper.md
+++ b/.cursor/agents/wave-shipper.md
@@ -86,13 +86,20 @@ tail/grep and trust `&&` — check exit codes bare.
   last push is up: mark the PR ready for review, wait for the change-gate
   to start, then comment and label.
 - Branch `wave/<product>-<YYYY-MM-DD>`; commits in English, no AI footers.
+- **Open the PR yourself with `gh pr create --head wave/<...> --draft`** —
+  do NOT rely on the platform's automatic PR creation, which uses a
+  `cursor/*` branch that the executor's `wave/*` pattern rejects (learned
+  from the first canary, #277). If the platform auto-opened a `cursor/*`
+  PR anyway, report its number for human closure (you never close PRs
+  yourself).
 - PR body: the selected resources and why this group, cost-classification
   evidence summary, the backlog diff, and the example's subject.
 - Comment your run report (selected / implemented / verified / anything
   skipped with reasons).
 - Apply the `wave-approved` label LAST — the executor starts watching
   checks the moment the label lands, and the apply-smoke change-gate must
-  run against your final push.
+  run against your final push. If labeling fails on token permissions,
+  say so explicitly in your report and ask a human to apply it.
 
 ## Hard rules
 

--- a/tool/check_bump_scope_test.dart
+++ b/tool/check_bump_scope_test.dart
@@ -140,8 +140,15 @@ void main() {
           'packages/terradart_google/lib/new_thing.dart',
           'examples/new_thing_quickstart/lib/main.dart',
           'README.md',
+          'CONTRIBUTING.md',
+          'packages/terradart_google/README.md',
+          'packages/terradart_agent/README.md',
           'website/src/content/docs/docs/why-terradart.mdx',
           'website/src/content/docs/docs/coverage.md',
+          'website/src/content/docs/docs/status.md',
+          'website/src/content/docs/docs/agent/index.md',
+          'website/src/content/docs/docs/agent/tools-reference.md',
+          'packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart',
           'tool/curation_backlog.yaml',
           'tool/apply_cost_denylist.yaml',
           'tool/doc_expectations.dart',
@@ -159,10 +166,11 @@ void main() {
           '.github/workflows/ci.yml',
           'tool/check_bump_scope.dart',
           'tool/exactly_one_lint_debt.yaml',
+          '.cursor/agents/wave-shipper.md',
         ],
         rules: rules,
       ),
-      hasLength(6),
+      hasLength(7),
     );
   });
 }

--- a/tool/wave_allowed_paths.yaml
+++ b/tool/wave_allowed_paths.yaml
@@ -21,16 +21,25 @@ packages/terradart_google/lib/
 packages/terradart_codegen/test/golden/
 packages/terradart_codegen/test/fixtures/wrap/expected_output/
 
-# Counts that move with the catalog
+# Counts that move with the catalog (the docs-consistency checker and the
+# count assertions FORCE these to change whenever the catalog grows — a
+# Wave cannot avoid touching them; learned from the first canary, #277)
 tool/doc_expectations.dart
 packages/terradart_google/test/catalog/catalog_count_test.dart
 packages/terradart_codegen/test/cli/wrap_command_test.dart
+packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart
 
 # Wave example + counts-bearing docs
 examples/
 README.md
+CONTRIBUTING.md
+packages/terradart_google/README.md
+packages/terradart_agent/README.md
 website/src/content/docs/docs/why-terradart.mdx
 website/src/content/docs/docs/coverage.md
+website/src/content/docs/docs/status.md
+website/src/content/docs/docs/agent/index.md
+website/src/content/docs/docs/agent/tools-reference.md
 
 # Ledgers a Wave legitimately edits
 tool/curation_backlog.yaml


### PR DESCRIPTION
## Summary

First wave-shipper canary (#277) surfaced two harness gaps — both on the harness side, not the agent's:

1. **The ledger was missing every counts-forced file.** When the catalog grows, the docs-consistency checker and count assertions FORCE updates to CONTRIBUTING.md, both package READMEs, the status/agent site pages, and yaml_loader_test's override count. The agent was obeying the checkers; the ledger didn't know about them. Verified: #277's actual 28-file list now passes `check_bump_scope --ledger tool/wave_allowed_paths.yaml`.
2. **Instruction gaps**: open the PR yourself from the `wave/*` branch (`gh pr create --head wave/… --draft`) — the platform's auto-PR uses a `cursor/*` branch the executor rightly rejects; and report labeling permission failures explicitly.

Exclusion set unchanged (MIGRATING/CHANGELOG/pubspecs/workflows/tool dart sources/exactly-one debt/.cursor/.claude — the reject test now pins `.cursor/agents/wave-shipper.md` too).

## Verification

- 9/9 scope-checker tests (allow-list extended, reject test extended)
- Real-world check: `gh pr view 277 --json files | check_bump_scope --ledger wave_allowed_paths.yaml` → OK (28 files)