### PR TITLE
feat(codegen): beta/GA overlap gate + keys-from-fixture extraction

### DIFF
--- a/.agents/skills/terradart-add-beta-resource/SKILL.md
+++ b/.agents/skills/terradart-add-beta-resource/SKILL.md
@@ -15,11 +15,12 @@ The beta-only catalog at the current provider pin is **filled**. Add a resource 
 **Task progress:**
 
 - [ ] 1. **Confirm beta-only.** The type must be absent from the GA fixture (`packages/terradart_codegen/test/fixtures/wrap/source/schema.json`) and present in the google-beta provider. If it exists in GA, stop — curate it in `terradart_google` instead ([`terradart-add-curated-resource`](../terradart-add-curated-resource/SKILL.md)).
-- [ ] 2. **Re-extract the fixture** with the new type APPENDED to the existing list (the fixture README records the current list — the extraction replaces the whole file, so dropping a name would silently shrink the catalog's schema):
+- [ ] 2. **Re-extract the fixture** with the new type added via union — the current set comes from the fixture itself (`schema.json` keys are the single source of truth; no name list is maintained anywhere else):
   ```bash
   dart tool/extract_schema_subset.dart \
     --provider=hashicorp/google-beta --version=<provider_version.txt> \
-    --resources=<existing,list,plus_new_type> \
+    --resources-from=packages/terradart_codegen/test/fixtures/wrap/source_beta/schema.json \
+    --resources=<new_type> \
     --out=packages/terradart_codegen/test/fixtures/wrap/source_beta
   ```
   Requires `terraform` on PATH and terraform-registry network access (no cloud credentials). If either is missing in your environment, stop and report — never hand-write schema JSON.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - if: matrix.package == 'terradart_core'
         run: dart analyze packages/ tool/ --fatal-infos --fatal-warnings
       - if: matrix.package == 'terradart_core'
-        run: dart test tool/render_formula_test.dart tool/render_to_file_test.dart tool/select_changed_examples_test.dart tool/check_bump_scope_test.dart
+        run: dart test tool/render_formula_test.dart tool/render_to_file_test.dart tool/select_changed_examples_test.dart tool/check_bump_scope_test.dart tool/extract_schema_subset_test.dart
       - run: dart test --reporter=github
         working-directory: packages/${{ matrix.package }}
 

--- a/packages/terradart_codegen/lib/src/codegen/universal_invariants/beta_overlap.dart
+++ b/packages/terradart_codegen/lib/src/codegen/universal_invariants/beta_overlap.dart
@@ -1,0 +1,26 @@
+// packages/terradart_codegen/lib/src/codegen/universal_invariants/beta_overlap.dart
+/// Gate 9 predicate: resource type names present in BOTH schema JSONs.
+///
+/// The GA fixture is the full `hashicorp/google` schema and the beta fixture
+/// is the filtered beta-only subset, so a non-empty intersection means a
+/// beta-only type has been promoted to GA — the "types that also exist in GA
+/// stay in `terradart_google`" invariant is broken.
+List<String> overlappingResourceTypes({
+  required Map<String, dynamic> gaSchema,
+  required Map<String, dynamic> betaSchema,
+}) {
+  Set<String> names(Map<String, dynamic> schema) {
+    final providerSchemas =
+        (schema['provider_schemas'] as Map?)?.cast<String, dynamic>() ??
+            const {};
+    final out = <String>{};
+    for (final body in providerSchemas.values) {
+      final resources = ((body as Map?)?['resource_schemas'] as Map?)
+          ?.cast<String, dynamic>();
+      if (resources != null) out.addAll(resources.keys);
+    }
+    return out;
+  }
+
+  return names(gaSchema).intersection(names(betaSchema)).toList()..sort();
+}

--- a/packages/terradart_codegen/test/codegen/universal_invariants/beta_overlap_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants/beta_overlap_test.dart
@@ -1,0 +1,51 @@
+// packages/terradart_codegen/test/codegen/universal_invariants/beta_overlap_test.dart
+import 'package:terradart_codegen/src/codegen/universal_invariants/beta_overlap.dart';
+import 'package:test/test.dart';
+
+Map<String, dynamic> schemaWith(String providerName, List<String> types) => {
+      'format_version': '1.0',
+      'provider_schemas': {
+        'registry.terraform.io/hashicorp/$providerName': {
+          'resource_schemas': {
+            for (final t in types)
+              t: {'version': 0, 'block': <String, dynamic>{}},
+          },
+        },
+      },
+    };
+
+void main() {
+  test('disjoint schemas produce no overlap', () {
+    expect(
+      overlappingResourceTypes(
+        gaSchema: schemaWith('google', ['google_a', 'google_b']),
+        betaSchema: schemaWith('google-beta', ['google_c']),
+      ),
+      isEmpty,
+    );
+  });
+
+  test('promoted types are reported sorted', () {
+    expect(
+      overlappingResourceTypes(
+        gaSchema: schemaWith('google', ['google_z', 'google_a', 'google_m']),
+        betaSchema: schemaWith('google-beta', ['google_z', 'google_a']),
+      ),
+      ['google_a', 'google_z'],
+    );
+  });
+
+  test('empty or malformed schemas mean no overlap', () {
+    expect(
+      overlappingResourceTypes(gaSchema: {}, betaSchema: {}),
+      isEmpty,
+    );
+    expect(
+      overlappingResourceTypes(
+        gaSchema: {'provider_schemas': <String, dynamic>{}},
+        betaSchema: schemaWith('google-beta', ['google_a']),
+      ),
+      isEmpty,
+    );
+  });
+}

--- a/packages/terradart_codegen/test/codegen/universal_invariants_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants_test.dart
@@ -1,7 +1,9 @@
 // packages/terradart_codegen/test/codegen/universal_invariants_test.dart
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:terradart_codegen/src/codegen/universal_invariants/beta_overlap.dart';
 import 'package:terradart_codegen/src/codegen/universal_invariants/enum_extractor.dart';
 import 'package:terradart_codegen/src/codegen/universal_invariants/enum_value_length.dart';
 import 'package:terradart_codegen/src/codegen/universal_invariants/nested_helper_prefix.dart';
@@ -351,6 +353,31 @@ void main() {
           reason: 'Short enum values found (consider verbose-natural form '
               'or add to allowList if legitimately short):\n'
               '${violations.join('\n')}');
+    });
+  });
+
+  group('Gate 9: beta-only catalog does not overlap the GA schema', () {
+    test('no source_beta resource type exists in the GA fixture', () {
+      final ga = jsonDecode(
+        File('test/fixtures/wrap/source/schema.json').readAsStringSync(),
+      ) as Map<String, dynamic>;
+      final beta = jsonDecode(
+        File('test/fixtures/wrap/source_beta/schema.json').readAsStringSync(),
+      ) as Map<String, dynamic>;
+      final promoted =
+          overlappingResourceTypes(gaSchema: ga, betaSchema: beta);
+      expect(
+        promoted,
+        isEmpty,
+        reason: 'beta-only type(s) promoted to GA: ${promoted.join(', ')}.\n'
+            'Playbook (maintainer, Tier 3 — never auto-repair):\n'
+            '1. Remove the factory from terradart_google_beta (breaking: '
+            'minor bump + MIGRATING.md).\n'
+            '2. Re-extract source_beta without the promoted type(s) '
+            '(see its README).\n'
+            '3. GA curation picks the type up via the normal backlog/wave '
+            'lane.',
+      );
     });
   });
 }

