### PR TITLE
docs(cookbook): document custom OAuth client setup for lunch-concierge IAP

### DIFF
--- a/cookbook/lunch-concierge/README.md
+++ b/cookbook/lunch-concierge/README.md
@@ -96,6 +96,26 @@ gcloud beta services identity create \
   --project="$GCP_PROJECT_ID"
 ```
 
+IAP also needs an OAuth client. Projects inside an organization get a
+Google-managed client automatically; a project without an organization must
+configure a custom OAuth client once, in the console, because external
+consent screens cannot be created through the API (which is also why this
+part is not in the Terraform stack):
+
+1. Configure the OAuth consent screen (Google Auth Platform > Branding) with
+   the audience set to External, and add `INVOKER_EMAIL` as a test user while
+   the app is in testing status.
+2. On the IAP page, open the Cloud Run service's settings and choose
+   Custom OAuth > Auto Generate Credentials. Alternatively, create a
+   web-application OAuth client manually, add the redirect URI
+   `https://iap.googleapis.com/v1/oauth/clientIds/CLIENT_ID:handleRedirect`,
+   and apply it with `gcloud iap settings set`.
+
+Until the OAuth client is configured, requests fail with
+`Empty Google Account OAuth client ID(s)/secret(s).` instead of redirecting
+to the Google sign-in. The deployer service account also needs
+`roles/iap.admin` so Terraform can manage the IAP access policy.
+
 The `google_iap_web_cloud_run_service_iam_member` grant uses a hand-rolled
 `Resource` subclass (`infra/lib/src/iap_access.dart`) because the
 terradart_google catalog has not curated IAP resources yet — it doubles as an


### PR DESCRIPTION
## Summary

Follow-up to #295. The IAP README section documented the service-identity bootstrap but not the OAuth client, which is the other once-per-project manual step — and the one that actually bites first: until a client is configured, IAP serves `Empty Google Account OAuth client ID(s)/secret(s).` instead of the Google sign-in redirect.

- Why it is manual (and not in the Terraform stack): projects without an organization cannot use the Google-managed OAuth client, and external consent screens cannot be created through the API
- Console steps: consent screen (external audience + test user) → IAP settings Custom OAuth auto-generate, with the manual client + `gcloud iap settings set` alternative and the IAP redirect URI format
- Notes the `roles/iap.admin` requirement for the deployer service account (without it, apply fails with a 403 reading the IAP IAM policy)

## Verification

- Docs-only change; the documented flow is exactly what brought the deployed demo from 502 to a working Google sign-in redirect (confirmed live: unauthenticated request now 302s to accounts.google.com)