### PR TITLE
fix(tool): coverage renderer fails closed on partial tf-out

### DIFF
--- a/.agents/skills/terradart-ship-wave/SKILL.md
+++ b/.agents/skills/terradart-ship-wave/SKILL.md
@@ -39,7 +39,7 @@ A Wave PR is **not done** when wrappers and `curatedDoc` land alone. It is done 
 - [ ] 3. **Example / docs debt** — implement or extend quickstart; update README Examples section; website counts if the minor bumps; sync `tool/example_debt.yaml` (remove covered entries, add reasoned ones only when deferring an example on purpose); if the quickstart provisions a high-cost resource, skip-list it so the cost gate (`tool/apply_smoke_test.sh` test 9) stays green.
 - [ ] 4. **Breaking API** — `MIGRATING.md` + migrate any affected examples in the same PR.
 - [ ] 5. **Counts** — bump `catalogEntryCount` / `curatedFactoryCount` and every phrase in `tool/doc_expectations.dart`; sync tests.
-- [ ] 5b. **Coverage page** — regenerate the site coverage page: `dart tool/render_coverage_page.dart` (CI's freshness check fails otherwise).
+- [ ] 5b. **Coverage page** — regenerate the site coverage page: `dart tool/example_synth_gates.dart --skip-validate` then `dart tool/render_coverage_page.dart` (needs ALL tf-out present — the renderer fails closed on partial synth; CI's freshness check fails otherwise).
 - [ ] 6. **Version & CHANGELOG** — lockstep `0.N.P` across four packages; root + per-package CHANGELOG entries.
 - [ ] 7. **CI** — nothing to wire: the `terraform_validate` matrix derives from `examples/` automatically (tool/select_changed_examples.dart).
 - [ ] 8. **Verify** — `tool/agent_verify.sh` (add `--maintainer` when touching wrap-init / wrap-promote).

--- a/.cursor/agents/wave-shipper.md
+++ b/.cursor/agents/wave-shipper.md
@@ -44,7 +44,9 @@ Follow the two skills exactly, in order, for each resource:
    — the runnable quickstart example, README Examples list,
    **cost-classify via the gcp-cost tools** (mandatory — record SKU
    evidence in `tool/apply_cost_denylist.yaml` comments), coverage page
-   regeneration (`dart tool/render_coverage_page.dart`), and the rest of
+   regeneration (`dart tool/example_synth_gates.dart --skip-validate`
+   then `dart tool/render_coverage_page.dart` — the renderer fails closed
+   on partial tf-out), and the rest of
    the checklist.
 
 Cloud Agent sessions do not get the gcp-cost MCP server through Cursor's

--- a/tool/render_coverage_page.dart
+++ b/tool/render_coverage_page.dart
@@ -146,11 +146,17 @@ Map<String, List<String>> _walkTfOuts() {
       (a, b) => a.path.compareTo(b.path),
     );
   var seen = 0;
+  var quickstarts = 0;
+  final missing = <String>[];
   for (final dir in dirs) {
     final slug = dir.path.split(Platform.pathSeparator).last;
     if (!slug.endsWith('_quickstart')) continue;
+    quickstarts++;
     final tfJson = File('${dir.path}/tf-out/main.tf.json');
-    if (!tfJson.existsSync()) continue;
+    if (!tfJson.existsSync()) {
+      missing.add(slug);
+      continue;
+    }
     seen++;
     final root = jsonDecode(tfJson.readAsStringSync()) as Map<String, dynamic>;
     for (final section in ['resource', 'data']) {
@@ -161,10 +167,14 @@ Map<String, List<String>> _walkTfOuts() {
       }
     }
   }
-  if (seen == 0) {
+  // Partial tf-out is as wrong as none: rendering from a subset silently
+  // blanks the other examples' back-references (first canary, PR #277).
+  if (seen < quickstarts) {
     print(
-      'render_coverage_page: no tf-out found — run '
-      '`dart tool/example_synth_gates.dart --skip-validate` first.',
+      'render_coverage_page: tf-out present for only $seen of $quickstarts '
+      'quickstarts — run `dart tool/example_synth_gates.dart '
+      '--skip-validate` first (missing: ${missing.take(5).join(', ')}'
+      '${missing.length > 5 ? ', …' : ''}).',
     );
     exit(1);
   }


### PR DESCRIPTION
## Summary

Second harness gap from the first wave-shipper canary (#277 → #279): the agent regenerated the coverage page with only its own example synthed, which silently blanked all 357 other example back-references. The zero-tf-out guard couldn't catch a *partial* state — one tf-out was enough to pass.

## Changes

- `render_coverage_page.dart` now requires tf-out for **every** quickstart directory (fails with the missing slugs listed); verified live: 58/59 → exit 1 naming the missing example, full synth → green
- wave-shipper instructions and ship-wave checklist state the synth-first precondition explicitly (`example_synth_gates --skip-validate` **then** the renderer)

The CI freshness check caught the canary's stale render — this closes the gap at the source so agents can't produce that state at all.

## Verification

- 3/3 renderer unit tests; live partial-tf-out fail + full-tf-out pass; analyze clean; docs-consistency green