### PR TITLE
docs: add pub.dev examples for appwrite and google_beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Per-package changelogs live alongside each package and are the system of record 
 
 ## Unreleased
 
+### Added
+
+- **`terradart_appwrite` / `terradart_google_beta`** — package-level
+  `example/main.dart` so pub.dev scores the "Package has an example"
+  documentation point.
+
 ## [0.25.1] - 2026-08-19
 
 Lockstep release across the workspace. **No breaking changes** vs `0.25.0`.

--- a/packages/terradart_appwrite/CHANGELOG.md
+++ b/packages/terradart_appwrite/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add `example/main.dart` so pub.dev scores the package-has-an-example
+  documentation point.
+
 ## 0.25.1
 
 - Lockstep release with the TerraDart workspace. No Appwrite factory or

--- a/packages/terradart_appwrite/README.md
+++ b/packages/terradart_appwrite/README.md
@@ -39,6 +39,8 @@ final class MyStack extends Stack {
 }
 ```
 
+A runnable copy lives in [`example/main.dart`](example/main.dart).
+
 Curated surface: `appwrite_project` (project barrel),
 `appwrite_storage_bucket` (storage barrel). Provider pinned at
 `2.0.0-beta.1` (exact — the provider is beta-maturity).

--- a/packages/terradart_appwrite/example/main.dart
+++ b/packages/terradart_appwrite/example/main.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+
+import 'package:terradart_appwrite/terradart_appwrite.dart';
+import 'package:terradart_core/terradart_core.dart';
+
+/// Minimal example: an Appwrite project and a storage bucket.
+///
+/// Credentials never enter synth output — authenticate at apply time
+/// via `APPWRITE_*` environment variables.
+final class HelloStack extends Stack {
+  HelloStack()
+      : super(
+          providers: [
+            const AppwriteProvider(
+              endpoint: 'https://cloud.appwrite.io/v1',
+              organizationId: 'YOUR-ORG-ID',
+            ),
+          ],
+        ) {
+    add(
+      AppwriteProject(
+        localName: 'hello',
+        name: TfArg.literal('hello'),
+      ),
+    );
+    add(
+      AppwriteStorageBucket(
+        localName: 'uploads',
+        name: TfArg.literal('uploads'),
+      ),
+    );
+  }
+}
+
+void main() {
+  final result = HelloStack().synth();
+  // ignore: avoid_print
+  print(const JsonEncoder.withIndent('  ').convert(result.tfJson));
+}

--- a/packages/terradart_appwrite/lib/src/appwrite_provider.dart
+++ b/packages/terradart_appwrite/lib/src/appwrite_provider.dart
@@ -26,6 +26,11 @@ const String kAppwriteProviderVersionConstraint = '2.0.0-beta.1';
 /// blocks in Terraform JSON do not interpolate references to resources.
 @immutable
 final class AppwriteProvider implements StackProvider {
+  /// Creates an Appwrite provider block.
+  ///
+  /// Do not pass API keys here — set `APPWRITE_API_KEY` /
+  /// `APPWRITE_ORGANIZATION_API_KEY` at apply time so credentials never
+  /// enter synth output.
   const AppwriteProvider({
     this.endpoint,
     this.projectId,

--- a/packages/terradart_google_beta/CHANGELOG.md
+++ b/packages/terradart_google_beta/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add `example/main.dart` so pub.dev scores the package-has-an-example
+  documentation point.
+
 ## 0.25.1
 
 - Fill the beta-only `hashicorp/google-beta` catalog: **128 resource

--- a/packages/terradart_google_beta/README.md
+++ b/packages/terradart_google_beta/README.md
@@ -29,6 +29,8 @@ final class MyStack extends Stack {
 }
 ```
 
