### PR TITLE
fix(cookbook): pin lunch-concierge deps and harden its container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Only cookbook/lunch-concierge/server/Dockerfile builds from this repo root.
+# Allowlist exactly what its COPY steps need so the rest of the monorepo
+# (and local build artifacts) never enter the build context.
+*
+!cookbook/lunch-concierge/client
+!cookbook/lunch-concierge/server
+!cookbook/lunch-concierge/shared
+**/.dart_tool
+**/build

--- a/cookbook/lunch-concierge/client/pubspec.yaml
+++ b/cookbook/lunch-concierge/client/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  genkit: any
-  google_fonts: any
+  genkit: ^0.14.1
+  google_fonts: ^8.2.0
   lunch_concierge_shared:
     path: ../shared
 
 dev_dependencies:
-  flutter_lints: any
+  flutter_lints: ^6.0.0
 
 flutter:
   uses-material-design: true

--- a/cookbook/lunch-concierge/server/Dockerfile
+++ b/cookbook/lunch-concierge/server/Dockerfile
@@ -1,5 +1,11 @@
-# Build with the repository root as the Docker context:
+# Build with the repository root as the Docker context (filtered by the
+# repo-root .dockerignore):
 # docker build -f cookbook/lunch-concierge/server/Dockerfile -t <image-uri> .
+#
+# The sed calls below detach shared/ and server/ from the repo's pub
+# workspace: a workspace member cannot run `pub get` standalone, and copying
+# the whole monorepo into the image just to satisfy the workspace root is
+# not worth it for a cookbook recipe.
 
 FROM ghcr.io/cirruslabs/flutter:stable AS client_builder
 WORKDIR /src/cookbook/lunch-concierge/client
@@ -14,19 +20,24 @@ FROM dart:stable AS server_builder
 WORKDIR /src/cookbook/lunch-concierge
 COPY cookbook/lunch-concierge/shared ./shared
 RUN sed -i '/^resolution: workspace$/d' shared/pubspec.yaml
-COPY cookbook/lunch-concierge/server ./server
+COPY cookbook/lunch-concierge/server/pubspec.yaml ./server/
 RUN sed -i '/^resolution: workspace$/d' server/pubspec.yaml
 WORKDIR /src/cookbook/lunch-concierge/server
 RUN dart pub get
-RUN mkdir -p /out
-RUN dart compile exe bin/server.dart -o /out/server
+COPY cookbook/lunch-concierge/server ./
+# The COPY above restores the workspace marker; strip it again and re-check
+# resolution against the cache warmed by the earlier `dart pub get`.
+RUN sed -i '/^resolution: workspace$/d' pubspec.yaml && dart pub get --offline
+RUN mkdir -p /out && dart compile exe bin/server.dart -o /out/server
 
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --home /app --shell /usr/sbin/nologin app
 WORKDIR /app
 COPY --from=server_builder /out/server /app/server
 COPY --from=client_builder /src/cookbook/lunch-concierge/client/build/web /app/public
 ENV PORT=8080
+USER app
 CMD ["/app/server"]

--- a/cookbook/lunch-concierge/server/pubspec.yaml
+++ b/cookbook/lunch-concierge/server/pubspec.yaml
@@ -8,15 +8,15 @@ environment:
 resolution: workspace
 
 dependencies:
-  genkit: any
-  genkit_shelf: any
-  genkit_vertexai: any
+  genkit: ^0.14.1
+  genkit_shelf: ^0.1.9
+  genkit_vertexai: ^0.2.9
   lunch_concierge_shared:
     path: ../shared
-  postgres: any
-  shelf: any
-  shelf_router: any
-  shelf_static: any
+  postgres: ^3.5.12
+  shelf: ^1.4.2
+  shelf_router: ^1.1.4
+  shelf_static: ^1.1.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/lunch-concierge/shared/pubspec.yaml
+++ b/cookbook/lunch-concierge/shared/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  schemantic: any
+  schemantic: ^0.2.0
 
 dev_dependencies:
-  build_runner: any
+  build_runner: ^2.15.0
   lints: ^6.0.0


### PR DESCRIPTION
## Summary

The server, shared, and client pubspecs declared every dependency as `any`. Because the Dockerfile detaches them from the pub workspace and no lockfile reaches the image, each docker build resolved whatever was latest on pub.dev, so deployed versions could drift from what CI tested. This PR pins carets to the versions the workspace lock already resolves (client: its standalone resolution); the workspace lockfile is unchanged.

Container build hardening in the same pass:

- Add a repo-root `.dockerignore` that allowlists only the three package dirs, keeping the rest of the monorepo, `.git`, and local `build`/`.dart_tool` artifacts out of the build context (~132KB total now) and out of the image stages.
- Copy `server/pubspec.yaml` before `dart pub get` so the dependency layer caches like the client stage already does; the full-source COPY restores the workspace marker, so strip it again and re-check resolution offline.
- Document why the workspace-detach seds exist.
- Run the runtime image as a non-root system user.

## Verification

- Workspace-root `dart pub get` leaves `pubspec.lock` untouched (the carets match what CI already tests).
- Standalone `dart pub get` / `flutter pub get` succeed with the pins after the same sed step the Dockerfile applies.
- The `server_builder` stage builds end-to-end locally: cached dependency layer, offline re-resolve after the source COPY, `dart compile exe` succeeds.
- `useradd` verified against `debian:bookworm-slim`.
- A context probe (busybox `COPY . /ctx`) shows only `client/{lib,web,pubspec.yaml}`, `server/`, and `shared/` enter the context.
- Not run locally: the client stage's `flutter build web` and the final runtime assembly (the Flutter base image is multi-GB). Both run in the deploy workflow on its next dispatch; the client stage's Dockerfile lines are unchanged.