--- a/packages/terradart_codegen/test/codegen/universal_invariants_test.dart
+++ b/packages/terradart_codegen/test/codegen/universal_invariants_test.dart
@@ -364,8 +364,7 @@ void main() {
       final beta = jsonDecode(
         File('test/fixtures/wrap/source_beta/schema.json').readAsStringSync(),
       ) as Map<String, dynamic>;
-      final promoted =
-          overlappingResourceTypes(gaSchema: ga, betaSchema: beta);
+      final promoted = overlappingResourceTypes(gaSchema: ga, betaSchema: beta);
       expect(
         promoted,
         isEmpty,

--- a/packages/terradart_codegen/test/fixtures/wrap/source_beta/README.md
+++ b/packages/terradart_codegen/test/fixtures/wrap/source_beta/README.md
@@ -1,141 +1,18 @@
 # Filtered schema fixture — hashicorp/google-beta
 
-Machine-extracted subset containing ONLY the curated resources below.
-Never hand-edit; re-extract with:
+Machine-extracted subset containing ONLY the curated resources. The keys of
+`schema.json` are the single source of truth for the set, and
+`provider_version.txt` records the extraction version. Never hand-edit
+either file. Re-extract the SAME set at the pinned version with:
 
 ```bash
 dart tool/extract_schema_subset.dart \
-  --provider=hashicorp/google-beta --version=7.44.0 \
-  --resources=google_active_directory_peering,google_api_gateway_api,google_api_gateway_api_config,google_api_gateway_api_config_iam_binding,google_api_gateway_api_config_iam_member,google_api_gateway_api_config_iam_policy,google_api_gateway_api_iam_binding,google_api_gateway_api_iam_member,google_api_gateway_api_iam_policy,google_api_gateway_gateway,google_api_gateway_gateway_iam_binding,google_api_gateway_gateway_iam_member,google_api_gateway_gateway_iam_policy,google_artifact_registry_vpcsc_config,google_biglake_hive_catalog,google_biglake_hive_catalog_iam_binding,google_biglake_hive_catalog_iam_member,google_biglake_hive_catalog_iam_policy,google_biglake_hive_database,google_biglake_hive_database_iam_binding,google_biglake_hive_database_iam_member,google_biglake_hive_database_iam_policy,google_biglake_hive_table,google_biglake_hive_table_iam_binding,google_biglake_hive_table_iam_member,google_biglake_hive_table_iam_policy,google_bigquery_analytics_hub_data_exchange_subscription,google_ces_evaluation,google_ces_security_settings,google_chronicle_soar_domain,google_cloud_identity_policy,google_compute_backend_bucket_iam_binding,google_compute_backend_bucket_iam_member,google_compute_backend_bucket_iam_policy,google_compute_backend_service_iam_binding,google_compute_backend_service_iam_member,google_compute_backend_service_iam_policy,google_compute_future_reservation,google_compute_instance_from_machine_image,google_compute_machine_image,google_compute_machine_image_iam_binding,google_compute_machine_image_iam_member,google_compute_machine_image_iam_policy,google_compute_network_edge_security_service,google_compute_network_firewall_policy_packet_mirroring_rule,google_compute_region_backend_bucket,google_compute_region_backend_bucket_iam_binding,google_compute_region_backend_bucket_iam_member,google_compute_region_backend_bucket_iam_policy,google_compute_region_backend_service_iam_binding,google_compute_region_backend_service_iam_member,google_compute_region_backend_service_iam_policy,google_compute_region_network_policy,google_compute_region_network_policy_traffic_classification_rule,google_dataflow_flex_template_job,google_dataform_config,google_dataform_repository_release_config,google_dataform_repository_workflow_config,google_dataplex_data_asset,google_firebase_ai_logic_config,google_firebase_ai_logic_prompt_template,google_firebase_ai_logic_prompt_template_lock,google_firebase_android_app,google_firebase_apple_app,google_firebase_database_instance,google_firebase_extensions_instance,google_firebase_hosting_channel,google_firebase_hosting_custom_domain,google_firebase_hosting_release,google_firebase_hosting_site,google_firebase_hosting_version,google_firebase_project,google_firebase_storage_bucket,google_firebase_storage_default_bucket,google_firebase_web_app,google_folder_service_identity,google_gke_hub_membership_rbac_role_binding,google_kms_folder_kaj_policy_config,google_kms_organization_kaj_policy_config,google_kms_project_kaj_policy_config,google_network_security_authorization_policy,google_network_security_sac_attachment,google_network_security_sac_realm,google_network_services_service_lb_policies,google_observability_folder_settings,google_observability_organization_settings,google_observability_project_settings,google_organization_service_identity,google_os_config_guest_policies,google_privileged_access_manager_settings,google_project_service_identity,google_runtimeconfig_config,google_runtimeconfig_config_iam_binding,google_runtimeconfig_config_iam_member,google_runtimeconfig_config_iam_policy,google_runtimeconfig_variable,google_saas_runtime_release,google_saas_runtime_rollout_kind,google_saas_runtime_saas,google_saas_runtime_tenant,google_saas_runtime_unit,google_saas_runtime_unit_kind,google_saas_runtime_unit_operation,google_security_scanner_scan_config,google_service_usage_consumer_quota_override,google_tags_tag_binding_collection,google_tpu_v2_queued_resource,google_tpu_v2_vm,google_vertex_ai_endpoint_iam_binding,google_vertex_ai_endpoint_iam_member,google_vertex_ai_endpoint_iam_policy,google_vertex_ai_feature_group_iam_binding,google_vertex_ai_feature_group_iam_member,google_vertex_ai_feature_group_iam_policy,google_vertex_ai_feature_online_store_featureview_iam_binding,google_vertex_ai_feature_online_store_featureview_iam_member,google_vertex_ai_feature_online_store_featureview_iam_policy,google_vertex_ai_feature_online_store_iam_binding,google_vertex_ai_feature_online_store_iam_member,google_vertex_ai_feature_online_store_iam_policy,google_vertex_ai_featurestore_entitytype_iam_binding,google_vertex_ai_featurestore_entitytype_iam_member,google_vertex_ai_featurestore_entitytype_iam_policy,google_vertex_ai_featurestore_iam_binding,google_vertex_ai_featurestore_iam_member,google_vertex_ai_featurestore_iam_policy,google_vertex_ai_metadata_store,google_vertex_ai_model_garden_enable_model \
+  --provider=hashicorp/google-beta \
+  --version="$(cat packages/terradart_codegen/test/fixtures/wrap/source_beta/provider_version.txt)" \
+  --resources-from=packages/terradart_codegen/test/fixtures/wrap/source_beta/schema.json \
   --out=packages/terradart_codegen/test/fixtures/wrap/source_beta
 ```
 
-Resources:
-- `google_active_directory_peering`
-- `google_api_gateway_api`
-- `google_api_gateway_api_config`
-- `google_api_gateway_api_config_iam_binding`
-- `google_api_gateway_api_config_iam_member`
-- `google_api_gateway_api_config_iam_policy`
-- `google_api_gateway_api_iam_binding`
-- `google_api_gateway_api_iam_member`
-- `google_api_gateway_api_iam_policy`
-- `google_api_gateway_gateway`
-- `google_api_gateway_gateway_iam_binding`
-- `google_api_gateway_gateway_iam_member`
-- `google_api_gateway_gateway_iam_policy`
-- `google_artifact_registry_vpcsc_config`
-- `google_biglake_hive_catalog`
-- `google_biglake_hive_catalog_iam_binding`
-- `google_biglake_hive_catalog_iam_member`
-- `google_biglake_hive_catalog_iam_policy`
-- `google_biglake_hive_database`
-- `google_biglake_hive_database_iam_binding`
-- `google_biglake_hive_database_iam_member`
-- `google_biglake_hive_database_iam_policy`
-- `google_biglake_hive_table`
-- `google_biglake_hive_table_iam_binding`
-- `google_biglake_hive_table_iam_member`
-- `google_biglake_hive_table_iam_policy`
-- `google_bigquery_analytics_hub_data_exchange_subscription`
-- `google_ces_evaluation`
-- `google_ces_security_settings`
-- `google_chronicle_soar_domain`
-- `google_cloud_identity_policy`
-- `google_compute_backend_bucket_iam_binding`
-- `google_compute_backend_bucket_iam_member`
-- `google_compute_backend_bucket_iam_policy`
-- `google_compute_backend_service_iam_binding`
-- `google_compute_backend_service_iam_member`
-- `google_compute_backend_service_iam_policy`
-- `google_compute_future_reservation`
-- `google_compute_instance_from_machine_image`
-- `google_compute_machine_image`
-- `google_compute_machine_image_iam_binding`
-- `google_compute_machine_image_iam_member`
-- `google_compute_machine_image_iam_policy`
-- `google_compute_network_edge_security_service`
-- `google_compute_network_firewall_policy_packet_mirroring_rule`
-- `google_compute_region_backend_bucket`
-- `google_compute_region_backend_bucket_iam_binding`
-- `google_compute_region_backend_bucket_iam_member`
-- `google_compute_region_backend_bucket_iam_policy`
-- `google_compute_region_backend_service_iam_binding`
-- `google_compute_region_backend_service_iam_member`
-- `google_compute_region_backend_service_iam_policy`
-- `google_compute_region_network_policy`
-- `google_compute_region_network_policy_traffic_classification_rule`
-- `google_dataflow_flex_template_job`
-- `google_dataform_config`
-- `google_dataform_repository_release_config`
-- `google_dataform_repository_workflow_config`
-- `google_dataplex_data_asset`
-- `google_firebase_ai_logic_config`
-- `google_firebase_ai_logic_prompt_template`
-- `google_firebase_ai_logic_prompt_template_lock`
-- `google_firebase_android_app`
-- `google_firebase_apple_app`
-- `google_firebase_database_instance`
-- `google_firebase_extensions_instance`
-- `google_firebase_hosting_channel`
-- `google_firebase_hosting_custom_domain`
-- `google_firebase_hosting_release`
-- `google_firebase_hosting_site`
-- `google_firebase_hosting_version`
-- `google_firebase_project`
-- `google_firebase_storage_bucket`
-- `google_firebase_storage_default_bucket`
-- `google_firebase_web_app`
-- `google_folder_service_identity`
-- `google_gke_hub_membership_rbac_role_binding`
-- `google_kms_folder_kaj_policy_config`
-- `google_kms_organization_kaj_policy_config`
-- `google_kms_project_kaj_policy_config`
-- `google_network_security_authorization_policy`
-- `google_network_security_sac_attachment`
-- `google_network_security_sac_realm`
-- `google_network_services_service_lb_policies`
-- `google_observability_folder_settings`
-- `google_observability_organization_settings`
-- `google_observability_project_settings`
-- `google_organization_service_identity`
-- `google_os_config_guest_policies`
-- `google_privileged_access_manager_settings`
-- `google_project_service_identity`
-- `google_runtimeconfig_config`
-- `google_runtimeconfig_config_iam_binding`
-- `google_runtimeconfig_config_iam_member`
-- `google_runtimeconfig_config_iam_policy`
-- `google_runtimeconfig_variable`
-- `google_saas_runtime_release`
-- `google_saas_runtime_rollout_kind`
-- `google_saas_runtime_saas`
-- `google_saas_runtime_tenant`
-- `google_saas_runtime_unit`
-- `google_saas_runtime_unit_kind`
-- `google_saas_runtime_unit_operation`
-- `google_security_scanner_scan_config`
-- `google_service_usage_consumer_quota_override`
-- `google_tags_tag_binding_collection`
-- `google_tpu_v2_queued_resource`
-- `google_tpu_v2_vm`
-- `google_vertex_ai_endpoint_iam_binding`
-- `google_vertex_ai_endpoint_iam_member`
-- `google_vertex_ai_endpoint_iam_policy`
-- `google_vertex_ai_feature_group_iam_binding`
-- `google_vertex_ai_feature_group_iam_member`
-- `google_vertex_ai_feature_group_iam_policy`
-- `google_vertex_ai_feature_online_store_featureview_iam_binding`
-- `google_vertex_ai_feature_online_store_featureview_iam_member`
-- `google_vertex_ai_feature_online_store_featureview_iam_policy`
-- `google_vertex_ai_feature_online_store_iam_binding`
-- `google_vertex_ai_feature_online_store_iam_member`
-- `google_vertex_ai_feature_online_store_iam_policy`
-- `google_vertex_ai_featurestore_entitytype_iam_binding`
-- `google_vertex_ai_featurestore_entitytype_iam_member`
-- `google_vertex_ai_featurestore_entitytype_iam_policy`
-- `google_vertex_ai_featurestore_iam_binding`
-- `google_vertex_ai_featurestore_iam_member`
-- `google_vertex_ai_featurestore_iam_policy`
-- `google_vertex_ai_metadata_store`
-- `google_vertex_ai_model_garden_enable_model`
+To ADD a resource, append it via union:
+`--resources-from=packages/terradart_codegen/test/fixtures/wrap/source_beta/schema.json --resources=<new_type>`.
+To REMOVE one, pass an explicit `--resources=` list without it.

--- a/tool/extract_schema_subset.dart
+++ b/tool/extract_schema_subset.dart
@@ -17,6 +17,14 @@
 //     --resources=google_project_service_identity[,google_x,...] \
 //     --out=packages/terradart_codegen/test/fixtures/wrap/source_beta
 //
+//   --resources-from=<schema.json>  read the resource set from an existing
+//                         fixture (its resource_schemas keys). May be
+//                         combined with --resources= — the union is
+//                         extracted (how terradart-add-beta-resource
+//                         appends a type without a baked-in name list;
+//                         the weekly schema bump passes it alone to
+//                         re-extract the same set at the new version).
+//
 //   --schema-json=<file>  read an existing `terraform providers schema
 //                         -json` dump instead of running terraform
 //                         (tests / offline use).
@@ -34,6 +42,26 @@ import 'dart:io';
 
 const _exitUsage = 64;
 const _exitExtract = 69;
+
+/// Returns the resource type names of an existing (filtered) fixture: the
+/// union of every provider's `resource_schemas` keys, sorted. Fails closed
+/// on an empty result — re-extracting an empty set must never silently
+/// produce an empty fixture.
+List<String> resourceNamesFromFixture(Map<String, dynamic> fixture) {
+  final providerSchemas =
+      (fixture['provider_schemas'] as Map?)?.cast<String, dynamic>() ??
+          const {};
+  final names = <String>{};
+  for (final body in providerSchemas.values) {
+    final resources =
+        ((body as Map?)?['resource_schemas'] as Map?)?.cast<String, dynamic>();
+    if (resources != null) names.addAll(resources.keys);
+  }
+  if (names.isEmpty) {
+    throw StateError('no resource_schemas found in the fixture');
+  }
+  return names.toList()..sort();
+}
 
 /// Returns a schema JSON containing only [resources] under
 /// `registry.terraform.io/<providerSource>`. Fails closed: an absent
@@ -84,6 +112,7 @@ Future<void> main(List<String> args) async {
   String? version;
   String? out;
   String? schemaJsonPath;
+  String? resourcesFrom;
   var resources = const <String>[];
   for (final a in args) {
     if (a.startsWith('--provider=')) {
@@ -92,6 +121,8 @@ Future<void> main(List<String> args) async {
       version = a.substring('--version='.length);
     } else if (a.startsWith('--resources=')) {
       resources = a.substring('--resources='.length).split(',');
+    } else if (a.startsWith('--resources-from=')) {
+      resourcesFrom = a.substring('--resources-from='.length);
     } else if (a.startsWith('--out=')) {
       out = a.substring('--out='.length);
     } else if (a.startsWith('--schema-json=')) {
@@ -101,10 +132,21 @@ Future<void> main(List<String> args) async {
       exit(_exitUsage);
     }
   }
+  if (resourcesFrom != null) {
+    // Union: the fixture's current set is the base, --resources adds to it
+    // (used by terradart-add-beta-resource to append a new type without a
+    // baked-in name list).
+    final base = resourceNamesFromFixture(
+      jsonDecode(File(resourcesFrom).readAsStringSync())
+          as Map<String, dynamic>,
+    );
+    resources = {...base, ...resources}.toList()..sort();
+  }
   if (provider == null || out == null || resources.isEmpty) {
     stderr.writeln(
       'Usage: dart tool/extract_schema_subset.dart --provider=NS/NAME '
-      '--version=X.Y.Z --resources=a,b --out=DIR [--schema-json=FILE]',
+      '--version=X.Y.Z (--resources=a,b | --resources-from=FIXTURE.json '
+      '| both) --out=DIR [--schema-json=FILE]',
     );
     exit(_exitUsage);
   }
@@ -188,22 +230,26 @@ terraform {
   if (version != null) {
     File('${outDir.path}/provider_version.txt').writeAsStringSync('$version\n');
   }
-  final sortedResources = [...resources]..sort();
+  final fixtureDir = out.replaceAll(r'\', '/');
   File('${outDir.path}/README.md').writeAsStringSync('''
 # Filtered schema fixture — $provider
 
-Machine-extracted subset containing ONLY the curated resources below.
-Never hand-edit; re-extract with:
+Machine-extracted subset containing ONLY the curated resources. The keys of
+`schema.json` are the single source of truth for the set, and
+`provider_version.txt` records the extraction version. Never hand-edit
+either file. Re-extract the SAME set at the pinned version with:
 
 ```bash
 dart tool/extract_schema_subset.dart \\
-  --provider=$provider --version=${version ?? '<X.Y.Z>'} \\
-  --resources=${sortedResources.join(',')} \\
-  --out=${out.replaceAll(r'\', '/')}
+  --provider=$provider \\
+  --version="\$(cat $fixtureDir/provider_version.txt)" \\
+  --resources-from=$fixtureDir/schema.json \\
+  --out=$fixtureDir
 ```
 
-Resources:
-${sortedResources.map((r) => '- `$r`').join('\n')}
+To ADD a resource, append it via union:
+`--resources-from=$fixtureDir/schema.json --resources=<new_type>`.
+To REMOVE one, pass an explicit `--resources=` list without it.
 ''');
   print(
     'extract_schema_subset: wrote ${resources.length} resource(s) to '

--- a/tool/extract_schema_subset.dart
+++ b/tool/extract_schema_subset.dart
@@ -87,8 +87,7 @@ Map<String, dynamic> filterSchemaSubset(
   final allResources =
       (providerBody['resource_schemas'] as Map?)?.cast<String, dynamic>() ??
           const {};
-  final missing =
-      resources.where((r) => !allResources.containsKey(r)).toList();
+  final missing = resources.where((r) => !allResources.containsKey(r)).toList();
   if (missing.isNotEmpty) {
     throw StateError(
       'requested resource(s) absent from $providerKey: '

--- a/tool/extract_schema_subset_test.dart
+++ b/tool/extract_schema_subset_test.dart
@@ -81,4 +81,34 @@ void main() {
       throwsA(isA<StateError>()),
     );
   });
+
+  group('resourceNamesFromFixture', () {
+    test('returns the sorted resource keys of the fixture', () {
+      expect(
+        resourceNamesFromFixture(full),
+        ['google_compute_instance', 'google_project_service_identity'],
+      );
+    });
+
+    test('ignores data sources', () {
+      expect(
+        resourceNamesFromFixture(full),
+        isNot(contains('google_project')),
+      );
+    });
+
+    test('throws StateError on a fixture with no resources', () {
+      expect(
+        () => resourceNamesFromFixture({
+          'provider_schemas': {
+            'registry.terraform.io/hashicorp/google-beta': {
+              'resource_schemas': <String, dynamic>{},
+            },
+          },
+        }),
+        throwsStateError,
+      );
+      expect(() => resourceNamesFromFixture({}), throwsStateError);
+    });
+  });
 }

--- a/tool/extract_schema_subset_test.dart
+++ b/tool/extract_schema_subset_test.dart
@@ -40,7 +40,7 @@ void main() {
     );
     expect(out['format_version'], '1.0');
     final schemas = (out['provider_schemas']
-            as Map)['registry.terraform.io/hashicorp/google-beta'] as Map;
+        as Map)['registry.terraform.io/hashicorp/google-beta'] as Map;
     final resources = schemas['resource_schemas'] as Map;
     expect(resources.keys, ['google_project_service_identity']);
     expect(
@@ -53,8 +53,7 @@ void main() {
     expect(schemas.containsKey('data_source_schemas'), isFalse);
   });
 
-  test('fails closed when a requested resource is absent from the schema',
-      () {
+  test('fails closed when a requested resource is absent from the schema', () {
     expect(
       () => filterSchemaSubset(
         full,


### PR DESCRIPTION
First of two PRs for the google-beta bump lane (the workflow wiring follows separately).

- **Gate 9 (universal invariants)**: fails when any `source_beta` resource type appears in the GA schema fixture — a beta-only type promoted to GA breaks the "types that also exist in GA stay in `terradart_google`" invariant. The failure message carries the maintainer playbook (demote from beta = breaking; GA curation via the backlog). Runs in per-PR CI and in the schema-bump QA gates.
- **`extract_schema_subset.dart --resources-from=<fixture>`**: reads the resource set from an existing fixture's `schema.json` keys (union with `--resources=` for additions). The weekly bump re-extracts the same set at the new version; `terradart-add-beta-resource` appends a type in one command.
- **Single-sourcing**: the emitted fixture README no longer bakes in the version or the 128-name list — `schema.json` keys + `provider_version.txt` are the only copies. Committed beta README regenerated; add-beta-resource skill updated. Re-extraction determinism proven offline (`schema.json` byte-identical).

Also wires `tool/extract_schema_subset_test.dart` into the CI tool-test list (it already ran in `tool/agent_verify.sh` but was missing from `ci.yml`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5e0e0899accaf5aee94e302eaccc34a04693c914. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->