+A runnable copy lives in [`example/main.dart`](example/main.dart).
+
 Curated surface: **128 resource factories** across per-service barrels
 (`firebase`, `compute`, `vertex_ai`, `api_gateway`, `biglake`, …).
 The first factory remains `google_project_service_identity` (project

--- a/packages/terradart_google_beta/example/main.dart
+++ b/packages/terradart_google_beta/example/main.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google_beta/terradart_google_beta.dart';
+
+/// Minimal example: pre-provision the Pub/Sub service agent (beta-only).
+final class HelloStack extends Stack {
+  HelloStack({required String projectId})
+      : super(
+          providers: [
+            GoogleBetaProvider(project: projectId, region: 'us-central1'),
+          ],
+        ) {
+    add(
+      GoogleProjectServiceIdentity(
+        localName: 'pubsub_agent',
+        service: TfArg.literal('pubsub.googleapis.com'),
+      ),
+    );
+  }
+}
+
+void main() {
+  final result = HelloStack(projectId: 'YOUR-PROJECT-ID').synth();
+  // ignore: avoid_print
+  print(const JsonEncoder.withIndent('  ').convert(result.tfJson));
+}

--- a/packages/terradart_google_beta/lib/src/google_beta_provider.dart
+++ b/packages/terradart_google_beta/lib/src/google_beta_provider.dart
@@ -21,6 +21,7 @@ const String kBetaProviderVersionConstraint = '~> 7.0';
 /// there is no `TfArgRef` use case here. Pass literal strings only.
 @immutable
 final class GoogleBetaProvider implements StackProvider {
+  /// Creates a `google-beta` provider block.
   const GoogleBetaProvider({
     this.project,
     this.region,

--- a/tool/check_docs_consistency.dart
+++ b/tool/check_docs_consistency.dart
@@ -1,4 +1,5 @@
-// check_docs_consistency.dart — verifies docs caret minors and catalog counts.
+// check_docs_consistency.dart — verifies docs caret minors, catalog counts,
+// and that every published package ships a Dart file under example/.
 //
 // Text-only: the example synth gates (coverage + API-enablement ratchet +
 // local terraform validate) live in tool/example_synth_gates.dart and run as
@@ -131,6 +132,8 @@ Future<void> main() async {
     }
   }
 
+  _checkPublishedPackageExamples(errors);
+
   if (errors.isEmpty) {
     print('check_docs_consistency: OK');
     exit(0);
@@ -220,6 +223,39 @@ void _checkCaretMinor(
   for (final phrase in mustContain) {
     if (!text.contains(phrase)) {
       errors.add('$path: expected phrase "$phrase"');
+    }
+  }
+}
+
+/// pub.dev's "Package has an example" point requires a Dart file under
+/// `example/` in the published tarball. Un-published workspace packages
+/// (`publish_to: none`) are skipped.
+void _checkPublishedPackageExamples(List<String> errors) {
+  final packagesDir = Directory('packages');
+  if (!packagesDir.existsSync()) {
+    errors.add('Missing directory: packages');
+    return;
+  }
+  final dirs = packagesDir.listSync().whereType<Directory>().toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+  for (final dir in dirs) {
+    final pubspec = File('${dir.path}/pubspec.yaml');
+    if (!pubspec.existsSync()) continue;
+    final text = pubspec.readAsStringSync();
+    if (RegExp(r'^publish_to:\s*none\s*$', multiLine: true).hasMatch(text)) {
+      continue;
+    }
+    final exampleDir = Directory('${dir.path}/example');
+    final hasDart = exampleDir.existsSync() &&
+        exampleDir
+            .listSync()
+            .whereType<File>()
+            .any((f) => f.path.endsWith('.dart'));
+    if (!hasDart) {
+      errors.add(
+        '${dir.path}/example: published package needs a Dart example '
+        '(pub.dev "Package has an example")',
+      );
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

pub.dev/pana scores `terradart_appwrite` and `terradart_google_beta` at **10/20** on *Provide documentation*:

- Dartdoc coverage already passes (20%+).
- **Failed:** `Package has an example` — neither published package shipped `example/`.

Sibling packages (`terradart_core`, `terradart_google`, `terradart_codegen`) already have `example/main.dart`.

The listed missing constructor / `tfType` / `tfAddress` symbols are generated (or inherited from `Resource`) and already sit well above the 20% bar. This PR does not regenerate wrappers.

## What

- Add `packages/terradart_appwrite/example/main.dart` (project + storage bucket; credentials stay out of synth).
- Add `packages/terradart_google_beta/example/main.dart` (Pub/Sub `GoogleProjectServiceIdentity`).
- Document the hand-written `AppwriteProvider` / `GoogleBetaProvider` constructors.
- Point each package README at the new example.
- Ratchet: `tool/check_docs_consistency.dart` requires every published package (`publish_to` not `none`) to ship a Dart file under `example/`.

## Test plan

- `dart run` both new examples and confirm they print Terraform JSON.
- `dart analyze` on the two packages (includes `example/`).
- `dart tool/check_docs_consistency.dart`.
- `tool/agent_verify.sh` (full gate before marking ready).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccf4a9e1-2634-4eba-aa2a-c5f40fd4af22?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccf4a9e1-2634-4eba-aa2a-c5f40fd4af22&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

