### PR TITLE
chore(examples): cover Vector DataObject; skip apply for write-ops cost

### DIFF
--- a/examples/vector_quickstart/README.md
+++ b/examples/vector_quickstart/README.md
@@ -1,14 +1,18 @@
 # Vector Search collection quickstart
 
-End-to-end terradart example for a Vector Search 2.0 collection
-(`google_vector_search_collection`) with a JSON data schema and a dense
-vector field — the same shape as the provider
-`vectorsearch_collection_basic` example (without Vertex embedding config).
+End-to-end terradart example for Vector Search 2.0:
+
+- `google_vector_search_collection` — JSON data schema + dense vector field
+- `google_vector_search_data_object` — one sample row (zero embedding)
 
 Creating a collection alone does not provision index-serving capacity.
-`google_vector_search_index` is curated in `terradart_google` but listed in
-`tool/example_debt.yaml` because the API defaults dedicated infrastructure
-to two PERFORMANCE_OPTIMIZED replicas (hourly billing).
+`google_vector_search_index` stays in `tool/example_debt.yaml` because the
+API defaults dedicated infrastructure to two PERFORMANCE_OPTIMIZED replicas
+(hourly billing).
+
+**Apply-smoke:** this example is listed in `tool/apply_smoke_skip.yaml`.
+DataObject meters Write Ops (~$0.18/count) and payload storage; synth +
+`terraform validate` still cover both factories.
 
 ## Prerequisites
 

--- a/examples/vector_quickstart/lib/main.dart
+++ b/examples/vector_quickstart/lib/main.dart
@@ -1,13 +1,16 @@
-/// Vector Search 2.0 collection quickstart.
+/// Vector Search 2.0 collection + data object quickstart.
 ///
-/// Enables `vectorsearch.googleapis.com` and creates a regional
-/// `google_vector_search_collection` with a minimal data schema and a dense
-/// vector field (dimensions only — no Vertex embedding config). Collection
-/// metadata alone does not provision index-serving capacity units.
+/// Enables `vectorsearch.googleapis.com` and creates:
+/// - a regional [GoogleVectorSearchCollection] with a minimal data schema and
+///   a dense vector field (dimensions only — no Vertex embedding config),
+/// - one [GoogleVectorSearchDataObject] row (zero vector) in that collection.
 ///
-/// `google_vector_search_index` is curated but deferred to
-/// `tool/example_debt.yaml` because the API defaults dedicated infrastructure
-/// to two PERFORMANCE_OPTIMIZED replicas (hourly capacity-unit billing).
+/// **Apply-smoke:** listed in `tool/apply_smoke_skip.yaml` so real apply is
+/// skipped — DataObject meters Write Ops (`C1E5-1A7F-E9B3` ~$0.18/count) and
+/// payload storage. Synth + `terraform validate` still cover both factories.
+///
+/// `google_vector_search_index` stays in `tool/example_debt.yaml` (hourly
+/// capacity-unit defaults).
 ///
 /// Run `bin/infra.dart` to synth into `tf-out/`.
 library;
@@ -17,7 +20,7 @@ import 'package:terradart_google/project.dart';
 import 'package:terradart_google/provider.dart';
 import 'package:terradart_google/vector.dart';
 
