### PR TITLE
fix(cloudflare): ship catalog_entry.dart in the package

### DIFF
--- a/packages/terradart_cloudflare/lib/src/catalog_entry.dart
+++ b/packages/terradart_cloudflare/lib/src/catalog_entry.dart
@@ -1,0 +1,59 @@
+/// Whether a catalog entry is a managed resource or a read-only data source.
+enum CatalogKind {
+  /// A managed Terraform resource (`resource.<type>.<name>`), emitted as a
+  /// `final class … extends Resource` wrapper.
+  resource,
+
+  /// A read-only Terraform data source (`data.<type>.<name>`), emitted as a
+  /// `final class … extends Data` wrapper.
+  dataSource,
+}
+
+/// Static metadata describing one curated terradart_cloudflare factory.
+///
+/// This type is **hand-written** (it is part of the public catalog API
+/// consumed by terradart_agent's MCP server). Only the `terradartCatalog`
+/// *list* of [CatalogEntry] values lives in the generated `_catalog.g.dart`,
+/// which `terradart wrap` regenerates — one entry per curated resource and
+/// data source. Edit this type by hand; never hand-edit the generated list
+/// (regenerate via `terradart wrap`).
+final class CatalogEntry {
+  const CatalogEntry({
+    required this.tfType,
+    required this.className,
+    required this.barrel,
+    required this.kind,
+    required this.summary,
+    required this.constructorParams,
+    required this.nestedTypes,
+    required this.sensitiveFields,
+    required this.docComment,
+  });
+
+  /// Terraform type string, e.g. `google_pubsub_topic`.
+  final String tfType;
+
+  /// Dart wrapper class name, e.g. `GooglePubsubTopic`.
+  final String className;
+
+  /// Per-service barrel (outputDir), e.g. `pubsub`.
+  final String barrel;
+
+  /// Resource vs data source.
+  final CatalogKind kind;
+
+  /// One-line summary (first sentence of the doc comment).
+  final String summary;
+
+  /// Constructor parameter names in declared order.
+  final List<String> constructorParams;
+
+  /// Names of nested helper types emitted alongside this resource.
+  final List<String> nestedTypes;
+
+  /// Sensitive field paths (dotted), masked at synth time.
+  final List<String> sensitiveFields;
+
+  /// Full doc comment text (markdown).
+  final String docComment;
+}


### PR DESCRIPTION
The v0.25.2 Phase 6 dry-run exposed 10 analyzer errors in `terradart_cloudflare`: `_catalog.g.dart` imports `catalog_entry.dart`, but the hand-written file was missed when the package skeleton was cloned from appwrite (#620) — the same packaging-defect class #608 fixed for the beta package.

Why no gate caught it: the workspace root `analysis_options.yaml` excludes `**/*.g.dart`, so local/CI analysis never sees the broken import; it only surfaces in the standalone analysis `dart pub publish` runs (where the package-local options, with no exclude, apply). Verified: with the file in place, the publish dry-run's analyzer errors are gone (the remaining warning is the local git-dirty notice, absent on a clean CI checkout).

Ported from `terradart_appwrite` with the package-name mention adjusted. Follow-up candidate (not in this PR): a standalone per-package analysis lane to close the structural gap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only addition of a public metadata type already used by generated catalog code; no runtime or security behavior changes.
> 
> **Overview**
> Adds the missing hand-written `CatalogEntry` / `CatalogKind` types to `terradart_cloudflare` so generated `_catalog.g.dart` can resolve its import.
> 
> The file was omitted when the package skeleton was cloned from appwrite. Workspace analysis excludes `*.g.dart`, so the broken import only showed up in `dart pub publish` dry-run. Ported from `terradart_appwrite` with package-name comments adjusted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9386d70e48d5bff86e4c05d4d48c00f53a07a695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->