### PR TITLE
fix(hooks): disable gcloud prompts in orphan-check

### DIFF
--- a/tool/apply_smoke_orphan_check.sh
+++ b/tool/apply_smoke_orphan_check.sh
@@ -15,6 +15,11 @@
 #   GCP_VALIDATE_PROJECT_ID=terradart-validate tool/apply_smoke_orphan_check.sh
 set -euo pipefail
 
+# Non-interactive: disabled APIs otherwise prompt "enable and retry? (y/N)"
+# and hang Cloud Agents (no TTY). With prompts off, gcloud fails closed and
+# run_list treats that as "(skip)" — still read-only, never enables APIs.
+export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`tool/apply_smoke_orphan_check.sh` hung for 8+ minutes on Cloud Agents when Dataproc Metastore / AlloyDB APIs are not enabled on `terradart-validate`: `gcloud` prompts `enable and retry? (y/N)?` and waits for a TTY that does not exist.

Export `CLOUDSDK_CORE_DISABLE_PROMPTS=1` at the top of the script so disabled APIs fail closed and existing `run_list` `(skip)` handling continues. Still read-only — never enables APIs or deletes resources.

## Test plan

- [x] Confirmed orphan-check succeeds with `CLOUDSDK_CORE_DISABLE_PROMPTS=1` on a Cloud Agent (~17s, exit 0)
- [ ] Merge; next orphan-check run needs no manual env var

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae7e9186-0894-4b33-9381-94941023769e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae7e9186-0894-4b33-9381-94941023769e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

