### PR TITLE
test(coverage): stop requiring a live uncurated GA sentinel

### DIFF
--- a/packages/terradart_codegen/lib/src/codegen/barrels/barrels.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/barrels/barrels.yaml
@@ -438,8 +438,6 @@ barrels:
       /// Identity Platform — project Auth config, multi-tenant realms,
       /// tenant OIDC IdP metadata, leftover default-supported / SAML IdP
       /// configs, and Cloud Identity groups / memberships (apply-excluded).
-      /// `google_identity_platform_oauth_idp_config` stays uncurated as
-      /// the coverage-fixture sentinel.
   integrations:
     doc: |-
       /// Application Integration — provision a regional client

--- a/packages/terradart_coverage/test/fixtures/real_plan_src/main.tf
+++ b/packages/terradart_coverage/test/fixtures/real_plan_src/main.tf
@@ -7,9 +7,10 @@
 #   terraform plan -out=tfplan.bin      # no credentials needed (managed resources only)
 #   terraform show -json tfplan.bin > ../real_plan_show.json
 #
-# Mixes curated terradart_google resources with not-in-catalog ones across a
-# root module and a child module, so the coverage report exercises both the
-# supported and the uncovered paths.
+# Mixes resources across a root module and a child module so the coverage
+# report exercises Terraform's real document shape. Do not keep a live GA
+# type uncurated just to populate notInCatalog — that path is tested with
+# a fabricated type in coverage_report_test.dart.
 
 terraform {
   required_providers {
@@ -62,7 +63,7 @@ resource "google_compute_router_nat" "nat" {
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }
 
-# --- Not curated yet (expected: not in catalog) ---
+# --- Still uncurated in terradart_google (not a required sentinel) ---
 
 resource "google_identity_platform_oauth_idp_config" "hello" {
   name      = "oidc.hello"

--- a/packages/terradart_coverage/test/real_plan_test.dart
+++ b/packages/terradart_coverage/test/real_plan_test.dart
@@ -14,11 +14,11 @@ import 'package:test/test.dart';
 /// many top-level keys we intentionally ignore), unlike the hand-written maps
 /// in the other tests.
 ///
-/// At capture time (after curating `google_dialogflow_conversation_profile`)
-/// the not-in-catalog type is `google_identity_platform_oauth_idp_config`.
-/// The assertions below deliberately avoid pinning that exact percentage
-/// so the test survives catalog growth; they pin the catalog-independent
-/// parse and the structural invariants instead.
+/// Assertions pin the catalog-independent parse and structural invariants.
+/// They do **not** require a live uncurated GA type — keeping one resource
+/// out of the catalog just to populate `notInCatalog` is the wrong ratchet.
+/// The uncovered path is covered by `coverage_report_test` with the
+/// fabricated type `google_notreal_thing`.
 void main() {
   final json =
       jsonDecode(File('test/fixtures/real_plan_show.json').readAsStringSync())
@@ -59,16 +59,9 @@ void main() {
       );
       expect(report.summary.supportedTypes, report.supported.length);
 
-      // The real plan mixes curated and uncurated types, so both lists fire.
+      // This plan always includes curated types. `notInCatalog` may be
+      // empty once every type in the fixture is curated — that is fine.
       expect(report.supported, isNotEmpty);
-      expect(
-        report.notInCatalog,
-        isNotEmpty,
-        reason:
-            'fixture is expected to contain at least one uncurated type; '
-            'if terradart_google has since curated them, regenerate the '
-            'fixture',
-      );
 
       // google_storage_bucket is a foundational resource — always curated.
       expect(

--- a/packages/terradart_google/lib/identity.dart
+++ b/packages/terradart_google/lib/identity.dart
@@ -3,8 +3,6 @@
 /// Identity Platform — project Auth config, multi-tenant realms,
 /// tenant OIDC IdP metadata, leftover default-supported / SAML IdP
 /// configs, and Cloud Identity groups / memberships (apply-excluded).
-/// `google_identity_platform_oauth_idp_config` stays uncurated as
-/// the coverage-fixture sentinel.
 library;
 
 export 'src/identity/google_cloud_identity_group.dart'

--- a/tool/curation_backlog.yaml
+++ b/tool/curation_backlog.yaml
@@ -37,12 +37,12 @@
 # path.
 #
 # 2026-08-15 remaining-uncurated batch: the other 89 GA-fixture leftovers
-# (logging org/folder/billing, Identity Platform IdP configs except the
-# coverage sentinel, billing, DMS, Datastream, Assured Workloads, Cloud
-# Domains, …) shipped on the apply-excluded path. The only remaining
-# uncurated GA type is `google_identity_platform_oauth_idp_config`
-# (coverage-report sentinel in terradart_coverage). An empty backlog is
-# a normal wave-shipper no-op until the weekly schema bump appends newly
+# (logging org/folder/billing, Identity Platform IdP configs except
+# `google_identity_platform_oauth_idp_config`, billing, DMS, Datastream,
+# Assured Workloads, Cloud Domains, …) shipped on the apply-excluded path.
+# That last type is ordinary leftover, not a coverage sentinel — the
+# uncovered report path uses a fabricated type. An empty backlog is a
+# normal wave-shipper no-op until the weekly schema bump appends newly
 # detected types.
 
 entries:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`terradart_coverage`'s real-plan test no longer requires a live uncurated GA type so `notInCatalog` stays non-empty.

The uncovered path is already covered by `coverage_report_test` with the fabricated type `google_notreal_thing`. Keeping `google_identity_platform_oauth_idp_config` out of the catalog was the wrong ratchet.

This PR does **not** curate that last leftover. It only unblocks doing so.

## Test plan

- [x] `dart test` in `packages/terradart_coverage` — 34 passed
- [x] `terradart wrap --check` — 1926 files match
- [x] `tool/agent_verify.sh` — `agent_verify: OK`
- [x] GitHub CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffa93-ed55-7023-b05f-03de890397c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffa93-ed55-7023-b05f-03de890397c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

