### PR TITLE
docs(fixtures): Magic Modules provenance and licensing README

### DIFF
--- a/packages/terradart_codegen/test/fixtures/wrap/source/mm/README.md
+++ b/packages/terradart_codegen/test/fixtures/wrap/source/mm/README.md
@@ -1,0 +1,19 @@
+# Magic Modules fixture provenance
+
+The `google_*.yaml` files in this directory are **verbatim, byte-for-byte
+copies** of mmv1 resource definitions from
+[GoogleCloudPlatform/magic-modules](https://github.com/GoogleCloudPlatform/magic-modules),
+which is licensed under the Apache License 2.0 — the same license as this
+repository (see the root `LICENSE`). They are Copyright Google LLC, and each
+file retains its original license header. No modifications are made on sync:
+`tool/sync_mm_yaml.dart` writes the fetched bytes as-is.
+
+- **Per-file upstream URLs** live in the manifest,
+  [`tool/mm_yaml_sources.yaml`](../../../../../../../tool/mm_yaml_sources.yaml).
+- Files whose manifest entry says `upstream: null` cover resources that are
+  handwritten in terraform-provider-google and have **no mmv1 counterpart**;
+  those YAML files are TerraDart-authored in the same format (not Google
+  copies).
+- Drift against upstream is audited by
+  `tool/check_mm_upstream_fingerprint.dart` and refreshed by the weekly
+  schema-bump workflow.


### PR DESCRIPTION
## Summary

Attribution polish prompted by a licensing review before the upcoming talk: the `mm/` fixtures are verbatim Apache-2.0 copies from GoogleCloudPlatform/magic-modules, and while the substantive requirements were already met (license headers retained by the byte-for-byte sync, root LICENSE is the same Apache 2.0, per-file upstream URLs in `tool/mm_yaml_sources.yaml`), the terms were not stated where the files live.

- New `mm/README.md`: verbatim-copy statement, Google LLC copyright, manifest pointer, and the `upstream: null` (TerraDart-authored, handwritten-resource) distinction
- Checked: upstream has no NOTICE file to carry over; the sync tool writes fetched bytes unmodified, so no change-notices are required