### PR TITLE
docs(pub): package examples + appwrite catalog note rewrite

### DIFF
--- a/packages/terradart_appwrite/README.md
+++ b/packages/terradart_appwrite/README.md
@@ -4,10 +4,9 @@ Curated factory wrappers for **Appwrite** resources (the official
 [`appwrite/appwrite`](https://registry.terraform.io/providers/appwrite/appwrite)
 Terraform provider), for Dart-first Terraform stacks.
 
-The catalog is curated on demand — resources are added against concrete
-requests (this package exists because of
-[#76](https://github.com/nozomi-koborinai/terradart/issues/76)), not by
-sweeping the provider.
+Curated factories are added on request — if you need a resource that is
+not wrapped yet, open a
+[feature request](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
 
 **Credentials never appear in synth output.** `AppwriteProvider` has no
 API-key parameters; authenticate at apply time via `APPWRITE_API_KEY` /

--- a/packages/terradart_appwrite/example/main.dart
+++ b/packages/terradart_appwrite/example/main.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_appwrite/terradart_appwrite.dart';
+
+/// Minimal example: an Appwrite storage bucket, synthesized to Terraform
+/// JSON. Credentials never appear in synth output — authenticate at
+/// apply time via the APPWRITE_API_KEY / APPWRITE_ORGANIZATION_API_KEY
+/// environment variables.
+final class HelloStack extends Stack {
+  HelloStack()
+      : super(
+          providers: [
+            const AppwriteProvider(
+              endpoint: 'https://cloud.appwrite.io/v1',
+              projectId: 'my-project',
+            ),
+          ],
+        ) {
+    add(
+      AppwriteStorageBucket(
+        localName: 'uploads',
+        name: TfArg.literal('uploads'),
+        maximumFileSize: TfArg.literal(10485760),
+      ),
+    );
+  }
+}
+
+void main() {
+  final result = HelloStack().synth();
+  // ignore: avoid_print
+  print(const JsonEncoder.withIndent('  ').convert(result.tfJson));
+}

--- a/packages/terradart_appwrite/lib/terradart_appwrite.dart
+++ b/packages/terradart_appwrite/lib/terradart_appwrite.dart
@@ -3,8 +3,8 @@
 /// Curated **Appwrite** surface for TerraDart (official
 /// `appwrite/appwrite` Terraform provider).
 ///
-/// Demand-driven catalog — resources are curated on request
-/// (issue #76 lineage). Credentials never appear in synth output:
+/// Curated factories are added on request — open a feature request for
+/// resources not wrapped yet. Credentials never appear in synth output:
 /// authentication happens at apply time via APPWRITE_API_KEY /
 /// APPWRITE_ORGANIZATION_API_KEY environment variables.
 ///

--- a/packages/terradart_codegen/lib/src/codegen/barrels/barrels_appwrite.yaml
+++ b/packages/terradart_codegen/lib/src/codegen/barrels/barrels_appwrite.yaml
@@ -9,8 +9,8 @@ umbrellaDoc: |-
   /// Curated **Appwrite** surface for TerraDart (official
   /// `appwrite/appwrite` Terraform provider).
   ///
-  /// Demand-driven catalog — resources are curated on request
-  /// (issue #76 lineage). Credentials never appear in synth output:
+  /// Curated factories are added on request — open a feature request for
+  /// resources not wrapped yet. Credentials never appear in synth output:
   /// authentication happens at apply time via APPWRITE_API_KEY /
   /// APPWRITE_ORGANIZATION_API_KEY environment variables.
   ///

--- a/packages/terradart_google_beta/example/main.dart
+++ b/packages/terradart_google_beta/example/main.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google_beta/terradart_google_beta.dart';
+
+/// Minimal example: enable Firebase on an existing GCP project (a
+/// beta-only resource), synthesized to Terraform JSON.
+final class HelloBetaStack extends Stack {
+  HelloBetaStack({required String projectId})
+      : super(
+          providers: [
+            GoogleBetaProvider(project: projectId, region: 'us-central1'),
+          ],
+        ) {
+    add(
+      GoogleFirebaseProject(
+        localName: 'firebase',
+        project: TfArg.literal(projectId),
+      ),
+    );
+  }
+}
+
+void main() {
+  final result = HelloBetaStack(projectId: 'YOUR-PROJECT-ID').synth();
+  // ignore: avoid_print
+  print(const JsonEncoder.withIndent('  ').convert(result.tfJson));
+}


### PR DESCRIPTION
Two pub.dev presentation fixes for `terradart_google_beta` and `terradart_appwrite` (both currently score 150/160; `terradart_google` scores 160).

- **Package examples**: both packages fail the pana "Package has an example" check (0/10) — the only failing check. Adds a single-file `example/main.dart` to each, following the `terradart_google` example format: a minimal `Stack` synthesized to Terraform JSON (`GoogleFirebaseProject` for beta, the README's storage-bucket stack for appwrite). Both executed locally and synth the expected JSON with the right provider pins. The score moves on the next published release.
- **Appwrite catalog note**: the README and the generated umbrella dartdoc introduced the catalog with an internal issue reference ("this package exists because of #76") and a defensive negative ("not by sweeping the provider"). Rewritten as a plain invitation — curated factories are added on request; open a feature request for resources not wrapped yet. The umbrella wording lives in `barrels_appwrite.yaml` (`umbrellaDoc`), so the change is made there and the package regenerated via `terradart wrap`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes; no runtime, API, or security behavior is modified.
> 
> **Overview**
> Adds `example/main.dart` for `terradart_appwrite` and `terradart_google_beta` so pub.dev’s “Package has an example” check can pass. Each example is a minimal `Stack` that synths Terraform JSON (storage bucket vs Firebase project), matching the existing `terradart_google` pattern.
> 
> Rewrites the Appwrite catalog copy in the README and generated umbrella dartdoc (via `barrels_appwrite.yaml`) from an internal #76 / “not sweeping the provider” note into a plain invitation to open a feature request for missing resources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cafec14ffdbcaa85d2856965217939ce4483610c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->