### PR TITLE
chore(hooks): add gcloud for Cloud Agent validate audits

### DIFF
--- a/.cursor/agents/apply-smoke-diagnose.md
+++ b/.cursor/agents/apply-smoke-diagnose.md
@@ -47,9 +47,12 @@ verification pitfalls, and guardrails all bind you.
 - **F. Escalate** (fix would need `packages/**` — provider drift at the
   factory level; SA permissions / WIF / infrastructure; a bug in
   `tool/apply_smoke.sh` itself; teardown/destroy failures — possible
-  orphaned resources cost real money and you have no gcloud; or you are
-  not confident): analysis comment only, with your recommended next step.
-  Do not attempt the fix.
+  orphaned resources cost real money; or you are not confident): analysis
+  comment only, with your recommended next step. Do not attempt the fix.
+  When Cursor Secret `GCP_VALIDATE_SA_JSON` is present, you MAY run
+  `tool/apply_smoke_orphan_check.sh` (read-only) and quote its output as
+  evidence — never `gcloud … delete` / create; reclaim via the Apply smoke
+  janitor. If `gcloud` or the secret is missing, say so and escalate.
 
 ## Open fix PRs (classes A-D only)
 

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -4,7 +4,8 @@
 # Referenced by .cursor/environment.json ("install"). Cursor runs this once on
 # VM boot and caches the result as a snapshot, so it MUST be idempotent: it can
 # run again on partially cached state. Mirrors the toolchain documented in
-# AGENTS.md "Cursor Cloud specific instructions" (Dart SDK stable + Terraform).
+# AGENTS.md "Cursor Cloud specific instructions" (Dart SDK stable + Terraform
+# + Google Cloud CLI for read-only terradart-validate audits).
 set -euo pipefail
 
 # apt steps need root; the default cloud image may run install as a non-root
