### PR TITLE
chore(backlog): skip Oracle Exadata exascale config

### DIFF
--- a/tool/curation_backlog.yaml
+++ b/tool/curation_backlog.yaml
@@ -103,3 +103,4 @@ entries:
   - resource: google_oracle_database_cloud_exadata_infrastructure_exascale_config
     detected_at: 2026-07-01
     provider_version: 7.39.0
+    note: skipped by wave-shipper — requires parent google_oracle_database_cloud_exadata_infrastructure; oracle_exadata_quickstart is apply-smoke skip-listed (Oracle zone entitlement / live Exascale vault wiring — API rejects placeholder wiring on terradart-validate)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Human-reviewed backlog skip for the last Oracle leftover that wave-shipper correctly identified as standalone-project inapplicable.

## Change

Add `skipped by wave-shipper` note to `google_oracle_database_cloud_exadata_infrastructure_exascale_config`:

- Resource requires parent `google_oracle_database_cloud_exadata_infrastructure`
- `oracle_exadata_quickstart` is already in `tool/apply_smoke_skip.yaml` (Oracle zone entitlement / live Exascale vault wiring; API rejects placeholder wiring on `terradart-validate`)

## Intentionally not skipped

`google_network_services_agent_gateway` stays unskipped. Schema marks `registries` as optional; a stronger apply-time check is still needed before recording a permanent skip (#308 overstated that gate).

## Test plan

- [x] YAML only; Agent Gateway entry unchanged
- [ ] After merge, daily wave-shipper should escalate on Agent Gateway alone (skip-only day → no PR per #309) until that resource is resolved

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f74a9-bd5e-73f0-86ee-1e30c150302e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f74a9-bd5e-73f0-86ee-1e30c150302e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

