### PR TITLE
chore(backlog): skip google_network_services_agent_gateway

### DIFF
--- a/tool/curation_backlog.yaml
+++ b/tool/curation_backlog.yaml
@@ -100,6 +100,7 @@ entries:
   - resource: google_network_services_agent_gateway
     detected_at: 2026-07-01
     provider_version: 7.39.0
+    note: skipped by maintainer — provider example needs google_compute_network_attachment + agentregistry API + registries URI; sibling google_agent_registry_* already skip-noted (Agent Identity); google_managed/self_managed is an exactly_one_of sealed design; not standalone-project applyable on terradart-validate without that scaffolding
   - resource: google_oracle_database_cloud_exadata_infrastructure_exascale_config
     detected_at: 2026-07-01
     provider_version: 7.39.0


### PR DESCRIPTION
## Summary
- Add a skip note for `google_network_services_agent_gateway`, the last un-skipped `tool/curation_backlog.yaml` entry.
- Provider docs’ full example needs `google_compute_network_attachment`, `agentregistry.googleapis.com`, and registry URIs; sibling `google_agent_registry_*` entries are already skip-noted. `google_managed` / `self_managed` is an `exactly_one_of` sealed design.
- With this, daily **wave-shipper** should no-op on empty shippable backlog (matches the 1–2m “Succeeded / no tools” runs in Automations) until the next schema bump adds resources.

## Context (Automations)
Reviewed Cloud Agents: `wave-shipper` (daily 9:00 JST), `schema-bump-postprocess`, `apply-smoke-diagnose` — all Active, 100% success. Short daily runs are intentional idle/skip days, not failures.

## Test plan
- [x] `tool/curation_backlog.yaml` has zero entries without a `note: skipped …`
- [ ] Optional: next morning wave-shipper run stays a short no-op