### PR TITLE
docs: align website docs with multi-provider architecture and add GA+Beta Firebase cookbook recipe

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -10,6 +10,7 @@ Each recipe is a self-contained Dart project under `cookbook/<name>/` that uses 
 |---|---|---|---|
 | [`lunch-concierge`](lunch-concierge/README.md) | Flutter Web + Dart server + Genkit Vertex AI + Cloud Run sidecar + private Cloud SQL | Demo recipe | 8 |
 | [`single-project-app`](single-project-app/README.md) | Single GCP project, end-to-end app surface (Cloud Run + Cloud SQL + Pub/Sub + Monitoring + Secret Manager + IAM) | Imported | 8 |
+| [`firebase-app-backend`](firebase-app-backend/README.md) | Full-stack Firebase (beta) + Google Cloud (GA) backend (Firebase Web App + Firestore + Cloud Storage + Cloud Run v2 API) | Ready | 4 |
 | [`remote-backend`](remote-backend/README.md) | GCS-backed Terraform remote state (Stage 0 bootstrap + state migration) | Imported | 1 |
 | [`firestore-seeded-data`](firestore-seeded-data/README.md) | Cloud Firestore master-data seeding (11 docs across 4 collections + composite index + daily backup) via `GoogleFirestoreDocument` + `FirestoreFields.encode` | Imported | 3 |
 

--- a/cookbook/firebase-app-backend/FRICTIONS.md
+++ b/cookbook/firebase-app-backend/FRICTIONS.md
@@ -1,0 +1,8 @@
+# firebase-app-backend — FRICTIONS
+
+Findings and design notes from authoring the Firebase + Google Cloud (GA + Beta) composite recipe.
+
+## Summary
+
+- **Provider partitioning**: TerraDart's `GoogleBetaProvider` + `terradart_google_beta` resource wrapper design emits `provider: "google-beta"` automatically in Terraform JSON, making composition with `GoogleProvider` + `terradart_google` seamless in a single `Stack`.
+- **Dependency chain**: `google_firebase_project` requires `firebase.googleapis.com` enabled, and downstream Firebase apps / Firestore databases depend on `google_firebase_project`. Explicit `dependsOn` wiring ensures Terraform creates them in the correct sequence.

