### PR TITLE
fix(cookbook): make lunch-concierge hero copy day-neutral and finish Agent Platform rename

### DIFF
--- a/cookbook/lunch-concierge/client/lib/main.dart
+++ b/cookbook/lunch-concierge/client/lib/main.dart
@@ -328,7 +328,7 @@ final class _NorenHeaderState extends State<_NorenHeader>
                   const Spacer(),
                   if (!compact)
                     Text(
-                      'GENKIT × VERTEX AI × CLOUD SQL',
+                      'GENKIT × AGENT PLATFORM × CLOUD SQL',
                       style: _mono(
                         size: 11,
                         color: Colors.white60,
@@ -356,7 +356,7 @@ final class _Headline extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          '昼休みの気分を、\n一枚の食券にする。',
+          '明日のランチを決める。',
           style: _display(
             size: wide ? 42 : 30,
             height: 1.35,
@@ -621,8 +621,8 @@ final class _DispenserTrayState extends State<_DispenserTray>
           _GhostTicket(
             title: widget.loading ? '発券中…' : '食券はまだありません。',
             body: widget.loading
-                ? 'Genkit が今日の候補を考えています。'
-                : '条件を入れてボタンを押すと、今日の候補がここに発券されます。',
+                ? 'Genkit が候補を考えています。'
+                : '条件を入れてボタンを押すと、ランチの候補がここに発券されます。',
           )
         else ...[
           Text(


### PR DESCRIPTION
## Summary

- Hero headline becomes 明日のランチを決める。 — the previous line read as mood copy and did not say what the app does, and the talk demo runs in the evening where lunchtime framing lands oddly
- Dispenser empty/loading strings drop the 今日 wording so the copy works at any hour
- The noren plate still said `GENKIT × VERTEX AI × CLOUD SQL` in uppercase, which the #297 rename missed — now `AGENT PLATFORM`

## Verification

- `flutter analyze` and `dart format` clean; release build rendered against the local mock and the one-line hero lays out correctly at 1440px