### PR TITLE
chore(beta): wire the lockstep bump and the add-resource skill for the beta lane

### DIFF
--- a/.agents/skills/terradart-add-beta-resource/SKILL.md
+++ b/.agents/skills/terradart-add-beta-resource/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: terradart-add-beta-resource
+description: Add a beta-only curated factory to terradart_google_beta (filtered-fixture extraction, google_beta override, wrap with provider pin). Use when extending the demand-driven google-beta catalog with a new beta-only google_* resource.
+metadata:
+  last_modified: 2026-08-19
+---
+# Add a beta-only curated resource
+
+Read [`CONTEXT.md`](../../../CONTEXT.md) for vocabulary. The beta lane's coordinates live in [`tool/providers.yaml`](../../../tool/providers.yaml); its philosophy (demand-driven, filtered fixture, no backlog/wave lane) is in `AGENTS.md`'s Current-phase section. Do **not** hand-edit files under `packages/terradart_google_beta/lib/src/` or the `source_beta/` fixture — regenerate both.
+
+The beta catalog is **demand-driven**: add a resource only against a concrete request (issue / maintainer ask), never by sweeping the provider. GA resources belong in `terradart_google` — check the GA schema fixture first; a resource present there is NOT beta-only.
+
+## Workflow
+
+**Task progress:**
+
+- [ ] 1. **Confirm beta-only.** The type must be absent from the GA fixture (`packages/terradart_codegen/test/fixtures/wrap/source/schema.json`) and present in the google-beta provider. If it exists in GA, stop — curate it in `terradart_google` instead ([`terradart-add-curated-resource`](../terradart-add-curated-resource/SKILL.md)).
+- [ ] 2. **Re-extract the fixture** with the new type APPENDED to the existing list (the fixture README records the current list — the extraction replaces the whole file, so dropping a name would silently shrink the catalog's schema):
+  ```bash
+  dart tool/extract_schema_subset.dart \
+    --provider=hashicorp/google-beta --version=<provider_version.txt> \
+    --resources=<existing,list,plus_new_type> \
+    --out=packages/terradart_codegen/test/fixtures/wrap/source_beta
+  ```
+  Requires `terraform` on PATH and terraform-registry network access (no cloud credentials). If either is missing in your environment, stop and report — never hand-write schema JSON.
+- [ ] 3. **Write the override** at `packages/terradart_codegen/lib/src/codegen/wrapper_overrides/google_beta/yaml/<type>.yaml`. Same axes and rules as GA overrides (Generation Policy binds you: thin overrides, human decisions only, IAM binding/policy `curatedDoc` authoritative-semantics rule). There is no MM enrichment on this lane (`mm: false`) — `deriveEnums` has nothing to derive; hand enums go in `prelude`.
+- [ ] 4. **Barrels manifest:** if the override's `outputDir` introduces a new barrel, add it to `barrels_google_beta.yaml` with a `doc:` (fail-closed — wrap errors without it).
+- [ ] 5. **Regenerate** (the `--resource-provider` pin is mandatory — beta shares the GA `google_*` type prefix):
+  ```bash
+  cd packages/terradart_codegen
+  dart run bin/terradart.dart wrap \
+    --provider hashicorp/google-beta \
+    --source test/fixtures/wrap/source_beta \
+    --output ../terradart_google_beta/lib/src \
+    --overrides-root lib/src/codegen/wrapper_overrides/google_beta/yaml \
+    --barrels-manifest lib/src/codegen/barrels/barrels_google_beta.yaml \
+    --resource-provider google-beta
+  ```
+- [ ] 6. **Cost-classify the type** (policy, apply or not): gcp-cost tools (`dart tool/gcp_cost_call.dart` in cloud-agent sessions) → record evidence in `tool/apply_cost_denylist.yaml` per its header format. When unsure, leave unclassified and say so.
+- [ ] 7. **Example coverage:** extend `examples/beta_service_identity_quickstart` (or a new beta example) so the factory appears in a synth, or record a reasoned `tool/example_debt.yaml` line. NOTE: the synth coverage gate currently reads only the GA catalog, so beta coverage is enforced by THIS checklist, not by machine — a beta coverage gate is future harness work; do not treat the gate's silence as permission to skip.
+- [ ] 8. **Ledger check:** any new beta example must be listed in `tool/apply_smoke_skip.yaml` under the google-beta-lane section (beta apply policy is not designed; synth + `terraform validate` only).
+- [ ] 9. **Package test:** extend `packages/terradart_google_beta/test/synth_test.dart` when the new factory has synth-visible behavior worth pinning (provider pin, sealed slots, sensitive fields).
+- [ ] 10. **CHANGELOG:** add the factory to `packages/terradart_google_beta/CHANGELOG.md` under the next version heading.
+
+## Verification
+
+Run the FULL gate from the repo root before opening or updating a PR (it includes the beta `wrap --check` and the beta package suite; CI's `wrap_check` job re-runs the beta lane on every PR):
+
+```bash
+tool/agent_verify.sh
+```
+
+Check exit codes bare — never pipe into tail/grep and trust `&&`.
+
+## PR conventions
+
+Single-purpose PR, Conventional Commit `feat(beta): curate <resource>`. Commit messages carry the demand source (issue link), the cost-classification evidence summary, and the example decision. English, no AI footers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ Committed maintainer skills live under [`.agents/skills/`](.agents/skills/) (Age
 |-------|----------|
 | [`terradart-agent-verify`](.agents/skills/terradart-agent-verify/SKILL.md) | Finishing any agent or maintainer change |
 | [`terradart-add-curated-resource`](.agents/skills/terradart-add-curated-resource/SKILL.md) | Adding or updating a curated `google_*` factory |
+| [`terradart-add-beta-resource`](.agents/skills/terradart-add-beta-resource/SKILL.md) | Adding a beta-only factory to `terradart_google_beta` (demand-driven) |
 | [`terradart-ship-wave`](.agents/skills/terradart-ship-wave/SKILL.md) | Landing a Wave release (curated + example/docs + counts + CHANGELOG + GitHub release notes) |
 | [`terradart-backfill-examples`](.agents/skills/terradart-backfill-examples/SKILL.md) | Shrinking `tool/example_debt.yaml` (the maintenance-phase work queue) in existing quickstarts |
 | [`terradart-tighten-example-topology`](.agents/skills/terradart-tighten-example-topology/SKILL.md) | Wiring backfilled factories into sibling refs; `tool/check_example_topology.dart` |

--- a/tool/bump_version.sh
+++ b/tool/bump_version.sh
@@ -275,7 +275,7 @@ echo "==> Verifying no stale '$OLD' references remain"
 set +e
 STALE=$(
   grep -nE "^version: ${OLD_RE}\$" packages/*/pubspec.yaml 2>/dev/null
-  grep -nE "terradart_(core|codegen|google|coverage): \\^${OLD_RE}([^0-9A-Za-z.-]|\$)" \
+  grep -nE "terradart_(core|codegen|google|google_beta|coverage): \\^${OLD_RE}([^0-9A-Za-z.-]|\$)" \
     packages/*/pubspec.yaml examples/*/pubspec.yaml \
     cookbook/*/pubspec.yaml cookbook/*/*/pubspec.yaml \
     README.md website/src/content/docs/docs/getting-started.md \

--- a/tool/bump_version.sh
+++ b/tool/bump_version.sh
@@ -12,9 +12,10 @@
 #   - packages/terradart_core/pubspec.yaml        (version: line)
 #   - packages/terradart_codegen/pubspec.yaml     (version: + terradart_core caret)
 #   - packages/terradart_google/pubspec.yaml      (version: + terradart_core caret + terradart_codegen dev caret)
+#   - packages/terradart_google_beta/pubspec.yaml (version: + terradart_core caret)
 #   - packages/terradart_agent/pubspec.yaml       (version: + terradart_core caret + terradart_google caret)
 #   - packages/terradart_agent/lib/src/version.dart  (packageVersion const — lockstep with its pubspec)
-#   - examples/*/pubspec.yaml                     (terradart_core + terradart_google carets)
+#   - examples/*/pubspec.yaml                     (terradart_core + terradart_google + terradart_google_beta carets)
 #   - cookbook/*/pubspec.yaml,                    (terradart_core + terradart_google carets on
 #     cookbook/*/*/pubspec.yaml                    workspace-member cookbook recipes)
 #   - README.md                                   (Quickstart pubspec sample + `dart pub global activate terradart_codegen ^...` line + status blurb)
@@ -92,7 +93,7 @@ sed_inplace() {
 
 # 1. `version:` field on the package pubspecs.
 echo "  Package versions:"
-for pkg in terradart_core terradart_codegen terradart_google terradart_agent terradart_coverage; do
+for pkg in terradart_core terradart_codegen terradart_google terradart_google_beta terradart_agent terradart_coverage; do
   sed_inplace "s#^version: ${OLD_RE}\$#version: ${NEW}#" "packages/$pkg/pubspec.yaml"
   echo "    - packages/$pkg/pubspec.yaml -> $NEW"
 done
@@ -106,6 +107,8 @@ sed_inplace "s#^( *terradart_core): \\^${OLD_RE}\$#\\1: ^${NEW}#" packages/terra
 echo "    - terradart_google.dependencies.terradart_core: ^${NEW}"
 sed_inplace "s#^( *terradart_codegen): \\^${OLD_RE}\$#\\1: ^${NEW}#" packages/terradart_google/pubspec.yaml
 echo "    - terradart_google.dev_dependencies.terradart_codegen: ^${NEW}"
+sed_inplace "s#^( *terradart_core): \\^${OLD_RE}\$#\\1: ^${NEW}#" packages/terradart_google_beta/pubspec.yaml
+echo "    - terradart_google_beta.dependencies.terradart_core: ^${NEW}"
 sed_inplace "s#^( *terradart_core): \\^${OLD_RE}\$#\\1: ^${NEW}#" packages/terradart_agent/pubspec.yaml
 echo "    - terradart_agent.dependencies.terradart_core: ^${NEW}"
 sed_inplace "s#^( *terradart_google): \\^${OLD_RE}\$#\\1: ^${NEW}#" packages/terradart_agent/pubspec.yaml
@@ -125,10 +128,10 @@ echo "    - packages/terradart_agent/lib/src/version.dart -> $NEW"
 echo "  Example pubspecs:"
 EXAMPLE_COUNT=0
 for f in examples/*/pubspec.yaml; do
-  sed_inplace "s#^( *terradart_(core|google)): \\^${OLD_RE}\$#\\1: ^${NEW}#" "$f"
+  sed_inplace "s#^( *terradart_(core|google|google_beta)): \\^${OLD_RE}\$#\\1: ^${NEW}#" "$f"
   EXAMPLE_COUNT=$((EXAMPLE_COUNT + 1))
 done
-echo "    - bumped $EXAMPLE_COUNT examples to terradart_{core,google}: ^$NEW"
+echo "    - bumped $EXAMPLE_COUNT examples to terradart_{core,google,google_beta}: ^$NEW"
 
 # 3b. Cookbook recipe pubspecs (workspace members under cookbook/, one or two
 #     levels deep — e.g. cookbook/single-project-app/ and


### PR DESCRIPTION
## Summary

Closes the two operational-readiness gaps left after the google-beta vertical slice (#604–#606): the release tooling did not know the new package, and there was no checklist making beta curation delegable to cloud agents.

## Changes

- **`tool/bump_version.sh`** — the lockstep bump now covers `terradart_google_beta`: its `version:`, its `terradart_core` caret, and `terradart_google_beta` carets in example pubspecs. Without this, the next release would have stranded the beta package at the old version — the exact stale-caret pitfall AGENTS.md warns that workspace resolution hides locally and per-package CI then exposes. Verified by running the script for real in a scratch worktree (`0.99.0`) and inspecting every beta target line.
- **`.agents/skills/terradart-add-beta-resource`** — the 10-step checklist that turns "add `google_x` to beta" into delegable work: beta-only confirmation against the GA fixture, fixture **re-extraction with the append-not-replace rule** (the extraction replaces the whole file — dropping a name silently shrinks the catalog schema), the mandatory `--resource-provider google-beta` pin, cost-classification per policy, the skip-ledger rule for beta examples, and an honest note that beta example coverage is checklist-enforced until a beta coverage gate exists (the synth gate reads only the GA catalog today). Registered in the `AGENTS.md` skills table.

## Deliberately out of scope

- `publish.yml` — publishing `terradart_google_beta` to pub.dev remains a maintainer decision; the package stays out of the publish pipeline until then.

## Verification

- `bash -n`, `check_docs_consistency` — OK
- Live bump test in a scratch worktree: beta pubspec, core caret, and the beta example's caret all moved to the test version
- `tool/agent_verify.sh` — full gate OK (exit code checked bare)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and release-script scope only; no runtime or auth changes. Mis-bumped carets would surface via existing verify/stale grep, not production risk.
> 
> **Overview**
> Operational readiness for **`terradart_google_beta`** after the vertical slice: release tooling and a delegable agent checklist.
> 
> **`tool/bump_version.sh`** now includes **`terradart_google_beta`** in the lockstep bump—package `version:`, its **`terradart_core`** caret, and **`terradart_google_beta`** carets in example pubspecs—plus stale-reference checks for **`google_beta`**. Without this, the next release could leave the beta package on an old version while workspace resolution hides the mismatch locally.
> 
> A new **`.agents/skills/terradart-add-beta-resource`** skill documents a **10-step** demand-driven workflow (beta-only GA check, fixture re-extraction with append-not-replace, **`--resource-provider google-beta`**, cost classification, example/ledger/test/CHANGELOG steps). It is registered in **`AGENTS.md`** next to the GA curated-resource skill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e706aaa5a3ce4997f663fa525d41261b65896711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->