### PR TITLE
fix(examples): drop flaky Bigtable schema bundle into example debt

### DIFF
--- a/examples/bigtable_quickstart/README.md
+++ b/examples/bigtable_quickstart/README.md
@@ -1,6 +1,6 @@
 # Bigtable quickstart
 
-Provisions a development Cloud Bigtable instance with table, app profile, GC policy, authorized / logical / materialized views, a protobuf schema bundle, and additive IAM grants.
+Provisions a production Cloud Bigtable instance with table, app profile, GC policy, authorized / logical / materialized views, and additive IAM grants.
 
 ## Prerequisites
 
@@ -22,17 +22,16 @@ terraform validate
 
 ## What gets created
 
-- A **development** Bigtable instance `quickstart-events` with one cluster in `us-central1-b`
+- A **production** Bigtable instance `quickstart-events` with one cluster in `us-central1-b`
 - Table `events` with column family `cf1`
 - Default app profile routing to the cluster
 - 7-day max-age GC policy on `cf1`
 - Authorized view `tenant-a`, logical view `recent-events`, materialized view `event-counts`
-- Protobuf schema bundle `events-proto`
 - IAM grants: `roles/bigtable.viewer` on the instance and `roles/bigtable.reader` on the table for service account `bt-reader`
 
-## Wave 73 factories exercised
+Protobuf schema bundles are curated but tracked in `tool/example_debt.yaml` — create races with table settle (`Parent table is either creating or deleting`) even after a 90s wait.
 
-All ten curated Bigtable factories appear in synth output:
+## Factories exercised
 
 - `google_bigtable_instance`
 - `google_bigtable_table`
@@ -41,6 +40,5 @@ All ten curated Bigtable factories appear in synth output:
 - `google_bigtable_authorized_view`
 - `google_bigtable_logical_view`
 - `google_bigtable_materialized_view`
-- `google_bigtable_schema_bundle`
 - `google_bigtable_instance_iam_member`
 - `google_bigtable_table_iam_member`

--- a/examples/bigtable_quickstart/lib/main.dart
+++ b/examples/bigtable_quickstart/lib/main.dart
@@ -2,8 +2,10 @@
 ///
 /// Defines `EventsStack`: provisions a single-node production Bigtable instance with
 /// one cluster, a table + column family, app profile routing, GC policy,
-/// authorized / logical / materialized views, a protobuf schema bundle,
-/// and additive IAM grants for a reader service account.
+/// authorized / logical / materialized views, and additive IAM grants for a
+/// reader service account. Schema bundles stay in `tool/example_debt.yaml` —
+/// after table settle waits they still race with "Parent table is either
+/// creating or deleting" at apply time (monthly sweep 2026-08-01).
 library;
 
 import 'package:terradart_core/terradart_core.dart';
@@ -13,7 +15,7 @@ import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/time.dart';
 
