### PR TITLE
fix(ci): wave-open prefers a feat/fix subject for the PR title

### DIFF
--- a/.cursor/agents/wave-shipper.md
+++ b/.cursor/agents/wave-shipper.md
@@ -31,7 +31,11 @@ verification pitfalls, cost-classify rules, and guardrails all bind you.
 - Prefer example subject matter that CAN be really applied: the executor
   refuses to auto-merge a Wave whose example is skip-listed, so a Wave that
   needs `apply_smoke_skip.yaml` will end as a human-merge PR — acceptable
-  when unavoidable, but prefer apply-able designs.
+  when unavoidable, but prefer apply-able designs. **When the only sensible
+  example IS skip-listed** (e.g. IAM adjuncts belonging in iam_quickstart),
+  say so explicitly in the feat commit message ("example is skip-listed:
+  <reason> — human merge expected") so the human reviewer knows the
+  auto-merge refusal is by design, not a defect.
 
 ## Implement
 

--- a/.github/workflows/wave-open.yml
+++ b/.github/workflows/wave-open.yml
@@ -56,7 +56,13 @@ jobs:
             echo
             echo "Files changed: $(git diff --name-only "origin/main...$HEAD_SHA" | wc -l | tr -d ' ')"
           } > "$body_file"
-          title=$(git log -1 --format=%s "$HEAD_SHA" | sed 's/ \[wave-ready\]//')
+          # Prefer the branch's first feat/fix subject as the PR title — the
+          # HEAD commit is often just the [wave-ready] finalize marker, which
+          # would otherwise become the squash-merge title on main.
+          title=$(git log --format=%s "origin/main..$HEAD_SHA" | grep -E '^(feat|fix)' | tail -1 || true)
+          if [ -z "$title" ]; then
+            title=$(git log -1 --format=%s "$HEAD_SHA" | sed 's/ \[wave-ready\]//')
+          fi
 
           if [ -z "$number" ]; then
             if [ "$ready" = "true" ]; then


### PR DESCRIPTION
Polish from the first zero-touch Wave (#291): the marker commit's subject became the squash title on main. wave-open now prefers the branch's first feat/fix subject (HEAD fallback), and the agent instructions ask for an explicit note when the only sensible example is skip-listed (human-merge-by-design marker for the reviewer).