### PR TITLE
chore(apply-smoke): probe License Manager configurations in the orphan check

### DIFF
--- a/tool/apply_smoke_orphan_check.sh
+++ b/tool/apply_smoke_orphan_check.sh
@@ -90,7 +90,9 @@ run_rest() {
     return 0
   fi
   local names
-  names="$(printf '%s' "$out" | grep -o '"name": *"[^"]*"' | sed 's/.*: *"//; s/"$//')"
+  # grep exits 1 on a healthy empty list; without the guard, set -e
+  # would abort the whole probe on the happiest possible response.
+  names="$(printf '%s' "$out" | grep -o '"name": *"[^"]*"' | sed 's/.*: *"//; s/"$//')" || true
   if [[ -z "$names" ]]; then
     echo "(none)"
   else

--- a/tool/apply_smoke_orphan_check.sh
+++ b/tool/apply_smoke_orphan_check.sh
@@ -57,6 +57,49 @@ run_list() {
   echo
 }
 
+# REST variant for services without a stable gcloud list surface.
+# A disabled API is NOT treated as all-clear: existence-billed resources
+# (the License Manager class) can keep billing behind a disabled API, so
+# that case prints a warning instead of a silent skip.
+run_rest() {
+  local label="$1" url="$2"
+  echo "== $label =="
+  local token out rc=0
+  token="$(gcloud auth print-access-token 2>/dev/null)" || rc=$?
+  if [[ "$rc" -ne 0 || -z "$token" ]]; then
+    echo "(skip: no access token)"
+    echo
+    return 0
+  fi
+  out="$(curl -sS --max-time 20 -H "Authorization: Bearer $token" "$url" 2>&1)" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    echo "(skip: $(echo "$out" | head -n 1))"
+    echo
+    return 0
+  fi
+  if printf '%s' "$out" | grep -q 'SERVICE_DISABLED'; then
+    echo "(warn: API disabled — cannot enumerate, but existence-billed"
+    echo " orphans can keep billing behind a disabled API; if billing looks"
+    echo " suspicious, verify via Cloud Billing reports / support)"
+    echo
+    return 0
+  fi
+  if printf '%s' "$out" | grep -q '"error"'; then
+    echo "(skip: $(printf '%s' "$out" | grep -o '"status": *"[A-Z_]*"' | head -n 1))"
+    echo
+    return 0
+  fi
+  local names
+  names="$(printf '%s' "$out" | grep -o '"name": *"[^"]*"' | sed 's/.*: *"//; s/"$//')"
+  if [[ -z "$names" ]]; then
+    echo "(none)"
+  else
+    found=1
+    echo "$names"
+  fi
+  echo
+}
+
 # Global / aggregated list commands.
 run_list "Compute Engine instances" \
   gcloud compute instances list
@@ -81,6 +124,17 @@ for region in "${REGIONS[@]}"; do
     gcloud metastore services list --location="$region"
   run_list "AlloyDB clusters ($region)" \
     gcloud alloydb clusters list --region="$region"
+done
+
+# License Manager-class resources bill merely by existing — the class
+# behind the 2026-08 cost spike (Office SPLA licenses billing daily; see
+# tool/apply_cost_denylist.yaml header). It has no stable gcloud list
+# surface, so probe the REST API in the example's location plus global.
+# TODO: Discovery Engine licenseConfigs / userStores belong to the same
+# never_apply class — add them once their REST list paths are verified.
+for loc in "${REGIONS[@]}" global; do
+  run_rest "License Manager configurations ($loc)" \
+    "https://licensemanager.googleapis.com/v1/projects/$PROJECT_ID/locations/$loc/configurations"
 done
 
 if [[ "$found" -eq 1 ]]; then


### PR DESCRIPTION
## Summary

The orphan probe (`tool/apply_smoke_orphan_check.sh`) — the read-only tool AGENTS.md points at whenever billing looks suspicious — covered compute-style resources (instances, clusters, VPNs, Redis, …) but not the class that actually caused the 2026-08 cost spike: License Manager configurations that bill merely by existing. This adds it.

## Changes

- New `run_rest` helper for services without a stable gcloud list surface: token via `gcloud auth print-access-token`, one GET, names grepped from the JSON — same read-only, fail-soft "(skip: …)" behavior as `run_list`.
- Probes `licensemanager.googleapis.com` configurations in the example's locations (`us-central1`, `asia-northeast1`) plus `global`.
- One deliberate semantic difference: a `SERVICE_DISABLED` response prints a **warning**, not a silent skip — existence-billed resources can keep billing behind a disabled API, so "API disabled" must not read as all-clear when the probe was run because billing looked suspicious.
- Discovery Engine `licenseConfigs` / `userStores` belong to the same `never_apply` class; left as a TODO until their REST list paths are verified against a live project (guessed paths would 404 into a misleading skip).

## Verification

- `bash -n` clean; the `SERVICE_DISABLED` warn path verified against the real endpoint (terradart-validate currently returns exactly that)
- `tool/agent_verify.sh` — full gate OK (exit code checked bare)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only diagnostic script only; no production apply paths or credential changes beyond existing gcloud auth usage.
> 
> **Overview**
> Extends the read-only orphan probe so it can catch **License Manager configurations**—existence-billed resources tied to the 2026-08 cost spike—that were missing from the gcloud-based inventory.
> 
> Adds a **`run_rest`** helper (token + GET + name extraction) for APIs without a stable `gcloud list` surface, mirroring `run_list`’s fail-soft skips. **`licensemanager.googleapis.com`** configurations are queried in `us-central1`, `asia-northeast1`, and `global`. When the API returns **`SERVICE_DISABLED`**, the script prints an explicit **warning** instead of a silent skip, because hidden existence-billed orphans can keep billing even when enumeration fails. Discovery Engine license resources are noted as a **TODO** until REST list paths are verified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17af5862a4e666bb9360c595f129e3e4cb6140f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->