### PR TITLE
feat(codegen): parameterize wrap's overrides root, barrels manifest, and umbrella

### DIFF
--- a/packages/terradart_codegen/lib/src/cli/wrap_command.dart
+++ b/packages/terradart_codegen/lib/src/cli/wrap_command.dart
@@ -69,6 +69,21 @@ class WrapCommand extends Command<int> {
             '`wrap-promote` markers that would otherwise break the '
             'full-registry load.',
         valueHelp: 'TERRAFORM_TYPE',
+      )
+      ..addOption(
+        'overrides-root',
+        help: 'Directory of wrapper-override YAMLs. Defaults to the '
+            'committed google registry '
+            '(src/codegen/wrapper_overrides/yaml/); other providers pass '
+            'their own root.',
+        valueHelp: 'DIR',
+      )
+      ..addOption(
+        'barrels-manifest',
+        help: 'Authored barrels manifest. Defaults to the committed google '
+            'manifest (src/codegen/barrels/barrels.yaml); other providers '
+            'pass their own (its umbrellaFile axis names the umbrella).',
+        valueHelp: 'FILE',
       );
   }
 
@@ -165,26 +180,36 @@ class WrapCommand extends Command<int> {
         ? baseIr
         : const IrMerger().merge(base: baseIr, overrides: mmOverrides);
 
-    // 2. Resolve the YAML override root. In `dart test` the package_config
-    //    is provided by the runner, so `Isolate.resolvePackageUri` succeeds.
-    //    Production CLI invocations (`dart run` / `dart compile exe`) also
-    //    have a package config available. Compile-time AOT snapshots are
-    //    the one mode where this can fail; surface a clear software error.
-    final yamlRootUri = await Isolate.resolvePackageUri(
-      Uri.parse(
-          'package:terradart_codegen/src/codegen/wrapper_overrides/yaml/'),
-    );
-    if (yamlRootUri == null) {
-      stderr.writeln(
-        'terradart wrap: failed to resolve '
-        'package:terradart_codegen yaml root.',
+    // 2. Resolve the YAML override root: the --overrides-root flag when
+    //    given (non-google providers carry their own registry), else the
+    //    committed google registry via package URI. In `dart test` the
+    //    package_config is provided by the runner, so
+    //    `Isolate.resolvePackageUri` succeeds. Production CLI invocations
+    //    (`dart run` / `dart compile exe`) also have a package config
+    //    available. Compile-time AOT snapshots are the one mode where this
+    //    can fail; surface a clear software error.
+    final overridesRootArg = argResults?['overrides-root'] as String?;
+    final String yamlRootPath;
+    if (overridesRootArg != null) {
+      yamlRootPath = overridesRootArg;
+    } else {
+      final yamlRootUri = await Isolate.resolvePackageUri(
+        Uri.parse(
+            'package:terradart_codegen/src/codegen/wrapper_overrides/yaml/'),
       );
-      return CliExitCodes.software;
+      if (yamlRootUri == null) {
+        stderr.writeln(
+          'terradart wrap: failed to resolve '
+          'package:terradart_codegen yaml root.',
+        );
+        return CliExitCodes.software;
+      }
+      yamlRootPath = yamlRootUri.toFilePath();
     }
     final LoadedOverrides loaded;
     try {
       loaded = loadWrapperOverrides(
-        rootDir: yamlRootUri.toFilePath(),
+        rootDir: yamlRootPath,
         only: only,
       );
     } on StateError catch (e) {
@@ -315,20 +340,28 @@ class WrapCommand extends Command<int> {
       // manifest (doc, file-name override, hand-written extraExports). Same
       // `--only` skip rationale as the catalog: barrels are whole-registry
       // artifacts, so a single-resource regen must not clobber them.
-      final manifestUri = await Isolate.resolvePackageUri(
-        Uri.parse('package:terradart_codegen/src/codegen/barrels/barrels.yaml'),
-      );
-      if (manifestUri == null) {
-        stderr.writeln(
-          'terradart wrap: failed to resolve barrels.yaml package path.',
+      final manifestArg = argResults?['barrels-manifest'] as String?;
+      final String manifestPath;
+      if (manifestArg != null) {
+        manifestPath = manifestArg;
+      } else {
+        final manifestUri = await Isolate.resolvePackageUri(
+          Uri.parse(
+              'package:terradart_codegen/src/codegen/barrels/barrels.yaml'),
         );
-        return CliExitCodes.software;
+        if (manifestUri == null) {
+          stderr.writeln(
+            'terradart wrap: failed to resolve barrels.yaml package path.',
+          );
+          return CliExitCodes.software;
+        }
+        manifestPath = manifestUri.toFilePath();
       }
       final Map<String, String> barrelFiles;
       try {
         barrelFiles = buildBarrelFiles(
           entries: catalogEntries,
-          manifest: loadBarrelManifest(manifestUri.toFilePath()),
+          manifest: loadBarrelManifest(manifestPath),
         );
       } on StateError catch (e) {
         stderr.writeln('terradart wrap: $e');

--- a/packages/terradart_codegen/lib/src/codegen/barrels/barrel_emitter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/barrels/barrel_emitter.dart
@@ -68,7 +68,7 @@ Map<String, String> buildBarrelFiles({
       files: byBarrel[barrel]!,
     );
   }
-  out['terradart_google'] = _emitUmbrella(
+  out[manifest.umbrellaFile] = _emitUmbrella(
     manifest: manifest,
     barrelFileStems: [
       for (final barrel in byBarrel.keys)

--- a/packages/terradart_codegen/lib/src/codegen/barrels/barrel_manifest.dart
+++ b/packages/terradart_codegen/lib/src/codegen/barrels/barrel_manifest.dart
@@ -18,9 +18,15 @@ class BarrelManifest {
     required this.umbrellaDoc,
     required this.umbrellaExtraExports,
     required this.barrels,
+    this.umbrellaFile = 'terradart_google',
   });
 
-  /// Verbatim `///` doc block for the `terradart_google.dart` umbrella.
+  /// Umbrella file stem under `lib/` (e.g. `terradart_google_beta` for the
+  /// beta package). Defaults to the original google umbrella so existing
+  /// manifests need no edit.
+  final String umbrellaFile;
+
+  /// Verbatim `///` doc block for the umbrella.
   final String umbrellaDoc;
 
   /// Verbatim `export '...';` directives the umbrella carries beyond the
@@ -64,7 +70,12 @@ BarrelManifest loadBarrelManifest(String path) {
   if (yaml is! YamlMap) {
     throw FormatException('$path: top-level must be a YAML mapping');
   }
-  const allowedTop = {'umbrellaDoc', 'umbrellaExtraExports', 'barrels'};
+  const allowedTop = {
+    'umbrellaFile',
+    'umbrellaDoc',
+    'umbrellaExtraExports',
+    'barrels',
+  };
   for (final key in yaml.keys) {
     if (!allowedTop.contains(key)) {
       throw FormatException('$path: unknown top-level key: $key');
@@ -73,6 +84,11 @@ BarrelManifest loadBarrelManifest(String path) {
   final umbrellaDoc = yaml['umbrellaDoc'];
   if (umbrellaDoc is! String || umbrellaDoc.trim().isEmpty) {
     throw FormatException('$path: umbrellaDoc must be a non-empty string');
+  }
+  final umbrellaFileNode = yaml['umbrellaFile'];
+  if (umbrellaFileNode != null &&
+      (umbrellaFileNode is! String || umbrellaFileNode.trim().isEmpty)) {
+    throw FormatException('$path: umbrellaFile must be a non-empty string');
   }
   final umbrellaExtra =
       _stringList(yaml['umbrellaExtraExports'], path, 'umbrellaExtraExports');
@@ -114,6 +130,8 @@ BarrelManifest loadBarrelManifest(String path) {
     umbrellaDoc: umbrellaDoc.trimRight(),
     umbrellaExtraExports: umbrellaExtra,
     barrels: barrels,
+    umbrellaFile:
+        umbrellaFileNode is String ? umbrellaFileNode : 'terradart_google',
   );
 }
 

--- a/packages/terradart_codegen/test/cli/wrap_command_test.dart
+++ b/packages/terradart_codegen/test/cli/wrap_command_test.dart
@@ -717,6 +717,126 @@ paramOrder:
       }
     });
   });
+
+  group('WrapCommand provider parameterization', () {
+    test(
+        'wraps a non-google provider from a custom overrides root and '
+        'barrels manifest, without an mm/ directory', () async {
+      final tmp = await Directory.systemTemp.createTemp('wrap_beta_');
+      try {
+        // Source: schema.json only — deliberately NO mm/ directory (the
+        // documented schema-only path a provider without Magic Modules
+        // metadata will take).
+        final sourceDir = Directory(p.join(tmp.path, 'source'))..createSync();
+        File(p.join(sourceDir.path, 'schema.json')).writeAsStringSync(
+          jsonEncode({
+            'format_version': '1.0',
+            'provider_schemas': {
+              'registry.terraform.io/hashicorp/google-beta': {
+                'resource_schemas': {
+                  'google_project_service_identity': {
+                    'version': 0,
+                    'block': {
+                      'attributes': {
+                        'id': {'type': 'string', 'computed': true},
+                        'project': {
+                          'type': 'string',
+                          'optional': true,
+                          'computed': true,
+                        },
+                        'service': {'type': 'string', 'required': true},
+                        'email': {'type': 'string', 'computed': true},
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        );
+
+        // Overrides live OUTSIDE the package default root.
+        final overridesDir = Directory(p.join(tmp.path, 'overrides'))
+          ..createSync();
+        File(
+          p.join(overridesDir.path, 'google_project_service_identity.yaml'),
+        ).writeAsStringSync('''
+outputDir: project
+deriveClassDoc: true
+deriveOutputGetters: true
+
+paramOrder:
+  - service
+  - project
+''');
+
+        // A per-package barrels manifest that also names the umbrella.
+        final manifestFile = File(p.join(tmp.path, 'barrels_beta.yaml'))
+          ..writeAsStringSync('''
+umbrellaFile: terradart_google_beta
+umbrellaDoc: |-
+  /// google-beta curated surface umbrella.
+umbrellaExtraExports: []
+barrels:
+  project:
+    doc: |-
+      /// Project-level beta resources.
+''');
+
+        final runner = buildCliRunner();
+        final code = await runner.run([
+          'wrap',
+          '--provider',
+          'hashicorp/google-beta',
+          '--source',
+          sourceDir.path,
+          '--output',
+          _libSrcOut(tmp),
+          '--overrides-root',
+          overridesDir.path,
+          '--barrels-manifest',
+          manifestFile.path,
+        ]);
+        expect(code, 0);
+
+        final files = <String>[];
+        for (final ent in Directory(tmp.path).listSync(recursive: true)) {
+          if (ent is File && ent.path.endsWith('.dart')) {
+            files.add(p.relative(ent.path, from: tmp.path));
+          }
+        }
+        expect(
+          files,
+          contains(
+            p.join(
+              'lib',
+              'src',
+              'project',
+              'google_project_service_identity.dart',
+            ),
+          ),
+        );
+        expect(files, contains(p.join('lib', 'project.dart')));
+        // The umbrella takes the manifest's name — not terradart_google.
+        expect(files, contains(p.join('lib', 'terradart_google_beta.dart')));
+        expect(
+          files,
+          isNot(contains(p.join('lib', 'terradart_google.dart'))),
+        );
+      } finally {
+        await tmp.delete(recursive: true);
+      }
+    });
+
+    test('umbrellaFile defaults to terradart_google when absent', () {
+      final manifest = const BarrelManifest(
+        umbrellaDoc: '/// Umbrella.',
+        umbrellaExtraExports: [],
+        barrels: {'app': BarrelSpec(doc: '/// App.')},
+      );
+      expect(manifest.umbrellaFile, 'terradart_google');
+    });
+  });
 }
 
 /// Loads `resource_schemas[terraformType].block` straight from an


### PR DESCRIPTION
## Summary

PR-a of the google-beta vertical slice (design: local `docs/beta-provider-slice-design.md`; the slice rehearses provider parameterization for cloudflare and beyond). The generation pipeline had exactly three google-isms left, all resolved here — with defaults chosen so every existing google invocation behaves byte-identically.

## Changes

- `terradart wrap` gains `--overrides-root DIR` (override-YAML registry; default = the committed google registry via package URI) and `--barrels-manifest FILE` (authored barrels manifest; default = the committed google `barrels.yaml`).
- The barrels manifest gains an optional `umbrellaFile` axis naming the umbrella file stem (default `terradart_google`, so no existing manifest needs an edit); the barrel emitter uses it instead of the hardcoded literal.
- Integration test pins the whole non-google path in one pass: a `hashicorp/google-beta`-keyed schema, wrapped from a custom overrides root and custom manifest, with **no `mm/` directory** — exercising the documented schema-only path a provider without Magic Modules metadata takes — emitting `lib/terradart_google_beta.dart` and not `terradart_google.dart`.

## Verification

- TDD: the new tests were written first and watched fail (missing flags → `UsageException`, missing `umbrellaFile` getter → compile error)
- Full codegen suite: 479 tests green (regression-free — the 1927-file google integration test passes unchanged on defaults)
- `tool/agent_verify.sh` — full gate OK (exit code checked bare)

## Next (separate PRs)

- PR-b: beta schema fixture (filtered extraction tool + `source_beta/`)
- PR-c: `terradart_google_beta` package + first curated resource (`google_project_service_identity`) + example + ledger entries + `tool/providers.yaml` with its first consumers (`agent_verify` / docs-consistency wiring)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Codegen CLI and barrel manifest parsing only; google defaults unchanged and covered by existing 1927-file integration test.
> 
> **Overview**
> Removes the last hardcoded **google** assumptions from `terradart wrap` so other providers (e.g. `hashicorp/google-beta`) can run the same pipeline with their own override registry and barrels manifest, while **defaults** keep existing google invocations byte-identical.
> 
> **CLI:** New `--overrides-root` (wrapper YAML directory; default = committed google registry via package URI) and `--barrels-manifest` (authored `barrels.yaml`; default = committed google manifest).
> 
> **Barrels:** Manifests may set optional `umbrellaFile` (stem under `lib/`); barrel emission uses it instead of the literal `terradart_google` (default remains `terradart_google` when omitted).
> 
> **Tests:** Integration test runs wrap for `google-beta` from a custom overrides root and manifest with **schema-only** input (no `mm/`), expecting `lib/terradart_google_beta.dart` and not `terradart_google.dart`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8206f8729d2f968c1f8138eb3477af870e222194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->