### PR TITLE
chore: lockstep 0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Per-package changelogs live alongside each package and are the system of record 
 
 ## Unreleased
 
+## [0.25.2] - 2026-08-22
+
+Lockstep release across the workspace. **No breaking changes** vs `0.25.1`.
+
+### Added
+
+- **`terradart_cloudflare`** — new curated package for the official `cloudflare/cloudflare` provider (exact-pinned at 5.23.0): `CloudflareProvider` (schema-sensitive attributes structurally excluded — apply authenticates via `CLOUDFLARE_*` env vars), `CloudflareZone`, and `CloudflareDnsRecord`. Coverage via [`cloudflare_dns_quickstart`](examples/cloudflare_dns_quickstart/) (synth + `terraform validate`; apply-smoke skip-listed).
+- **Plugin-framework schema support** — `terradart_codegen` now normalizes `nested_type` object attributes (Terraform plugin-framework providers) into the nested-block IR; computed-only object attributes stay out of constructors.
+- **Package examples** — `terradart_google_beta` and `terradart_appwrite` ship an in-package `example/main.dart` (pub.dev pana example check).
+
 ## [0.25.1] - 2026-08-19
 
 Lockstep release across the workspace. **No breaking changes** vs `0.25.0`.

--- a/cookbook/firestore-seeded-data/pubspec.yaml
+++ b/cookbook/firestore-seeded-data/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/lunch-concierge/infra/pubspec.yaml
+++ b/cookbook/lunch-concierge/infra/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/remote-backend/pubspec.yaml
+++ b/cookbook/remote-backend/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/single-project-app/pubspec.yaml
+++ b/cookbook/single-project-app/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/access_context_quickstart/pubspec.yaml
+++ b/examples/access_context_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/api_security_quickstart/pubspec.yaml
+++ b/examples/api_security_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/apigee_quickstart/pubspec.yaml
+++ b/examples/apigee_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/app_engine_quickstart/pubspec.yaml
+++ b/examples/app_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/apphub_quickstart/pubspec.yaml
+++ b/examples/apphub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/appwrite_quickstart/pubspec.yaml
+++ b/examples/appwrite_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_appwrite: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_appwrite: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/artifact_registry_quickstart/pubspec.yaml
+++ b/examples/artifact_registry_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/beta_leftover_quickstart/pubspec.yaml
+++ b/examples/beta_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google_beta: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google_beta: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/beta_service_identity_quickstart/pubspec.yaml
+++ b/examples/beta_service_identity_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google_beta: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google_beta: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/biglake_quickstart/pubspec.yaml
+++ b/examples/biglake_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_datapolicyv2_quickstart/pubspec.yaml
+++ b/examples/bigquery_datapolicyv2_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_quickstart/pubspec.yaml
+++ b/examples/bigquery_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigtable_quickstart/pubspec.yaml
+++ b/examples/bigtable_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ces_quickstart/pubspec.yaml
+++ b/examples/ces_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/chronicle_quickstart/pubspec.yaml
+++ b/examples/chronicle_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_asset_quickstart/pubspec.yaml
+++ b/examples/cloud_asset_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_build_quickstart/pubspec.yaml
+++ b/examples/cloud_build_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_functions_quickstart/pubspec.yaml
+++ b/examples/cloud_functions_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_quickstart/pubspec.yaml
+++ b/examples/cloud_run_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_v1_quickstart/pubspec.yaml
+++ b/examples/cloud_run_v1_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_scheduler_quickstart/pubspec.yaml
+++ b/examples/cloud_scheduler_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_sql_quickstart/pubspec.yaml
+++ b/examples/cloud_sql_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_tasks_quickstart/pubspec.yaml
+++ b/examples/cloud_tasks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/clouddeploy_quickstart/pubspec.yaml
+++ b/examples/clouddeploy_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloudflare_dns_quickstart/pubspec.yaml
+++ b/examples/cloudflare_dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_cloudflare: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_cloudflare: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/colab_quickstart/pubspec.yaml
+++ b/examples/colab_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_cloud_armor_tier_quickstart/pubspec.yaml
+++ b/examples/compute_cloud_armor_tier_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_default_network_tier_quickstart/pubspec.yaml
+++ b/examples/compute_default_network_tier_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_instance_settings_quickstart/pubspec.yaml
+++ b/examples/compute_instance_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_lb_quickstart/pubspec.yaml
+++ b/examples/compute_lb_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_preview_feature_quickstart/pubspec.yaml
+++ b/examples/compute_preview_feature_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_quickstart/pubspec.yaml
+++ b/examples/compute_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_rollout_quickstart/pubspec.yaml
+++ b/examples/compute_rollout_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_route_quickstart/pubspec.yaml
+++ b/examples/compute_route_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_snapshot_settings_quickstart/pubspec.yaml
+++ b/examples/compute_snapshot_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_vpn_gateway_quickstart/pubspec.yaml
+++ b/examples/compute_vpn_gateway_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/config_deployment_quickstart/pubspec.yaml
+++ b/examples/config_deployment_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/contact_center_insights_quickstart/pubspec.yaml
+++ b/examples/contact_center_insights_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/container_analysis_quickstart/pubspec.yaml
+++ b/examples/container_analysis_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_catalog_quickstart/pubspec.yaml
+++ b/examples/data_catalog_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_lineage_quickstart/pubspec.yaml
+++ b/examples/data_lineage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_source_leftover_quickstart/pubspec.yaml
+++ b/examples/data_source_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataform_quickstart/pubspec.yaml
+++ b/examples/dataform_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataplex_quickstart/pubspec.yaml
+++ b/examples/dataplex_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataproc_autoscaling_quickstart/pubspec.yaml
+++ b/examples/dataproc_autoscaling_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataproc_metastore_quickstart/pubspec.yaml
+++ b/examples/dataproc_metastore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/deferred_leftover_quickstart/pubspec.yaml
+++ b/examples/deferred_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/developer_connect_quickstart/pubspec.yaml
+++ b/examples/developer_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_es_quickstart/pubspec.yaml
+++ b/examples/dialogflow_es_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_quickstart/pubspec.yaml
+++ b/examples/dialogflow_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/discovery_engine_quickstart/pubspec.yaml
+++ b/examples/discovery_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dlp_quickstart/pubspec.yaml
+++ b/examples/dlp_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dns_quickstart/pubspec.yaml
+++ b/examples/dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/document_ai_quickstart/pubspec.yaml
+++ b/examples/document_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/endpoints_quickstart/pubspec.yaml
+++ b/examples/endpoints_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/eventarc_quickstart/pubspec.yaml
+++ b/examples/eventarc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/filestore_quickstart/pubspec.yaml
+++ b/examples/filestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_check_quickstart/pubspec.yaml
+++ b/examples/firebase_app_check_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_hosting_quickstart/pubspec.yaml
+++ b/examples/firebase_app_hosting_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_data_connect_quickstart/pubspec.yaml
+++ b/examples/firebase_data_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_remote_config_quickstart/pubspec.yaml
+++ b/examples/firebase_remote_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebaserules_quickstart/pubspec.yaml
+++ b/examples/firebaserules_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_document_quickstart/pubspec.yaml
+++ b/examples/firestore_document_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_quickstart/pubspec.yaml
+++ b/examples/firestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gemini_quickstart/pubspec.yaml
+++ b/examples/gemini_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_hub_feature_quickstart/pubspec.yaml
+++ b/examples/gke_hub_feature_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_hub_quickstart/pubspec.yaml
+++ b/examples/gke_hub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_quickstart/pubspec.yaml
+++ b/examples/gke_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/healthcare_quickstart/pubspec.yaml
+++ b/examples/healthcare_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iam_quickstart/pubspec.yaml
+++ b/examples/iam_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iap_settings_quickstart/pubspec.yaml
+++ b/examples/iap_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iap_tunnel_quickstart/pubspec.yaml
+++ b/examples/iap_tunnel_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/identity_platform_quickstart/pubspec.yaml
+++ b/examples/identity_platform_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/integrations_quickstart/pubspec.yaml
+++ b/examples/integrations_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_autokey_quickstart/pubspec.yaml
+++ b/examples/kms_autokey_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_quickstart/pubspec.yaml
+++ b/examples/kms_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/license_manager_quickstart/pubspec.yaml
+++ b/examples/license_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/migration_center_quickstart/pubspec.yaml
+++ b/examples/migration_center_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/model_armor_quickstart/pubspec.yaml
+++ b/examples/model_armor_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/monitoring_quickstart/pubspec.yaml
+++ b/examples/monitoring_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ncc_hub_quickstart/pubspec.yaml
+++ b/examples/ncc_hub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/netapp_metadata_quickstart/pubspec.yaml
+++ b/examples/netapp_metadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_connectivity_quickstart/pubspec.yaml
+++ b/examples/network_connectivity_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_management_vpc_flow_logs_quickstart/pubspec.yaml
+++ b/examples/network_management_vpc_flow_logs_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_backend_auth_quickstart/pubspec.yaml
+++ b/examples/network_security_backend_auth_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_dns_threat_quickstart/pubspec.yaml
+++ b/examples/network_security_dns_threat_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_gateway_policy_quickstart/pubspec.yaml
+++ b/examples/network_security_gateway_policy_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_lists_quickstart/pubspec.yaml
+++ b/examples/network_security_lists_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_tls_quickstart/pubspec.yaml
+++ b/examples/network_security_tls_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_ull_quickstart/pubspec.yaml
+++ b/examples/network_security_ull_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_services_mesh_quickstart/pubspec.yaml
+++ b/examples/network_services_mesh_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/notebooks_quickstart/pubspec.yaml
+++ b/examples/notebooks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/observability_quickstart/pubspec.yaml
+++ b/examples/observability_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ops_quickstart/pubspec.yaml
+++ b/examples/ops_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_autonomous_database_quickstart/pubspec.yaml
+++ b/examples/oracle_autonomous_database_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_db_system_quickstart/pubspec.yaml
+++ b/examples/oracle_db_system_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_exadata_quickstart/pubspec.yaml
+++ b/examples/oracle_exadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_goldengate_quickstart/pubspec.yaml
+++ b/examples/oracle_goldengate_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/org_leftover_quickstart/pubspec.yaml
+++ b/examples/org_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/parameter_manager_quickstart/pubspec.yaml
+++ b/examples/parameter_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/privileged_access_manager_quickstart/pubspec.yaml
+++ b/examples/privileged_access_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/project_iam_audit_config_quickstart/pubspec.yaml
+++ b/examples/project_iam_audit_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/public_ca_quickstart/pubspec.yaml
+++ b/examples/public_ca_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/pubsub_quickstart/pubspec.yaml
+++ b/examples/pubsub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/scc_quickstart/pubspec.yaml
+++ b/examples/scc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/secret_manager_quickstart/pubspec.yaml
+++ b/examples/secret_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/service_directory_quickstart/pubspec.yaml
+++ b/examples/service_directory_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/sourcerepo_quickstart/pubspec.yaml
+++ b/examples/sourcerepo_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/spanner_instance_config_quickstart/pubspec.yaml
+++ b/examples/spanner_instance_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_intelligence_quickstart/pubspec.yaml
+++ b/examples/storage_intelligence_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_quickstart/pubspec.yaml
+++ b/examples/storage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_transfer_quickstart/pubspec.yaml
+++ b/examples/storage_transfer_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/tags_quickstart/pubspec.yaml
+++ b/examples/tags_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/transcoder_quickstart/pubspec.yaml
+++ b/examples/transcoder_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/usage_export_quickstart/pubspec.yaml
+++ b/examples/usage_export_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vector_quickstart/pubspec.yaml
+++ b/examples/vector_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vertex_ai_quickstart/pubspec.yaml
+++ b/examples/vertex_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vm_compliance_quickstart/pubspec.yaml
+++ b/examples/vm_compliance_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/wif_trust_domain_quickstart/pubspec.yaml
+++ b/examples/wif_trust_domain_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/workflows_quickstart/pubspec.yaml
+++ b/examples/workflows_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/terradart_agent/CHANGELOG.md
+++ b/packages/terradart_agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.2 - 2026-08-22
+
+Lockstep release with `terradart_cloudflare` 0.25.2. MCP catalog is unchanged (GA `hashicorp/google` only). No MCP protocol or tool changes.
+
 ## 0.25.1 - 2026-08-19
 
 Lockstep release with `terradart_google_beta` 0.25.1. MCP catalog is unchanged (GA `hashicorp/google` only). No MCP protocol or tool changes.

