### PR TITLE
chore: lockstep 0.25.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to file. terradart is **alpha** on
-        **0.24.x** today. Single-maintainer;
+        **0.25.x** today. Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         **PII note**: synthesized `.tf.json`, error output, and schema excerpts

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to file. terradart is **alpha** on
-        **0.24.x** today. Single-maintainer;
+        **0.25.x** today. Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         Feature requests are welcome — no timeline promises, but they help

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to ask. terradart is **alpha** on
-        **0.24.x** today. Single-maintainer;
+        **0.25.x** today. Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         Docs: https://terradart.dev/docs/getting-started/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to terradart are documented here. The format follows [Keep a
 
 Per-package changelogs live alongside each package and are the system of record for `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_agent`, and `terradart_coverage` — this top-level file summarises cross-cutting milestones.
 
+## [0.25.0] - 2026-08-15
+
+Lockstep release across the workspace. **No breaking changes** vs `0.24.0`.
+
+The GA HashiCorp `google` provider catalog is filled. `google-beta` is coming soon.
+
+### Added
+
+- **`terradart_google`** — remaining GA `hashicorp/google` resources and data sources. Catalog: **1332 curated resource factories + 461 data sources** (1793 catalog entries; 131 service barrels).
+- **Examples** — leftover and data-source stacks on the apply-excluded path, including [`deferred_leftover_quickstart`](examples/deferred_leftover_quickstart/) and [`data_source_leftover_quickstart`](examples/data_source_leftover_quickstart/).
+
+### Changed
+
+- **Docs / site** — public copy says the GA catalog is filled; landing page shows Alpha; `google-beta` is coming soon.
+- **`terradart_coverage`** — coverage report no longer requires a live uncurated GA type as a sentinel.
+
 ## [0.24.0] - 2026-07-03
 
 Lockstep release across the workspace. **Breaking** — see [MIGRATING.md](MIGRATING.md). Nested blocks on 19 resources moved from raw `TfArg<Map>` params to generated typed helper classes (`deriveNestedTypes`), typing 49 nested enum sites; serialized Terraform JSON is semantically unchanged. `--strict-nested` enum coverage is now enforced in CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing to terradart
 
