### PR TITLE
docs(cookbook): rename Vertex AI to Agent Platform in lunch-concierge copy

### DIFF
--- a/cookbook/lunch-concierge/README.md
+++ b/cookbook/lunch-concierge/README.md
@@ -1,8 +1,8 @@
 # Lunch Concierge
 
 Lunch Concierge is a full-stack TerraDart cookbook recipe for showing how
-Flutter Web, a Dart server, Genkit, Vertex AI, Cloud Run, and Cloud SQL can be
-connected through Dart-authored infrastructure.
+Flutter Web, a Dart server, Genkit, Agent Platform, Cloud Run, and Cloud SQL
+can be connected through Dart-authored infrastructure.
 
 ## Architecture
 
@@ -15,7 +15,7 @@ Cloud Run service: lunch-concierge
     - Flutter Web static files
     - shelf HTTP server
     - genkit_shelf endpoint
-    - Genkit Dart + Vertex AI Gemini
+    - Genkit Dart + Agent Platform (Gemini)
     - postgres client
 
   cloud-sql-proxy sidecar

--- a/cookbook/lunch-concierge/client/lib/main.dart
+++ b/cookbook/lunch-concierge/client/lib/main.dart
@@ -365,7 +365,7 @@ final class _Headline extends StatelessWidget {
         ),
         const SizedBox(height: 14),
         const Text(
-          '場所・気分・予算を入れると、Genkit と Vertex AI が候補を考えて、Cloud SQL に履歴を残します。',
+          '場所・気分・予算を入れると、Genkit と Agent Platform が候補を考えて、Cloud SQL に履歴を残します。',
           style: TextStyle(
             color: _Palette.muted,
             fontSize: 15,

--- a/cookbook/lunch-concierge/infra/lib/lunch_concierge_stack.dart
+++ b/cookbook/lunch-concierge/infra/lib/lunch_concierge_stack.dart
@@ -1,7 +1,7 @@
 /// Lunch Concierge infrastructure.
 ///
 /// This Stack keeps Terraform as the execution layer while authoring the
-/// Cloud Run + Cloud SQL + Vertex AI surface in Dart.
+/// Cloud Run + Cloud SQL + Agent Platform surface in Dart.
 library;
 
 import 'package:terradart_core/terradart_core.dart';


### PR DESCRIPTION
## Summary

Aligns the lunch-concierge example's prose with the current product name: the client hero line, the README overview and architecture sketch, and the stack doc comment now say Agent Platform.

Technical identifiers are untouched on purpose — `aiplatform.googleapis.com`, the `genkit_vertexai` package, and `roles/aiplatform.user` are real IDs.

## Verification

- `dart analyze` clean on infra; `flutter analyze` clean and `flutter build web --release` succeeds on the client