### PR TITLE
fix(tool): allowlist Dataproc cluster third_party null MM upstream

### DIFF
--- a/tool/check_mm_upstream_fingerprint.dart
+++ b/tool/check_mm_upstream_fingerprint.dart
@@ -46,6 +46,7 @@ const _fingerprintFalsePositives = <String>{
   'google_recaptcha_enterprise_key', // third_party resource_recaptcha_enterprise_key.go
   'google_composer_environment', // third_party resource_composer_environment.go.tmpl; no mmv1/products/composer/Environment.yaml
   'google_composer_user_workloads_secret', // third_party resource_composer_user_workloads_secret.go.tmpl; no mmv1 YAML
+  'google_dataproc_cluster', // third_party resource_dataproc_cluster.go; no mmv1/products/dataproc/Cluster.yaml (product has AutoscalingPolicy/Batch/SessionTemplate only)
 };
 
 bool _isIamAdjunct(String tfType) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`google_dataproc_cluster` is handwritten under `mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go` and has **no** `mmv1/products/dataproc/Cluster.yaml` (the product folder only has AutoscalingPolicy / Batch / SessionTemplate). It still carries `effective_labels`, so `check_mm_upstream_fingerprint` would flag `upstream: null` as a mislabel.

Allowlist the false-positive before the curated Dataproc Cluster Wave sets `upstream: null` (same pattern as Composer in #372).

## Test plan

- [x] `dart tool/check_mm_upstream_fingerprint.dart` → OK
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f86d1-f701-7847-8974-d1dacb4a0ade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f86d1-f701-7847-8974-d1dacb4a0ade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

