### PR TITLE
docs: restructure root README for multi-package monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,39 @@
 
 > **Type-safe IaC for Dart.**
 >
-> Google Cloud infrastructure as real Dart code — typed, refactor-safe, drop-in for `terraform apply`.
+> Cloud infrastructure as real Dart code — typed, refactor-safe, drop-in for `terraform apply`.
 
 **Alpha** — no SemVer until v1.0.0, but breaking changes land only on **minor** bumps. Pin `^0.25.x`, read [`MIGRATING.md`](MIGRATING.md) before minor bumps, and see [status on terradart.dev](https://terradart.dev/docs/status/).
 
-<!-- identity -->
-[![pub: terradart_core](https://img.shields.io/pub/v/terradart_core.svg?label=pub%3A%20core)](https://pub.dev/packages/terradart_core)
-[![pub: terradart_codegen](https://img.shields.io/pub/v/terradart_codegen.svg?label=pub%3A%20codegen)](https://pub.dev/packages/terradart_codegen)
-[![pub: terradart_google](https://img.shields.io/pub/v/terradart_google.svg?label=pub%3A%20google)](https://pub.dev/packages/terradart_google)
-[![pub points](https://img.shields.io/pub/points/terradart_core)](https://pub.dev/packages/terradart_core/score)
+[![CI](https://github.com/nozomi-koborinai/terradart/actions/workflows/ci.yml/badge.svg)](https://github.com/nozomi-koborinai/terradart/actions/workflows/ci.yml)
 [![Dart SDK](https://img.shields.io/badge/Dart-%E2%89%A53.6-blue.svg)](https://dart.dev)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-<!-- health -->
-[![CI](https://github.com/nozomi-koborinai/terradart/actions/workflows/ci.yml/badge.svg)](https://github.com/nozomi-koborinai/terradart/actions/workflows/ci.yml)
-[![Schema Bump](https://github.com/nozomi-koborinai/terradart/actions/workflows/schema-bump.yml/badge.svg)](https://github.com/nozomi-koborinai/terradart/actions/workflows/schema-bump.yml)
+[![Docs](https://img.shields.io/badge/docs-terradart.dev-blue.svg)](https://terradart.dev)
+
+---
+
+See [terradart.dev](https://terradart.dev) for documentation, guides, and API reference.
+
+| Package | Description | Pub |
+| :--- | :--- | :--- |
+| [`terradart_core`](packages/terradart_core) | Core runtime — `Stack`, `Resource`, `Provider`, `Data`, `TfArg`, and synth behavior. | [![pub](https://img.shields.io/pub/v/terradart_core.svg)](https://pub.dev/packages/terradart_core) |
+| [`terradart_google`](packages/terradart_google) | Curated factory wrappers for Google Cloud resources (`hashicorp/google`). | [![pub](https://img.shields.io/pub/v/terradart_google.svg)](https://pub.dev/packages/terradart_google) |
+| [`terradart_google_beta`](packages/terradart_google_beta) | Curated factory wrappers for beta-only Google Cloud resources (`hashicorp/google-beta`). | [![pub](https://img.shields.io/pub/v/terradart_google_beta.svg)](https://pub.dev/packages/terradart_google_beta) |
+| [`terradart_appwrite`](packages/terradart_appwrite) | Curated factory wrappers for Appwrite resources (`appwrite/appwrite`). | [![pub](https://img.shields.io/pub/v/terradart_appwrite.svg)](https://pub.dev/packages/terradart_appwrite) |
+| [`terradart_cloudflare`](packages/terradart_cloudflare) | Curated factory wrappers for Cloudflare resources (`cloudflare/cloudflare`). | [![pub](https://img.shields.io/pub/v/terradart_cloudflare.svg)](https://pub.dev/packages/terradart_cloudflare) |
+| [`terradart_agent`](packages/terradart_agent) | MCP server (`terradart-mcp`) exposing the curated factory catalog to AI agents. | *(unlisted)* |
+| [`terradart_codegen`](packages/terradart_codegen) | Maintainer generation tooling and CLI (`terradart wrap`). | [![pub](https://img.shields.io/pub/v/terradart_codegen.svg)](https://pub.dev/packages/terradart_codegen) |
+
+---
+
+## Quickstart
+
+```yaml
+# pubspec.yaml
+dependencies:
+  terradart_core: ^0.25.x
+  terradart_google: ^0.25.x
+```
 
 ```dart
 // docs:pitch:start
@@ -103,11 +122,21 @@ final class AppInfraStack extends Stack {
 // docs:pitch:end
 ```
 
-Cloud SQL, IAM, and a multi-container Cloud Run service with a `cloud-sql-proxy` sidecar — the kind of stack you would otherwise maintain in HCL or the console. Per-service imports (`cloud_run.dart`, `cloud_sql.dart`, …) keep IDE completion scoped; the legacy `package:terradart_google/terradart_google.dart` barrel re-export remains supported.
+```bash
+dart pub get
+dart run bin/infra.dart                                  # synth → tf-out/
+cd tf-out && terraform init && terraform apply
+```
 
-More on [terradart.dev](https://terradart.dev/) and in [`examples/`](examples/).
+Per-service imports (`cloud_run.dart`, `cloud_sql.dart`, …) keep IDE completion scoped; the legacy `package:terradart_google/terradart_google.dart` barrel re-export remains supported.
 
-## The boundary
+Runnable end-to-end example: [`examples/pubsub_quickstart/`](examples/pubsub_quickstart/).
+
+---
+
+## What you get
+
+### The boundary: type-safe handoff to your runtime code
 
 **the boundary** = the place where infrastructure values (topic IDs, queue names, secret refs, IAM members) flow into runtime Dart code. Today that boundary is held together by string literals on both sides:
 
@@ -150,18 +179,6 @@ Future<void> handle(PubsubEvent event) async {
 
 Rename `orders-prod` in the Stack and the handler will not compile until the reference is fixed.
 
-## Why TerraDart
-
-A Dart team that wants to describe Google Cloud infrastructure has had three options up to now, none of which keep this boundary type-safe:
-
-- **HCL** is mature and battle-tested, but the only way a Dart subscriber can read a topic ID is `terraform output | jq` and string parsing. The boundary is a string literal on both sides.
-- **CDKTF** was the natural home for "infrastructure as real code" on top of Terraform. HashiCorp [archived CDKTF in December 2025](https://github.com/hashicorp/terraform-cdk); its TypeScript / Python / Java / Go targets never reached Dart, and the project's deprecation removes the long-term incentive for anyone to add it.
-- **Pulumi** ships first-class TypeScript / Python / Go / Java / .NET SDKs, but no Dart SDK and no announced plans. Its state and provider-invocation model also diverge from the standard `terraform apply` pipeline most teams already run.
-
-TerraDart deliberately occupies the Dart-shaped slot CDKTF did not reach and Pulumi did not pursue — synthesizing standard `*.tf.json` so your existing `terraform apply` pipeline runs unchanged.
-
-## What you get
-
 ### Typed enums for every fixed-value field
 
 ```dart
@@ -199,24 +216,9 @@ GoogleCloudRunV2Service(
 
 `Stack` subclasses are regular Dart classes. Loops, conditionals, env config, dependency injection — all work the way they already work. There is no synth CLI; you call `stack.writeTo('tf-out')` from your own `bin/infra.dart` (or `stack.synth()` for an in-memory `SynthResult` without writing to disk).
 
-## Quickstart
+---
 
-```yaml
-# pubspec.yaml
-dependencies:
-  terradart_core: ^0.25.x
-  terradart_google: ^0.25.x
-```
-
-```bash
-dart pub get
-dart run bin/infra.dart                                  # synth → tf-out/
-cd tf-out && terraform init && terraform apply
-```
-
-Runnable end-to-end:  [`examples/pubsub_quickstart/`](examples/pubsub_quickstart/).
-
-## terradart-mcp
+## AI Agent MCP Server (`terradart-mcp`)
 
 **Alpha.** [`terradart-mcp`](packages/terradart_agent/) is an MCP server that exposes the curated factory **catalog** to coding agents (Claude Code, Cursor, Claude Desktop). Five read-only tools — `list_barrels`, `list_resources`, `get_resource_schema`, `get_quickstart`, and `check_coverage` — help agents author correct Dart without guessing factory names. It does **not** run Terraform or touch GCP.
 
@@ -227,130 +229,23 @@ brew install nozomi-koborinai/tap/terradart-mcp
 
 Docs: [terradart.dev/docs/agent/](https://terradart.dev/docs/agent/)
 
-## What ships
+---
 
-[`terradart_google`](packages/terradart_google/README.md) ships **1332 curated resource factories + 461 data sources** (1793 catalog entries) across per-service barrels (`compute`, `pubsub`, `cloud_run`, `bigquery`, …). The GA `hashicorp/google` catalog is filled.
+## Coverage & Examples
 
-[`terradart_google_beta`](packages/terradart_google_beta/README.md) ships the **beta-only** `hashicorp/google-beta` catalog (**128 resource factories**, schema pin tracking the weekly GA bump). Import `package:terradart_google_beta` and `GoogleBetaProvider`; wrappers pin the `google-beta` meta-argument. Types that also exist in GA stay in `terradart_google`.
+- [`terradart_google`](packages/terradart_google/README.md) ships **1332 curated resource factories + 461 data sources** (1793 catalog entries) across per-service barrels (`compute`, `pubsub`, `cloud_run`, `bigquery`, …). The GA `hashicorp/google` catalog is filled.
+- [`terradart_google_beta`](packages/terradart_google_beta/README.md) ships the **beta-only** `hashicorp/google-beta` catalog (**128 resource factories**, schema pin tracking the weekly GA bump).
+- [`terradart_appwrite`](packages/terradart_appwrite/README.md) and [`terradart_cloudflare`](packages/terradart_cloudflare/README.md) provide curated factories for Appwrite and Cloudflare infrastructure.
 
-The full factory table with example pointers is on [Coverage](https://terradart.dev/docs/coverage/). In Dart, discover factories via `package:terradart_google/catalog.dart` (`terradartCatalog`). CI verifies regeneration is byte-deterministic via `terradart wrap --check`.
+Explore ready-to-run examples in [`examples/`](examples/):
+- **Foundational & IAM**: [Pub/Sub](examples/pubsub_quickstart/), [Cloud Tasks](examples/cloud_tasks_quickstart/), [Secret Manager](examples/secret_manager_quickstart/), [IAM](examples/iam_quickstart/)
+- **Compute & Networking**: [Compute & Firewall](examples/compute_quickstart/), [GKE](examples/gke_quickstart/), [Cloud DNS](examples/dns_quickstart/)
+- **Data & Storage**: [Cloud Storage](examples/storage_quickstart/), [BigQuery](examples/bigquery_quickstart/), [Cloud Bigtable](examples/bigtable_quickstart/), [KMS](examples/kms_quickstart/)
+- **Application Platform**: [Cloud Run v2](examples/cloud_run_quickstart/), [Cloud Monitoring](examples/monitoring_quickstart/), [Workflows](examples/workflows_quickstart/), [Eventarc](examples/eventarc_quickstart/)
 
-## Examples
+See the full factory table on [terradart.dev/docs/coverage/](https://terradart.dev/docs/coverage/).
 
-Foundational
-
-- [Pub/Sub topic/schema IAM member / binding / policy](examples/pubsub_quickstart/)
-- [Cloud Tasks queue + IAM member](examples/cloud_tasks_quickstart/)
-- [Secret Manager (write-only fields + global/regional secret IAM binding/policy)](examples/secret_manager_quickstart/)
-- [Cloud Scheduler → Pub/Sub target](examples/cloud_scheduler_quickstart/)
-- [Apigee data collector + analytics datastore](examples/apigee_quickstart/)
-- [IAM members across Pub/Sub, Tasks, Secret Manager, and IAP (App Engine, Agent Registry, location web), plus OS Login SSH public key and apply-excluded workforce leftovers](examples/iam_quickstart/)
-- [Privileged Access Manager entitlement](examples/privileged_access_manager_quickstart/)
-- [WIF trust-domain pool + namespace + managed identity](examples/wif_trust_domain_quickstart/)
-- [Project IAM audit config + deny policy](examples/project_iam_audit_config_quickstart/)
-- [IAP settings + location-web IAM binding/policy](examples/iap_settings_quickstart/)
-- [Application Integration client + dummy auth config](examples/integrations_quickstart/)
-- [Cloud Endpoints OpenAPI service + service IAM member](examples/endpoints_quickstart/)
-- [IAP tunnel destination group](examples/iap_tunnel_quickstart/)
-- [Identity Platform tenant + project/tenant OIDC IdP](examples/identity_platform_quickstart/)
-- [Container Analysis note + note IAM binding/policy](examples/container_analysis_quickstart/)
-- [App Hub application](examples/apphub_quickstart/)
-
-Compute & networking
-
-- [Compute network + external address (typed enums)](examples/compute_quickstart/) — extended with bulk per-instance MIG config, global + regional network firewall policy (rule + IAM member), and zonal VM extension policy
-- [GKE cluster + node pool + Hub fleet membership](examples/gke_quickstart/)
-- [DNS managed zone (private) + zone IAM binding/policy](examples/dns_quickstart/)
-
-Data & storage
-
-- [GCS bucket + bucket object](examples/storage_quickstart/)
-- [Cloud Storage Intelligence project config](examples/storage_intelligence_quickstart/)
-- [Storage Transfer + inventory reports + ACLs](examples/storage_transfer_quickstart/)
-- [BigQuery Data Policy V2 (raw access + email mask)](examples/bigquery_datapolicyv2_quickstart/)
-- [BigQuery dataset (sealed `Access` hierarchy)](examples/bigquery_quickstart/)
-- [Cloud Bigtable instance + table + views + IAM](examples/bigtable_quickstart/)
-- [Data Catalog taxonomy / entry / tag template](examples/data_catalog_quickstart/)
-- [Data Lineage config](examples/data_lineage_quickstart/)
-- [Dataform team folder + nested folder](examples/dataform_quickstart/)
-- [Cloud Asset Inventory project feed](examples/cloud_asset_quickstart/)
-- [Dataplex data product + IAM member](examples/dataplex_quickstart/)
-- [Vertex AI Search data store + engine + schema / control / serving config + IAM](examples/discovery_engine_quickstart/)
-- [Cloud KMS project Autokey config](examples/kms_autokey_quickstart/)
-- [Cloud KMS keyring + crypto key + ciphertext/import job](examples/kms_quickstart/)
-- [License Manager Office SPLA configuration](examples/license_manager_quickstart/)
-- [Model Armor template](examples/model_armor_quickstart/)
-- [Transcoder job template](examples/transcoder_quickstart/)
-- [Spanner user-managed instance config](examples/spanner_instance_config_quickstart/)
-- [Firebase Security Rules ruleset](examples/firebaserules_quickstart/)
-- [Vector Search collection](examples/vector_quickstart/)
-- [Migration Center sources, discovery, import, groups, and reports](examples/migration_center_quickstart/)
-- [Dataproc Metastore service and federation](examples/dataproc_metastore_quickstart/)
-- [Dataproc autoscaling policy + workflow template](examples/dataproc_autoscaling_quickstart/)
-- [Filestore High Scale SSD snapshot](examples/filestore_quickstart/)
-- [Artifact Registry project config + Docker repo + download rule + location tag binding](examples/artifact_registry_quickstart/)
-
-Application platform & operations
-
-- [Cloud Run v2 service (sealed `EnvVarSource`)](examples/cloud_run_quickstart/)
-- [Cloud Run v1 hello service](examples/cloud_run_v1_quickstart/)
-- [Access Context Manager policy + perimeter + apply-excluded leftover attachments](examples/access_context_quickstart/)
-- [Security Command Center leftover sources / mute / custom modules / exports](examples/scc_quickstart/)
-- [Org leftover hierarchical firewall / Cloud Armor / BYOIP / Storage Intelligence / Wasm](examples/org_leftover_quickstart/)
-- [Deferred leftover remaining GA factories (org / billing / DMS / Datastream / …)](examples/deferred_leftover_quickstart/)
-- [Beta leftover remaining beta-only factories](examples/beta_leftover_quickstart/)
-- [Data-source leftover remaining GA data sources (read-only, apply-excluded)](examples/data_source_leftover_quickstart/)
-- [OS Config + Binary Authorization VM compliance](examples/vm_compliance_quickstart/) (STOPPED v2 policy orchestrator)
-- [API Keys + reCAPTCHA Enterprise + connectivity test](examples/api_security_quickstart/)
-- [Logging sinks (project / folder / org) → BigQuery](examples/ops_quickstart/)
-- [Monitoring alert policy with typed `Aligner` / `Reducer`](examples/monitoring_quickstart/)
-- [Infrastructure Manager Git blueprint deployment](examples/config_deployment_quickstart/)
-- [Dialogflow CX SIP trunk](examples/dialogflow_quickstart/)
-- [Dialogflow ES agent + intent / entity type / fulfillment / version / environment](examples/dialogflow_es_quickstart/)
-- [Customer Engagement Suite app + agent + toolset + example + deployment](examples/ces_quickstart/)
-- [Developer Connect account connector](examples/developer_connect_quickstart/)
-- [NetApp Volumes metadata (vault / policy / host group)](examples/netapp_metadata_quickstart/)
-- [Network Connectivity CCI transport](examples/network_connectivity_quickstart/)
-- [Network Connectivity Center hub / spoke](examples/ncc_hub_quickstart/)
-- [Network Security ULL mirroring](examples/network_security_ull_quickstart/)
-- [Oracle GoldenGate deployment and connections](examples/oracle_goldengate_quickstart/)
-- [Oracle Autonomous Database on ODB networking](examples/oracle_autonomous_database_quickstart/)
-- [Oracle Base Database DB System](examples/oracle_db_system_quickstart/)
-- [Oracle Exadata and ExaDB](examples/oracle_exadata_quickstart/)
-- [Chronicle custom list](examples/chronicle_quickstart/)
-- [Eventarc message bus + pipeline + Pub/Sub trigger](examples/eventarc_quickstart/)
-- [Resource Manager tags (key + value + binding + IAM member/binding/policy)](examples/tags_quickstart/)
-- [Service Directory namespace + service + endpoint + IAM member/binding/policy](examples/service_directory_quickstart/)
-- [Workflows workflow from inline YAML](examples/workflows_quickstart/)
-- [App Engine application + standard/flex versions + routing](examples/app_engine_quickstart/)
-- [Compute static route + Cloud Router Named Set + network firewall policy IAM + project metadata item](examples/compute_route_quickstart/)
-- [Compute zonal instance settings](examples/compute_instance_settings_quickstart/)
-- [Compute Engine preview feature](examples/compute_preview_feature_quickstart/)
-- [Compute Engine rollout plan](examples/compute_rollout_quickstart/)
-- [Compute VPN gateway shells](examples/compute_vpn_gateway_quickstart/)
-- [Compute project Cloud Armor tier](examples/compute_cloud_armor_tier_quickstart/)
-- [Compute project default network tier](examples/compute_default_network_tier_quickstart/)
-- [Compute Engine usage export bucket](examples/usage_export_quickstart/)
-- [Compute project snapshot settings](examples/compute_snapshot_settings_quickstart/)
-- [Document AI OCR processor + default version](examples/document_ai_quickstart/)
-- [Parameter Manager global + regional parameters](examples/parameter_manager_quickstart/)
-- [Network Security address group + URL list](examples/network_security_lists_quickstart/)
-- [Network Security client + server TLS policies](examples/network_security_tls_quickstart/)
-- [Network Security gateway security policy + ALLOW rule](examples/network_security_gateway_policy_quickstart/)
-- [Network Security backend authentication config](examples/network_security_backend_auth_quickstart/)
-- [Network Security DNS threat detector](examples/network_security_dns_threat_quickstart/)
-- [Network Management VPC Flow Logs config](examples/network_management_vpc_flow_logs_quickstart/)
-- [Public CA ACME external account key](examples/public_ca_quickstart/)
-- [Network Services Mesh + HTTP/gRPC/TCP routes + endpoint policy](examples/network_services_mesh_quickstart/)
-- [Cloud Healthcare dataset + DICOM/consent/HL7v2/FHIR stores](examples/healthcare_quickstart/)
-- [Contact Center AI Insights analysis rule + view + QA scorecard/revision/question + assessment + auto-labeling](examples/contact_center_insights_quickstart/)
-- [Colab Enterprise runtime template + template IAM + paused schedule](examples/colab_quickstart/)
-- [Cloud Source Repositories repo + IAM](examples/sourcerepo_quickstart/)
-- [Vertex AI Workbench environment (container image)](examples/notebooks_quickstart/)
-- [Sensitive Data Protection (DLP) inspect / de-identify templates + stored info type + paused job trigger](examples/dlp_quickstart/)
-- [Cloud Observability trace scope](examples/observability_quickstart/)
-- [GKE Hub fleet scope, namespace, scope RBAC, and rollout sequence (no cluster)](examples/gke_hub_quickstart/)
-- [GKE Hub Multi-Cluster Service Discovery feature](examples/gke_hub_feature_quickstart/)
+---
 
 ## How it compares
 
@@ -361,56 +256,28 @@ Application platform & operations
 | Drop-in for `terraform apply` | ✅ (emits `*.tf.json`) | ✅ (native) | ✅ | ⚠️ (different state model) |
 | Project status | Alpha | Mature | **Archived Dec 2025** | Active |
 
+---
+
 ## Non-goals
 
 - **Not a Terraform replacement.** TerraDart synthesizes JSON; `terraform plan / apply` runs as before. State stays where you already keep it.
-- **Not a multi-cloud tool yet.** Google provider only. AWS / Azure may follow if the curated surface stabilizes — no promise.
+- **Not a multi-cloud abstraction layer.** Curated wrappers faithfully mirror provider schemas rather than imposing cross-cloud abstractions.
 - **Not a constructs framework.** Composite abstractions are out of scope for the pre-1.0 cycle.
 - **Not module-block support.** Compose Terraform modules in HCL alongside TerraDart-generated `*.tf.json` — both feed the same `terraform apply`.
+
+---
 
 ## Status
 
 **Alpha**, pre-1.0 (0.25.x). No SemVer until v1.0.0, but breaking changes land only on **minor** bumps, always documented in [`MIGRATING.md`](MIGRATING.md); pin `^0.25.x` and take patches freely. Beta needs external validation — see the [path to beta](https://terradart.dev/docs/status/#path-to-beta). Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
 
-## Schema-bump automation (Plan 5.E)
-
-A weekly GitHub Actions workflow (`.github/workflows/schema-bump.yml`)
-auto-detects new `terraform-provider-google` v7 minor/patch releases and
-upstream `magic-modules` MM YAML overlay updates. Each Monday morning JST
-the workflow opens a PR titled `chore(schema): weekly bump YYYY-MM-DD`
-whose body is a structured drift report. When the workflow finds nothing
-to report, no PR is created.
-
-**Weekly maintenance flow:**
-
-1. PR appears (or not — silence means clean week).
-2. Read the drift report's Summary table. If everything is ✅, squash-merge.
-3. Wrappers (and barrels) are regenerated by the workflow and included in
-   the PR — the `wrap --check` row confirms the committed result. If the
-   regenerate step failed, fix `wrapper_overrides/yaml/*.yaml` locally,
-   re-run `terradart wrap`, and push to the bump branch.
-4. For new resources: review the appended `tool/curation_backlog.yaml`
-   entries and decide whether to queue them for a future Wave.
-5. For a `⚠️ NEW MAJOR AVAILABLE: v8.x` banner: do not bump in the same PR —
-   plan a separate v8 migration effort (curated-surface regression sweep).
-
-**Ad-hoc trigger:** workflow_dispatch on the Actions tab (with `dry_run`
-input for detection-only runs).
-
-**Repo secret:** `SCHEMA_BUMP_PAT` — a fine-grained PAT with **Contents**
-and **Pull requests** write access. The default `GITHUB_TOKEN` can push the
-bump branch but cannot open the PR when the repository blocks Actions from
-creating pull requests.
-
-**Why not Renovate for terraform-provider-google?** Renovate has no
-auto-detection path with our repo shape (no `.tf` or `.terraform-version`
-file). The schema-bump workflow is the single source of truth for provider
-bump tracking. Dart toolchain bumps still use Renovate as configured in
-`renovate.json`.
+---
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). For security issues, use the [GitHub private security advisory flow](SECURITY.md).
+
+---
 
 ## Trademarks
 
@@ -419,6 +286,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). For security issues, use the [GitHub pri
 Dart™ and the related logo are trademarks of Google LLC. We are not endorsed by or affiliated with Google LLC.
 
 TerraDart is an independent open-source project and is not affiliated with, endorsed by, or sponsored by HashiCorp or Google.
+
+---
 
 ## License & acknowledgements
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restructure root `README.md` to reflect the multi-package monorepo architecture (following the style of `genkit-ai/genkit-dart`):

- **Packages table**: Added a consolidated table mapping each package (`terradart_core`, `terradart_google`, `terradart_google_beta`, `terradart_appwrite`, `terradart_cloudflare`, `terradart_agent`, `terradart_codegen`) with descriptions and pub.dev badges.
- **Streamlined structure**: Reordered into Hero → Packages Table → Quickstart → Features (The boundary, Enums, Sealed Types, Plain Dart) → Agent MCP Server → Coverage & Examples → Comparison / Non-goals / Status.
- **Cleaned up maintainer & example debt**: Trimmed the 100+ line example inventory to key category highlights pointing to `terradart.dev/docs/coverage` and `examples/`; removed internal maintainer schema-bump workflow details (maintained in `AGENTS.md`).

## Verification

- `dart tool/check_docs_consistency.dart` passed.
- `tool/agent_verify.sh` passed (full gate: docs consistency, static analysis, package test suites, wrap check, lint-override, smoke test).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0291b-a5ef-75d6-a7ec-4ac74144614c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0291b-a5ef-75d6-a7ec-4ac74144614c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

