### PR TITLE
fix(tool): allowlist Composer third_party null MM upstreams

### DIFF
--- a/tool/check_mm_upstream_fingerprint.dart
+++ b/tool/check_mm_upstream_fingerprint.dart
@@ -44,6 +44,8 @@ const _fingerprintFalsePositives = <String>{
   'google_dataplex_zone', // MM Zone.yaml is IAM-only (exclude_resource: true)
   'google_dataplex_asset', // MM Asset.yaml is IAM-only (exclude_resource: true)
   'google_recaptcha_enterprise_key', // third_party resource_recaptcha_enterprise_key.go
+  'google_composer_environment', // third_party resource_composer_environment.go.tmpl; no mmv1/products/composer/Environment.yaml
+  'google_composer_user_workloads_secret', // third_party resource_composer_user_workloads_secret.go.tmpl; no mmv1 YAML
 };
 
 bool _isIamAdjunct(String tfType) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Allowlist `google_composer_environment` and `google_composer_user_workloads_secret` in `check_mm_upstream_fingerprint` — both are handwritten under `mmv1/third_party/terraform/services/composer` (no `mmv1/products/composer/Environment.yaml`) but carry `effective_labels` fingerprints.

Prerequisite for the Cloud Composer curated Wave (`wave/composer-2026-07-22`).

## Test plan

- [ ] `dart tool/check_mm_upstream_fingerprint.dart` exits 0

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f86d1-f701-7847-8974-d1dacb4a0ade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f86d1-f701-7847-8974-d1dacb4a0ade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