--- a/packages/terradart_agent/lib/src/version.dart
+++ b/packages/terradart_agent/lib/src/version.dart
@@ -1,4 +1,4 @@
 /// The terradart-mcp binary version, kept in lockstep with pubspec.yaml's
 /// `version:` field by `tool/bump_version.sh`. The lockstep is guarded by
 /// test/version_test.dart so the two can never silently drift.
-const String packageVersion = '0.25.1';
+const String packageVersion = '0.25.2';

--- a/packages/terradart_agent/pubspec.yaml
+++ b/packages/terradart_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_agent
 description: terradart-mcp — MCP server exposing the curated GCP factory catalog of TerraDart.
-version: 0.25.1
+version: 0.25.2
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -16,9 +16,9 @@ executables:
   terradart-mcp: terradart_mcp
 
 dependencies:
-  terradart_core: ^0.25.1
-  terradart_google: ^0.25.1
-  terradart_coverage: ^0.25.1
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
+  terradart_coverage: ^0.25.2
   genkit: ^0.14.1
   genkit_mcp: ^0.2.1
   schemantic: ^0.2.0

--- a/packages/terradart_appwrite/CHANGELOG.md
+++ b/packages/terradart_appwrite/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.25.2 - 2026-08-22
+
+- Add an in-package `example/main.dart` (pub.dev pana example check) and
+  rewrite the catalog note as a feature-request invitation. No factory or
+  provider changes.
+
 ## 0.25.1
 
 - Lockstep release with the TerraDart workspace. No Appwrite factory or