@@ -51,10 +52,27 @@ if [[ ! -x "$GCMS_BIN" ]] || [[ "$(cat "$GCMS_PIN" 2>/dev/null || true)" != "$GC
   printf '%s\n' "$GCMS_VER" | $SUDO tee "$GCMS_PIN" >/dev/null
 fi
 
+# --- Google Cloud CLI (read-only orphan audits of terradart-validate) ------
+# Auth is NOT provisioned here — agents materialize the Cursor Secret
+# GCP_VALIDATE_SA_JSON via tool/gcloud_validate_auth.sh (see AGENTS.md).
+if ! command -v gcloud >/dev/null 2>&1; then
+  $SUDO apt-get install -y --no-install-recommends \
+    apt-transport-https ca-certificates gnupg curl
+  if [[ ! -f /usr/share/keyrings/cloud.google.gpg ]]; then
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+      | $SUDO gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+  fi
+  echo 'deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main' \
+    | $SUDO tee /etc/apt/sources.list.d/google-cloud-sdk.list >/dev/null
+  $SUDO apt-get update
+  $SUDO apt-get install -y google-cloud-cli
+fi
+
 # --- Resolve workspace dependencies (cheap; safe to re-run) ----------------
 # apt installs Dart under /usr/lib/dart/bin (symlinked into /usr/bin); add it to
 # PATH defensively in case the symlink is absent on a given base image.
 export PATH="/usr/lib/dart/bin:$PATH"
 dart --version
 terraform version
+gcloud --version | head -n 1
 dart pub get

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,9 @@ When a resource can't apply on a standalone project at all — org-only (Shared 
 
 ## Cursor Cloud specific instructions
 
-Cloud Agent VMs provision their toolchain from [`.cursor/environment.json`](.cursor/environment.json), whose `install` step runs the idempotent [`.cursor/install.sh`](.cursor/install.sh): it installs **Dart SDK stable** (≥ 3.10; workspace root requires ^3.6, `terradart_agent` requires ^3.10) from the official apt repo and **Terraform** (≥ 1.11) from HashiCorp apt, then runs `dart pub get`. Cursor caches the result as a snapshot, so later agent boots are fast. Edit `install.sh` when the toolchain changes — do not rely on a hand-built snapshot.
+Cloud Agent VMs provision their toolchain from [`.cursor/environment.json`](.cursor/environment.json), whose `install` step runs the idempotent [`.cursor/install.sh`](.cursor/install.sh): it installs **Dart SDK stable** (≥ 3.10; workspace root requires ^3.6, `terradart_agent` requires ^3.10) from the official apt repo, **Terraform** (≥ 1.11) from HashiCorp apt, and the **Google Cloud CLI** (`gcloud`) from Google's apt repo, then runs `dart pub get`. Cursor caches the result as a snapshot, so later agent boots are fast. Edit `install.sh` when the toolchain changes — do not rely on a hand-built snapshot. After changing `install.sh`, rebuild / refresh the Cloud Agent environment snapshot so new boots pick up `gcloud`.
+
+**gcloud + terradart-validate (read-only).** CLI alone is not enough — register a **separate** Cursor Secret `GCP_VALIDATE_SA_JSON` (inline service-account JSON) for a **read-only** SA on `terradart-validate` (list/get style roles such as `roles/viewer` / Browser; no create/delete). Do **not** reuse the gcp-cost `GOOGLE_APPLICATION_CREDENTIALS` secret (Billing Catalog only). Auth helper: `eval "$(tool/gcloud_validate_auth.sh)"`. High-cost orphan probe (never mutates): `tool/apply_smoke_orphan_check.sh`. Reclaim orphans via the **Apply smoke janitor** workflow / `tool/apply_smoke.sh --all --destroy-only` — agents must not ad-hoc `gcloud … delete`.
 
 **gcp-cost MCP.** `.cursor/mcp.json` launches [`tool/gcp-cost-mcp-wrapper.sh`](tool/gcp-cost-mcp-wrapper.sh), which materializes the Cursor Secret `GOOGLE_APPLICATION_CREDENTIALS` (inline JSON) to `~/.config/gcp-cost/service-account.json` (`chmod 600`) before exec'ing `gcp-cost-mcp-server`. Register the service-account JSON as a Cursor Secret; do not commit credentials. Public Cloud Billing Catalog pricing needs no project API enablement; prefer a dedicated low-privilege SA over a production key. Cursor's MCP integration reaches this server from the local IDE only; Cloud Agent sessions never launch command-type MCP servers (verified 2026-07-04), so they call the same tools through [`tool/gcp_cost_call.dart`](tool/gcp_cost_call.dart) (maintainer ops, not part of any shipped package) — a judgment-free genkit_mcp-client transport that launches the server via the wrapper above (terradart_agent thus dogfoods genkit_mcp on both sides: server and host). Wrappers that decide *for* the agent (pre-picked SKUs, canned classifications) remain forbidden; CI verifies only the resulting denylist comments (test 13).
 
@@ -251,6 +253,8 @@ There is no long-running dev server for core work. Primary flows:
 | Agent gate (lint, tests, wrap check, smoke) | `tool/agent_verify.sh` |
 | Suspected mislabeled `upstream: null` | `dart tool/check_mm_upstream_fingerprint.dart` |
 | Apply-smoke selection (no GCP) | `tool/apply_smoke.sh --all --dry-run` |
+| Auth gcloud for validate project (read-only) | `eval "$(tool/gcloud_validate_auth.sh)"` |
+| High-cost orphan probe (read-only) | `tool/apply_smoke_orphan_check.sh` |
 | Apply one example for real | `GCP_PROJECT_ID=terradart-validate tool/apply_smoke.sh --example <slug>` |
 | Example coverage + API-enablement ratchet | `dart tool/example_synth_gates.dart` |
 | Publish readiness (per package) | `cd packages/<pkg> && dart pub publish --dry-run` |

--- a/tool/apply_smoke_orphan_check.sh
+++ b/tool/apply_smoke_orphan_check.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Read-only inventory of high-cost / sticky resources in terradart-validate.
+#
+# Use after a failed apply-smoke run (or anytime billing looks suspicious) to
+# confirm orphans that terraform destroy may have missed. NEVER creates or
+# deletes — reclaim via tool/apply_smoke_janitor.sh / the Apply smoke janitor
+# workflow (or an explicit maintainer destroy).
+#
+# Prerequisites:
+#   - gcloud on PATH (.cursor/install.sh)
+#   - Cursor Secret GCP_VALIDATE_SA_JSON (read-only SA on terradart-validate)
+#
+# Usage (repo root):
+#   tool/apply_smoke_orphan_check.sh
+#   GCP_VALIDATE_PROJECT_ID=terradart-validate tool/apply_smoke_orphan_check.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+chmod +x tool/gcloud_validate_auth.sh
+# shellcheck disable=SC1090
+eval "$(tool/gcloud_validate_auth.sh)"
+PROJECT_ID="${GCP_VALIDATE_PROJECT_ID:-terradart-validate}"
+
+# Regions used by examples / apply-smoke (keep short — this is a probe, not a
+# full inventory of every GCP region).
+REGIONS=(us-central1 asia-northeast1)
+
+echo ">> orphan-check: project=$PROJECT_ID (read-only)"
+echo
+
+found=0
+
+run_list() {
+  local label="$1"
+  shift
+  echo "== $label =="
+  local out rc=0
+  out="$("$@" --project="$PROJECT_ID" --format='value(name)' 2>&1)" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    echo "(skip: $(echo "$out" | head -n 2 | tr '\n' ' '))"
+    echo
+    return 0
+  fi
+  if [[ -z "${out//[$' \t\n']/}" ]]; then
+    echo "(none)"
+  else
+    found=1
+    echo "$out"
+  fi
+  echo
+}
+
+# Global / aggregated list commands.
+run_list "Compute Engine instances" \
+  gcloud compute instances list
+run_list "GKE clusters" \
+  gcloud container clusters list
+run_list "Cloud SQL instances" \
+  gcloud sql instances list
+run_list "Bigtable instances" \
+  gcloud bigtable instances list
+run_list "VPN tunnels" \
+  gcloud compute vpn-tunnels list
+run_list "Cloud Routers (NAT / VPN peers often attach here)" \
+  gcloud compute routers list
+
+# Regional APIs — probe the two regions examples use.
+for region in "${REGIONS[@]}"; do
+  run_list "Memorystore Redis ($region)" \
+    gcloud redis instances list --region="$region"
+  run_list "Filestore ($region)" \
+    gcloud filestore instances list --zone="$region-a"
+  run_list "Dataproc Metastore ($region)" \
+    gcloud metastore services list --location="$region"
+  run_list "AlloyDB clusters ($region)" \
+    gcloud alloydb clusters list --region="$region"
+done
+
+if [[ "$found" -eq 1 ]]; then
+  echo "orphan-check: RESOURCES FOUND — investigate billing; reclaim with Apply smoke janitor / apply_smoke.sh --destroy-only (do not delete ad hoc from the agent)." >&2
+  exit 1
+fi
+
+echo "orphan-check: OK (no listed high-cost resources found)"
+exit 0

--- a/tool/gcloud_validate_auth.sh
+++ b/tool/gcloud_validate_auth.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Materialize Cursor Secret GCP_VALIDATE_SA_JSON for read-only gcloud against
+# terradart-validate. Maintainer ops — not part of any shipped package.
+#
+# Usage (from repo root, after the secret is registered in Cursor):
+#   eval "$(tool/gcloud_validate_auth.sh)"
+#   gcloud compute instances list --project="$GCP_VALIDATE_PROJECT_ID"
+#
+# Or let tool/apply_smoke_orphan_check.sh call this for you.
+#
+# Secrets / env:
+#   GCP_VALIDATE_SA_JSON     — required; inline service-account JSON (Cursor Secret)
+#   GCP_VALIDATE_PROJECT_ID  — optional; defaults to terradart-validate
+#
+# Does NOT reuse GOOGLE_APPLICATION_CREDENTIALS (that secret is for the
+# public Billing Catalog / gcp-cost MCP and should stay low-privilege).
+set -euo pipefail
+
+readonly KEY_FILE="${HOME}/.config/terradart-validate/service-account.json"
+PROJECT_ID="${GCP_VALIDATE_PROJECT_ID:-terradart-validate}"
+
+if [[ -z "${GCP_VALIDATE_SA_JSON:-}" ]]; then
+  echo "gcloud_validate_auth.sh: set Cursor Secret GCP_VALIDATE_SA_JSON (inline SA JSON for terradart-validate read-only)." >&2
+  echo "Do not reuse the gcp-cost GOOGLE_APPLICATION_CREDENTIALS secret." >&2
+  exit 64
+fi
+
+if [[ "${GCP_VALIDATE_SA_JSON}" != \{* ]]; then
+  echo "gcloud_validate_auth.sh: GCP_VALIDATE_SA_JSON must be an inline JSON object (starts with '{')." >&2
+  exit 64
+fi
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "gcloud_validate_auth.sh: gcloud not on PATH — rebuild the Cloud Agent snapshot after merging .cursor/install.sh changes." >&2
+  exit 69
+fi
+
+install -d -m 700 "$(dirname "$KEY_FILE")"
+umask 077
+printf '%s' "$GCP_VALIDATE_SA_JSON" >"$KEY_FILE"
+chmod 600 "$KEY_FILE"
+
+# Activate for gcloud's credential store. Do NOT export
+# GOOGLE_APPLICATION_CREDENTIALS — that Cursor Secret is reserved for the
+# gcp-cost Billing Catalog SA and must stay separate.
+gcloud auth activate-service-account \
+  --key-file="$KEY_FILE" \
+  --project="$PROJECT_ID" \
+  --quiet >/dev/null
+
+# Emit exports for `eval "$(…)"` callers (gcloud-scoped only).
+printf 'export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=%q\n' "$KEY_FILE"
+printf 'export GCP_VALIDATE_PROJECT_ID=%q\n' "$PROJECT_ID"
+printf 'export CLOUDSDK_CORE_PROJECT=%q\n' "$PROJECT_ID"
+echo "gcloud_validate_auth.sh: authenticated for project $PROJECT_ID (read-only SA expected)" >&2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enable Cloud Agents to **read-only** inspect `terradart-validate` for high-cost orphans after apply-smoke failures.

- Install `google-cloud-cli` in `.cursor/install.sh` (idempotent apt)
- `tool/gcloud_validate_auth.sh` — materialize Cursor Secret `GCP_VALIDATE_SA_JSON` (separate from gcp-cost Billing Catalog SA)
- `tool/apply_smoke_orphan_check.sh` — list high-cost surfaces; never mutates
- Docs: `AGENTS.md` + apply-smoke diagnose runbook

## Maintainer follow-up (not in this PR)

1. Create a **read-only** SA on `terradart-validate` (e.g. `roles/viewer` / Browser; no create/delete).
2. Register its JSON as Cursor Secret `GCP_VALIDATE_SA_JSON`.
3. Rebuild / refresh the Cloud Agent environment snapshot so new boots pick up `gcloud` from `install.sh`.

## Test plan

- [x] `bash -n` on new scripts
- [x] `install.sh` installs `gcloud` in this VM
- [x] auth helper fails closed without `GCP_VALIDATE_SA_JSON`
- [x] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae7e9186-0894-4b33-9381-94941023769e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae7e9186-0894-4b33-9381-94941023769e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