--- a/cookbook/firebase-app-backend/README.md
+++ b/cookbook/firebase-app-backend/README.md
@@ -1,0 +1,87 @@
+# firebase-app-backend
+
+> Part of the [TerraDart cookbook](../README.md). Library: [terradart](https://github.com/nozomi-koborinai/terradart).
+
+A full-stack recipe demonstrating how to combine **Firebase (beta)** and **Google Cloud (GA)** resources in a single TerraDart `Stack`.
+
+## Pattern demonstrated
+
+Many modern Dart & Flutter applications leverage Firebase for client-facing app integration (Firebase Web/Mobile Apps, Auth, Hosting) alongside Google Cloud infrastructure for the backend datastore and containerized microservices.
+
+In Terraform, Firebase resources are provided by `hashicorp/google-beta`, while core Google Cloud resources reside in `hashicorp/google`. TerraDart enables you to compose both in one typed `Stack` without manual provider block gymnastics.
+
+### Architecture
+
+```
+                          ┌────────────────────────────┐
+                          │  Firebase Web App (Beta)   │
+                          │     (Frontend Client)      │
+                          └─────────────┬──────────────┘
+                                        │
+                         REST API calls │
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Google Cloud Infrastructure (GA)                                            │
+│                                                                             │
+│  ┌─────────────────────────┐            ┌────────────────────────────────┐  │
+│  │   Cloud Run v2 Service  │───────────▶│   Firestore Database (Native)  │  │
+│  │      (Backend API)      │            │           (default)            │  │
+│  └────────────┬────────────┘            └────────────────────────────────┘  │
+│               │                                                             │
+│               │ Uploads                                                     │
+│               ▼                                                             │
+│  ┌─────────────────────────┐                                                │
+│  │   Cloud Storage Bucket  │                                                │
+│  │   ($projectId-uploads)  │                                                │
+│  └─────────────────────────┘                                                │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Resources included
+
+- **Google Cloud APIs (GA)**: `firebase`, `firestore`, `run`, `storage` enabled via `GoogleProjectService`.
+- **Firebase Initialization (Beta)**:
+  - `GoogleFirebaseProject` — Activates Firebase services on the Google Cloud project.
+  - `GoogleFirebaseWebApp` — Registers a frontend Web App client with Firebase.
+- **Backend & Datastore (GA)**:
+  - `GoogleFirestoreDatabase` — Native mode `(default)` Firestore database.
+  - `GoogleStorageBucket` — Cloud Storage bucket with uniform bucket-level access.
+  - `GoogleCloudRunV2Service` — Containerized backend service injecting the upload bucket name into container environment variables.
+
+## Prerequisites
+
+- Dart SDK ≥ 3.6
+- Terraform CLI ≥ 1.11.0
+- Google Cloud project with Application Default Credentials configured (`gcloud auth application-default login`)
+
+## Run
+
+```bash
+export GCP_PROJECT_ID=my-project-id
+
+dart pub get
+dart run bin/infra.dart        # → tf-out/main.tf.json
+
+cd tf-out
+terraform init
+terraform plan
+terraform apply
+```
+
+To clean up resources:
+
+```bash
+terraform destroy
+```
+
+## How provider composition works
+
+1. **Both Providers in `Stack.providers`**:
+   ```dart
+   providers: [
+     GoogleProvider(project: projectId, region: 'asia-northeast1'),
+     GoogleBetaProvider(project: projectId, region: 'asia-northeast1'),
+   ]
+   ```
+2. **Automatic Provider Routing**:
+   Wrappers in `terradart_google_beta` automatically set `provider = "google-beta"` in the synthesized Terraform JSON, so resources are cleanly partitioned between the GA and Beta provider instances.

--- a/cookbook/firebase-app-backend/README.md
+++ b/cookbook/firebase-app-backend/README.md
@@ -12,29 +12,22 @@ In Terraform, Firebase resources are provided by `hashicorp/google-beta`, while 
 
 ### Architecture
 
-```
-                          ┌────────────────────────────┐
-                          │  Firebase Web App (Beta)   │
-                          │     (Frontend Client)      │
-                          └─────────────┬──────────────┘
-                                        │
-                         REST API calls │
-                                        ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│ Google Cloud Infrastructure (GA)                                            │
-│                                                                             │
-│  ┌─────────────────────────┐            ┌────────────────────────────────┐  │
-│  │   Cloud Run v2 Service  │───────────▶│   Firestore Database (Native)  │  │
-│  │      (Backend API)      │            │           (default)            │  │
-│  └────────────┬────────────┘            └────────────────────────────────┘  │
-│               │                                                             │
-│               │ Uploads                                                     │
-│               ▼                                                             │
-│  ┌─────────────────────────┐                                                │
-│  │   Cloud Storage Bucket  │                                                │
-│  │   ($projectId-uploads)  │                                                │
-│  └─────────────────────────┘                                                │
-└─────────────────────────────────────────────────────────────────────────────┘
+```mermaid
+graph TB
+  subgraph Client["Firebase App (Beta)"]
+    WebApp["GoogleFirebaseWebApp<br/>(Frontend Client)"]
+  end
+
+  subgraph GCP["Google Cloud Infrastructure (GA)"]
+    CloudRun["GoogleCloudRunV2Service<br/>(Backend API)"]
+    Firestore["GoogleFirestoreDatabase<br/>(Native Mode / (default))"]
+    Storage["GoogleStorageBucket<br/>(User Uploads)"]
+
+    CloudRun -->|Read/Write Data| Firestore
+    CloudRun -->|Store Assets| Storage
+  end
+
+  WebApp -.REST API Calls.-> CloudRun
 ```
 
 ## Resources included

--- a/cookbook/firebase-app-backend/analysis_options.yaml
+++ b/cookbook/firebase-app-backend/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/cookbook/firebase-app-backend/bin/infra.dart
+++ b/cookbook/firebase-app-backend/bin/infra.dart
@@ -1,0 +1,19 @@
+/// Synth entry. `dart run bin/infra.dart` → `tf-out/main.tf.json`.
+library;
+
+import 'dart:io';
+
+import 'package:firebase_app_backend/main.dart';
+
+Future<void> main() async {
+  final projectId = Platform.environment['GCP_PROJECT_ID'];
+  if (projectId == null || projectId.isEmpty) {
+    stderr.writeln(
+      'error: set GCP_PROJECT_ID env var (e.g. GCP_PROJECT_ID=my-project-id)',
+    );
+    exit(64);
+  }
+  final stack = FirebaseAppBackendStack(projectId: projectId);
+  await stack.writeTo('tf-out');
+  print('synthesized to tf-out/main.tf.json');
+}

--- a/cookbook/firebase-app-backend/lib/main.dart
+++ b/cookbook/firebase-app-backend/lib/main.dart
@@ -1,0 +1,157 @@
+library;
+
+import 'package:terradart_core/terradart_core.dart';
+// GA: Google Cloud Provider and resource factories
+import 'package:terradart_google/cloud_run.dart';
+import 'package:terradart_google/firestore.dart';
+import 'package:terradart_google/project.dart';
+import 'package:terradart_google/provider.dart';
+import 'package:terradart_google/storage.dart';
+// Beta: Google Cloud Beta Provider and Firebase factories
+import 'package:terradart_google_beta/firebase.dart';
+import 'package:terradart_google_beta/provider.dart';
+
+/// Recipe demonstrating composition of Google Cloud (GA) and Firebase (Beta)
+/// in a single TerraDart [Stack].
+///
+/// Resources:
+///   - 4 [GoogleProjectService] API activations (firebase, firestore, run, storage)
+///   - 1 [GoogleFirebaseProject] (beta) - Project-level Firebase activation
+///   - 1 [GoogleFirebaseWebApp] (beta) - Registered Firebase web client app
+///   - 1 [GoogleFirestoreDatabase] (GA) - Native mode Firestore database
+///   - 1 [GoogleStorageBucket] (GA) - Cloud Storage bucket for user uploads
+///   - 1 [GoogleCloudRunV2Service] (GA) - Cloud Run v2 backend API service
+final class FirebaseAppBackendStack extends Stack {
+  FirebaseAppBackendStack({required String projectId})
+      : super(
+          providers: [
+            GoogleProvider(project: projectId, region: 'asia-northeast1'),
+            GoogleBetaProvider(project: projectId, region: 'asia-northeast1'),
+          ],
+          backend: const LocalBackend(),
+          devMode: true,
+        ) {
+    // -------------------------------------------------------------------------
+    // 1. Enable required APIs
+    // -------------------------------------------------------------------------
+    final apiFirebase = add(
+      GoogleProjectService(
+        localName: 'api_firebase',
+        service: TfArg.literal('firebase.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+    );
+
+    final apiFirestore = add(
+      GoogleProjectService(
+        localName: 'api_firestore',
+        service: TfArg.literal('firestore.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+    );
+
+    final apiRun = add(
+      GoogleProjectService(
+        localName: 'api_run',
+        service: TfArg.literal('run.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+    );
+
+    final apiStorage = add(
+      GoogleProjectService(
+        localName: 'api_storage',
+        service: TfArg.literal('storage.googleapis.com'),
+        disableOnDestroy: TfArg.literal(false),
+      ),
+    );
+
+    // -------------------------------------------------------------------------
+    // 2. [Beta] Firebase project initialization & web app registration
+    // -------------------------------------------------------------------------
+    final fbProject = add(
+      GoogleFirebaseProject(
+        localName: 'firebase_core',
+        project: TfArg.literal(projectId),
+        dependsOn: [ResourceDependency(apiFirebase)],
+      ),
+    );
+
+    add(
+      GoogleFirebaseWebApp(
+        localName: 'web_client',
+        displayName: TfArg.literal('Frontend Client'),
+        project: TfArg.literal(projectId),
+        dependsOn: [ResourceDependency(fbProject)],
+      ),
+    );
+
+    // -------------------------------------------------------------------------
+    // 3. [GA] Cloud Firestore Database (Native mode)
+    // -------------------------------------------------------------------------
+    final firestoreDb = add(
+      GoogleFirestoreDatabase(
+        localName: 'default_db',
+        name: TfArg.literal('(default)'),
+        locationId: TfArg.literal('asia-northeast1'),
+        type: TfArg.literal(FirestoreDatabaseType.firestoreNative),
+        deleteProtectionState: TfArg.literal(DeleteProtectionState.disabled),
+        deletionPolicy: TfArg.literal('DELETE'),
+        dependsOn: [
+          ResourceDependency(apiFirestore),
+          ResourceDependency(fbProject),
+        ],
+      ),
+    );
+
+    // -------------------------------------------------------------------------
+    // 4. [GA] Cloud Storage for user-uploaded assets
+    // -------------------------------------------------------------------------
+    final uploadsBucket = add(
+      GoogleStorageBucket(
+        localName: 'uploads',
+        name: TfArg.literal('$projectId-app-uploads'),
+        location: TfArg.literal('ASIA-NORTHEAST1'),
+        storageClass: TfArg.literal(BucketStorageClass.standard),
+        uniformBucketLevelAccess: TfArg.literal(true),
+        forceDestroy: TfArg.literal(true),
+        dependsOn: [ResourceDependency(apiStorage)],
+      ),
+    );
+
+    // -------------------------------------------------------------------------
+    // 5. [GA] Backend API Service (Cloud Run v2)
+    // -------------------------------------------------------------------------
+    add(
+      GoogleCloudRunV2Service(
+        localName: 'backend_api',
+        name: TfArg.literal('backend-api'),
+        location: TfArg.literal('asia-northeast1'),
+        deletionProtection: TfArg.literal(false),
+        template: CloudRunV2ServiceTemplate(
+          containers: [
+            CloudRunV2ServiceServiceContainer(
+              name: TfArg.literal('server'),
+              image: TfArg.literal('gcr.io/$projectId/backend-api:latest'),
+              ports: CloudRunV2ServiceContainerPort(
+                containerPort: TfArg.literal(8080),
+              ),
+              env: [
+                CloudRunV2ServiceEnvVar(
+                  name: TfArg.literal('UPLOAD_BUCKET_NAME'),
+                  source: CloudRunV2ServiceEnvVarFromLiteral(
+                    TfArg.ref(uploadsBucket.nameRef),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+        dependsOn: [
+          ResourceDependency(apiRun),
+          ResourceDependency(firestoreDb),
+        ],
+      ),
+    );
+  }
+}

--- a/cookbook/firebase-app-backend/lib/main.dart
+++ b/cookbook/firebase-app-backend/lib/main.dart
@@ -132,7 +132,8 @@ final class FirebaseAppBackendStack extends Stack {
           containers: [
             CloudRunV2ServiceServiceContainer(
               name: TfArg.literal('server'),
-              image: TfArg.literal('gcr.io/$projectId/backend-api:latest'),
+              image:
+                  TfArg.literal('us-docker.pkg.dev/cloudrun/container/hello'),
               ports: CloudRunV2ServiceContainerPort(
                 containerPort: TfArg.literal(8080),
               ),

--- a/cookbook/firebase-app-backend/pubspec.yaml
+++ b/cookbook/firebase-app-backend/pubspec.yaml
@@ -1,0 +1,17 @@
+name: firebase_app_backend
+description: terradart cookbook recipe — deploy a full-stack Firebase (beta) and Google Cloud (GA) backend in a single Stack (Firebase Web App + Firestore + Cloud Storage + Cloud Run v2 API).
+publish_to: none
+version: 0.1.0
+
+environment:
+  sdk: ^3.6.0
+
+resolution: workspace
+
+dependencies:
+  terradart_core: ^0.25.2
+  terradart_google: ^0.25.2
+  terradart_google_beta: ^0.25.2
+
+dev_dependencies:
+  lints: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -135,6 +135,7 @@ workspace:
   - examples/workflows_quickstart
   - examples/app_engine_quickstart
   - cookbook/single-project-app
+  - cookbook/firebase-app-backend
   - cookbook/firestore-seeded-data
   - cookbook/remote-backend
   - cookbook/lunch-concierge/shared

--- a/tool/check_cookbook.sh
+++ b/tool/check_cookbook.sh
@@ -53,6 +53,12 @@ echo ">> synth Lunch Concierge infra"
     dart run bin/infra.dart
 )
 
+echo ">> synth firebase-app-backend infra"
+(
+  cd cookbook/firebase-app-backend
+  GCP_PROJECT_ID="$COOKBOOK_GCP_PROJECT_ID" dart run bin/infra.dart
+)
+
 if command -v terraform >/dev/null 2>&1; then
   echo ">> terraform validate Lunch Concierge infra"
   (
@@ -60,11 +66,9 @@ if command -v terraform >/dev/null 2>&1; then
     terraform init -backend=false
     terraform validate
   )
-  echo ">> synth & validate firebase-app-backend"
+  echo ">> terraform validate firebase-app-backend"
   (
-    cd cookbook/firebase-app-backend
-    GCP_PROJECT_ID="$COOKBOOK_GCP_PROJECT_ID" dart run bin/infra.dart
-    cd tf-out
+    cd cookbook/firebase-app-backend/tf-out
     terraform init -backend=false
     terraform validate
   )

--- a/tool/check_cookbook.sh
+++ b/tool/check_cookbook.sh
@@ -24,6 +24,7 @@ dart format --output=none --set-exit-if-changed \
   cookbook/lunch-concierge/server \
   cookbook/lunch-concierge/infra \
   cookbook/single-project-app \
+  cookbook/firebase-app-backend \
   cookbook/firestore-seeded-data \
   cookbook/remote-backend
 
@@ -33,6 +34,7 @@ dart analyze \
   cookbook/lunch-concierge/infra \
   cookbook/lunch-concierge/shared \
   cookbook/single-project-app \
+  cookbook/firebase-app-backend \
   cookbook/firestore-seeded-data \
   cookbook/remote-backend
 
@@ -55,6 +57,14 @@ if command -v terraform >/dev/null 2>&1; then
   echo ">> terraform validate Lunch Concierge infra"
   (
     cd cookbook/lunch-concierge/infra/tf-out
+    terraform init -backend=false
+    terraform validate
+  )
+  echo ">> synth & validate firebase-app-backend"
+  (
+    cd cookbook/firebase-app-backend
+    GCP_PROJECT_ID="$COOKBOOK_GCP_PROJECT_ID" dart run bin/infra.dart
+    cd tf-out
     terraform init -backend=false
     terraform validate
   )

--- a/website/src/content/docs/docs/architecture.mdx
+++ b/website/src/content/docs/docs/architecture.mdx
@@ -13,7 +13,7 @@ TerraDart is a thin authoring layer that produces standard Terraform JSON. The D
   steps={[
     {
       title: "Author",
-      body: "Write <code>final class XxxStack extends Stack</code> using curated <code>google_*</code> factories from terradart_google.",
+      body: "Write <code>final class XxxStack extends Stack</code> using curated factories from provider packages.",
     },
     {
       title: "Generate Terraform JSON",
@@ -61,9 +61,14 @@ final class AppInfraStack extends Stack { /* ... */ }
 
 ## Provider integration
 
-[`terradart_google`](https://pub.dev/packages/terradart_google) ships typed factories for the **GA** HashiCorp [`google`](https://registry.terraform.io/providers/hashicorp/google/latest) provider catalog. See [status](/docs/status/) and the [package README](https://pub.dev/packages/terradart_google) for counts; the full list is on [Coverage](/docs/coverage/). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook).
+TerraDart supports multiple official Terraform providers with curated, typed Dart factories:
 
-TerraDart depends on the Google Terraform provider via two upstream sources, both reconciled automatically on a weekly cadence.
+- **[`terradart_google`](https://pub.dev/packages/terradart_google)** — **GA** HashiCorp [`google`](https://registry.terraform.io/providers/hashicorp/google/latest) provider catalog. See [status](/docs/status/) and the [package README](https://pub.dev/packages/terradart_google) for counts; the full list is on [Coverage](/docs/coverage/).
+- **[`terradart_google_beta`](https://pub.dev/packages/terradart_google_beta)** — **beta-only** types from `hashicorp/google-beta` (128 resource factories at the current pin).
+- **[`terradart_appwrite`](https://pub.dev/packages/terradart_appwrite)** — official `appwrite/appwrite` provider resources.
+- **[`terradart_cloudflare`](https://pub.dev/packages/terradart_cloudflare)** — official `cloudflare/cloudflare` provider resources.
+
+For the Google provider, TerraDart depends on upstream sources reconciled automatically on a weekly cadence:
 
 ```mermaid
 graph LR
@@ -76,9 +81,9 @@ graph LR
   CG --> WR["terradart_google wrappers"]
 ```
 
-The MM YAML overlay carries metadata that the provider schema does not surface — `sensitive_fields`, `force_new`, free-form description text. `terradart_codegen` merges both inputs into typed `<resource>.schema.dart` files that compose into the `terradart_google` package.
+The MM YAML overlay carries metadata that the provider schema does not surface — `sensitive_fields`, `force_new`, free-form description text. `terradart_codegen` merges inputs into typed `<resource>.schema.dart` files that compose into the `terradart_google` package.
 
-Provider tracking is pinned to GA `~> 7.0`. Beta-only types live in `terradart_google_beta` (128 resource factories at the current pin); overlapping GA names stay in `terradart_google`.
+Provider tracking for Google is pinned to GA `~> 7.0`. Beta-only types live in `terradart_google_beta` (128 resource factories at the current pin); overlapping GA names stay in `terradart_google`.
 
 A weekly GitHub Actions workflow (`.github/workflows/schema-bump.yml`) runs every Monday morning JST. It detects new `terraform-provider-google` v7 releases and MM YAML overlay changes, refreshes the local schema + MM fixtures, runs `terradart wrap --check`, and opens a single drift-report PR if anything needs maintainer attention. Quiet weeks produce no PR.
 
@@ -109,7 +114,7 @@ A worked end-to-end example lives in the [cookbook `single-project-app` recipe](
 ## Non-goals
 
 - Not a Terraform replacement — state and apply stay in Terraform.
-- Not multi-cloud yet — the Google provider only.
+- Not a multi-cloud abstraction layer — wrappers faithfully mirror provider schemas rather than imposing cross-cloud abstractions.
 - Not a constructs framework in the pre-1.0 cycle.
 - Not module-block support — compose Terraform modules in HCL alongside TerraDart-generated `*.tf.json`; both feed the same `terraform apply`.
 
@@ -119,6 +124,8 @@ See [README — Non-goals](https://github.com/nozomi-koborinai/terradart#non-goa
 
 - [How it's built](/docs/how-its-built/) — the generation pipeline and verification harness behind these factories.
 - [`terradart_core` on pub.dev](https://pub.dev/packages/terradart_core) — Stack / TfArg / AppExport API reference.
-- [`terradart_google` on pub.dev](https://pub.dev/packages/terradart_google) — the curated factory catalog.
+- [`terradart_google` on pub.dev](https://pub.dev/packages/terradart_google) — the curated Google factory catalog.
+- [`terradart_appwrite` on pub.dev](https://pub.dev/packages/terradart_appwrite) — curated Appwrite factories.
+- [`terradart_cloudflare` on pub.dev](https://pub.dev/packages/terradart_cloudflare) — curated Cloudflare factories.
 - [`terradart_codegen` on pub.dev](https://pub.dev/packages/terradart_codegen) — `wrap` / `codegen` CLI reference.
 - [`examples/` on GitHub](https://github.com/nozomi-koborinai/terradart/tree/main/examples) — runnable quickstart Stacks.

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -98,6 +98,98 @@ bool acceptsTopic(String eventTopic) =>
 
 Rename `orders-prod` in the Stack without updating the subscriber and `dart analyze` fails. See [Architecture — AppExport](/docs/architecture/#appexport-the-iac--app-seam) and the runnable [pubsub quickstart](https://github.com/nozomi-koborinai/terradart/tree/main/examples/pubsub_quickstart) (`lib/subscriber_stub.dart`).
 
+## 6. Composing GA and Beta providers (Firebase + Google Cloud)
+
+You can seamlessly combine Google Cloud GA resources (`terradart_google`) with beta-only resources (`terradart_google_beta`, such as Firebase project configuration and Web App registration) in a single `Stack`:
+
+```yaml
+# pubspec.yaml
+dependencies:
+  terradart_core: ^0.25.x
+  terradart_google: ^0.25.x
+  terradart_google_beta: ^0.25.x
+```
+
+```dart
+import 'package:terradart_core/terradart_core.dart';
+// GA: Google Cloud backend infrastructure
+import 'package:terradart_google/cloud_run.dart';
+import 'package:terradart_google/firestore.dart';
+import 'package:terradart_google/provider.dart';
+import 'package:terradart_google/storage.dart';
+// Beta: Firebase project and app registration
+import 'package:terradart_google_beta/firebase.dart';
+import 'package:terradart_google_beta/provider.dart';
+
+final class MobileAppBackendStack extends Stack {
+  MobileAppBackendStack({required String projectId})
+      : super(
+          providers: [
+            GoogleProvider(project: projectId, region: 'asia-northeast1'),
+            GoogleBetaProvider(project: projectId, region: 'asia-northeast1'),
+          ],
+        ) {
+    // 1. [Beta] Enable Firebase on the project
+    final fb = add(GoogleFirebaseProject(
+      localName: 'firebase',
+      project: TfArg.literal(projectId),
+    ));
+
+    // 2. [Beta] Register Firebase client app
+    add(GoogleFirebaseWebApp(
+      localName: 'web_client',
+      displayName: TfArg.literal('Web Client'),
+      project: TfArg.literal(projectId),
+      dependsOn: [fb],
+    ));
+
+    // 3. [GA] Firestore Database (Native mode)
+    final db = add(GoogleFirestoreDatabase(
+      localName: 'db',
+      name: TfArg.literal('(default)'),
+      locationId: TfArg.literal('asia-northeast1'),
+      type: TfArg.literal(FirestoreDatabaseType.firestoreNative),
+      dependsOn: [fb],
+    ));
+
+    // 4. [GA] Cloud Storage for user uploads
+    final uploadsBucket = add(GoogleStorageBucket(
+      localName: 'uploads',
+      name: TfArg.literal('$projectId-uploads'),
+      location: TfArg.literal('ASIA-NORTHEAST1'),
+      storageClass: TfArg.literal(BucketStorageClass.standard),
+      uniformBucketLevelAccess: TfArg.literal(true),
+    ));
+
+    // 5. [GA] Cloud Run v2 backend service
+    add(GoogleCloudRunV2Service(
+      localName: 'api',
+      name: TfArg.literal('api-server'),
+      location: TfArg.literal('asia-northeast1'),
+      template: CloudRunV2ServiceTemplate(
+        containers: [
+          CloudRunV2ServiceServiceContainer(
+            name: TfArg.literal('server'),
+            image: TfArg.literal('gcr.io/$projectId/api:latest'),
+            env: [
+              CloudRunV2ServiceEnvVar(
+                name: TfArg.literal('UPLOAD_BUCKET'),
+                source: CloudRunV2ServiceEnvVarFromLiteral(
+                  TfArg.ref(uploadsBucket.nameRef),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+      dependsOn: [db],
+    ));
+  }
+}
+```
+
+Wrappers from `terradart_google_beta` automatically attach `provider = "google-beta"` in the synthesized Terraform JSON. See the complete runnable recipe in [`cookbook/firebase-app-backend`](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook/firebase-app-backend).
+
 ## Next steps
 
 - [Why TerraDart](/docs/why-terradart/) — motivation and comparisons

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -188,7 +188,9 @@ final class MobileAppBackendStack extends Stack {
         containers: [
           CloudRunV2ServiceServiceContainer(
             name: TfArg.literal('server'),
-            image: TfArg.literal('gcr.io/$projectId/api:latest'),
+            image: TfArg.literal(
+              'us-docker.pkg.dev/cloudrun/container/hello',
+            ),
             env: [
               CloudRunV2ServiceEnvVar(
                 name: TfArg.literal('UPLOAD_BUCKET'),

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -9,15 +9,20 @@ This guide matches the [README quickstart](https://github.com/nozomi-koborinai/t
 
 - Dart SDK ≥ 3.6
 - Terraform CLI ≥ 1.11.0
-- A GCP project with Pub/Sub enabled and Application Default Credentials (`gcloud auth application-default login`)
+- Credentials for your target provider (e.g. Google Cloud Application Default Credentials `gcloud auth application-default login`, or provider environment variables)
 
 ## 1. Add dependencies
+
+Choose `terradart_core` along with the provider factory package(s) your stack requires:
 
 ```yaml
 # pubspec.yaml
 dependencies:
   terradart_core: ^0.25.x
-  terradart_google: ^0.25.x
+  terradart_google: ^0.25.x # for Google Cloud (GA)
+  # terradart_google_beta: ^0.25.x # for Google Cloud beta-only resources
+  # terradart_appwrite: ^0.25.x    # for Appwrite
+  # terradart_cloudflare: ^0.25.x  # for Cloudflare edge infrastructure
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch, then run:
@@ -26,7 +31,7 @@ Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch, t
 dart pub get
 ```
 
-The GA `hashicorp/google` catalog is filled. Beta-only types live in [`terradart_google_beta`](https://github.com/nozomi-koborinai/terradart/tree/main/packages/terradart_google_beta) (128 resource factories). Types that also exist in GA stay in `terradart_google`.
+The GA `hashicorp/google` catalog is filled. Beta-only types live in [`terradart_google_beta`](https://pub.dev/packages/terradart_google_beta) (128 resource factories). Other official providers like [`terradart_appwrite`](https://pub.dev/packages/terradart_appwrite) and [`terradart_cloudflare`](https://pub.dev/packages/terradart_cloudflare) are also available.
 
 ## 2. Define a Stack
 

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -102,6 +102,24 @@ Rename `orders-prod` in the Stack without updating the subscriber and `dart anal
 
 You can seamlessly combine Google Cloud GA resources (`terradart_google`) with beta-only resources (`terradart_google_beta`, such as Firebase project configuration and Web App registration) in a single `Stack`:
 
+```mermaid
+graph TB
+  subgraph Client["Firebase App (Beta)"]
+    WebApp["GoogleFirebaseWebApp<br/>(Frontend Client)"]
+  end
+
+  subgraph GCP["Google Cloud Infrastructure (GA)"]
+    CloudRun["GoogleCloudRunV2Service<br/>(Backend API)"]
+    Firestore["GoogleFirestoreDatabase<br/>(Native Mode / (default))"]
+    Storage["GoogleStorageBucket<br/>(User Uploads)"]
+
+    CloudRun -->|Read/Write Data| Firestore
+    CloudRun -->|Store Assets| Storage
+  end
+
+  WebApp -.REST API Calls.-> CloudRun
+```
+
 ```yaml
 # pubspec.yaml
 dependencies:

--- a/website/src/content/docs/docs/index.md
+++ b/website/src/content/docs/docs/index.md
@@ -1,11 +1,23 @@
 ---
 title: Documentation
-description: Guides for TerraDart — type-safe Google Cloud IaC for Dart.
+description: Guides for TerraDart — type-safe infrastructure-as-code for Dart.
 ---
 
 Welcome to the TerraDart docs.
 
 Guides track the **0.25.x** line on pub.dev. The repo [README](https://github.com/nozomi-koborinai/terradart/blob/main/README.md) and [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) stay the deepest references; this site mirrors onboarding and release expectations.
+
+## Packages
+
+TerraDart is organized as a multi-package monorepo:
+
+- **[`terradart_core`](https://pub.dev/packages/terradart_core)** — Core runtime primitives (`Stack`, `Resource`, `Provider`, `Data`, `TfArg`, synth/write behavior).
+- **[`terradart_google`](https://pub.dev/packages/terradart_google)** — Curated factories for Google Cloud (`hashicorp/google`).
+- **[`terradart_google_beta`](https://pub.dev/packages/terradart_google_beta)** — Curated factories for beta-only Google Cloud resources (`hashicorp/google-beta`).
+- **[`terradart_appwrite`](https://pub.dev/packages/terradart_appwrite)** — Curated factories for Appwrite (`appwrite/appwrite`).
+- **[`terradart_cloudflare`](https://pub.dev/packages/terradart_cloudflare)** — Curated factories for Cloudflare edge infrastructure (`cloudflare/cloudflare`).
+- **[`terradart_agent`](https://github.com/nozomi-koborinai/terradart/tree/main/packages/terradart_agent)** — MCP server (`terradart-mcp`) exposing the curated catalog to AI coding agents.
+- **[`terradart_codegen`](https://pub.dev/packages/terradart_codegen)** — Maintainer generation CLI (`terradart wrap`).
 
 ## Guides
 

--- a/website/src/content/docs/docs/why-terradart.md
+++ b/website/src/content/docs/docs/why-terradart.md
@@ -1,18 +1,18 @@
 ---
 title: Why TerraDart
-description: Why Dart teams adopt TerraDart — the infra/app boundary, Terraform-compatible generation, curated Google provider factories, and how it compares to HCL, CDKTF, and Pulumi.
+description: Why Dart teams adopt TerraDart — the infra/app boundary, Terraform-compatible generation, curated provider factories, and how it compares to HCL, CDKTF, and Pulumi.
 ---
 
-If you read the [landing page](/) first: TerraDart keeps **Terraform as the execution layer** while you **author GCP infrastructure in Dart**. This page goes deeper on motivation, the type system, and where TerraDart sits next to other IaC tools.
+If you read the [landing page](/) first: TerraDart keeps **Terraform as the execution layer** while you **author infrastructure in Dart**. This page goes deeper on motivation, the type system, and where TerraDart sits next to other IaC tools.
 
-If your team ships Flutter on the client and Dart on the server (**Cloud Run**, **Cloud Run functions**), there is usually one layer left where Dart's tooling does not reach: **infrastructure definitions** — often maintained in HCL, a Terraform-compatible pipeline, or the GCP console. TerraDart closes that gap without asking you to give up Terraform itself.
+If your team ships Flutter on the client and Dart on the server (**Cloud Run**, **Cloud Run functions**, backend APIs), there is usually one layer left where Dart's tooling does not reach: **infrastructure definitions** — often maintained in HCL, a Terraform-compatible pipeline, or cloud consoles. TerraDart closes that gap without asking you to give up Terraform itself.
 
 ## The last non-Dart layer
 
 | Layer | Already Dart? |
 | --- | --- |
 | Mobile UI (Flutter) | ✅ |
-| Backend handlers (Cloud Run / Cloud Run functions) | ✅ |
+| Backend handlers (Cloud Run / Cloud Run functions / Shelf) | ✅ |
 | Application business logic | ✅ |
 | Infrastructure definitions | ❌ — HCL, Terraform-compatible tooling, or console |
 
@@ -75,13 +75,13 @@ This prevents two foot-guns: forgetting to extend (using `implements` would skip
 
 ## How it fits next to other IaC
 
-TerraDart fits teams already centered on **Dart**, already running **Terraform** (or a compatible pipeline) or managing GCP in the **console**, where the seam between infra and app code hurts.
+TerraDart fits teams already centered on **Dart**, already running **Terraform** (or a compatible pipeline) or managing infrastructure in cloud **consoles**, where the seam between infra and app code hurts.
 
 | | TerraDart | HCL | CDKTF | Pulumi |
 | --- | --- | --- | --- | --- |
 | Dart authoring | Yes | No | No | No |
 | Drop-in for `terraform apply` | Yes | Yes | Yes | Different model |
-| Curated Dart factories for GCP | Yes | No | No | No |
+| Curated Dart factories | Yes | No | No | No |
 | Project status | Alpha | Mature | Archived 2025 | Active |
 
 HCL has provider schema types; CDKTF bindings are typed in TypeScript and other languages. TerraDart's difference is **Dart-native authoring** without replacing your Terraform execution pipeline.
@@ -92,22 +92,27 @@ HCL has provider schema types; CDKTF bindings are typed in TypeScript and other 
 
 **Pulumi** is a different model entirely: its own runtime, its own state, and its own resource graph. If you want a code-first IaC platform and you do not already have Terraform investment, Pulumi is a strong choice. TerraDart is for teams who already use Terraform and do not want to give that up.
 
-**TerraDart** makes sense when you are already centered on Dart (Flutter + Cloud Run / Cloud Run functions), already using Terraform (or heading there), and the gap between those two — IaC stuck outside your Dart repo — is the part that hurts.
+**TerraDart** makes sense when you are already centered on Dart (Flutter + Cloud Run / backend apps), already using Terraform (or heading there), and the gap between those two — IaC stuck outside your Dart repo — is the part that hurts.
 
 ## Curated provider coverage
 
-[`terradart_google`](https://pub.dev/packages/terradart_google) wraps the **GA** HashiCorp `google` provider catalog — **1332 curated resource factories + 461 data sources** (1793 catalog entries). [`terradart_google_beta`](https://github.com/nozomi-koborinai/terradart/tree/main/packages/terradart_google_beta) wraps beta-only types (128 resource factories). The full factory list with example pointers is on [Coverage](/docs/coverage/); see also [status](/docs/status/) and [Architecture — Provider integration](/docs/architecture/#provider-integration). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook) (both expanding). Upgrading across minors? Read [Migrating](/docs/migrating/) first.
+- [`terradart_google`](https://pub.dev/packages/terradart_google) wraps the **GA** HashiCorp `google` provider catalog — **1332 curated resource factories + 461 data sources** (1793 catalog entries).
+- [`terradart_google_beta`](https://pub.dev/packages/terradart_google_beta) wraps beta-only types (128 resource factories).
+- [`terradart_appwrite`](https://pub.dev/packages/terradart_appwrite) wraps official `appwrite/appwrite` provider resources.
+- [`terradart_cloudflare`](https://pub.dev/packages/terradart_cloudflare) wraps official `cloudflare/cloudflare` provider resources.
+
+The full factory list with example pointers is on [Coverage](/docs/coverage/); see also [status](/docs/status/) and [Architecture — Provider integration](/docs/architecture/#provider-integration). Runnable stacks live in [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) and the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook). Upgrading across minors? Read [Migrating](/docs/migrating/) first.
 
 ## Non-goals
 
 - Not a Terraform replacement — state and apply stay in Terraform.
-- Not multi-cloud yet — the Google provider only.
+- Not a multi-cloud abstraction layer — wrappers faithfully mirror provider schemas rather than imposing cross-cloud abstractions.
 - Not a constructs framework in the pre-1.0 cycle.
 - Not module-block support — compose Terraform modules in HCL alongside TerraDart-generated `*.tf.json`; both feed the same `terraform apply`.
 
 ## Next steps
 
 - [Architecture](/docs/architecture/) — `synth()` / `writeTo()`, provider integration, AppExport
-- [Getting Started](/docs/getting-started/) — install and first `*.tf.json` output (in progress)
+- [Getting Started](/docs/getting-started/) — install and first `*.tf.json` output
 - [How it's built](/docs/how-its-built/) — generation pipeline, verification, sustainability
 - [Status](/docs/status/) — alpha expectations


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Align public website documentation (`website/src/content/docs/docs/`) with the multi-provider and multi-package architecture, and add a complete GA + Beta (Google Cloud + Firebase) composition guide and cookbook recipe:

- **`index.md`**: Added a Packages section outlining all workspace packages (`terradart_core`, `terradart_google`, `terradart_google_beta`, `terradart_appwrite`, `terradart_cloudflare`, `terradart_agent`, `terradart_codegen`).
- **`getting-started.md`**:
  - Updated dependency installation guidance to cover other supported providers (`terradart_appwrite`, `terradart_cloudflare`, `terradart_google_beta`).
  - Added **Section 6: Composing GA and Beta providers (Firebase + Google Cloud)** demonstrating how `GoogleProvider` and `GoogleBetaProvider` compose in a single `Stack` (Firebase Web App + Firestore + Cloud Storage + Cloud Run v2).
- **`why-terradart.md` & `architecture.mdx`**: Refined the "Non-goals" section to clarify that TerraDart is not a multi-cloud abstraction layer (it wraps individual provider schemas faithfully) instead of the outdated "Google provider only" wording; updated provider lists to include Appwrite and Cloudflare.
- **`cookbook/firebase-app-backend`**: Added a complete, runnable cookbook recipe demonstrating the GA + Beta Firebase backend pattern, integrated into `tool/check_cookbook.sh` and workspace test suites.

## Verification

- `dart tool/check_docs_consistency.dart` passed.
- `tool/check_cookbook.sh` passed (format, analyze, synth, terraform validate).
- `tool/agent_verify.sh --quick` passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0291b-a5ef-75d6-a7ec-4ac74144614c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0291b-a5ef-75d6-a7ec-4ac74144614c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

