### PR TITLE
fix(ci): default lunch-concierge deploy image tag to the commit SHA

### DIFF
--- a/.github/workflows/lunch-concierge-deploy.yml
+++ b/.github/workflows/lunch-concierge-deploy.yml
@@ -13,9 +13,11 @@ on:
           - apply
           - destroy
       image_tag:
-        description: Container image tag to build and deploy.
-        required: true
-        default: demo
+        description: >-
+          Container image tag to build and deploy. Leave empty to use the
+          commit SHA, which guarantees a Terraform diff and a new revision.
+        required: false
+        default: ""
         type: string
 
 concurrency:
@@ -61,8 +63,11 @@ jobs:
       - run: dart pub get
 
       - name: Resolve deployment inputs
+        env:
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
-          image_uri="${REGION}-docker.pkg.dev/${PROJECT_ID}/lunch-concierge/app:${{ inputs.image_tag }}"
+          tag="${INPUT_IMAGE_TAG:-${GITHUB_SHA::12}}"
+          image_uri="${REGION}-docker.pkg.dev/${PROJECT_ID}/lunch-concierge/app:${tag}"
           echo "IMAGE_URI=$image_uri" >> "$GITHUB_ENV"
 
       - name: Generate shared schemas


### PR DESCRIPTION
## Summary

The deploy workflow's fixed `demo` tag family created a footgun: pushing a new image moves the tag, but the Cloud Run spec string stays identical, so `terraform apply` reports no changes and the serving revision keeps the digest it pinned at creation. This bit three times this week, most recently when a pre-merge dispatch claimed `demo-v3` and the post-merge rebuild silently deployed nothing.

- `image_tag` now defaults to `${GITHUB_SHA::12}` — every apply carries a spec diff, so a new revision always rolls out and the tag names exactly what was built
- Explicit `image_tag` still overrides (useful for `destroy`, where the image-cleanup step targets the given tag)
- The tag interpolation moves from inline `${{ inputs.image_tag }}` in the run script to an env-routed variable, matching the repo's workflow hygiene

## Verification

- Workflow YAML parses; no other consumers of the `image_tag` input exist in the file
- Behavior change is dispatch-only (no push triggers on this workflow)