### PR TITLE
feat(cookbook): redesign lunch-concierge client around a noren and ticket-machine motif

### DIFF
--- a/cookbook/lunch-concierge/client/lib/main.dart
+++ b/cookbook/lunch-concierge/client/lib/main.dart
@@ -1,9 +1,69 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:genkit/client.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:lunch_concierge_shared/schema.dart';
 
 void main() {
   runApp(const LunchConciergeApp());
+}
+
+// Indigo noren cloth, unbleached paper, sumi ink, vermilion stamp.
+abstract final class _Palette {
+  static const noren = Color(0xFF152C44);
+  static const machine = Color(0xFF1D3A5C);
+  static const paper = Color(0xFFF3EFE6);
+  static const ticket = Color(0xFFFCFAF3);
+  static const ink = Color(0xFF23272E);
+  static const muted = Color(0xFF5A6270);
+  static const accent = Color(0xFFC13A1F);
+  static const hairline = Color(0xFFDDD5C2);
+}
+
+TextStyle _display({
+  double? size,
+  FontWeight weight = FontWeight.w900,
+  Color color = _Palette.ink,
+  double? height,
+  double? letterSpacing,
+}) {
+  return GoogleFonts.zenOldMincho(
+    fontSize: size,
+    fontWeight: weight,
+    color: color,
+    height: height,
+    letterSpacing: letterSpacing,
+  );
+}
+
+TextStyle _mono({
+  double? size,
+  FontWeight weight = FontWeight.w500,
+  Color color = _Palette.muted,
+  double? height,
+  double? letterSpacing,
+}) {
+  return GoogleFonts.ibmPlexMono(
+    fontSize: size,
+    fontWeight: weight,
+    color: color,
+    height: height,
+    letterSpacing: letterSpacing,
+  );
+}
+
+String _formatYen(int amount) {
+  final digits = amount.toString();
+  final buffer = StringBuffer('¥');
+  for (var i = 0; i < digits.length; i++) {
+    buffer.write(digits[i]);
+    final remaining = digits.length - 1 - i;
+    if (remaining > 0 && remaining % 3 == 0) {
+      buffer.write(',');
+    }
+  }
+  return buffer.toString();
 }
 
 final class LunchConciergeApp extends StatelessWidget {
@@ -15,11 +75,10 @@ final class LunchConciergeApp extends StatelessWidget {
       title: 'Lunch Concierge',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
-          seedColor: const Color(0xFFE36B2C),
+          seedColor: _Palette.machine,
           brightness: Brightness.light,
         ),
-        scaffoldBackgroundColor: const Color(0xFFFFF8EA),
-        fontFamily: 'sans',
+        scaffoldBackgroundColor: _Palette.paper,
         useMaterial3: true,
       ),
       home: const LunchPage(),
