### PR TITLE
fix(ci): admit root pubspec for new-example Waves with a content gate

### DIFF
--- a/.github/workflows/wave-merge.yml
+++ b/.github/workflows/wave-merge.yml
@@ -106,11 +106,24 @@ jobs:
           if dart tool/check_bump_scope.dart --ledger tool/wave_allowed_paths.yaml \
               < /tmp/changed.txt > /tmp/scope.txt 2>&1; then
             cat /tmp/scope.txt
-            echo "verdict=pass" >> "$GITHUB_OUTPUT"
           else
             cat /tmp/scope.txt
             fail "changed files outside tool/wave_allowed_paths.yaml (see workflow log)"
           fi
+          # The root pubspec is ledger-admitted only so a NEW example can be
+          # listed as a workspace member; anything beyond `- examples/…`
+          # additions (dependency edits, removals) must not auto-merge.
+          if grep -qx 'pubspec.yaml' /tmp/changed.txt; then
+            head_sha=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
+            git fetch -q origin main "$head_sha"
+            if git diff "origin/main...$head_sha" -- pubspec.yaml \
+              | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
+              | grep -vE '^\+  - examples/[a-z0-9_]+$' | grep -q .; then
+              fail "pubspec.yaml diff contains more than workspace example additions"
+            fi
+            echo "pubspec.yaml diff: workspace example additions only"
+          fi
+          echo "verdict=pass" >> "$GITHUB_OUTPUT"
 
       - name: Wait for required checks
         id: checks

--- a/tool/check_bump_scope_test.dart
+++ b/tool/check_bump_scope_test.dart
@@ -149,6 +149,7 @@ void main() {
           'website/src/content/docs/docs/agent/index.md',
           'website/src/content/docs/docs/agent/tools-reference.md',
           'packages/terradart_codegen/test/codegen/wrapper_overrides/yaml_loader_test.dart',
+          'pubspec.yaml',
           'tool/curation_backlog.yaml',
           'tool/apply_cost_denylist.yaml',
           'tool/doc_expectations.dart',

--- a/tool/wave_allowed_paths.yaml
+++ b/tool/wave_allowed_paths.yaml
@@ -41,6 +41,12 @@ website/src/content/docs/docs/status.md
 website/src/content/docs/docs/agent/index.md
 website/src/content/docs/docs/agent/tools-reference.md
 
+# Root workspace manifest — a NEW example must be listed as a workspace
+# member (Dart workspaces enumerate members explicitly). The executor
+# additionally verifies the pubspec diff contains ONLY `- examples/…`
+# workspace additions, so dependency edits still cannot auto-merge.
+pubspec.yaml
+
 # Ledgers a Wave legitimately edits
 tool/curation_backlog.yaml
 tool/apply_cost_denylist.yaml


### PR DESCRIPTION
## Summary

Second wave-shipper canary surfaced the next structural gap: a Wave that **adds** an example must list it as a workspace member (Dart workspaces enumerate members explicitly), so touching root `pubspec.yaml` is unavoidable — but blanket-admitting it would surrender the additive-only guarantee for dependency edits.

## Changes

- `tool/wave_allowed_paths.yaml` admits root `pubspec.yaml` (package pubspecs stay rejected — exact-path rule)
- `wave-merge.yml`'s verify step gains a **content gate**: when the PR touches `pubspec.yaml`, the diff against main may contain ONLY `+  - examples/…` workspace-addition lines; any dependency edit, removal, or other change fails the verdict

Verified against the real `wave/artifact-registry-2026-07-04` diff: 25 files pass the ledger, and the pubspec content gate passes (one workspace addition).

Also learned this run (recorded for the permanent fix): the agent token cannot create PRs at all (403 on gh and API) — #277's PR was the platform's auto-PR, not the agent's. PR creation/labeling likely moves to a push-triggered workflow; design pending Monday's bump-agent observation.