-/// Cloud Bigtable stack exercising every Wave 73 factory.
+/// Cloud Bigtable stack for the applyable Wave 73 surface (schema bundle deferred).
 final class EventsStack extends Stack {
   EventsStack({required String projectId})
       : super(
@@ -114,23 +116,6 @@ final class EventsStack extends Stack {
       ),
     );
 
-    final schemaBundle = add(
-      GoogleBigtableSchemaBundle(
-        localName: 'events_proto',
-        schemaBundleId: TfArg.literal('events-proto'),
-        instance: TfArg.ref(instance.nameRef),
-        table: TfArg.ref(table.nameRef),
-        protoSchema: BigtableSchemaBundleProtoSchema(
-          // HashiCorp provider test fixture (minimal Author message).
-          protoDescriptors: TfArg.literal(
-            'CnEKGXByb3RvX3NjaGVtYV9idW5kbGUucHJvdG8SI2djbG91ZC5iaWd0YWJsZS5zY2hlbWFfYnVuZGxlcy50ZXN0IicKBkF1dGhvchIdCgpmaXJzdF9uYW1lGAEgASgJUglmaXJzdE5hbWViBnByb3RvMw==',
-          ),
-        ),
-        ignoreWarnings: TfArg.literal(true),
-        dependsOn: tableReadyDeps,
-      ),
-    );
-
     final logicalView = add(
       GoogleBigtableLogicalView(
         localName: 'recent',
@@ -138,7 +123,7 @@ final class EventsStack extends Stack {
         instance: TfArg.ref(instance.nameRef),
         query: TfArg.literal('SELECT _key, cf1 FROM `events`'),
         deletionProtection: TfArg.literal(false),
-        dependsOn: [ResourceDependency(schemaBundle)],
+        dependsOn: tableReadyDeps,
       ),
     );
 

--- a/tool/example_debt.yaml
+++ b/tool/example_debt.yaml
@@ -578,6 +578,13 @@ GoogleComputeInstanceIamPolicy: iam-adjunct-debt: sibling GoogleComputeInstanceI
 GoogleComputeSubnetworkIamBinding: iam-adjunct-debt: sibling GoogleComputeSubnetworkIamMember already in compute_quickstart; authoritative binding not needed in smoke
 GoogleComputeSubnetworkIamPolicy: iam-adjunct-debt: sibling GoogleComputeSubnetworkIamMember already in compute_quickstart; authoritative policy not needed in smoke
 
+# Bigtable schema bundles race with table settle even after a 90s TimeSleep
+# (monthly sweep 2026-08-01: "Parent table … is either creating or deleting").
+# Ordering/wait retries did not make apply deterministic; keep the factory
+# curated and drop it from bigtable_quickstart so the rest of the stack can
+# apply. Sibling IAM binding/policy stay on the iam-adjunct-debt path below.
+GoogleBigtableSchemaBundle: Bigtable schema-bundle create returns 400 "Parent table is either creating or deleting" after table + GC + authorized-view settle waits (90s TimeSleep still failed on monthly sweep 2026-08-01); dropped from bigtable_quickstart rather than extending another flaky wait
+
 # Bigtable IAM binding/policy — sibling *IamMember already in
 # bigtable_quickstart (iam-adjunct-debt path; AGENTS.md Wave shipping).
 GoogleBigtableInstanceIamBinding: iam-adjunct-debt: sibling GoogleBigtableInstanceIamMember already in bigtable_quickstart; authoritative binding not needed in smoke

--- a/website/src/content/docs/docs/coverage.md
+++ b/website/src/content/docs/docs/coverage.md
@@ -338,7 +338,7 @@ Import per service: `import 'package:terradart_google/<barrel>.dart';`
 | `google_bigtable_instance_iam_policy` | `GoogleBigtableInstanceIamPolicy` | — |
 | `google_bigtable_logical_view` | `GoogleBigtableLogicalView` | [bigtable_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/bigtable_quickstart) |
 | `google_bigtable_materialized_view` | `GoogleBigtableMaterializedView` | [bigtable_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/bigtable_quickstart) |
-| `google_bigtable_schema_bundle` | `GoogleBigtableSchemaBundle` | [bigtable_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/bigtable_quickstart) |
+| `google_bigtable_schema_bundle` | `GoogleBigtableSchemaBundle` | — |
 | `google_bigtable_table` | `GoogleBigtableTable` | [bigtable_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/bigtable_quickstart) |
 | `google_bigtable_table_iam_binding` | `GoogleBigtableTableIamBinding` | — |
 | `google_bigtable_table_iam_member` | `GoogleBigtableTableIamMember` | [bigtable_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/bigtable_quickstart) |


### PR DESCRIPTION
## Summary
- Refs #442 (`bigtable_quickstart` failure on monthly apply-smoke [30685969464](https://github.com/nozomi-koborinai/terradart/actions/runs/30685969464)).
- After table + GC + authorized-view settle (90s `TimeSleep`), `google_bigtable_schema_bundle` still failed with `Parent table … is either creating or deleting`.
- Drop the factory from `bigtable_quickstart`, record `GoogleBigtableSchemaBundle` in `tool/example_debt.yaml`, and wire logical/materialized views off the table-ready wait instead.

## Test plan
- [x] `dart tool/check_docs_consistency.dart`
- [x] `tool/agent_verify.sh --quick`
- [x] `examples/bigtable_quickstart` synth + `terraform validate` (no `schema_bundle` in tf-out)
- [x] `dart tool/example_synth_gates.dart --skip-validate`
- [ ] CI (PR apply-smoke should skip bigtable via `apply_smoke_pr_skip.yaml` — no real Bigtable apply on this PR)
- [ ] Close #442 after the next monthly full sweep is green (or a manual full-sweep dispatch confirms bigtable)