@@ -83,31 +142,20 @@ final class _LunchPageState extends State<LunchPage> {
 
   @override
   Widget build(BuildContext context) {
-    final result = _result;
-    final suggestions = result?.suggestions ?? const <LunchSuggestion>[];
-
     return Scaffold(
-      body: DecoratedBox(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [Color(0xFFFFF8EA), Color(0xFFFFE1B8)],
-          ),
-        ),
-        child: SafeArea(
-          child: Center(
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 1120),
-              child: ListView(
-                padding: const EdgeInsets.fromLTRB(24, 28, 24, 40),
-                children: [
-                  const _HeroHeader(),
-                  const SizedBox(height: 28),
-                  LayoutBuilder(
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            const _NorenHeader(),
+            Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 1024),
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(24, 40, 24, 24),
+                  child: LayoutBuilder(
                     builder: (context, constraints) {
-                      final wide = constraints.maxWidth >= 860;
-                      final form = _OrderCard(
+                      final wide = constraints.maxWidth >= 840;
+                      final machine = _MachinePanel(
                         areaController: _areaController,
                         moodController: _moodController,
                         budgetController: _budgetController,
@@ -115,146 +163,222 @@ final class _LunchPageState extends State<LunchPage> {
                         onAsk: _ask,
                         error: _error,
                       );
-                      final resultPane = _ResultBoard(
-                        result: result,
-                        suggestions: suggestions,
+                      final tray = _DispenserTray(
+                        loading: _loading,
+                        result: _result,
                       );
-                      if (!wide) {
-                        return Column(
-                          children: [
-                            form,
-                            const SizedBox(height: 20),
-                            resultPane,
-                          ],
-                        );
-                      }
-                      return Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
                         children: [
-                          Expanded(flex: 5, child: form),
-                          const SizedBox(width: 22),
-                          Expanded(flex: 6, child: resultPane),
+                          _Headline(wide: wide),
+                          const SizedBox(height: 36),
+                          if (wide)
+                            Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                SizedBox(width: 396, child: machine),
+                                const SizedBox(width: 32),
+                                Expanded(child: tray),
+                              ],
+                            )
+                          else ...[
+                            machine,
+                            const SizedBox(height: 32),
+                            tray,
+                          ],
+                          const SizedBox(height: 56),
+                          Center(
+                            child: Text(
+                              'TERRADART COOKBOOK — LUNCH CONCIERGE',
+                              style: _mono(
+                                size: 10,
+                                color: _Palette.muted.withValues(alpha: 0.7),
+                                letterSpacing: 3,
+                              ),
+                            ),
+                          ),
                         ],
                       );
                     },
                   ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+final class _NorenHeader extends StatefulWidget {
+  const _NorenHeader();
+
+  @override
+  State<_NorenHeader> createState() => _NorenHeaderState();
+}
+
+final class _NorenHeaderState extends State<_NorenHeader>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _sway;
+
+  @override
+  void initState() {
+    super.initState();
+    _sway = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 6),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (MediaQuery.disableAnimationsOf(context)) {
+      _sway.stop();
+    } else if (!_sway.isAnimating) {
+      _sway.repeat();
+    }
+  }
+
+  @override
+  void dispose() {
+    _sway.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final compact = MediaQuery.sizeOf(context).width < 640;
+    const bandHeight = 46.0;
+    final panelHeight = compact ? 88.0 : 108.0;
+    return SizedBox(
+      height: bandHeight + panelHeight - 2,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          Positioned(
+            top: bandHeight - 6,
+            left: 0,
+            right: 0,
+            height: panelHeight + 4,
+            child: ExcludeSemantics(
+              child: AnimatedBuilder(
+                animation: _sway,
+                builder: (context, _) {
+                  final t = _sway.value * 2 * math.pi;
+                  return Row(
+                    children: [
+                      for (var i = 0; i < 5; i++) ...[
+                        if (i > 0) const SizedBox(width: 10),
+                        Expanded(
+                          child: Transform(
+                            alignment: Alignment.topCenter,
+                            transform: Matrix4.skewX(
+                              0.035 * math.sin(t + i * 0.85),
+                            ),
+                            child: Container(
+                              decoration: const BoxDecoration(
+                                color: _Palette.noren,
+                                borderRadius: BorderRadius.vertical(
+                                  bottom: Radius.circular(6),
+                                ),
+                              ),
+                              child: i == 2
+                                  ? Center(
+                                      child: Text(
+                                        '昼',
+                                        style: _display(
+                                          size: compact ? 40 : 52,
+                                          color: Colors.white,
+                                          height: 1,
+                                        ),
+                                      ),
+                                    )
+                                  : null,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            height: bandHeight,
+            child: Container(
+              color: _Palette.noren,
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Row(
+                children: [
+                  Text(
+                    'LUNCH CONCIERGE',
+                    style: _mono(
+                      size: 13,
+                      weight: FontWeight.w700,
+                      color: Colors.white,
+                      letterSpacing: 4,
+                    ),
+                  ),
+                  const Spacer(),
+                  if (!compact)
+                    Text(
+                      'GENKIT × VERTEX AI × CLOUD SQL',
+                      style: _mono(
+                        size: 11,
+                        color: Colors.white60,
+                        letterSpacing: 2,
+                      ),
+                    ),
                 ],
               ),
             ),
           ),
+        ],
+      ),
+    );
+  }
+}
+
+final class _Headline extends StatelessWidget {
+  const _Headline({required this.wide});
+
+  final bool wide;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '昼休みの気分を、\n一枚の食券にする。',
+          style: _display(
+            size: wide ? 42 : 30,
+            height: 1.35,
+            letterSpacing: 1,
+          ),
         ),
-      ),
-    );
-  }
-}
-
-final class _HeroHeader extends StatelessWidget {
-  const _HeroHeader();
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(28),
-      decoration: BoxDecoration(
-        color: const Color(0xFF24372A),
-        borderRadius: BorderRadius.circular(30),
-        boxShadow: const [
-          BoxShadow(
-            color: Color(0x26000000),
-            blurRadius: 30,
-            offset: Offset(0, 18),
-          ),
-        ],
-      ),
-      child: const Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _Kicker('Lunch Concierge'),
-                SizedBox(height: 18),
-                Text(
-                  '昼休みの気分を、\n一枚のメニューにする。',
-                  style: TextStyle(
-                    color: Color(0xFFFFF8EA),
-                    fontSize: 42,
-                    height: 1.06,
-                    fontWeight: FontWeight.w800,
-                    letterSpacing: -1.4,
-                  ),
-                ),
-                SizedBox(height: 16),
-                Text(
-                  '場所・気分・予算を渡すと、Genkit と Vertex AI が候補を考え、Cloud SQL に相談履歴を残します。',
-                  style: TextStyle(
-                    color: Color(0xFFE9DCC8),
-                    fontSize: 16,
-                    height: 1.6,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          SizedBox(width: 24),
-          _LunchStamp(),
-        ],
-      ),
-    );
-  }
-}
-
-final class _Kicker extends StatelessWidget {
-  const _Kicker(this.label);
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return Text(
-      label.toUpperCase(),
-      style: const TextStyle(
-        color: Color(0xFFFFB84D),
-        fontSize: 12,
-        fontWeight: FontWeight.w800,
-        letterSpacing: 2.2,
-      ),
-    );
-  }
-}
-
-final class _LunchStamp extends StatelessWidget {
-  const _LunchStamp();
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 122,
-      height: 122,
-      decoration: BoxDecoration(
-        color: const Color(0xFFFFF8EA),
-        borderRadius: BorderRadius.circular(28),
-        border: Border.all(color: const Color(0xFFE36B2C), width: 3),
-      ),
-      child: const Center(
-        child: Text(
-          '昼\n券',
-          textAlign: TextAlign.center,
+        const SizedBox(height: 14),
+        const Text(
+          '場所・気分・予算を入れると、Genkit と Vertex AI が候補を考えて、Cloud SQL に履歴を残します。',
           style: TextStyle(
-            color: Color(0xFFE36B2C),
-            fontSize: 34,
-            height: 0.95,
-            fontWeight: FontWeight.w900,
+            color: _Palette.muted,
+            fontSize: 15,
+            height: 1.7,
           ),
         ),
-      ),
+      ],
     );
   }
 }
 
-final class _OrderCard extends StatelessWidget {
-  const _OrderCard({
+final class _MachinePanel extends StatelessWidget {
+  const _MachinePanel({
     required this.areaController,
     required this.moodController,
     required this.budgetController,
@@ -272,61 +396,97 @@ final class _OrderCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _Panel(
+    return Container(
+      padding: const EdgeInsets.all(26),
+      decoration: BoxDecoration(
+        color: _Palette.machine,
+        borderRadius: BorderRadius.circular(6),
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const _Kicker('Order slip'),
-          const SizedBox(height: 12),
-          const Text(
-            '今日の条件',
-            style: TextStyle(
-              color: Color(0xFF24372A),
-              fontSize: 26,
-              fontWeight: FontWeight.w800,
-            ),
+          Row(
+            children: [
+              Text(
+                'TICKET MACHINE',
+                style: _mono(
+                  size: 11,
+                  weight: FontWeight.w700,
+                  color: Colors.white54,
+                  letterSpacing: 2.5,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                'NO.001',
+                style: _mono(size: 11, color: Colors.white38),
+              ),
+            ],
           ),
           const SizedBox(height: 22),
-          _LunchTextField(
+          _MachineField(
             controller: areaController,
             label: 'どのあたり？',
             hint: '渋谷',
           ),
           const SizedBox(height: 14),
-          _LunchTextField(
+          _MachineField(
             controller: moodController,
             label: 'どんな気分？',
             hint: 'あっさり、辛い、温かい',
           ),
           const SizedBox(height: 14),
-          _LunchTextField(
+          _MachineField(
             controller: budgetController,
             label: '予算',
             hint: '1200',
             suffix: '円',
             keyboardType: TextInputType.number,
           ),
-          const SizedBox(height: 22),
+          const SizedBox(height: 24),
           FilledButton(
             style: FilledButton.styleFrom(
-              backgroundColor: const Color(0xFFE36B2C),
+              backgroundColor: _Palette.accent,
               foregroundColor: Colors.white,
-              padding: const EdgeInsets.symmetric(vertical: 18),
-              textStyle: const TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w800,
+              disabledBackgroundColor: const Color(0x26FFFFFF),
+              disabledForegroundColor: Colors.white54,
+              minimumSize: const Size.fromHeight(56),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(4),
               ),
+              textStyle: _display(size: 17, weight: FontWeight.w700),
             ),
             onPressed: loading ? null : onAsk,
-            child: Text(loading ? '相談中...' : 'ランチを相談する'),
+            child: Text(loading ? '発券中…' : '食券を発行する'),
           ),
           if (error != null) ...[
-            const SizedBox(height: 16),
-            Text(
-              error!,
-              style: const TextStyle(
-                color: Color(0xFFB42318),
-                fontWeight: FontWeight.w600,
+            const SizedBox(height: 18),
+            Container(
+              padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+              decoration: const BoxDecoration(
+                color: Color(0x33000000),
+                border: Border(
+                  left: BorderSide(color: _Palette.accent, width: 3),
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    '発券できませんでした。',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    error!,
+                    maxLines: 6,
+                    overflow: TextOverflow.ellipsis,
+                    style: _mono(size: 11, color: Colors.white70, height: 1.5),
+                  ),
+                ],
               ),
             ),
           ],
@@ -336,8 +496,8 @@ final class _OrderCard extends StatelessWidget {
   }
 }
 
-final class _LunchTextField extends StatelessWidget {
-  const _LunchTextField({
+final class _MachineField extends StatelessWidget {
+  const _MachineField({
     required this.controller,
     required this.label,
     required this.hint,
@@ -356,179 +516,480 @@ final class _LunchTextField extends StatelessWidget {
     return TextField(
       controller: controller,
       keyboardType: keyboardType,
+      cursorColor: Colors.white,
+      style: const TextStyle(color: Colors.white, fontSize: 15),
       decoration: InputDecoration(
         labelText: label,
         hintText: hint,
         suffixText: suffix,
+        suffixStyle: _mono(size: 13, color: Colors.white54),
+        labelStyle: const TextStyle(color: Colors.white70, fontSize: 14),
+        floatingLabelStyle: const TextStyle(color: Colors.white, fontSize: 14),
+        hintStyle: const TextStyle(color: Colors.white38),
         filled: true,
-        fillColor: const Color(0xFFFFF8EA),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(18),
-          borderSide: const BorderSide(color: Color(0xFFE4CDAA)),
+        fillColor: const Color(0x17FFFFFF),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(4),
+          borderSide: const BorderSide(color: Colors.white24),
         ),
         focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(18),
-          borderSide: const BorderSide(color: Color(0xFFE36B2C), width: 2),
+          borderRadius: BorderRadius.circular(4),
+          borderSide: const BorderSide(color: Colors.white, width: 2),
         ),
       ),
     );
   }
 }
 
-final class _ResultBoard extends StatelessWidget {
-  const _ResultBoard({required this.result, required this.suggestions});
+final class _DispenserTray extends StatefulWidget {
+  const _DispenserTray({required this.loading, required this.result});
 
+  final bool loading;
   final LunchResponse? result;
-  final List<LunchSuggestion> suggestions;
+
+  @override
+  State<_DispenserTray> createState() => _DispenserTrayState();
+}
+
+final class _DispenserTrayState extends State<_DispenserTray>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _dispense;
+
+  @override
+  void initState() {
+    super.initState();
+    _dispense = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1100),
+      value: 1,
+    );
+  }
+
+  @override
+  void didUpdateWidget(_DispenserTray oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.result != null && widget.result != oldWidget.result) {
+      if (MediaQuery.disableAnimationsOf(context)) {
+        _dispense.value = 1;
+      } else {
+        _dispense.forward(from: 0);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _dispense.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    if (result == null) {
-      return const _Panel(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+    final result = widget.result;
+    final suggestions = result?.suggestions ?? const <LunchSuggestion>[];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
           children: [
-            _Kicker('Menu board'),
-            SizedBox(height: 16),
             Text(
-              'まだ白紙のメニューです。',
-              style: TextStyle(
-                color: Color(0xFF24372A),
-                fontSize: 26,
-                fontWeight: FontWeight.w800,
+              'DISPENSER',
+              style: _mono(
+                size: 11,
+                weight: FontWeight.w700,
+                letterSpacing: 2.5,
               ),
             ),
-            SizedBox(height: 10),
-            Text(
-              '条件を入れると、候補が食券みたいなカードで並びます。',
-              style: TextStyle(color: Color(0xFF6C5B45), height: 1.5),
-            ),
+            const Spacer(),
+            if (widget.loading)
+              Text(
+                'PRINTING…',
+                style: _mono(
+                  size: 11,
+                  weight: FontWeight.w700,
+                  color: _Palette.accent,
+                  letterSpacing: 2,
+                ),
+              ),
           ],
         ),
-      );
-    }
-
-    return _Panel(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const _Kicker('Today\'s menu'),
-          const SizedBox(height: 14),
+        const SizedBox(height: 10),
+        _SlotBar(active: widget.loading),
+        const SizedBox(height: 20),
+        if (result == null)
+          _GhostTicket(
+            title: widget.loading ? '発券中…' : '食券はまだありません。',
+            body: widget.loading
+                ? 'Genkit が今日の候補を考えています。'
+                : '条件を入れてボタンを押すと、今日の候補がここに発券されます。',
+          )
+        else ...[
           Text(
-            result!.message,
-            style: const TextStyle(
-              color: Color(0xFF24372A),
-              fontSize: 20,
-              fontWeight: FontWeight.w700,
-              height: 1.45,
+            result.message,
+            style: _display(
+              size: 18,
+              weight: FontWeight.w700,
+              height: 1.65,
             ),
           ),
           const SizedBox(height: 18),
           for (var i = 0; i < suggestions.length; i++) ...[
-            _MenuTicket(index: i + 1, suggestion: suggestions[i]),
-            if (i != suggestions.length - 1) const SizedBox(height: 12),
+            if (i > 0) const SizedBox(height: 14),
+            _DispensedTicket(
+              animation: _dispense,
+              interval: Interval(
+                (i * 0.18).clamp(0.0, 0.6),
+                ((i * 0.18) + 0.5).clamp(0.0, 1.0),
+                curve: Curves.easeOutCubic,
+              ),
+              child: _Ticket(index: i + 1, suggestion: suggestions[i]),
+            ),
           ],
         ],
+      ],
+    );
+  }
+}
+
+final class _DispensedTicket extends StatelessWidget {
+  const _DispensedTicket({
+    required this.animation,
+    required this.interval,
+    required this.child,
+  });
+
+  final Animation<double> animation;
+  final Interval interval;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final curved = CurvedAnimation(parent: animation, curve: interval);
+    return FadeTransition(
+      opacity: curved,
+      child: SlideTransition(
+        position: Tween<Offset>(
+          begin: const Offset(0, -0.22),
+          end: Offset.zero,
+        ).animate(curved),
+        child: child,
       ),
     );
   }
 }
 
-final class _MenuTicket extends StatelessWidget {
-  const _MenuTicket({required this.index, required this.suggestion});
+final class _SlotBar extends StatefulWidget {
+  const _SlotBar({required this.active});
 
-  final int index;
-  final LunchSuggestion suggestion;
+  final bool active;
+
+  @override
+  State<_SlotBar> createState() => _SlotBarState();
+}
+
+final class _SlotBarState extends State<_SlotBar>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _pulse;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulse = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
+    _syncPulse();
+  }
+
+  @override
+  void didUpdateWidget(_SlotBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.active != widget.active) {
+      _syncPulse();
+    }
+  }
+
+  void _syncPulse() {
+    if (widget.active) {
+      _pulse.repeat(reverse: true);
+    } else {
+      _pulse.stop();
+      _pulse.value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _pulse.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.all(18),
+      height: 12,
       decoration: BoxDecoration(
-        color: const Color(0xFFFFF8EA),
-        borderRadius: BorderRadius.circular(22),
-        border: Border.all(color: const Color(0xFFE4CDAA)),
+        color: _Palette.noren,
+        borderRadius: BorderRadius.circular(6),
       ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Container(
-            width: 42,
-            height: 42,
-            decoration: const BoxDecoration(
-              color: Color(0xFFFFB84D),
-              shape: BoxShape.circle,
+      alignment: Alignment.center,
+      child: AnimatedBuilder(
+        animation: _pulse,
+        builder: (context, _) {
+          final color = widget.active
+              ? Color.lerp(
+                  const Color(0xFF0A1826),
+                  _Palette.accent,
+                  _pulse.value,
+                )!
+              : const Color(0xFF0A1826);
+          return Container(
+            height: 4,
+            margin: const EdgeInsets.symmetric(horizontal: 10),
+            decoration: BoxDecoration(
+              color: color,
+              borderRadius: BorderRadius.circular(2),
             ),
-            child: Center(
-              child: Text(
-                '$index',
-                style: const TextStyle(
-                  color: Color(0xFF24372A),
-                  fontWeight: FontWeight.w900,
-                ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+final class _GhostTicket extends StatelessWidget {
+  const _GhostTicket({required this.title, required this.body});
+
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: const _DashedBorderPainter(),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 30, 24, 30),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: _display(size: 21, weight: FontWeight.w700),
+            ),
+            const SizedBox(height: 10),
+            Text(
+              body,
+              style: const TextStyle(
+                color: _Palette.muted,
+                fontSize: 14,
+                height: 1.7,
               ),
             ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+final class _Ticket extends StatelessWidget {
+  const _Ticket({required this.index, required this.suggestion});
+
+  final int index;
+  final LunchSuggestion suggestion;
+
+  static const _stubWidth = 60.0;
+  static const _perforationWidth = 16.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Container(
+          decoration: BoxDecoration(
+            color: _Palette.ticket,
+            borderRadius: BorderRadius.circular(4),
+            border: Border.all(color: _Palette.hairline),
+            boxShadow: const [
+              BoxShadow(color: Color(0x141D3A5C), offset: Offset(2, 3)),
+            ],
           ),
-          const SizedBox(width: 14),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+          child: IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Text(
-                  suggestion.name,
-                  style: const TextStyle(
-                    color: Color(0xFF24372A),
-                    fontSize: 18,
-                    fontWeight: FontWeight.w800,
+                Container(
+                  width: _stubWidth,
+                  decoration: const BoxDecoration(
+                    color: _Palette.machine,
+                    borderRadius: BorderRadius.horizontal(
+                      left: Radius.circular(3),
+                    ),
+                  ),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        '食\n券',
+                        textAlign: TextAlign.center,
+                        style: _display(
+                          size: 16,
+                          weight: FontWeight.w700,
+                          color: Colors.white,
+                          height: 1.25,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'No.${index.toString().padLeft(2, '0')}',
+                        style: _mono(size: 9, color: Colors.white54),
+                      ),
+                    ],
                   ),
                 ),
-                const SizedBox(height: 6),
-                Text(
-                  suggestion.reason,
-                  style: const TextStyle(
-                    color: Color(0xFF6C5B45),
-                    height: 1.5,
+                const SizedBox(
+                  width: _perforationWidth,
+                  child: CustomPaint(painter: _PerforationPainter()),
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(4, 16, 18, 16),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                suggestion.name,
+                                style: _display(
+                                  size: 17,
+                                  weight: FontWeight.w700,
+                                  height: 1.4,
+                                ),
+                              ),
+                              const SizedBox(height: 6),
+                              Text(
+                                suggestion.reason,
+                                style: const TextStyle(
+                                  color: _Palette.muted,
+                                  fontSize: 13.5,
+                                  height: 1.65,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Text(
+                              _formatYen(suggestion.estimatedPriceYen),
+                              style: _mono(
+                                size: 16,
+                                weight: FontWeight.w700,
+                                color: _Palette.ink,
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+                            const Text(
+                              '目安',
+                              style: TextStyle(
+                                color: _Palette.muted,
+                                fontSize: 10,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ],
             ),
           ),
-          const SizedBox(width: 12),
-          Text(
-            '${suggestion.estimatedPriceYen}円',
-            style: const TextStyle(
-              color: Color(0xFFE36B2C),
-              fontWeight: FontWeight.w900,
-            ),
-          ),
-        ],
+        ),
+        const Positioned(
+          left: _stubWidth + _perforationWidth / 2 - 6,
+          top: -5,
+          child: _PunchNotch(),
+        ),
+        const Positioned(
+          left: _stubWidth + _perforationWidth / 2 - 6,
+          bottom: -5,
+          child: _PunchNotch(),
+        ),
+      ],
+    );
+  }
+}
+
+final class _PunchNotch extends StatelessWidget {
+  const _PunchNotch();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 12,
+      height: 12,
+      decoration: const BoxDecoration(
+        color: _Palette.paper,
+        shape: BoxShape.circle,
       ),
     );
   }
 }
 
-final class _Panel extends StatelessWidget {
-  const _Panel({required this.child});
-
-  final Widget child;
+final class _PerforationPainter extends CustomPainter {
+  const _PerforationPainter();
 
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        color: const Color(0xD6FFFFFF),
-        borderRadius: BorderRadius.circular(28),
-        border: Border.all(color: const Color(0x33E36B2C)),
-        boxShadow: const [
-          BoxShadow(
-            color: Color(0x1F6C4A2A),
-            blurRadius: 24,
-            offset: Offset(0, 14),
-          ),
-        ],
-      ),
-      child: child,
-    );
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = const Color(0xFFCFC7B4)
+      ..strokeWidth = 1.2;
+    final x = size.width / 2;
+    for (var y = 4.0; y < size.height - 2; y += 8) {
+      canvas.drawLine(Offset(x, y), Offset(x, y + 4), paint);
+    }
   }
+
+  @override
+  bool shouldRepaint(_PerforationPainter oldDelegate) => false;
+}
+
+final class _DashedBorderPainter extends CustomPainter {
+  const _DashedBorderPainter();
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = const Color(0xFFC9C1AD)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.2;
+    final path = Path()
+      ..addRRect(
+        RRect.fromRectAndRadius(
+          Offset.zero & size,
+          const Radius.circular(4),
+        ),
+      );
+    for (final metric in path.computeMetrics()) {
+      var distance = 0.0;
+      while (distance < metric.length) {
+        canvas.drawPath(
+          metric.extractPath(distance, math.min(distance + 6, metric.length)),
+          paint,
+        );
+        distance += 11;
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_DashedBorderPainter oldDelegate) => false;
 }

--- a/cookbook/lunch-concierge/client/pubspec.yaml
+++ b/cookbook/lunch-concierge/client/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   genkit: any
+  google_fonts: any
   lunch_concierge_shared:
     path: ../shared
 

--- a/cookbook/lunch-concierge/client/web/index.html
+++ b/cookbook/lunch-concierge/client/web/index.html
@@ -6,9 +6,11 @@
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="Lunch Concierge Flutter Web demo.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#152C44">
+  <link rel="icon" href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="10" fill="%23152C44"/><text x="32" y="46" font-size="38" text-anchor="middle" fill="%23FCFAF3" font-family="serif" font-weight="700">昼</text></svg>'>
   <title>Lunch Concierge</title>
 </head>
-<body>
+<body style="background-color: #F3EFE6">
   <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Replaces the lunch-concierge Flutter client's generic cream-and-orange card layout with a design grounded in the demo's subject: a Japanese shokudo ticket machine.

- **Noren header**: indigo band with slit panels, the center panel carries the 昼 mark; hems sway with a subtle skew loop
- **Ticket-machine form panel**: indigo, mono machine-plate labels, vermilion 食券を発行する button
- **Suggestions as meal tickets**: indigo stub + perforation dashes + punched notches, mincho dish names, tabular mono prices
- **Stateful dispenser**: slot bar pulses vermilion while printing; tickets slide out with a staggered animation; empty state is a dashed ghost ticket
- Adds `google_fonts` (Zen Old Mincho display / IBM Plex Mono utility); body text stays on the engine default
- `web/index.html`: theme-color and an inline SVG 昼 favicon
- All motion respects `MediaQuery.disableAnimations`

Client-only change; server, shared, and infra are untouched.

## Verification

- `flutter analyze` clean on client; `dart analyze` clean on server/shared/infra; `dart fix --dry-run` has nothing to fix
- `flutter build web --release` succeeds; full states (empty / loading / results / error-free path / mobile 390px) exercised against a local mock of the Genkit flow endpoint with Playwright screenshots
- genkit family already at pub.dev latest (genkit 0.14.1, genkit_shelf 0.1.9, genkit_vertexai 0.2.9) in the root lock and in the client's floating resolution
- Infra cross-checked while here: re-synth with CI placeholder values produces zero diff against the committed `tf-out/main.tf.json`, and `terraform validate` passes