### PR TITLE
docs(website): show Alpha instead of Pre-alpha

### DIFF
--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -13,7 +13,7 @@
       />
     </a>
     <nav class="site-header-nav">
-      <span class="pre-alpha pre-alpha--header">Pre-alpha</span>
+      <span class="phase-badge phase-badge--header">Alpha</span>
       <a href="/docs/" class="site-header-link">Docs</a>
       <a
         href="https://github.com/nozomi-koborinai/terradart"

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -5,7 +5,7 @@ import HeroMark from "./HeroMark.astro";
 <section class="hero">
   <div class="container-edit hero-inner">
     <div class="hero-copy">
-      <p class="pre-alpha">Pre-alpha</p>
+      <p class="phase-badge">Alpha</p>
 
       <h1 class="display-hero">
         <span class="display-hero-line">Type-safe IaC</span>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -56,7 +56,7 @@ import Footer from "../components/Footer.astro";
         },
         {
           label: "Project status",
-          cells: ["Pre-alpha", "Mature", "Archived 2025", "Active"],
+          cells: ["Alpha", "Mature", "Archived 2025", "Active"],
         },
       ]}
     />

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -94,7 +94,7 @@
     margin: 2rem 0 2.25rem;
   }
 
-  .pre-alpha {
+  .phase-badge {
     display: inline-block;
     font-size: 0.75rem;
     letter-spacing: 0.12em;
@@ -103,7 +103,7 @@
     margin-bottom: 1.25rem;
   }
 
-  .pre-alpha--header {
+  .phase-badge--header {
     margin-bottom: 0;
     font-size: 0.6875rem;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The landing page still said **Pre-alpha** while Status, README, and Getting Started already describe the **0.24.x alpha** line.

## What changed

- Hero badge, header badge, and comparison table: Pre-alpha → Alpha
- CSS class renamed `pre-alpha` → `phase-badge` so the hook is not stuck on the old name

## Out of scope

- No version bump (still 0.24.x)
- Historical CHANGELOG “pre-alpha” notes left as history
- Not beta

## Verify

- `bun run build` in `website/`: `dist/index.html` has `Alpha` badges, `Pre-alpha` count is 0
- `dart tool/check_docs_consistency.dart` — OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffa93-ed55-7023-b05f-03de890397c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffa93-ed55-7023-b05f-03de890397c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