--- a/packages/terradart_appwrite/pubspec.yaml
+++ b/packages/terradart_appwrite/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_appwrite
 description: Curated factory wrappers for Appwrite resources (official appwrite/appwrite Terraform provider) for Dart-first Terraform stacks.
-version: 0.25.1
+version: 0.25.2
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
+  terradart_core: ^0.25.2
   meta: ^1.15.0
 
 dev_dependencies:

--- a/packages/terradart_cloudflare/CHANGELOG.md
+++ b/packages/terradart_cloudflare/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.25.2
 
 - Initial release: `CloudflareProvider` (secret-free by design — the
   schema's sensitive attributes `api_token` / `api_key` /

--- a/packages/terradart_cloudflare/pubspec.yaml
+++ b/packages/terradart_cloudflare/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_cloudflare
 description: Curated factory wrappers for Cloudflare resources (official cloudflare/cloudflare Terraform provider) for Dart-first Terraform stacks.
-version: 0.25.1
+version: 0.25.2
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
+  terradart_core: ^0.25.2
   meta: ^1.15.0
 
 dev_dependencies:

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.2 - 2026-08-22
+
+Plugin-framework schema support: `SchemaJsonParser` normalizes `nested_type` object attributes into the nested-block IR (first consumer: the cloudflare 5.23.0 fixture); computed-only object attributes are excluded from constructors. No user-facing CLI flag changes.
+
 ## 0.25.1 - 2026-08-19
 
 Lockstep release with `terradart_google_beta` 0.25.1 (beta-only catalog filled). No user-facing CLI flag changes.

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart maintainer tooling — parses Terraform provider schema JSON and Magic Modules YAML and emits curated factory wrappers via terradart wrap. Ships the terradart CLI.
-version: 0.25.1
+version: 0.25.2
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -33,7 +33,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.25.1
+  terradart_core: ^0.25.2
 
 dev_dependencies:
   http: ^1.0.0

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.2 - 2026-08-22
+
+Lockstep release with `terradart_cloudflare` 0.25.2 (initial release). No `terradart_core` API changes.
+
 ## 0.25.1 - 2026-08-19
 
 Lockstep release with `terradart_google_beta` 0.25.1 (beta-only catalog filled). No `terradart_core` API changes.

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.25.1
+version: 0.25.2
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_coverage/CHANGELOG.md
+++ b/packages/terradart_coverage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.2 - 2026-08-22
+
+Lockstep release with `terradart_cloudflare` 0.25.2. No functional changes in this package.
+
 ## 0.25.1 - 2026-08-19
 
 Lockstep release with `terradart_google_beta` 0.25.1. No functional changes in this package.

--- a/packages/terradart_coverage/pubspec.yaml
+++ b/packages/terradart_coverage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_coverage
 description: Read-only Terraform coverage checker — reports how much of a Terraform config is covered by curated terradart_google factories.
-version: 0.25.1
+version: 0.25.2
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -15,7 +15,7 @@ executables:
   terradart-coverage: terradart_coverage
 
 dependencies:
-  terradart_google: ^0.25.1
+  terradart_google: ^0.25.2
   args: ^2.5.0
 
 dev_dependencies:

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.2 - 2026-08-22
+
+Lockstep release. **No breaking changes** vs `0.25.1`. No `terradart_google` API changes — the new curated surface ships in `terradart_cloudflare`.
+
 ## 0.25.1 - 2026-08-19
 
 Lockstep release. **No breaking changes** vs `0.25.0`. No `terradart_google` API changes — the beta-only catalog fill ships in `terradart_google_beta`.

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: Curated factory wrappers for Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.
-version: 0.25.1
+version: 0.25.2
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -22,11 +22,11 @@ false_secrets:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
+  terradart_core: ^0.25.2
   meta: ^1.15.0
 
 dev_dependencies:
-  terradart_codegen: ^0.25.1
+  terradart_codegen: ^0.25.2
   path: ^1.9.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/packages/terradart_google_beta/CHANGELOG.md
+++ b/packages/terradart_google_beta/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.25.2 - 2026-08-22
+
+- Add an in-package `example/main.dart` (pub.dev pana example check). No
+  factory or provider changes; the schema pin now tracks the weekly GA
+  bump automatically.
+
 ## 0.25.1
 
 - Fill the beta-only `hashicorp/google-beta` catalog: **128 resource

--- a/packages/terradart_google_beta/pubspec.yaml
+++ b/packages/terradart_google_beta/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google_beta
 description: Curated factory wrappers for beta-only Google Cloud resources (hashicorp/google-beta) for Dart-first Terraform stacks.
-version: 0.25.1
+version: 0.25.2
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.1
+  terradart_core: ^0.25.2
   meta: ^1.15.0
 
 dev_dependencies:


### PR DESCRIPTION
Lockstep release across the workspace. **No breaking changes** vs 0.25.1.

- **`terradart_cloudflare` 0.25.2** — initial release (#618–#621): `CloudflareProvider` + `CloudflareZone` + `CloudflareDnsRecord`, exact-pinned at provider 5.23.0. First pub.dev publish is the usual manual maintainer step after the tag-driven phases complete (`skip_if_published` keeps Phase 6 a no-op until then).
- **`terradart_codegen` 0.25.2** — plugin-framework `nested_type` schema support (#618).
- **`terradart_google_beta` / `terradart_appwrite` 0.25.2** — in-package pana examples (#617); appwrite catalog note rewrite.
- Everything else moves in lockstep with no functional change.

Pre-flight done per RELEASE.md: full gate green, `terradart_core` publish dry-run clean (the cloudflare dry-run version-solve failure is the documented phase-ordering behavior — resolvable once core 0.25.2 is on pub.dev).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only lockstep bump; no runtime or auth/security logic is modified in this diff.
> 
> **Overview**
> Lockstep **0.25.2** across packages, examples, and cookbooks. **No breaking changes** vs `0.25.1`.
> 
> This PR is the release bump: `pubspec.yaml` versions/constraints, per-package changelogs, top-level `CHANGELOG.md`, and `terradart_agent` `packageVersion`. Functional work (Cloudflare package, plugin-framework `nested_type` parsing, pana examples) is documented as already landed; most packages record no API change here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66ae94d56edb474239e3939d388bcb745210b42c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->