-/// Vector Search stack: schema-only collection.
+/// Vector Search stack: schema collection + one payload data object.
 final class VectorSearchStack extends Stack {
   VectorSearchStack({required String projectId})
       : super(
@@ -25,6 +28,10 @@ final class VectorSearchStack extends Stack {
             GoogleProvider(project: projectId, region: 'us-central1'),
           ],
         ) {
+    const location = 'us-central1';
+    // Match collection vector_schema dimensions; zeros avoid inventing content.
+    final zeroEmbedding = List<Object?>.filled(768, 0.0);
+
     final apiVectorSearch = add(
       GoogleProjectService(
         localName: 'api_vectorsearch',
@@ -33,13 +40,13 @@ final class VectorSearchStack extends Stack {
       ),
     );
 
-    add(
+    final collection = add(
       GoogleVectorSearchCollection(
         localName: 'docs',
-        location: TfArg.literal('us-central1'),
+        location: TfArg.literal(location),
         collectionId: TfArg.literal('terradart-docs'),
         displayName: TfArg.literal('TerraDart docs'),
-        description: TfArg.literal('Schema-only Vector Search collection'),
+        description: TfArg.literal('Vector Search collection + data object'),
         dataSchema: TfArg.literal(
           '{"type":"object","properties":{"title":{"type":"string"},'
           '"plot":{"type":"string"}}}',
@@ -54,6 +61,31 @@ final class VectorSearchStack extends Stack {
         ],
         deletionPolicy: TfArg.literal('DELETE'),
         dependsOn: [ResourceDependency(apiVectorSearch)],
+      ),
+    );
+
+    add(
+      GoogleVectorSearchDataObject(
+        localName: 'sample_doc',
+        location: TfArg.literal(location),
+        collectionId: TfArg.ref(collection.collectionIdRef),
+        dataObjectId: TfArg.literal('terradart-sample-doc'),
+        data: TfArg.literal(
+          '{"title":"TerraDart smoke","plot":"Schema coverage only"}',
+        ),
+        vectors: [
+          VectorSearchDataObjectVectors(
+            fieldName: TfArg.literal('text_embedding'),
+            dense: VectorSearchDataObjectVectorsDense(
+              values: TfArg.literal(zeroEmbedding),
+            ),
+          ),
+        ],
+        deletionPolicy: TfArg.literal('DELETE'),
+        dependsOn: [
+          ResourceDependency(apiVectorSearch),
+          ResourceDependency(collection),
+        ],
       ),
     );
   }

--- a/tool/apply_smoke_skip.yaml
+++ b/tool/apply_smoke_skip.yaml
@@ -106,3 +106,11 @@ oracle_goldengate_quickstart: GoldenGate apply needs Oracle zone entitlement and
 # this must NOT apply even in the full sweep, so it belongs here. synth +
 # terraform validate still cover it.
 license_manager_quickstart: reserves Office SPLA licenses (license_count, active) that bill for the configuration's existence with no VM attached; a brief apply→destroy still accrues high Microsoft license fees — synth + terraform validate cover it instead
+
+# --- Vector Search DataObject meters Write Ops + payload storage ---
+# Collection-only was applyable (~$0 schema). Adding google_vector_search_data_object
+# for synth coverage introduces Write Ops SKU C1E5-1A7F-E9B3 ~$0.18/count plus
+# Data Stored 1AE9-553C-C219 while the object exists. Skip the whole example
+# (apply is example-scoped) so personal validate projects do not accrue those
+# meters; synth + terraform validate still cover collection + data object.
+vector_quickstart: Vector Search DataObject meters Write Ops (C1E5-1A7F-E9B3 ~$0.18/count) and payload storage; apply skipped intentionally — synth + terraform validate cover google_vector_search_collection and google_vector_search_data_object

--- a/tool/example_debt.yaml
+++ b/tool/example_debt.yaml
@@ -127,7 +127,6 @@ GoogleSccV2ProjectNotificationConfig: requires an organization-activated Securit
 # Vector Search indexes default dedicated_infrastructure to two
 # PERFORMANCE_OPTIMIZED replicas (hourly capacity-unit SKUs). vector_quickstart
 # exercises the schema-only collection instead.
-GoogleVectorSearchDataObject: gcp-cost Vector Search 0181-3AAD-0CB9 Data Stored 1AE9-553C-C219 $0.3/GiBy.mo + Write Ops C1E5-1A7F-E9B3 $0.18/count — deferred quickstart (vector_quickstart covers GoogleVectorSearchCollection only; no examples/** change)
 GoogleVectorSearchIndex: API defaults dedicated_infrastructure to PERFORMANCE_OPTIMIZED with min/max_replica_count=2 (Vector Search V2 capacity units billed hourly, e.g. SKU 2ECA-1449-C093 $0.065/h); including the index would force apply_smoke_pr_skip and block wave auto-merge — vector_quickstart covers GoogleVectorSearchCollection only
 
 # Secure Source Manager instances are existence-billed at ~$1000/mo (Fixed

--- a/website/src/content/docs/docs/coverage.md
+++ b/website/src/content/docs/docs/coverage.md
@@ -1538,7 +1538,7 @@ Import per service: `import 'package:terradart_google/<barrel>.dart';`
 | Terraform type | Dart factory | Example |
 | --- | --- | --- |
 | `google_vector_search_collection` | `GoogleVectorSearchCollection` | [vector_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/vector_quickstart) |
-| `google_vector_search_data_object` | `GoogleVectorSearchDataObject` | — |
+| `google_vector_search_data_object` | `GoogleVectorSearchDataObject` | [vector_quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/vector_quickstart) |
 | `google_vector_search_index` | `GoogleVectorSearchIndex` | — |
 
 ## vertex_ai


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pays down `GoogleVectorSearchDataObject` debt by extending [`examples/vector_quickstart`](examples/vector_quickstart/) with one sample data object (zero dense embedding).

**Apply intentionally skipped:** `vector_quickstart` is added to [`tool/apply_smoke_skip.yaml`](tool/apply_smoke_skip.yaml). DataObject meters Write Ops (`C1E5-1A7F-E9B3` ~$0.18/count) and payload storage; apply is example-scoped, so this also drops live apply proof for the parent collection. Synth + `terraform validate` still cover both factories.

`google_vector_search_index` remains in `tool/example_debt.yaml` (hourly capacity units).

## Trade-off (explicit)

| Before | After |
| --- | --- |
| Collection applyable (~$0 schema) | Whole example skip-listed |
| DataObject in debt | DataObject in synth |

## Test plan

- [x] Local synth + `terraform validate`
- [x] `tool/apply_smoke_test.sh` (skip entry honored)
- [x] `tool/agent_verify.sh`
- [ ] CI green (apply-smoke should skip `vector_quickstart`)
- [ ] Squash-merge when green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99494d9f-7d5e-4d9d-9ba1-e21e08299343?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99494d9f-7d5e-4d9d-9ba1-e21e08299343&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

