### PR TITLE
chore: lockstep 0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Per-package changelogs live alongside each package and are the system of record 
 
 ## Unreleased
 
+## [0.25.1] - 2026-08-19
+
+Lockstep release across the workspace. **No breaking changes** vs `0.25.0`.
+
+### Added
+
 - **`terradart_google_beta`** — fill the beta-only `hashicorp/google-beta` catalog (**128 resource factories** at provider 7.44.0). Coverage via [`beta_leftover_quickstart`](examples/beta_leftover_quickstart/) (synth + `terraform validate`; apply-smoke skip-listed). Beta-only data sources stay uncurated.
 
 ## [0.25.0] - 2026-08-15

--- a/cookbook/firestore-seeded-data/pubspec.yaml
+++ b/cookbook/firestore-seeded-data/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/lunch-concierge/infra/pubspec.yaml
+++ b/cookbook/lunch-concierge/infra/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/remote-backend/pubspec.yaml
+++ b/cookbook/remote-backend/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/single-project-app/pubspec.yaml
+++ b/cookbook/single-project-app/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/access_context_quickstart/pubspec.yaml
+++ b/examples/access_context_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/api_security_quickstart/pubspec.yaml
+++ b/examples/api_security_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/apigee_quickstart/pubspec.yaml
+++ b/examples/apigee_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/app_engine_quickstart/pubspec.yaml
+++ b/examples/app_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/apphub_quickstart/pubspec.yaml
+++ b/examples/apphub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/appwrite_quickstart/pubspec.yaml
+++ b/examples/appwrite_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_appwrite: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_appwrite: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/artifact_registry_quickstart/pubspec.yaml
+++ b/examples/artifact_registry_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/beta_leftover_quickstart/pubspec.yaml
+++ b/examples/beta_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google_beta: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google_beta: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/beta_service_identity_quickstart/pubspec.yaml
+++ b/examples/beta_service_identity_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google_beta: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google_beta: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/biglake_quickstart/pubspec.yaml
+++ b/examples/biglake_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_datapolicyv2_quickstart/pubspec.yaml
+++ b/examples/bigquery_datapolicyv2_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_quickstart/pubspec.yaml
+++ b/examples/bigquery_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigtable_quickstart/pubspec.yaml
+++ b/examples/bigtable_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ces_quickstart/pubspec.yaml
+++ b/examples/ces_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/chronicle_quickstart/pubspec.yaml
+++ b/examples/chronicle_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_asset_quickstart/pubspec.yaml
+++ b/examples/cloud_asset_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_build_quickstart/pubspec.yaml
+++ b/examples/cloud_build_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_functions_quickstart/pubspec.yaml
+++ b/examples/cloud_functions_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_quickstart/pubspec.yaml
+++ b/examples/cloud_run_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_v1_quickstart/pubspec.yaml
+++ b/examples/cloud_run_v1_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_scheduler_quickstart/pubspec.yaml
+++ b/examples/cloud_scheduler_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_sql_quickstart/pubspec.yaml
+++ b/examples/cloud_sql_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_tasks_quickstart/pubspec.yaml
+++ b/examples/cloud_tasks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/clouddeploy_quickstart/pubspec.yaml
+++ b/examples/clouddeploy_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/colab_quickstart/pubspec.yaml
+++ b/examples/colab_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_cloud_armor_tier_quickstart/pubspec.yaml
+++ b/examples/compute_cloud_armor_tier_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_default_network_tier_quickstart/pubspec.yaml
+++ b/examples/compute_default_network_tier_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_instance_settings_quickstart/pubspec.yaml
+++ b/examples/compute_instance_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_lb_quickstart/pubspec.yaml
+++ b/examples/compute_lb_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_preview_feature_quickstart/pubspec.yaml
+++ b/examples/compute_preview_feature_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_quickstart/pubspec.yaml
+++ b/examples/compute_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_rollout_quickstart/pubspec.yaml
+++ b/examples/compute_rollout_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_route_quickstart/pubspec.yaml
+++ b/examples/compute_route_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_snapshot_settings_quickstart/pubspec.yaml
+++ b/examples/compute_snapshot_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_vpn_gateway_quickstart/pubspec.yaml
+++ b/examples/compute_vpn_gateway_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/config_deployment_quickstart/pubspec.yaml
+++ b/examples/config_deployment_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/contact_center_insights_quickstart/pubspec.yaml
+++ b/examples/contact_center_insights_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/container_analysis_quickstart/pubspec.yaml
+++ b/examples/container_analysis_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_catalog_quickstart/pubspec.yaml
+++ b/examples/data_catalog_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_lineage_quickstart/pubspec.yaml
+++ b/examples/data_lineage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_source_leftover_quickstart/pubspec.yaml
+++ b/examples/data_source_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataform_quickstart/pubspec.yaml
+++ b/examples/dataform_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataplex_quickstart/pubspec.yaml
+++ b/examples/dataplex_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataproc_autoscaling_quickstart/pubspec.yaml
+++ b/examples/dataproc_autoscaling_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataproc_metastore_quickstart/pubspec.yaml
+++ b/examples/dataproc_metastore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/deferred_leftover_quickstart/pubspec.yaml
+++ b/examples/deferred_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/developer_connect_quickstart/pubspec.yaml
+++ b/examples/developer_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_es_quickstart/pubspec.yaml
+++ b/examples/dialogflow_es_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_quickstart/pubspec.yaml
+++ b/examples/dialogflow_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/discovery_engine_quickstart/pubspec.yaml
+++ b/examples/discovery_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dlp_quickstart/pubspec.yaml
+++ b/examples/dlp_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dns_quickstart/pubspec.yaml
+++ b/examples/dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/document_ai_quickstart/pubspec.yaml
+++ b/examples/document_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/endpoints_quickstart/pubspec.yaml
+++ b/examples/endpoints_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/eventarc_quickstart/pubspec.yaml
+++ b/examples/eventarc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/filestore_quickstart/pubspec.yaml
+++ b/examples/filestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_check_quickstart/pubspec.yaml
+++ b/examples/firebase_app_check_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_hosting_quickstart/pubspec.yaml
+++ b/examples/firebase_app_hosting_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_data_connect_quickstart/pubspec.yaml
+++ b/examples/firebase_data_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_remote_config_quickstart/pubspec.yaml
+++ b/examples/firebase_remote_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebaserules_quickstart/pubspec.yaml
+++ b/examples/firebaserules_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_document_quickstart/pubspec.yaml
+++ b/examples/firestore_document_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_quickstart/pubspec.yaml
+++ b/examples/firestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gemini_quickstart/pubspec.yaml
+++ b/examples/gemini_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_hub_feature_quickstart/pubspec.yaml
+++ b/examples/gke_hub_feature_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_hub_quickstart/pubspec.yaml
+++ b/examples/gke_hub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_quickstart/pubspec.yaml
+++ b/examples/gke_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/healthcare_quickstart/pubspec.yaml
+++ b/examples/healthcare_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iam_quickstart/pubspec.yaml
+++ b/examples/iam_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iap_settings_quickstart/pubspec.yaml
+++ b/examples/iap_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iap_tunnel_quickstart/pubspec.yaml
+++ b/examples/iap_tunnel_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/identity_platform_quickstart/pubspec.yaml
+++ b/examples/identity_platform_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/integrations_quickstart/pubspec.yaml
+++ b/examples/integrations_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_autokey_quickstart/pubspec.yaml
+++ b/examples/kms_autokey_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_quickstart/pubspec.yaml
+++ b/examples/kms_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/license_manager_quickstart/pubspec.yaml
+++ b/examples/license_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/migration_center_quickstart/pubspec.yaml
+++ b/examples/migration_center_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/model_armor_quickstart/pubspec.yaml
+++ b/examples/model_armor_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/monitoring_quickstart/pubspec.yaml
+++ b/examples/monitoring_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ncc_hub_quickstart/pubspec.yaml
+++ b/examples/ncc_hub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/netapp_metadata_quickstart/pubspec.yaml
+++ b/examples/netapp_metadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_connectivity_quickstart/pubspec.yaml
+++ b/examples/network_connectivity_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_management_vpc_flow_logs_quickstart/pubspec.yaml
+++ b/examples/network_management_vpc_flow_logs_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_backend_auth_quickstart/pubspec.yaml
+++ b/examples/network_security_backend_auth_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_dns_threat_quickstart/pubspec.yaml
+++ b/examples/network_security_dns_threat_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_gateway_policy_quickstart/pubspec.yaml
+++ b/examples/network_security_gateway_policy_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_lists_quickstart/pubspec.yaml
+++ b/examples/network_security_lists_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_tls_quickstart/pubspec.yaml
+++ b/examples/network_security_tls_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_ull_quickstart/pubspec.yaml
+++ b/examples/network_security_ull_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_services_mesh_quickstart/pubspec.yaml
+++ b/examples/network_services_mesh_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/notebooks_quickstart/pubspec.yaml
+++ b/examples/notebooks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/observability_quickstart/pubspec.yaml
+++ b/examples/observability_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ops_quickstart/pubspec.yaml
+++ b/examples/ops_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_autonomous_database_quickstart/pubspec.yaml
+++ b/examples/oracle_autonomous_database_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_db_system_quickstart/pubspec.yaml
+++ b/examples/oracle_db_system_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_exadata_quickstart/pubspec.yaml
+++ b/examples/oracle_exadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_goldengate_quickstart/pubspec.yaml
+++ b/examples/oracle_goldengate_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/org_leftover_quickstart/pubspec.yaml
+++ b/examples/org_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/parameter_manager_quickstart/pubspec.yaml
+++ b/examples/parameter_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/privileged_access_manager_quickstart/pubspec.yaml
+++ b/examples/privileged_access_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/project_iam_audit_config_quickstart/pubspec.yaml
+++ b/examples/project_iam_audit_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/public_ca_quickstart/pubspec.yaml
+++ b/examples/public_ca_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/pubsub_quickstart/pubspec.yaml
+++ b/examples/pubsub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/scc_quickstart/pubspec.yaml
+++ b/examples/scc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/secret_manager_quickstart/pubspec.yaml
+++ b/examples/secret_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/service_directory_quickstart/pubspec.yaml
+++ b/examples/service_directory_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/sourcerepo_quickstart/pubspec.yaml
+++ b/examples/sourcerepo_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/spanner_instance_config_quickstart/pubspec.yaml
+++ b/examples/spanner_instance_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_intelligence_quickstart/pubspec.yaml
+++ b/examples/storage_intelligence_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_quickstart/pubspec.yaml
+++ b/examples/storage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_transfer_quickstart/pubspec.yaml
+++ b/examples/storage_transfer_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/tags_quickstart/pubspec.yaml
+++ b/examples/tags_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/transcoder_quickstart/pubspec.yaml
+++ b/examples/transcoder_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/usage_export_quickstart/pubspec.yaml
+++ b/examples/usage_export_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vector_quickstart/pubspec.yaml
+++ b/examples/vector_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vertex_ai_quickstart/pubspec.yaml
+++ b/examples/vertex_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vm_compliance_quickstart/pubspec.yaml
+++ b/examples/vm_compliance_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/wif_trust_domain_quickstart/pubspec.yaml
+++ b/examples/wif_trust_domain_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/workflows_quickstart/pubspec.yaml
+++ b/examples/workflows_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/terradart_agent/CHANGELOG.md
+++ b/packages/terradart_agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.1 - 2026-08-19
+
+Lockstep release with `terradart_google_beta` 0.25.1. MCP catalog is unchanged (GA `hashicorp/google` only). No MCP protocol or tool changes.
+
 ## 0.25.0 - 2026-08-15
 
 Lockstep release with `terradart_google` 0.25.0. Catalog: **1793 entries** (1332 curated resource factories + 461 data sources) across **131 service barrels**. No MCP protocol or tool changes.

