### PR TITLE
docs: say the GA google catalog is filled

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for taking time to look at this. terradart is an **alpha** single-maintai
 
 terradart ships one consumer surface:
 
-- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**1332 curated resource factories + 461 data sources** as of 0.24.x). Bug fixes, tests, and doc improvements welcome. New resources land via `terradart wrap` overrides — open an issue first to discuss scope.
+- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**1332 curated resource factories + 461 data sources** as of 0.24.x). Bug fixes, tests, and doc improvements welcome. The GA catalog is filled; new `google-beta` types land via `terradart wrap` overrides — open an issue first to discuss scope.
 
 Within a **minor** line (`^0.24.x`), no breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (the alpha change policy — see [status](https://terradart.dev/docs/status/)).
 

--- a/README.md
+++ b/README.md
@@ -227,11 +227,11 @@ Docs: [terradart.dev/docs/agent/](https://terradart.dev/docs/agent/)
 
 ## What ships
 
-[`terradart_google`](packages/terradart_google/README.md) ships **1332 curated resource factories + 461 data sources** (1793 catalog entries) across per-service barrels (`compute`, `pubsub`, `cloud_run`, `bigquery`, …). Surfaces include Compute, GKE, BigQuery, Cloud Run, IAM, networking, and Vertex AI.
+[`terradart_google`](packages/terradart_google/README.md) ships **1332 curated resource factories + 461 data sources** (1793 catalog entries) across per-service barrels (`compute`, `pubsub`, `cloud_run`, `bigquery`, …). The GA `hashicorp/google` catalog is filled; `google-beta` is later.
 
 The full factory table with example pointers is on [Coverage](https://terradart.dev/docs/coverage/). In Dart, discover factories via `package:terradart_google/catalog.dart` (`terradartCatalog`). CI verifies regeneration is byte-deterministic via `terradart wrap --check`.
 
-For any other `google_*` resource: open a [feature request](https://github.com/nozomi-koborinai/terradart/issues/new/choose) to discuss adding it to the curated surface.
+For `google-beta` types, open a [feature request](https://github.com/nozomi-koborinai/terradart/issues/new/choose) to discuss adding them.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 [![Schema Bump](https://github.com/nozomi-koborinai/terradart/actions/workflows/schema-bump.yml/badge.svg)](https://github.com/nozomi-koborinai/terradart/actions/workflows/schema-bump.yml)
 
 ```dart
+// docs:pitch:start
 // infra/lib/app_infra.dart
 // A Stack is one Terraform root module of GCP resources, written in Dart.
 import 'package:terradart_core/terradart_core.dart';
@@ -99,6 +100,7 @@ final class AppInfraStack extends Stack {
     ));
   }
 }
+// docs:pitch:end
 ```
 
 Cloud SQL, IAM, and a multi-container Cloud Run service with a `cloud-sql-proxy` sidecar — the kind of stack you would otherwise maintain in HCL or the console. Per-service imports (`cloud_run.dart`, `cloud_sql.dart`, …) keep IDE completion scoped; the legacy `package:terradart_google/terradart_google.dart` barrel re-export remains supported.
@@ -227,7 +229,7 @@ Docs: [terradart.dev/docs/agent/](https://terradart.dev/docs/agent/)
 
 ## What ships
 
-[`terradart_google`](packages/terradart_google/README.md) ships **1332 curated resource factories + 461 data sources** (1793 catalog entries) across per-service barrels (`compute`, `pubsub`, `cloud_run`, `bigquery`, …). The GA `hashicorp/google` catalog is filled; `google-beta` is later.
+[`terradart_google`](packages/terradart_google/README.md) ships **1332 curated resource factories + 461 data sources** (1793 catalog entries) across per-service barrels (`compute`, `pubsub`, `cloud_run`, `bigquery`, …). The GA `hashicorp/google` catalog is filled; `google-beta` is coming soon.
 
 The full factory table with example pointers is on [Coverage](https://terradart.dev/docs/coverage/). In Dart, discover factories via `package:terradart_google/catalog.dart` (`terradartCatalog`). CI verifies regeneration is byte-deterministic via `terradart wrap --check`.
 

--- a/cookbook/single-project-app/lib/service.dart
+++ b/cookbook/single-project-app/lib/service.dart
@@ -7,7 +7,6 @@ import 'package:terradart_google/cloud_sql.dart';
 import 'package:terradart_google/iam.dart';
 import 'package:terradart_google/secret_manager.dart';
 
-// docs:pitch:start (rendered on terradart.dev's landing page — keep compiling)
 GoogleCloudRunV2Service buildCloudRunService({
   required GoogleServiceAccount runSa,
   required GoogleSqlDatabaseInstance sqlInstance,
@@ -58,7 +57,6 @@ GoogleCloudRunV2Service buildCloudRunService({
         ],
       ),
     );
-// docs:pitch:end
 
 GoogleCloudRunV2ServiceIamMember buildCloudRunInvoker(
   GoogleCloudRunV2Service coffeeService,

--- a/packages/terradart_codegen/README.md
+++ b/packages/terradart_codegen/README.md
@@ -8,7 +8,7 @@ This package ships the `terradart` CLI for **maintainers** and contributors cura
 - **`terradart wrap-init`** — scaffold a new wrapper override YAML from schema + MM hints.
 - **`terradart wrap-promote`** — propose `enum_values` and `dartTypeOverrides` blocks for human review.
 
-End users depend on [`terradart_google`](https://pub.dev/packages/terradart_google) directly; they do not run generation locally. Missing resources are curation requests (open a [feature issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose)).
+End users depend on [`terradart_google`](https://pub.dev/packages/terradart_google) directly; they do not run generation locally. The GA `hashicorp/google` catalog is filled; `google-beta` types are later (open a [feature issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose)).
 
 ## Installation
 

--- a/packages/terradart_codegen/README.md
+++ b/packages/terradart_codegen/README.md
@@ -8,7 +8,7 @@ This package ships the `terradart` CLI for **maintainers** and contributors cura
 - **`terradart wrap-init`** — scaffold a new wrapper override YAML from schema + MM hints.
 - **`terradart wrap-promote`** — propose `enum_values` and `dartTypeOverrides` blocks for human review.
 
-End users depend on [`terradart_google`](https://pub.dev/packages/terradart_google) directly; they do not run generation locally. The GA `hashicorp/google` catalog is filled; `google-beta` types are later (open a [feature issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose)).
+End users depend on [`terradart_google`](https://pub.dev/packages/terradart_google) directly; they do not run generation locally. The GA `hashicorp/google` catalog is filled; `google-beta` types are coming soon (open a [feature issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose)).
 
 ## Installation
 

--- a/packages/terradart_google/README.md
+++ b/packages/terradart_google/README.md
@@ -2,7 +2,7 @@
 
 Ships **1332 curated resource factories + 461 data sources** (1793 catalog entries)
 
-The GA `hashicorp/google` catalog is filled. The full factory table with example pointers is on [Coverage](https://terradart.dev/docs/coverage/). Discover factories programmatically via `package:terradart_google/catalog.dart` (`terradartCatalog`).
+The GA `hashicorp/google` catalog is filled. `google-beta` is coming soon. The full factory table with example pointers is on [Coverage](https://terradart.dev/docs/coverage/). Discover factories programmatically via `package:terradart_google/catalog.dart` (`terradartCatalog`).
 
 ## How resources are built
 

--- a/packages/terradart_google/README.md
+++ b/packages/terradart_google/README.md
@@ -2,13 +2,13 @@
 
 Ships **1332 curated resource factories + 461 data sources** (1793 catalog entries)
 
-The full factory table with example pointers is on [Coverage](https://terradart.dev/docs/coverage/). Discover factories programmatically via `package:terradart_google/catalog.dart` (`terradartCatalog`).
+The GA `hashicorp/google` catalog is filled. The full factory table with example pointers is on [Coverage](https://terradart.dev/docs/coverage/). Discover factories programmatically via `package:terradart_google/catalog.dart` (`terradartCatalog`).
 
 ## How resources are built
 
 Factory wrappers under `lib/src/<service>/` are emitted by `terradart wrap` from curated overrides in [`terradart_codegen`](https://pub.dev/packages/terradart_codegen). They are committed so consumers depend on `terradart_google` without running codegen.
 
-CI verifies determinism via `terradart wrap --check`. For any other `google_*` resource, open an issue to request curation.
+CI verifies determinism via `terradart wrap --check`. For `google-beta` types, open an issue to request curation.
 
 Runtime primitives (`Stack`, `TfArg`, `writeTo`) live in [`terradart_core`](https://pub.dev/packages/terradart_core).
 

--- a/website/src/components/PitchCode.astro
+++ b/website/src/components/PitchCode.astro
@@ -15,27 +15,21 @@ const terradartPaper = {
 };
 
 /**
- * LP pitch snippet — extracted at build time from the cookbook's
- * single-project-app recipe (analyzed on every PR, apply-verified against a
- * real GCP project). Single source: editing the recipe updates the landing
- * page; removing the markers fails the site build. No hand-maintained copy.
+ * LP pitch snippet — extracted at build time from the repository README.
+ * Single source: editing the README fence updates the landing page;
+ * removing the markers fails the site build. No hand-maintained copy.
  */
-import serviceSource from "../../../cookbook/single-project-app/lib/service.dart?raw";
+import readmeSource from "../../../README.md?raw";
 
 const startMarker = "// docs:pitch:start";
 const endMarker = "// docs:pitch:end";
-const sourceLines = serviceSource.split("\n");
+const sourceLines = readmeSource.split("\n");
 const startIndex = sourceLines.findIndex((l) => l.includes(startMarker));
 const endIndex = sourceLines.findIndex((l) => l.includes(endMarker));
 if (startIndex < 0 || endIndex < 0 || endIndex <= startIndex) {
-  throw new Error(
-    "PitchCode: docs:pitch markers not found in cookbook/single-project-app/lib/service.dart",
-  );
+  throw new Error("PitchCode: docs:pitch markers not found in README.md");
 }
-const code = [
-  "// cookbook/single-project-app/lib/service.dart (excerpt — real, apply-verified code)",
-  ...sourceLines.slice(startIndex + 1, endIndex),
-].join("\n");
+const code = sourceLines.slice(startIndex + 1, endIndex).join("\n");
 
 const highlightedHtml = await codeToHtml(code, {
   lang: "dart",
@@ -48,11 +42,10 @@ const highlightedHtml = await codeToHtml(code, {
     <p class="section-label">Example</p>
     <h2 class="display-section">GCP resources in Dart</h2>
     <p class="pitch-code-lead">
-      A Cloud Run service wired to Cloud SQL with its password pulled from
-      Secret Manager&nbsp;&mdash; typed helper classes, sealed env-var sources, and
-      enums where the provider documents values. This is not marketing pseudocode:
-      it is an excerpt of a cookbook recipe that CI analyzes on every pull request
-      and applies against a real GCP project.
+      Cloud SQL, IAM, and a multi-container Cloud Run service with a
+      <code>cloud-sql-proxy</code> sidecar&nbsp;&mdash; a
+      <code>final class … extends Stack</code>. Same snippet as the
+      repository README.
     </p>
     <div class="pitch-code-figure">
       <div class="terra-stratum" aria-hidden="true"></div>
@@ -61,7 +54,7 @@ const highlightedHtml = await codeToHtml(code, {
     <p class="pitch-code-meta">
       <code>terradart_google</code> ships typed factories for the
       <strong>GA</strong> HashiCorp <code>google</code> provider catalog. The
-      <code>google-beta</code> provider is later. The
+      <code>google-beta</code> provider is coming soon. The
       full factory list with runnable examples is on
       <a href="/docs/coverage/" class="link-mark">Coverage</a>; complete stacks live in the
       <a

--- a/website/src/components/PitchCode.astro
+++ b/website/src/components/PitchCode.astro
@@ -59,8 +59,9 @@ const highlightedHtml = await codeToHtml(code, {
       <div class="pitch-code-wrap" set:html={highlightedHtml} />
     </div>
     <p class="pitch-code-meta">
-      <code>terradart_google</code> ships a <strong>curated</strong> subset of the
-      HashiCorp <code>google</code> provider&nbsp;&mdash; not every resource type yet. The
+      <code>terradart_google</code> ships typed factories for the
+      <strong>GA</strong> HashiCorp <code>google</code> provider catalog. The
+      <code>google-beta</code> provider is later. The
       full factory list with runnable examples is on
       <a href="/docs/coverage/" class="link-mark">Coverage</a>; complete stacks live in the
       <a

--- a/website/src/content/docs/docs/agent/index.md
+++ b/website/src/content/docs/docs/agent/index.md
@@ -13,7 +13,7 @@ It is built with [genkit_mcp](https://pub.dev/packages/genkit_mcp) (Genkit's MCP
 graph LR
   agent["coding agent<br/>(Claude Code / Cursor / Claude Desktop)"]
   mcp["terradart-mcp<br/>list_barrels · list_resources<br/>get_resource_schema · get_quickstart<br/>check_coverage"]
-  catalog["static catalog in terradart_google<br/>334 entries · 59 service barrels"]
+  catalog["static catalog in terradart_google<br/>1793 entries · 131 service barrels"]
   agent -->|stdio JSON-RPC MCP| mcp
   mcp -->|reads in-process| catalog
 ```

--- a/website/src/content/docs/docs/architecture.mdx
+++ b/website/src/content/docs/docs/architecture.mdx
@@ -61,7 +61,7 @@ final class AppInfraStack extends Stack { /* ... */ }
 
 ## Provider integration
 
-[`terradart_google`](https://pub.dev/packages/terradart_google) ships a **curated** subset of the HashiCorp [`google`](https://registry.terraform.io/providers/hashicorp/google/latest) provider — typed factories for common services, expanded release by release. It does not wrap every resource block in the upstream provider yet. See [status](/docs/status/) and the [package README](https://pub.dev/packages/terradart_google) for what is available today; [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook) add fuller stacks over time.
+[`terradart_google`](https://pub.dev/packages/terradart_google) ships typed factories for the **GA** HashiCorp [`google`](https://registry.terraform.io/providers/hashicorp/google/latest) provider catalog. See [status](/docs/status/) and the [package README](https://pub.dev/packages/terradart_google) for counts; the full list is on [Coverage](/docs/coverage/). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook).
 
 TerraDart depends on the Google Terraform provider via two upstream sources, both reconciled automatically on a weekly cadence.
 
@@ -78,7 +78,7 @@ graph LR
 
 The MM YAML overlay carries metadata that the provider schema does not surface — `sensitive_fields`, `force_new`, free-form description text. `terradart_codegen` merges both inputs into typed `<resource>.schema.dart` files that compose into the `terradart_google` package.
 
-Provider tracking is pinned to GA `~> 7.0`. The `-beta` provider is not yet curated; resources that only exist in beta are documented in `tool/mm_yaml_sources.yaml` with an `upstream: null` marker awaiting future opt-in.
+Provider tracking is pinned to GA `~> 7.0`. The `-beta` provider is later; resources that only exist in beta are documented in `tool/mm_yaml_sources.yaml` with an `upstream: null` marker.
 
 A weekly GitHub Actions workflow (`.github/workflows/schema-bump.yml`) runs every Monday morning JST. It detects new `terraform-provider-google` v7 releases and MM YAML overlay changes, refreshes the local schema + MM fixtures, runs `terradart wrap --check`, and opens a single drift-report PR if anything needs maintainer attention. Quiet weeks produce no PR.
 

--- a/website/src/content/docs/docs/architecture.mdx
+++ b/website/src/content/docs/docs/architecture.mdx
@@ -78,7 +78,7 @@ graph LR
 
 The MM YAML overlay carries metadata that the provider schema does not surface — `sensitive_fields`, `force_new`, free-form description text. `terradart_codegen` merges both inputs into typed `<resource>.schema.dart` files that compose into the `terradart_google` package.
 
-Provider tracking is pinned to GA `~> 7.0`. The `-beta` provider is later; resources that only exist in beta are documented in `tool/mm_yaml_sources.yaml` with an `upstream: null` marker.
+Provider tracking is pinned to GA `~> 7.0`. The `-beta` provider is coming soon; resources that only exist in beta are documented in `tool/mm_yaml_sources.yaml` with an `upstream: null` marker.
 
 A weekly GitHub Actions workflow (`.github/workflows/schema-bump.yml`) runs every Monday morning JST. It detects new `terraform-provider-google` v7 releases and MM YAML overlay changes, refreshes the local schema + MM fixtures, runs `terradart wrap --check`, and opens a single drift-report PR if anything needs maintainer attention. Quiet weeks produce no PR.
 

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -26,7 +26,7 @@ Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch, t
 dart pub get
 ```
 
-Non-curated `google_*` resources are not generated locally. Request new factories via a [GitHub feature issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
+The GA `hashicorp/google` catalog is filled. `google-beta` types are later and are not generated locally — request them via a [GitHub feature issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
 
 ## 2. Define a Stack
 

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -26,7 +26,7 @@ Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch, t
 dart pub get
 ```
 
-The GA `hashicorp/google` catalog is filled. `google-beta` types are later and are not generated locally — request them via a [GitHub feature issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
+The GA `hashicorp/google` catalog is filled. `google-beta` types are coming soon and are not generated locally — request them via a [GitHub feature issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
 
 ## 2. Define a Stack
 

--- a/website/src/content/docs/docs/how-its-built.mdx
+++ b/website/src/content/docs/docs/how-its-built.mdx
@@ -47,9 +47,9 @@ auditable.**
 - Anything the schema or Magic Modules can state — parameters, enum values,
   output getters, nested block shapes, documentation — is *derived*, so it
   moves automatically when upstream moves.
-- Human decisions — which resources to curate, how to model an
-  exactly-one-of block as a sealed class hierarchy, which surfaces to freeze
-  deliberately — live in thin, reviewable override files.
+- Human decisions — how to model an exactly-one-of block as a sealed class
+  hierarchy, which surfaces to freeze deliberately, and whether to opt into
+  `google-beta` later — live in thin, reviewable override files.
 - Every escape hatch is a **fail-closed ledger**: skipped examples, frozen
   surfaces, cost classifications, and coverage debts are recorded lines with
   reasons, and CI fails when an entry goes stale. Forgetting is impossible to

--- a/website/src/content/docs/docs/how-its-built.mdx
+++ b/website/src/content/docs/docs/how-its-built.mdx
@@ -49,7 +49,7 @@ auditable.**
   moves automatically when upstream moves.
 - Human decisions — how to model an exactly-one-of block as a sealed class
   hierarchy, which surfaces to freeze deliberately, and whether to opt into
-  `google-beta` later — live in thin, reviewable override files.
+  `google-beta` (coming soon) — live in thin, reviewable override files.
 - Every escape hatch is a **fail-closed ledger**: skipped examples, frozen
   surfaces, cost classifications, and coverage debts are recorded lines with
   reasons, and CI fails when an entry goes stale. Forgetting is impossible to

--- a/website/src/content/docs/docs/status.md
+++ b/website/src/content/docs/docs/status.md
@@ -19,7 +19,7 @@ There are no SemVer guarantees until **v1.0.0**, but breaking changes land only 
 
 - Breaking changes to the public Dart API or the emitted Terraform JSON land only on **minor** bumps, each with a [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) section; patch releases within `^0.N.x` are safe to take.
 - Use hosted `^0.24.x` carets on [pub.dev](https://pub.dev/packages/terradart_core) — not legacy `0.x.y-dev` pre-release tags.
-- Only the **curated** `terradart_google` surface is supported for users; non-curated resources require a curation request.
+- Only the **curated** `terradart_google` surface is supported for users. The GA `hashicorp/google` catalog is filled; `google-beta` is later.
 
 ## Change policy (from alpha onward)
 

--- a/website/src/content/docs/docs/status.md
+++ b/website/src/content/docs/docs/status.md
@@ -19,7 +19,7 @@ There are no SemVer guarantees until **v1.0.0**, but breaking changes land only 
 
 - Breaking changes to the public Dart API or the emitted Terraform JSON land only on **minor** bumps, each with a [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) section; patch releases within `^0.N.x` are safe to take.
 - Use hosted `^0.24.x` carets on [pub.dev](https://pub.dev/packages/terradart_core) — not legacy `0.x.y-dev` pre-release tags.
-- Only the **curated** `terradart_google` surface is supported for users. The GA `hashicorp/google` catalog is filled; `google-beta` is later.
+- Only the **curated** `terradart_google` surface is supported for users. The GA `hashicorp/google` catalog is filled; `google-beta` is coming soon.
 
 ## Change policy (from alpha onward)
 

--- a/website/src/content/docs/docs/why-terradart.md
+++ b/website/src/content/docs/docs/why-terradart.md
@@ -96,7 +96,7 @@ HCL has provider schema types; CDKTF bindings are typed in TypeScript and other 
 
 ## Curated provider coverage
 
-[`terradart_google`](https://pub.dev/packages/terradart_google) wraps the **GA** HashiCorp `google` provider catalog — **1332 curated resource factories + 461 data sources** (1793 catalog entries). The `google-beta` provider is later. The full factory list with example pointers is on [Coverage](/docs/coverage/); see also [status](/docs/status/) and [Architecture — Provider integration](/docs/architecture/#provider-integration). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook) (both expanding). Upgrading across minors? Read [Migrating](/docs/migrating/) first.
+[`terradart_google`](https://pub.dev/packages/terradart_google) wraps the **GA** HashiCorp `google` provider catalog — **1332 curated resource factories + 461 data sources** (1793 catalog entries). The `google-beta` provider is coming soon. The full factory list with example pointers is on [Coverage](/docs/coverage/); see also [status](/docs/status/) and [Architecture — Provider integration](/docs/architecture/#provider-integration). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook) (both expanding). Upgrading across minors? Read [Migrating](/docs/migrating/) first.
 
 ## Non-goals
 

--- a/website/src/content/docs/docs/why-terradart.md
+++ b/website/src/content/docs/docs/why-terradart.md
@@ -96,7 +96,7 @@ HCL has provider schema types; CDKTF bindings are typed in TypeScript and other 
 
 ## Curated provider coverage
 
-[`terradart_google`](https://pub.dev/packages/terradart_google) does not wrap every resource in the upstream HashiCorp `google` provider. It ships **typed factories for a growing, battle-tested subset** — **1332 curated resource factories + 461 data sources** (1793 catalog entries). The full factory list with example pointers is on [Coverage](/docs/coverage/); see also [status](/docs/status/) and [Architecture — Provider integration](/docs/architecture/#provider-integration). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook) (both expanding). Upgrading across minors? Read [Migrating](/docs/migrating/) first.
+[`terradart_google`](https://pub.dev/packages/terradart_google) wraps the **GA** HashiCorp `google` provider catalog — **1332 curated resource factories + 461 data sources** (1793 catalog entries). The `google-beta` provider is later. The full factory list with example pointers is on [Coverage](/docs/coverage/); see also [status](/docs/status/) and [Architecture — Provider integration](/docs/architecture/#provider-integration). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook) (both expanding). Upgrading across minors? Read [Migrating](/docs/migrating/) first.
 
 ## Non-goals
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Public docs still said `terradart_google` was a growing subset of HashiCorp `google`. The GA catalog on `main` is filled (1332 resources + 461 data sources). This PR updates that copy and the landing-page pitch.

## What changed

Say **the GA `hashicorp/google` catalog is filled** and **`google-beta` is coming soon** in:

- Why TerraDart, Architecture, Getting Started, Status, How it's built
- Landing-page pitch (`PitchCode.astro`)
- Root README, CONTRIBUTING, `terradart_google` / `terradart_codegen` READMEs
- Agent mermaid catalog counts (334/59 → 1793/131)

Landing example now extracts the repository README `AppInfraStack` (Cloud Run + Cloud SQL + IAM), not the cookbook coffee helper.

## Out of scope

- No version bump, CHANGELOG, or GitHub release (docs-only)
- No Cloudflare / other-provider teaser
- Landing-page **Pre-alpha** badge is unchanged (separate stale copy)

## Verify

- `dart tool/check_docs_consistency.dart` — OK
- `bun run build` in `website/` — OK; `dist/index.html` contains `AppInfraStack` and `coming soon`, not `coffee_service`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffa93-ed55-7023-b05f-03de890397c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffa93-ed55-7023-b05f-03de890397c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

