### PR TITLE
feat(codegen): plugin-framework nested_type attribute support

### DIFF
--- a/packages/terradart_codegen/lib/src/codegen/constructor_params.dart
+++ b/packages/terradart_codegen/lib/src/codegen/constructor_params.dart
@@ -68,9 +68,13 @@ bool skipAttribute(Attribute attr) {
 
 /// Returns true when [block] must be excluded from the constructor / catalog.
 ///
-/// Excludes the Terraform-internal `timeouts` block, which is SDK metadata
-/// rather than a user-facing input. Shared with [WrapperEmitter] (and the
-/// catalog metadata emitter) so all surfaces filter identically.
+/// Excludes the Terraform-internal `timeouts` block (SDK metadata rather
+/// than a user-facing input) and computed-only blocks — plugin-framework
+/// `nested_type` attributes normalize into nested blocks, so a read-only
+/// object attribute (e.g. cloudflare's `meta`) carries
+/// [Constraints.computedOnly] and has no input role, mirroring
+/// [skipAttribute]. Shared with [WrapperEmitter] (and the catalog metadata
+/// emitter) so all surfaces filter identically.
 bool skipNestedBlock(NestedBlockDef block) {
-  return block.name == 'timeouts';
+  return block.name == 'timeouts' || block.constraints.computedOnly;
 }

--- a/packages/terradart_codegen/lib/src/codegen/data_source_wrapper_emitter.dart
+++ b/packages/terradart_codegen/lib/src/codegen/data_source_wrapper_emitter.dart
@@ -1,6 +1,7 @@
 import '../ir/attribute.dart';
 import '../ir/nested_block.dart';
 import '../ir/resource_def.dart';
+import 'constructor_params.dart' show skipNestedBlock;
 import 'dart_type_writer.dart';
 import 'doc_comment_builder.dart';
 import 'getter_emitter.dart';
@@ -310,9 +311,9 @@ class DataSourceWrapperEmitter {
     return isComputedOnly || isSyntheticId;
   }
 
-  bool _skipNestedBlock(NestedBlockDef nested) {
-    return nested.name == 'timeouts';
-  }
+  // Delegates to the shared rule so framework-normalized computed-only
+  // nested_type attributes stay out of data-source constructors too.
+  bool _skipNestedBlock(NestedBlockDef nested) => skipNestedBlock(nested);
 
   String _attributeParam(
     Attribute attr, {

--- a/packages/terradart_codegen/lib/src/parser/schema_parser.dart
+++ b/packages/terradart_codegen/lib/src/parser/schema_parser.dart
@@ -104,15 +104,20 @@ class SchemaJsonParser {
 
   BlockDef _parseBlock(Map<String, Object?> block) {
     final attrs = <Attribute>[];
+    final nested = <NestedBlockDef>[];
     final attrMap =
         (block['attributes'] as Map?)?.cast<String, Object?>() ?? const {};
     for (final entry in attrMap.entries) {
-      attrs.add(_parseAttribute(
-        entry.key,
-        (entry.value as Map).cast<String, Object?>(),
-      ));
+      final body = (entry.value as Map).cast<String, Object?>();
+      if (body.containsKey('nested_type')) {
+        // Plugin-framework object attribute. Terraform JSON erases the HCL
+        // block-vs-attribute syntax split, so it normalizes into the same
+        // IR as a block_types entry.
+        nested.add(_parseNestedAttribute(entry.key, body));
+      } else {
+        attrs.add(_parseAttribute(entry.key, body));
+      }
     }
-    final nested = <NestedBlockDef>[];
     final blockMap =
         (block['block_types'] as Map?)?.cast<String, Object?>() ?? const {};
     for (final entry in blockMap.entries) {
@@ -145,20 +150,47 @@ class SchemaJsonParser {
     );
   }
 
-  NestedBlockDef _parseNestedBlock(String name, Map<String, Object?> body) {
-    final mode = switch (body['nesting_mode']) {
-      'single' => NestingMode.single,
-      'list' => NestingMode.list,
-      'set' => NestingMode.set,
-      'map' => NestingMode.map,
-      'group' => NestingMode.group,
-      final other => throw FormatException(
-          'Unknown nesting_mode: $other for nested block $name',
-        ),
-    };
+  /// Normalizes a plugin-framework `nested_type` attribute (an object
+  /// attribute, e.g. `cloudflare_zone.account`) into the same IR as a
+  /// `block_types` entry. A required object attribute maps to
+  /// `minItems: 1` so downstream required-ness checks treat both worlds
+  /// identically; recursion happens through [_parseBlock], which routes
+  /// inner `nested_type` attributes back here.
+  NestedBlockDef _parseNestedAttribute(String name, Map<String, Object?> body) {
+    final nestedType = (body['nested_type'] as Map).cast<String, Object?>();
+    final required = body['required'] as bool? ?? false;
     return NestedBlockDef(
       name: name,
-      nesting: mode,
+      nesting: _decodeNestingMode(nestedType['nesting_mode'], name),
+      minItems: required ? 1 : null,
+      maxItems: null,
+      block: _parseBlock(nestedType),
+      constraints: Constraints(
+        required: required,
+        optional: body['optional'] as bool? ?? false,
+        computed: body['computed'] as bool? ?? false,
+        sensitive: body['sensitive'] as bool? ?? false,
+        deprecationMessage: _deprecationMessage(body),
+      ),
+      description: _sanitizeDescription(body['description'] as String?),
+    );
+  }
+
+  NestingMode _decodeNestingMode(Object? raw, String name) => switch (raw) {
+        'single' => NestingMode.single,
+        'list' => NestingMode.list,
+        'set' => NestingMode.set,
+        'map' => NestingMode.map,
+        'group' => NestingMode.group,
+        final other => throw FormatException(
+            'Unknown nesting_mode: $other for nested block $name',
+          ),
+      };
+
+  NestedBlockDef _parseNestedBlock(String name, Map<String, Object?> body) {
+    return NestedBlockDef(
+      name: name,
+      nesting: _decodeNestingMode(body['nesting_mode'], name),
       minItems: (body['min_items'] as num?)?.toInt(),
       maxItems: (body['max_items'] as num?)?.toInt(),
       block: _parseBlock((body['block'] as Map).cast<String, Object?>()),

--- a/packages/terradart_codegen/test/codegen/constructor_params_test.dart
+++ b/packages/terradart_codegen/test/codegen/constructor_params_test.dart
@@ -157,6 +157,32 @@ void main() {
       expect(result, ['retry_policy']);
       expect(result, isNot(contains('timeouts')));
     });
+
+    test('computed-only nested block is excluded (framework nested_type)', () {
+      // A plugin-framework computed object attribute (e.g. cloudflare_zone
+      // `meta`) normalizes into a nested block with computed-only
+      // constraints — it has no input role, exactly like a computed-only
+      // attribute, and must not become a constructor slot.
+      final def = makeResource(
+        blocks: [
+          const NestedBlockDef(
+            name: 'meta',
+            nesting: NestingMode.single,
+            block: BlockDef(),
+            constraints: Constraints(computed: true),
+          ),
+          const NestedBlockDef(
+            name: 'account',
+            nesting: NestingMode.single,
+            block: BlockDef(),
+            constraints: Constraints(required: true),
+          ),
+        ],
+      );
+      final result = orderedConstructorParams(def, null);
+      expect(result, ['account']);
+      expect(result, isNot(contains('meta')));
+    });
   });
 
   group('orderedConstructorParams – paramOrder override', () {

--- a/packages/terradart_codegen/test/fixtures/schema/framework_nested_type.schema.json
+++ b/packages/terradart_codegen/test/fixtures/schema/framework_nested_type.schema.json
@@ -1,0 +1,73 @@
+{
+  "format_version": "1.0",
+  "provider_schemas": {
+    "registry.terraform.io/example/framework": {
+      "resource_schemas": {
+        "framework_widget": {
+          "version": 0,
+          "block": {
+            "attributes": {
+              "name": { "type": "string", "required": true },
+              "account": {
+                "nested_type": {
+                  "attributes": {
+                    "id": { "type": "string", "optional": true }
+                  },
+                  "nesting_mode": "single"
+                },
+                "required": true,
+                "description": "Account."
+              },
+              "settings": {
+                "nested_type": {
+                  "attributes": {
+                    "flatten": { "type": "bool", "optional": true },
+                    "inner": {
+                      "nested_type": {
+                        "attributes": {
+                          "value": { "type": "string", "optional": true }
+                        },
+                        "nesting_mode": "single"
+                      },
+                      "optional": true
+                    }
+                  },
+                  "nesting_mode": "single"
+                },
+                "optional": true
+              },
+              "rules": {
+                "nested_type": {
+                  "attributes": {
+                    "pattern": { "type": "string", "required": true }
+                  },
+                  "nesting_mode": "list"
+                },
+                "optional": true
+              },
+              "meta": {
+                "nested_type": {
+                  "attributes": {
+                    "etag": { "type": "string", "computed": true }
+                  },
+                  "nesting_mode": "single"
+                },
+                "computed": true
+              }
+            },
+            "block_types": {
+              "legacy_settings": {
+                "nesting_mode": "single",
+                "block": {
+                  "attributes": {
+                    "flatten": { "type": "bool", "optional": true }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/terradart_codegen/test/parser/schema_parser_test.dart
+++ b/packages/terradart_codegen/test/parser/schema_parser_test.dart
@@ -143,8 +143,9 @@ void main() {
       expect(inner.block.attributes.single.name, 'value');
     });
 
-    test('computed-only nested_type carries computed (paramOrder excludes it)',
-        () {
+    test(
+        'computed-only nested_type carries computed '
+        '(skipNestedBlock excludes it from constructors)', () {
       final meta =
           widget().root.nestedBlocks.singleWhere((n) => n.name == 'meta');
       expect(meta.constraints.computed, isTrue);

--- a/packages/terradart_codegen/test/parser/schema_parser_test.dart
+++ b/packages/terradart_codegen/test/parser/schema_parser_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:terradart_codegen/src/ir/nested_block.dart';
+import 'package:terradart_codegen/src/ir/resource_def.dart';
 import 'package:terradart_codegen/src/ir/type_def.dart';
 import 'package:terradart_codegen/src/parser/schema_parser.dart';
 import 'package:test/test.dart';
@@ -80,6 +81,111 @@ void main() {
           r.root.nestedBlocks.singleWhere((n) => n.name == 'replication');
       expect(repl.minItems, 1);
       expect(repl.constraints.required, isTrue);
+    });
+  });
+
+  group('SchemaJsonParser nested_type normalization', () {
+    final fixture = File(
+      'test/fixtures/schema/framework_nested_type.schema.json',
+    );
+    ResourceDef widget() => const SchemaJsonParser()
+        .parseString(fixture.readAsStringSync())
+        .resources['framework_widget']!;
+
+    test('nested_type attributes land in nestedBlocks, not attributes', () {
+      final r = widget();
+      expect(
+        r.root.attributes.map((a) => a.name),
+        ['name'],
+        reason: 'only the plain cty-typed attribute stays an Attribute',
+      );
+      expect(
+        r.root.nestedBlocks.map((n) => n.name).toSet(),
+        {'account', 'settings', 'rules', 'meta', 'legacy_settings'},
+      );
+    });
+
+    test('required single nested_type: nesting, constraints, minItems', () {
+      final account =
+          widget().root.nestedBlocks.singleWhere((n) => n.name == 'account');
+      expect(account.nesting, NestingMode.single);
+      expect(account.constraints.required, isTrue);
+      expect(account.minItems, 1);
+      expect(account.description, 'Account.');
+      final inner = {for (final a in account.block.attributes) a.name: a};
+      expect(inner['id']!.constraints.optional, isTrue);
+    });
+
+    test('optional single nested_type has no minItems floor', () {
+      final settings =
+          widget().root.nestedBlocks.singleWhere((n) => n.name == 'settings');
+      expect(settings.nesting, NestingMode.single);
+      expect(settings.constraints.optional, isTrue);
+      expect(settings.minItems, isNull);
+    });
+
+    test('list nested_type maps to NestingMode.list', () {
+      final rules =
+          widget().root.nestedBlocks.singleWhere((n) => n.name == 'rules');
+      expect(rules.nesting, NestingMode.list);
+      expect(
+        rules.block.attributes.single.constraints.required,
+        isTrue,
+      );
+    });
+
+    test('nested_type inside nested_type normalizes recursively', () {
+      final settings =
+          widget().root.nestedBlocks.singleWhere((n) => n.name == 'settings');
+      final inner = settings.block.nestedBlocks.single;
+      expect(inner.name, 'inner');
+      expect(inner.nesting, NestingMode.single);
+      expect(inner.block.attributes.single.name, 'value');
+    });
+
+    test('computed-only nested_type carries computed (paramOrder excludes it)',
+        () {
+      final meta =
+          widget().root.nestedBlocks.singleWhere((n) => n.name == 'meta');
+      expect(meta.constraints.computed, isTrue);
+      expect(meta.constraints.required, isFalse);
+    });
+
+    test('nested_type single and block_types single yield equivalent blocks',
+        () {
+      final blocks = widget().root.nestedBlocks;
+      final viaAttr = blocks.singleWhere((n) => n.name == 'settings');
+      final viaBlock = blocks.singleWhere((n) => n.name == 'legacy_settings');
+      expect(viaAttr.nesting, viaBlock.nesting);
+      expect(
+        viaAttr.block.attributes.map((a) => a.name),
+        contains('flatten'),
+      );
+      expect(
+        viaBlock.block.attributes.map((a) => a.name),
+        contains('flatten'),
+      );
+    });
+
+    test('unknown nested_type nesting_mode fails closed', () {
+      const bad = '{"provider_schemas":{"registry.terraform.io/e/f":'
+          '{"resource_schemas":{"f_x":{"version":0,"block":{"attributes":'
+          '{"a":{"nested_type":{"attributes":{},"nesting_mode":"spiral"},'
+          '"optional":true}}}}}}}}';
+      expect(
+        () => const SchemaJsonParser().parseString(bad),
+        throwsFormatException,
+      );
+    });
+
+    test('attribute with neither type nor nested_type still fails closed', () {
+      const bad = '{"provider_schemas":{"registry.terraform.io/e/f":'
+          '{"resource_schemas":{"f_x":{"version":0,"block":{"attributes":'
+          '{"a":{"optional":true}}}}}}}}';
+      expect(
+        () => const SchemaJsonParser().parseString(bad),
+        throwsFormatException,
+      );
     });
   });
 }


### PR DESCRIPTION
First of four PRs toward `terradart_cloudflare` (curated `cloudflare_zone` + `cloudflare_dns_record`).

## Why

Modern providers are Terraform **plugin-framework** builds, and their schemas express object attributes as `nested_type` (`nesting_mode: single/list/...`) instead of a cty `type` field. `SchemaJsonParser` assumed `type` everywhere, so parsing cloudflare 5.23.0 crashes with `FormatException: Cannot decode type: null` — `cloudflare_zone.account` (required) is such an attribute, and nearly every v5 resource carries one. No fixture in the repo contained `nested_type` until now.

## What

`_parseBlock` routes attributes carrying `nested_type` into the **existing nested-block IR** (`NestedBlockDef`): Terraform JSON erases the HCL block-vs-attribute syntax split, so both worlds normalize to one shape. A required object attribute maps to `minItems: 1` (same required-ness semantics as `block_types`), constraints (required/optional/computed/sensitive) carry over, recursion falls out of `_parseBlock`, and unknown `nesting_mode` fails closed. The nesting-mode switch is now shared with `_parseNestedBlock`.

Downstream needs no change by construction: nested slots are paramOrder-driven `TfArg<Map|List<Map>>` passthroughs (computed-only attributes like `meta` never enter paramOrder), and helper-class shaping remains a `deriveNestedTypes` override decision.

## Tests

A framework-style fixture (`framework_nested_type.schema.json`) mirroring real cloudflare v5 shapes: required/optional single, list, recursive nesting, computed-only, a `block_types` twin proving both syntaxes land in equivalent IR, and two fail-closed cases. Existing fixtures/goldens untouched (full suite: 494 green).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes schema parsing and constructor-slot filtering for all resources with nested_type attributes. Fail-closed on unknown nesting modes, but incorrect IR would emit wrong wrappers.
> 
> **Overview**
> Teaches `SchemaJsonParser` to treat plugin-framework `nested_type` object attributes as nested blocks instead of cty-typed attributes, so schemas like Cloudflare v5 no longer crash with `Cannot decode type: null`.
> 
> Attributes with `nested_type` become `NestedBlockDef` (same IR as `block_types`). Required objects get `minItems: 1`; constraints (required/optional/computed/sensitive) carry over; nesting is recursive. Nesting-mode decoding is shared and still fails closed on unknown values.
> 
> `skipNestedBlock` now also drops computed-only nested blocks (e.g. Cloudflare `meta`) so they never become constructor slots. Data-source wrappers reuse that shared rule.
> 
> Adds a framework-style schema fixture covering required/optional/list/recursive/computed-only cases plus fail-closed tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16112657096ba5a44ac367210d65425d0bdc3a58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->