### PR TITLE
fix(docs): link Feature Group feature to vertex_ai_quickstart coverage

### DIFF
--- a/website/src/content/docs/docs/coverage.md
+++ b/website/src/content/docs/docs/coverage.md
@@ -1040,7 +1040,7 @@ Import per service: `import 'package:terradart_google/<barrel>.dart';`
 | `google_vertex_ai_deployment_resource_pool` | `GoogleVertexAiDeploymentResourcePool` | — |
 | `google_vertex_ai_endpoint` | `GoogleVertexAiEndpoint` | — |
 | `google_vertex_ai_feature_group` | `GoogleVertexAiFeatureGroup` | [vertex_ai_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/vertex_ai_quickstart) |
-| `google_vertex_ai_feature_group_feature` | `GoogleVertexAiFeatureGroupFeature` | — |
+| `google_vertex_ai_feature_group_feature` | `GoogleVertexAiFeatureGroupFeature` | [vertex_ai_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/vertex_ai_quickstart) |
 | `google_vertex_ai_featurestore` | `GoogleVertexAiFeaturestore` | — |
 | `google_vertex_ai_featurestore_entitytype` | `GoogleVertexAiFeaturestoreEntitytype` | — |
 | `google_vertex_ai_featurestore_entitytype_feature` | `GoogleVertexAiFeaturestoreEntitytypeFeature` | — |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`#388` landed `GoogleVertexAiFeatureGroupFeature` in `vertex_ai_quickstart`, but committed `coverage.md` was rendered before that type appeared in synth output, so the Feature Registry feature row showed `—` instead of the quickstart link. CI’s `render_coverage_page.dart --check` (inside `apply_smoke.sh selection test`) failed on `main`.

## Change

- Re-run `dart tool/render_coverage_page.dart` after synth so `google_vertex_ai_feature_group_feature` links to `vertex_ai_quickstart`.

## Verify

- `dart tool/render_coverage_page.dart --check`
- `tool/apply_smoke_test.sh`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f86d1-f701-7847-8974-d1dacb4a0ade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f86d1-f701-7847-8974-d1dacb4a0ade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

