### PR TITLE
feat(cookbook): put lunch-concierge behind IAP

### DIFF
--- a/cookbook/lunch-concierge/README.md
+++ b/cookbook/lunch-concierge/README.md
@@ -81,6 +81,26 @@ terraform apply
 The targeted first apply creates the Artifact Registry repository so the image
 can be pushed. The second apply creates or updates the rest of the stack.
 
+## Access control (IAP)
+
+The Cloud Run service runs with IAP enabled: the run.app URL redirects to a
+Google sign-in, and only `INVOKER_EMAIL` holds
+`roles/iap.httpsResourceAccessor` (plus a direct `roles/run.invoker` grant as
+a token-based fallback). The stack grants `roles/run.invoker` to the IAP
+service agent, which must exist before the first apply. Provision it once per
+project:
+
+```bash
+gcloud beta services identity create \
+  --service=iap.googleapis.com \
+  --project="$GCP_PROJECT_ID"
+```
+
+The `google_iap_web_cloud_run_service_iam_member` grant uses a hand-rolled
+`Resource` subclass (`infra/lib/src/iap_access.dart`) because the
+terradart_google catalog has not curated IAP resources yet — it doubles as an
+example of expressing an uncurated resource without leaving Dart.
+
 ## Database bootstrap
 
 The Cloud Run service connects as the Cloud SQL IAM database user:

