### PR TITLE
chore(examples): trigger apply-smoke for ncc_hub_quickstart

### DIFF
--- a/examples/ncc_hub_quickstart/lib/main.dart
+++ b/examples/ncc_hub_quickstart/lib/main.dart
@@ -8,7 +8,9 @@
 /// - a private regional endpoint for Storage,
 /// - additive hub IAM for an inventory SA.
 ///
-/// Run `bin/infra.dart` to synth into `tf-out/`.
+/// Run `bin/infra.dart` to synth into `tf-out/`. Apply-smoke targets this
+/// stack on `terradart-validate` (not the Partner-CCI `network_connectivity`
+/// quickstart).
 library;
 
 import 'package:terradart_core/terradart_core.dart';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#509 landed while still a draft, so the apply-smoke change-gate never ran against `examples/ncc_hub_quickstart`.

This PR only touches the quickstart `lib/` so CI selects `ncc_hub` and runs real apply + destroy on `terradart-validate` (WIF). Doc comment clarifies this stack is the applyable NCC path (Partner CCI stays on the skipped `network_connectivity_quickstart`).

## Test plan

- [ ] Apply smoke job applies then destroys `ncc_hub`
- [ ] Other required CI green
- [ ] Squash-merge after smoke green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99494d9f-7d5e-4d9d-9ba1-e21e08299343?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99494d9f-7d5e-4d9d-9ba1-e21e08299343&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