--- a/packages/terradart_agent/lib/src/version.dart
+++ b/packages/terradart_agent/lib/src/version.dart
@@ -1,4 +1,4 @@
 /// The terradart-mcp binary version, kept in lockstep with pubspec.yaml's
 /// `version:` field by `tool/bump_version.sh`. The lockstep is guarded by
 /// test/version_test.dart so the two can never silently drift.
-const String packageVersion = '0.25.0';
+const String packageVersion = '0.25.1';

--- a/packages/terradart_agent/pubspec.yaml
+++ b/packages/terradart_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_agent
 description: terradart-mcp — MCP server exposing the curated GCP factory catalog of TerraDart.
-version: 0.25.0
+version: 0.25.1
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -16,9 +16,9 @@ executables:
   terradart-mcp: terradart_mcp
 
 dependencies:
-  terradart_core: ^0.25.0
-  terradart_google: ^0.25.0
-  terradart_coverage: ^0.25.0
+  terradart_core: ^0.25.1
+  terradart_google: ^0.25.1
+  terradart_coverage: ^0.25.1
   genkit: ^0.14.1
   genkit_mcp: ^0.2.1
   schemantic: ^0.2.0

--- a/packages/terradart_appwrite/CHANGELOG.md
+++ b/packages/terradart_appwrite/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.25.1
+
+- Lockstep release with the TerraDart workspace. No Appwrite factory or
+  provider changes.
+
 ## 0.25.0
 
 - Initial release: `AppwriteProvider` (credential-free by design — apply

--- a/packages/terradart_appwrite/pubspec.yaml
+++ b/packages/terradart_appwrite/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_appwrite
 description: Curated factory wrappers for Appwrite resources (official appwrite/appwrite Terraform provider) for Dart-first Terraform stacks.
-version: 0.25.0
+version: 0.25.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
+  terradart_core: ^0.25.1
   meta: ^1.15.0
 
 dev_dependencies:

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.1 - 2026-08-19
+
+Lockstep release with `terradart_google_beta` 0.25.1 (beta-only catalog filled). No user-facing CLI flag changes.
+
 ## 0.25.0 - 2026-08-15
 
 Lockstep release with `terradart_google` 0.25.0 (GA `hashicorp/google` catalog filled). Wrap emits GA data-source factories (`data_<type>.yaml` twins, `Data` class prefix). No user-facing CLI flag changes.

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart maintainer tooling — parses Terraform provider schema JSON and Magic Modules YAML and emits curated factory wrappers via terradart wrap. Ships the terradart CLI.
-version: 0.25.0
+version: 0.25.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -33,7 +33,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.25.0
+  terradart_core: ^0.25.1
 
 dev_dependencies:
   http: ^1.0.0

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.1 - 2026-08-19
+
+Lockstep release with `terradart_google_beta` 0.25.1 (beta-only catalog filled). No `terradart_core` API changes.
+
 ## 0.25.0 - 2026-08-15
 
 Lockstep release with `terradart_google` 0.25.0 (GA `hashicorp/google` catalog filled). No `terradart_core` API changes.

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.25.0
+version: 0.25.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_coverage/CHANGELOG.md
+++ b/packages/terradart_coverage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.1 - 2026-08-19
+
+Lockstep release with `terradart_google_beta` 0.25.1. No functional changes in this package.
+
 ## 0.25.0 - 2026-08-15
 
 Lockstep release with `terradart_google` 0.25.0. Coverage report no longer requires a live uncurated GA type as a sentinel.

--- a/packages/terradart_coverage/pubspec.yaml
+++ b/packages/terradart_coverage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_coverage
 description: Read-only Terraform coverage checker — reports how much of a Terraform config is covered by curated terradart_google factories.
-version: 0.25.0
+version: 0.25.1
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -15,7 +15,7 @@ executables:
   terradart-coverage: terradart_coverage
 
 dependencies:
-  terradart_google: ^0.25.0
+  terradart_google: ^0.25.1
   args: ^2.5.0
 
 dev_dependencies:

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.1 - 2026-08-19
+
+Lockstep release. **No breaking changes** vs `0.25.0`. No `terradart_google` API changes — the beta-only catalog fill ships in `terradart_google_beta`.
+
 ## 0.25.0 - 2026-08-15
 
 Lockstep release. **No breaking changes** vs `0.24.0`.

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: Curated factory wrappers for Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.
-version: 0.25.0
+version: 0.25.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -22,11 +22,11 @@ false_secrets:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
+  terradart_core: ^0.25.1
   meta: ^1.15.0
 
 dev_dependencies:
-  terradart_codegen: ^0.25.0
+  terradart_codegen: ^0.25.1
   path: ^1.9.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/packages/terradart_google_beta/CHANGELOG.md
+++ b/packages/terradart_google_beta/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.25.1
 
 - Fill the beta-only `hashicorp/google-beta` catalog: **128 resource
   factories** (74 core + 54 IAM adjuncts) at provider 7.44.0. Wrappers

--- a/packages/terradart_google_beta/pubspec.yaml
+++ b/packages/terradart_google_beta/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google_beta
 description: Curated factory wrappers for beta-only Google Cloud resources (hashicorp/google-beta) for Dart-first Terraform stacks.
-version: 0.25.0
+version: 0.25.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.0
+  terradart_core: ^0.25.1
   meta: ^1.15.0
 
 dev_dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Lockstep `0.25.1` across `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_google_beta`, `terradart_appwrite`, `terradart_agent`, and `terradart_coverage`. **No breaking changes** vs `0.25.0`. No `MIGRATING.md` section.

## Highlights

- **`terradart_google_beta`** — fill the beta-only `hashicorp/google-beta` catalog (**128 resource factories** at provider 7.44.0)
- Coverage via [`beta_leftover_quickstart`](examples/beta_leftover_quickstart/) (synth + `terraform validate`; apply-smoke skip-listed)
- Beta-only data sources stay uncurated
- `^0.25.x` users pick this up as a patch

This is not a Wave number and not a product-beta cut. It publishes the beta-only catalog fill that landed in #612.

## Out of scope

- No tag, GitHub release, or pub.dev publish in this PR (maintainer-manual after merge)
- Does not claim every factory is apply-verified
- Does not rewrite historical `0.25.0` “coming soon” changelog text

## After merge

1. Tag `v0.25.1` (triggers `.github/workflows/publish.yml`)
2. After publish is green, create the GitHub release (`v0.25.1` title only)

Draft notes:

```
Lockstep release across `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_google_beta`, `terradart_appwrite`, `terradart_agent`, and `terradart_coverage`. **No breaking changes** vs `0.25.0`.

## Highlights

- **`terradart_google_beta`:** **128 beta-only resource factories** at provider 7.44.0
- Coverage via [`beta_leftover_quickstart`](https://github.com/nozomi-koborinai/terradart/tree/main/examples/beta_leftover_quickstart) (synth + `terraform validate`; apply-smoke skip-listed)
- Beta-only data sources stay uncurated

## Upgrade

    dependencies:
      terradart_core: ^0.25.1
      terradart_google: ^0.25.1
      terradart_google_beta: ^0.25.1

Docs: [Getting started](https://terradart.dev/docs/getting-started/) · [Status](https://terradart.dev/docs/status/)

**Full Changelog**: https://github.com/nozomi-koborinai/terradart/compare/v0.25.0...v0.25.1
```

## Verify

- `tool/bump_version.sh 0.25.1` — package versions, inter-package carets, example/cookbook carets, `packageVersion`
- `dart tool/check_docs_consistency.dart` — OK (workspace minor `0.25.x`)
- `dart tool/example_synth_gates.dart` — 1921 factories, 119/119 `terraform validate`
- `terradart wrap --check` — GA 1927, beta 159, appwrite 6
- `terradart lint-override` — 1793 GA + 128 beta clean
- `tool/agent_verify.sh` — `agent_verify: OK`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0196f-04f5-7739-9756-3cd5fbcc390f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0196f-04f5-7739-9756-3cd5fbcc390f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