--- a/cookbook/lunch-concierge/infra/lib/lunch_concierge_stack.dart
+++ b/cookbook/lunch-concierge/infra/lib/lunch_concierge_stack.dart
@@ -46,6 +46,7 @@ final class LunchStack extends Stack {
       invokerEmail: invokerEmail,
       apiDeps: apis.apiDeps,
       vertexApi: apis.vertexApi,
+      iapApi: apis.iapApi,
       network: network,
       database: database,
       identity: identity,

--- a/cookbook/lunch-concierge/infra/lib/src/apis.dart
+++ b/cookbook/lunch-concierge/infra/lib/src/apis.dart
@@ -5,10 +5,15 @@ import 'package:terradart_google/project.dart';
 import 'constants.dart';
 
 final class LunchApis {
-  const LunchApis({required this.apiDeps, required this.vertexApi});
+  const LunchApis({
+    required this.apiDeps,
+    required this.vertexApi,
+    required this.iapApi,
+  });
 
   final List<ResourceDependency> apiDeps;
   final GoogleProjectService vertexApi;
+  final GoogleProjectService iapApi;
 }
 
 LunchApis addApisAndRepository(Stack stack) {
@@ -31,6 +36,14 @@ LunchApis addApisAndRepository(Stack stack) {
     ),
   );
 
+  final iapApi = stack.add(
+    GoogleProjectService(
+      localName: 'api_iap',
+      service: TfArg.literal('iap.googleapis.com'),
+      disableOnDestroy: TfArg.literal(false),
+    ),
+  );
+
   stack.add(
     GoogleArtifactRegistryRepository(
       localName: 'app_images',
@@ -42,5 +55,5 @@ LunchApis addApisAndRepository(Stack stack) {
     ),
   );
 
-  return LunchApis(apiDeps: apiDeps, vertexApi: vertexApi);
+  return LunchApis(apiDeps: apiDeps, vertexApi: vertexApi, iapApi: iapApi);
 }

--- a/cookbook/lunch-concierge/infra/lib/src/cloud_run.dart
+++ b/cookbook/lunch-concierge/infra/lib/src/cloud_run.dart
@@ -1,8 +1,10 @@
 import 'package:terradart_core/terradart_core.dart';
 import 'package:terradart_google/cloud_run.dart';
+import 'package:terradart_google/data.dart';
 
 import 'constants.dart';
 import 'database.dart';
+import 'iap_access.dart';
 import 'network.dart';
 import 'runtime_identity.dart';
 
@@ -12,6 +14,7 @@ GoogleCloudRunV2Service addCloudRunService({
   required String invokerEmail,
   required List<ResourceDependency> apiDeps,
   required Resource vertexApi,
+  required Resource iapApi,
   required LunchNetwork network,
   required LunchDatabase database,
   required LunchRuntimeIdentity identity,
@@ -22,6 +25,7 @@ GoogleCloudRunV2Service addCloudRunService({
       name: TfArg.literal(serviceName),
       location: TfArg.literal(region),
       ingress: TfArg.literal(Ingress.all),
+      iapEnabled: TfArg.literal(true),
       deletionProtection: TfArg.literal(false),
       template: CloudRunV2ServiceTemplate(
         serviceAccount: TfArg.ref(identity.serviceAccount.email),
@@ -73,6 +77,7 @@ GoogleCloudRunV2Service addCloudRunService({
       dependsOn: [
         ...apiDeps,
         ResourceDependency(vertexApi),
+        ResourceDependency(iapApi),
         ResourceDependency(network.subnet),
         ResourceDependency(network.runConnector),
         ResourceDependency(database.sql),
@@ -94,6 +99,36 @@ GoogleCloudRunV2Service addCloudRunService({
       role: TfArg.literal('roles/run.invoker'),
       member: TfArg.literal('user:$invokerEmail'),
       dependsOn: [ResourceDependency(service)],
+    ),
+  );
+
+  final project = stack.addData(GoogleProject(localName: 'project'));
+
+  // IAP fronts the run.app URL, so the IAP service agent is the caller
+  // Cloud Run must authorize. The agent exists once the IAP API identity
+  // is provisioned (see README bootstrap note).
+  stack.add(
+    GoogleCloudRunV2ServiceIamMember(
+      localName: 'iap_agent_invoker',
+      name: TfArg.ref(service.nameRef),
+      location: TfArg.literal(region),
+      role: TfArg.literal('roles/run.invoker'),
+      member: TfArg.literal(
+        'serviceAccount:service-${project.number.interpolation}'
+        '@gcp-sa-iap.iam.gserviceaccount.com',
+      ),
+      dependsOn: [ResourceDependency(service), ResourceDependency(iapApi)],
+    ),
+  );
+
+  stack.add(
+    IapWebCloudRunServiceIamMember(
+      localName: 'speaker_iap_access',
+      cloudRunServiceName: TfArg.ref(service.nameRef),
+      location: TfArg.literal(region),
+      role: TfArg.literal('roles/iap.httpsResourceAccessor'),
+      member: TfArg.literal('user:$invokerEmail'),
+      dependsOn: [ResourceDependency(service), ResourceDependency(iapApi)],
     ),
   );
 

--- a/cookbook/lunch-concierge/infra/lib/src/iap_access.dart
+++ b/cookbook/lunch-concierge/infra/lib/src/iap_access.dart
@@ -1,0 +1,31 @@
+import 'package:terradart_core/terradart_core.dart';
+
+/// Hand-rolled wrapper for `google_iap_web_cloud_run_service_iam_member`,
+/// which the terradart_google catalog has not curated yet. Swap to the
+/// typed factory once IAP lands in the catalog.
+final class IapWebCloudRunServiceIamMember extends Resource {
+  static const String tfType = 'google_iap_web_cloud_run_service_iam_member';
+
+  IapWebCloudRunServiceIamMember({
+    required super.localName,
+    required TfArg<String> cloudRunServiceName,
+    required TfArg<String> role,
+    required TfArg<String> member,
+    TfArg<String>? location,
+    TfArg<String>? project,
+    super.lifecycle,
+    super.dependsOn,
+  }) : super(
+          terraformType: tfType,
+          argMap: {
+            'cloud_run_service_name': cloudRunServiceName,
+            'role': role,
+            'member': member,
+            if (location != null) 'location': location,
+            if (project != null) 'project': project,
+          },
+        );
+
+  @override
+  Set<String> get sensitiveFields => const <String>{};
+}


### PR DESCRIPTION
## Summary

Fronts the lunch-concierge demo with Identity-Aware Proxy so the run.app URL gets a Google sign-in instead of a bare 403, while access stays restricted to `INVOKER_EMAIL`.

- `iap_enabled` on the Cloud Run v2 service (ingress stays `all`)
- `roles/run.invoker` for the IAP service agent — project number resolved with the `google_project` data source, composed via `TfRef.interpolation` (same pattern as tags_quickstart)
- `roles/iap.httpsResourceAccessor` for the invoker email
- `iap.googleapis.com` enabled alongside the existing per-service APIs
- The IAP grant is a hand-rolled `Resource` subclass (`infra/lib/src/iap_access.dart`) because `google_iap_web_cloud_run_service_iam_member` is not curated in terradart_google yet — doubles as a cookbook example of expressing an uncurated resource; swap to the typed factory once IAP lands in the catalog
- README documents the one-time `gcloud beta services identity create --service=iap.googleapis.com` bootstrap (GA provider cannot create service identities)

## Verification

- `dart analyze` clean, `dart format` clean
- Synth with CI placeholder values + `terraform validate` against vendored google provider 7.38: valid, and the emitted JSON carries the intended `iap_enabled`, agent-invoker interpolation, and accessor blocks
- IAP service agent already provisioned in the target demo project, so the first apply will not race the identity