-Thanks for taking time to look at this. terradart is an **alpha** single-maintainer project (0.24.x today; breaking changes land only on minor bumps — beta needs external validation, see the [path to beta](https://terradart.dev/docs/status/#path-to-beta)). Contributions are welcome on a best-effort basis.
+Thanks for taking time to look at this. terradart is an **alpha** single-maintainer project (0.25.x today; breaking changes land only on minor bumps — beta needs external validation, see the [path to beta](https://terradart.dev/docs/status/#path-to-beta)). Contributions are welcome on a best-effort basis.
 
 ## What kind of contribution?
 
 terradart ships one consumer surface:
 
-- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**1332 curated resource factories + 461 data sources** as of 0.24.x). Bug fixes, tests, and doc improvements welcome. The GA catalog is filled; new `google-beta` types land via `terradart wrap` overrides — open an issue first to discuss scope.
+- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**1332 curated resource factories + 461 data sources** as of 0.25.x). Bug fixes, tests, and doc improvements welcome. The GA catalog is filled; new `google-beta` types land via `terradart wrap` overrides — open an issue first to discuss scope.
 
-Within a **minor** line (`^0.24.x`), no breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (the alpha change policy — see [status](https://terradart.dev/docs/status/)).
+Within a **minor** line (`^0.25.x`), no breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (the alpha change policy — see [status](https://terradart.dev/docs/status/)).
 
 Bug reports / questions / feature requests: pick a template when [opening an issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 >
 > Google Cloud infrastructure as real Dart code — typed, refactor-safe, drop-in for `terraform apply`.
 
-**Alpha** — no SemVer until v1.0.0, but breaking changes land only on **minor** bumps. Pin `^0.24.x`, read [`MIGRATING.md`](MIGRATING.md) before minor bumps, and see [status on terradart.dev](https://terradart.dev/docs/status/).
+**Alpha** — no SemVer until v1.0.0, but breaking changes land only on **minor** bumps. Pin `^0.25.x`, read [`MIGRATING.md`](MIGRATING.md) before minor bumps, and see [status on terradart.dev](https://terradart.dev/docs/status/).
 
 <!-- identity -->
 [![pub: terradart_core](https://img.shields.io/pub/v/terradart_core.svg?label=pub%3A%20core)](https://pub.dev/packages/terradart_core)
@@ -204,8 +204,8 @@ GoogleCloudRunV2Service(
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.24.x
-  terradart_google: ^0.24.x
+  terradart_core: ^0.25.x
+  terradart_google: ^0.25.x
 ```
 
 ```bash
@@ -369,7 +369,7 @@ Application platform & operations
 
 ## Status
 
-**Alpha**, pre-1.0 (0.24.x). No SemVer until v1.0.0, but breaking changes land only on **minor** bumps, always documented in [`MIGRATING.md`](MIGRATING.md); pin `^0.24.x` and take patches freely. Beta needs external validation — see the [path to beta](https://terradart.dev/docs/status/#path-to-beta). Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
+**Alpha**, pre-1.0 (0.25.x). No SemVer until v1.0.0, but breaking changes land only on **minor** bumps, always documented in [`MIGRATING.md`](MIGRATING.md); pin `^0.25.x` and take patches freely. Beta needs external validation — see the [path to beta](https://terradart.dev/docs/status/#path-to-beta). Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
 
 ## Schema-bump automation (Plan 5.E)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,12 +31,12 @@ What does **not** count:
 
 ## Supported versions
 
-Pin dependencies with `^0.24.x` on [pub.dev](https://pub.dev/packages/terradart_core) today.
+Pin dependencies with `^0.25.x` on [pub.dev](https://pub.dev/packages/terradart_core) today.
 
 | Version | Status | Security fixes |
 |---|---|---|
-| **0.24.x** (alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
-| **0.11.x and older** | Unsupported | Upgrade to 0.24.x; see [MIGRATING.md](MIGRATING.md) |
+| **0.25.x** (alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
+| **0.11.x and older** | Unsupported | Upgrade to 0.25.x; see [MIGRATING.md](MIGRATING.md) |
 | Future beta line (TBD) | Best-effort with clearer minor-boundary policy | See [status on terradart.dev](https://terradart.dev/docs/status/) |
 
 ## Disclosure policy

--- a/cookbook/firestore-seeded-data/pubspec.yaml
+++ b/cookbook/firestore-seeded-data/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/lunch-concierge/README.md
+++ b/cookbook/lunch-concierge/README.md
@@ -1,6 +1,6 @@
 > Part of the [TerraDart cookbook](../README.md). Library: [terradart](https://github.com/nozomi-koborinai/terradart).
 >
-> **Status:** Full-stack demo recipe — Flutter Web + Dart server + Genkit (Agent Platform) + Cloud Run + private Cloud SQL, all authored in Dart. Targets `terradart_core` / `terradart_google` ^0.24.0.
+> **Status:** Full-stack demo recipe — Flutter Web + Dart server + Genkit (Agent Platform) + Cloud Run + private Cloud SQL, all authored in Dart. Targets `terradart_core` / `terradart_google` ^0.25.0.
 
 # Lunch Concierge
 

--- a/cookbook/lunch-concierge/infra/pubspec.yaml
+++ b/cookbook/lunch-concierge/infra/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/remote-backend/pubspec.yaml
+++ b/cookbook/remote-backend/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/single-project-app/pubspec.yaml
+++ b/cookbook/single-project-app/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/access_context_quickstart/pubspec.yaml
+++ b/examples/access_context_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/api_security_quickstart/pubspec.yaml
+++ b/examples/api_security_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/apigee_quickstart/pubspec.yaml
+++ b/examples/apigee_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/app_engine_quickstart/pubspec.yaml
+++ b/examples/app_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/apphub_quickstart/pubspec.yaml
+++ b/examples/apphub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/artifact_registry_quickstart/pubspec.yaml
+++ b/examples/artifact_registry_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/biglake_quickstart/pubspec.yaml
+++ b/examples/biglake_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_datapolicyv2_quickstart/pubspec.yaml
+++ b/examples/bigquery_datapolicyv2_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_quickstart/pubspec.yaml
+++ b/examples/bigquery_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigtable_quickstart/pubspec.yaml
+++ b/examples/bigtable_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ces_quickstart/pubspec.yaml
+++ b/examples/ces_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/chronicle_quickstart/pubspec.yaml
+++ b/examples/chronicle_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_asset_quickstart/pubspec.yaml
+++ b/examples/cloud_asset_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_build_quickstart/pubspec.yaml
+++ b/examples/cloud_build_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_functions_quickstart/pubspec.yaml
+++ b/examples/cloud_functions_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_quickstart/pubspec.yaml
+++ b/examples/cloud_run_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_v1_quickstart/pubspec.yaml
+++ b/examples/cloud_run_v1_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_scheduler_quickstart/pubspec.yaml
+++ b/examples/cloud_scheduler_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_sql_quickstart/pubspec.yaml
+++ b/examples/cloud_sql_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_tasks_quickstart/pubspec.yaml
+++ b/examples/cloud_tasks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/clouddeploy_quickstart/pubspec.yaml
+++ b/examples/clouddeploy_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/colab_quickstart/pubspec.yaml
+++ b/examples/colab_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_cloud_armor_tier_quickstart/pubspec.yaml
+++ b/examples/compute_cloud_armor_tier_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_default_network_tier_quickstart/pubspec.yaml
+++ b/examples/compute_default_network_tier_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_instance_settings_quickstart/pubspec.yaml
+++ b/examples/compute_instance_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_lb_quickstart/pubspec.yaml
+++ b/examples/compute_lb_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_preview_feature_quickstart/pubspec.yaml
+++ b/examples/compute_preview_feature_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_quickstart/pubspec.yaml
+++ b/examples/compute_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_rollout_quickstart/pubspec.yaml
+++ b/examples/compute_rollout_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_route_quickstart/pubspec.yaml
+++ b/examples/compute_route_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_snapshot_settings_quickstart/pubspec.yaml
+++ b/examples/compute_snapshot_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_vpn_gateway_quickstart/pubspec.yaml
+++ b/examples/compute_vpn_gateway_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/config_deployment_quickstart/pubspec.yaml
+++ b/examples/config_deployment_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/contact_center_insights_quickstart/pubspec.yaml
+++ b/examples/contact_center_insights_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/container_analysis_quickstart/pubspec.yaml
+++ b/examples/container_analysis_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_catalog_quickstart/pubspec.yaml
+++ b/examples/data_catalog_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_lineage_quickstart/pubspec.yaml
+++ b/examples/data_lineage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_source_leftover_quickstart/pubspec.yaml
+++ b/examples/data_source_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataform_quickstart/pubspec.yaml
+++ b/examples/dataform_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataplex_quickstart/pubspec.yaml
+++ b/examples/dataplex_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataproc_autoscaling_quickstart/pubspec.yaml
+++ b/examples/dataproc_autoscaling_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataproc_metastore_quickstart/pubspec.yaml
+++ b/examples/dataproc_metastore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/deferred_leftover_quickstart/pubspec.yaml
+++ b/examples/deferred_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/developer_connect_quickstart/pubspec.yaml
+++ b/examples/developer_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_es_quickstart/pubspec.yaml
+++ b/examples/dialogflow_es_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_quickstart/pubspec.yaml
+++ b/examples/dialogflow_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/discovery_engine_quickstart/pubspec.yaml
+++ b/examples/discovery_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dlp_quickstart/pubspec.yaml
+++ b/examples/dlp_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dns_quickstart/pubspec.yaml
+++ b/examples/dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/document_ai_quickstart/pubspec.yaml
+++ b/examples/document_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/endpoints_quickstart/pubspec.yaml
+++ b/examples/endpoints_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/eventarc_quickstart/pubspec.yaml
+++ b/examples/eventarc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/filestore_quickstart/pubspec.yaml
+++ b/examples/filestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_check_quickstart/pubspec.yaml
+++ b/examples/firebase_app_check_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_hosting_quickstart/pubspec.yaml
+++ b/examples/firebase_app_hosting_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_data_connect_quickstart/pubspec.yaml
+++ b/examples/firebase_data_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_remote_config_quickstart/pubspec.yaml
+++ b/examples/firebase_remote_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebaserules_quickstart/pubspec.yaml
+++ b/examples/firebaserules_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_document_quickstart/pubspec.yaml
+++ b/examples/firestore_document_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_quickstart/pubspec.yaml
+++ b/examples/firestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gemini_quickstart/pubspec.yaml
+++ b/examples/gemini_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_hub_feature_quickstart/pubspec.yaml
+++ b/examples/gke_hub_feature_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_hub_quickstart/pubspec.yaml
+++ b/examples/gke_hub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_quickstart/pubspec.yaml
+++ b/examples/gke_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/healthcare_quickstart/pubspec.yaml
+++ b/examples/healthcare_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iam_quickstart/pubspec.yaml
+++ b/examples/iam_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iap_settings_quickstart/pubspec.yaml
+++ b/examples/iap_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iap_tunnel_quickstart/pubspec.yaml
+++ b/examples/iap_tunnel_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/identity_platform_quickstart/pubspec.yaml
+++ b/examples/identity_platform_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/integrations_quickstart/pubspec.yaml
+++ b/examples/integrations_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_autokey_quickstart/pubspec.yaml
+++ b/examples/kms_autokey_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_quickstart/pubspec.yaml
+++ b/examples/kms_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/license_manager_quickstart/pubspec.yaml
+++ b/examples/license_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/migration_center_quickstart/pubspec.yaml
+++ b/examples/migration_center_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/model_armor_quickstart/pubspec.yaml
+++ b/examples/model_armor_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/monitoring_quickstart/pubspec.yaml
+++ b/examples/monitoring_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ncc_hub_quickstart/pubspec.yaml
+++ b/examples/ncc_hub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/netapp_metadata_quickstart/pubspec.yaml
+++ b/examples/netapp_metadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_connectivity_quickstart/pubspec.yaml
+++ b/examples/network_connectivity_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_management_vpc_flow_logs_quickstart/pubspec.yaml
+++ b/examples/network_management_vpc_flow_logs_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_backend_auth_quickstart/pubspec.yaml
+++ b/examples/network_security_backend_auth_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_dns_threat_quickstart/pubspec.yaml
+++ b/examples/network_security_dns_threat_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_gateway_policy_quickstart/pubspec.yaml
+++ b/examples/network_security_gateway_policy_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_lists_quickstart/pubspec.yaml
+++ b/examples/network_security_lists_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_tls_quickstart/pubspec.yaml
+++ b/examples/network_security_tls_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_ull_quickstart/pubspec.yaml
+++ b/examples/network_security_ull_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_services_mesh_quickstart/pubspec.yaml
+++ b/examples/network_services_mesh_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/notebooks_quickstart/pubspec.yaml
+++ b/examples/notebooks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/observability_quickstart/pubspec.yaml
+++ b/examples/observability_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ops_quickstart/pubspec.yaml
+++ b/examples/ops_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_autonomous_database_quickstart/pubspec.yaml
+++ b/examples/oracle_autonomous_database_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_db_system_quickstart/pubspec.yaml
+++ b/examples/oracle_db_system_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_exadata_quickstart/pubspec.yaml
+++ b/examples/oracle_exadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_goldengate_quickstart/pubspec.yaml
+++ b/examples/oracle_goldengate_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/org_leftover_quickstart/pubspec.yaml
+++ b/examples/org_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/parameter_manager_quickstart/pubspec.yaml
+++ b/examples/parameter_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/privileged_access_manager_quickstart/pubspec.yaml
+++ b/examples/privileged_access_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/project_iam_audit_config_quickstart/pubspec.yaml
+++ b/examples/project_iam_audit_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/public_ca_quickstart/pubspec.yaml
+++ b/examples/public_ca_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/pubsub_quickstart/pubspec.yaml
+++ b/examples/pubsub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/scc_quickstart/pubspec.yaml
+++ b/examples/scc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/secret_manager_quickstart/pubspec.yaml
+++ b/examples/secret_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/service_directory_quickstart/pubspec.yaml
+++ b/examples/service_directory_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/sourcerepo_quickstart/pubspec.yaml
+++ b/examples/sourcerepo_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/spanner_instance_config_quickstart/pubspec.yaml
+++ b/examples/spanner_instance_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_intelligence_quickstart/pubspec.yaml
+++ b/examples/storage_intelligence_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_quickstart/pubspec.yaml
+++ b/examples/storage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_transfer_quickstart/pubspec.yaml
+++ b/examples/storage_transfer_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/tags_quickstart/pubspec.yaml
+++ b/examples/tags_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/transcoder_quickstart/pubspec.yaml
+++ b/examples/transcoder_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/usage_export_quickstart/pubspec.yaml
+++ b/examples/usage_export_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vector_quickstart/pubspec.yaml
+++ b/examples/vector_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vertex_ai_quickstart/pubspec.yaml
+++ b/examples/vertex_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vm_compliance_quickstart/pubspec.yaml
+++ b/examples/vm_compliance_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/wif_trust_domain_quickstart/pubspec.yaml
+++ b/examples/wif_trust_domain_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/workflows_quickstart/pubspec.yaml
+++ b/examples/workflows_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/terradart_agent/CHANGELOG.md
+++ b/packages/terradart_agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.0 - 2026-08-15
+
+Lockstep release with `terradart_google` 0.25.0. Catalog: **1793 entries** (1332 curated resource factories + 461 data sources) across **131 service barrels**. No MCP protocol or tool changes.
+
 ## 0.24.0 - 2026-07-03
 
 Lockstep release with `terradart_core` / `terradart_google` 0.24.0. No functional changes in this package.

--- a/packages/terradart_agent/lib/src/version.dart
+++ b/packages/terradart_agent/lib/src/version.dart
@@ -1,4 +1,4 @@
 /// The terradart-mcp binary version, kept in lockstep with pubspec.yaml's
 /// `version:` field by `tool/bump_version.sh`. The lockstep is guarded by
 /// test/version_test.dart so the two can never silently drift.
-const String packageVersion = '0.24.0';
+const String packageVersion = '0.25.0';

--- a/packages/terradart_agent/pubspec.yaml
+++ b/packages/terradart_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_agent
 description: terradart-mcp — MCP server exposing the curated GCP factory catalog of TerraDart.
-version: 0.24.0
+version: 0.25.0
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -16,9 +16,9 @@ executables:
   terradart-mcp: terradart_mcp
 
 dependencies:
-  terradart_core: ^0.24.0
-  terradart_google: ^0.24.0
-  terradart_coverage: ^0.24.0
+  terradart_core: ^0.25.0
+  terradart_google: ^0.25.0
+  terradart_coverage: ^0.25.0
   genkit: ^0.14.1
   genkit_mcp: ^0.2.1
   schemantic: ^0.2.0

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.0 - 2026-08-15
+
+Lockstep release with `terradart_google` 0.25.0 (GA `hashicorp/google` catalog filled). Wrap emits GA data-source factories (`data_<type>.yaml` twins, `Data` class prefix). No user-facing CLI flag changes.
+
 ## 0.24.0 - 2026-07-03
 
 New maintainer derivation gate `deriveNestedTypes: true` (+ `nestedTypeExcludes`): generates typed helper classes for nested blocks from the provider schema — fields typed per schema, enums parsed from attribute descriptions (single-sourced with `check_override_enum_gaps`, which is now excludes-aware and strict on nested sites in CI). Non-breaking for the wrap CLI; overrides that do not set the gate are unaffected.

--- a/packages/terradart_codegen/README.md
+++ b/packages/terradart_codegen/README.md
@@ -15,7 +15,7 @@ End users depend on [`terradart_google`](https://pub.dev/packages/terradart_goog
 Activate on the same minor line as your workspace when working on the repo:
 
 ```bash
-dart pub global activate terradart_codegen ^0.24.x
+dart pub global activate terradart_codegen ^0.25.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_codegen) for the latest patch.

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart maintainer tooling — parses Terraform provider schema JSON and Magic Modules YAML and emits curated factory wrappers via terradart wrap. Ships the terradart CLI.
-version: 0.24.0
+version: 0.25.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -33,7 +33,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.24.0
+  terradart_core: ^0.25.0
 
 dev_dependencies:
   http: ^1.0.0

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.0 - 2026-08-15
+
+Lockstep release with `terradart_google` 0.25.0 (GA `hashicorp/google` catalog filled). No `terradart_core` API changes.
+
 ## 0.24.0 - 2026-07-03
 
 Lockstep release with `terradart_google` 0.24.0 (typed nested helpers). No `terradart_core` API changes.

--- a/packages/terradart_core/README.md
+++ b/packages/terradart_core/README.md
@@ -36,7 +36,7 @@ enum RoutingMode implements TerraformEnum {
 
 ```yaml
 dependencies:
-  terradart_core: ^0.24.x
+  terradart_core: ^0.25.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch. Read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before minor bumps.

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.24.0
+version: 0.25.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_coverage/CHANGELOG.md
+++ b/packages/terradart_coverage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.0 - 2026-08-15
+
+Lockstep release with `terradart_google` 0.25.0. Coverage report no longer requires a live uncurated GA type as a sentinel.
+
 ## 0.24.0 - 2026-07-03
 
 Lockstep release with `terradart_core` / `terradart_google` 0.24.0. No functional changes in this package.

--- a/packages/terradart_coverage/pubspec.yaml
+++ b/packages/terradart_coverage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_coverage
 description: Read-only Terraform coverage checker — reports how much of a Terraform config is covered by curated terradart_google factories.
-version: 0.24.0
+version: 0.25.0
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -15,7 +15,7 @@ executables:
   terradart-coverage: terradart_coverage
 
 dependencies:
-  terradart_google: ^0.24.0
+  terradart_google: ^0.25.0
   args: ^2.5.0
 
 dev_dependencies:

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.25.0 - 2026-08-15
+
+Lockstep release. **No breaking changes** vs `0.24.0`.
+
+The GA HashiCorp `google` provider catalog is filled. `google-beta` is coming soon.
+
+### Added
+
+- Remaining GA `hashicorp/google` resources and data sources. Catalog: **1332 curated resource factories + 461 data sources** (1793 catalog entries; 131 service barrels).
+- Leftover and data-source examples on the apply-excluded path (`deferred_leftover_quickstart`, `data_source_leftover_quickstart`, and related skip-listed quickstarts).
+
 ## 0.24.0 - 2026-07-03
 
 Lockstep release. **Breaking** — see [MIGRATING.md](../../MIGRATING.md).

--- a/packages/terradart_google/README.md
+++ b/packages/terradart_google/README.md
@@ -16,8 +16,8 @@ Runtime primitives (`Stack`, `TfArg`, `writeTo`) live in [`terradart_core`](http
 
 ```yaml
 dependencies:
-  terradart_core: ^0.24.x
-  terradart_google: ^0.24.x
+  terradart_core: ^0.25.x
+  terradart_google: ^0.25.x
 ```
 
 ## Usage example

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: Curated factory wrappers for Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.
-version: 0.24.0
+version: 0.25.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -22,11 +22,11 @@ false_secrets:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.24.0
+  terradart_core: ^0.25.0
   meta: ^1.15.0
 
 dev_dependencies:
-  terradart_codegen: ^0.24.0
+  terradart_codegen: ^0.25.0
   path: ^1.9.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -3,7 +3,7 @@ title: Getting Started
 description: Install TerraDart and generate your first *.tf.json from a Stack.
 ---
 
-This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.24.x** line. TerraDart is **alpha** — breaking changes land only on **minor** bumps; see [Status & versioning](/docs/status/) for the change policy and the [path to beta](/docs/status/#path-to-beta).
+This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.25.x** line. TerraDart is **alpha** — breaking changes land only on **minor** bumps; see [Status & versioning](/docs/status/) for the change policy and the [path to beta](/docs/status/#path-to-beta).
 
 ## Prerequisites
 
@@ -16,8 +16,8 @@ This guide matches the [README quickstart](https://github.com/nozomi-koborinai/t
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.24.x
-  terradart_google: ^0.24.x
+  terradart_core: ^0.25.x
+  terradart_google: ^0.25.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch, then run:

--- a/website/src/content/docs/docs/index.md
+++ b/website/src/content/docs/docs/index.md
@@ -5,7 +5,7 @@ description: Guides for TerraDart — type-safe Google Cloud IaC for Dart.
 
 Welcome to the TerraDart docs.
 
-Guides track the **0.24.x** line on pub.dev. The repo [README](https://github.com/nozomi-koborinai/terradart/blob/main/README.md) and [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) stay the deepest references; this site mirrors onboarding and release expectations.
+Guides track the **0.25.x** line on pub.dev. The repo [README](https://github.com/nozomi-koborinai/terradart/blob/main/README.md) and [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) stay the deepest references; this site mirrors onboarding and release expectations.
 
 ## Guides
 

--- a/website/src/content/docs/docs/status.md
+++ b/website/src/content/docs/docs/status.md
@@ -3,22 +3,22 @@ title: Status & versioning
 description: Alpha expectations, the path to beta, and how TerraDart versions releases.
 ---
 
-TerraDart is **alpha** on the **0.24.x** line today. Alpha means the maintainer-side quality gates are all done (see [Alpha gates](#alpha-gates-complete)) and the [change policy](#change-policy-from-alpha-onward) below is in force; what still separates alpha from **beta** is external validation — see [Path to beta](#path-to-beta).
+TerraDart is **alpha** on the **0.25.x** line today. Alpha means the maintainer-side quality gates are all done (see [Alpha gates](#alpha-gates-complete)) and the [change policy](#change-policy-from-alpha-onward) below is in force; what still separates alpha from **beta** is external validation — see [Path to beta](#path-to-beta).
 
-There are no SemVer guarantees until **v1.0.0**, but breaking changes land only on **minor** bumps: pin with `^0.24.x`, take patch releases freely, and read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before every minor bump. Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch.
+There are no SemVer guarantees until **v1.0.0**, but breaking changes land only on **minor** bumps: pin with `^0.25.x`, take patch releases freely, and read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before every minor bump. Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch.
 
 ## Release phases
 
 | Phase | Version line | What we promise |
 | --- | --- | --- |
-| **Alpha** | 0.24.x (current) | Maintainer-side gates are done (docs, CI, real-apply coverage). **No breaking changes within a minor** (`^0.N.x`); breaking changes only on minor bumps, always documented in `MIGRATING.md`. Not SemVer until 1.0.0. |
+| **Alpha** | 0.25.x (current) | Maintainer-side gates are done (docs, CI, real-apply coverage). **No breaking changes within a minor** (`^0.N.x`); breaking changes only on minor bumps, always documented in `MIGRATING.md`. Not SemVer until 1.0.0. |
 | **Beta** | TBD (needs external validation) | The same change policy, proven against real external usage — see [Path to beta](#path-to-beta). |
 | **1.0.0** | TBD | Stable SemVer for `terradart_core`, `terradart_google`, and `terradart_codegen`. |
 
 ## What to expect today (alpha)
 
 - Breaking changes to the public Dart API or the emitted Terraform JSON land only on **minor** bumps, each with a [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) section; patch releases within `^0.N.x` are safe to take.
-- Use hosted `^0.24.x` carets on [pub.dev](https://pub.dev/packages/terradart_core) — not legacy `0.x.y-dev` pre-release tags.
+- Use hosted `^0.25.x` carets on [pub.dev](https://pub.dev/packages/terradart_core) — not legacy `0.x.y-dev` pre-release tags.
 - Only the **curated** `terradart_google` surface is supported for users. The GA `hashicorp/google` catalog is filled; `google-beta` is coming soon.
 
 ## Change policy (from alpha onward)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Lockstep `0.25.0` across `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_agent`, and `terradart_coverage`. **No breaking changes** vs `0.24.0`. No `MIGRATING.md` section.

## Highlights

- The GA HashiCorp `google` provider catalog is filled
- Catalog: **1332 curated resource factories + 461 data sources** (1793 entries; 131 service barrels)
- `google-beta` is coming soon
- Landing / docs already say Alpha

This is not a Wave number. It publishes the leftover + data-source catalog fill that landed on `main` after `0.24.0`.

## Out of scope

- No tag, GitHub release, or pub.dev publish in this PR (maintainer-manual after merge)
- Not beta
- Does not claim every factory is apply-verified

## After merge

1. Tag `v0.25.0` (triggers `.github/workflows/publish.yml`)
2. After publish is green, create the GitHub release (`v0.25.0` title only)

Draft notes:

```
Lockstep release across `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_agent`, and `terradart_coverage`. **No breaking changes** vs `0.24.0`.

## Highlights

- **`terradart_google` catalog:** **1332 curated resource factories + 461 data sources** (**1793 entries**; **131 service barrels**)
- The GA HashiCorp `google` provider catalog is filled
- `google-beta` is coming soon

## Upgrade

    dependencies:
      terradart_core: ^0.25.0
      terradart_google: ^0.25.0

Docs: [Getting started](https://terradart.dev/docs/getting-started/) · [Status](https://terradart.dev/docs/status/)

**Full Changelog**: https://github.com/nozomi-koborinai/terradart/compare/v0.24.0...v0.25.0
```

## Verify

- `dart tool/check_docs_consistency.dart` — OK (workspace minor 0.25.x)
- `tool/agent_verify.sh` — `agent_verify: OK`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffa93-ed55-7023-b05f-03de890397c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffa93-ed55-7023-b05f-03de890397c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

