### PR TITLE
docs(website): update landing page copy for multi-provider architecture

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -24,7 +24,7 @@ export default defineConfig({
     starlight({
       title: "TerraDart",
       description:
-        "Documentation for TerraDart — type-safe Google Cloud IaC for Dart.",
+        "Documentation for TerraDart — type-safe infrastructure-as-code for Dart.",
       defaultLocale: "root",
       locales: {
         root: { label: "English", lang: "en" },

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -14,7 +14,7 @@ const year = new Date().getFullYear();
           class="h-7 w-auto"
         />
         <p class="text-mute mt-3 text-sm max-w-md">
-          Type-safe Google Cloud IaC for Dart. Generates standard
+          Type-safe cloud infrastructure for Dart. Generates standard
           <code class="font-mono text-[0.85em]">*.tf.json</code> — your existing
           <code class="font-mono text-[0.85em]">terraform apply</code> pipeline
           runs unchanged.

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -13,7 +13,7 @@ import HeroMark from "./HeroMark.astro";
       </h1>
 
       <p class="body-lead hero-lead">
-        Terraform stays. <strong>You author in Dart.</strong> Define typed GCP
+        Terraform stays. <strong>You author in Dart.</strong> Define typed cloud
         resources and emit standard <code>*.tf.json</code> for the
         <code>terraform apply</code> pipeline you already run.
       </p>

--- a/website/src/components/PitchCode.astro
+++ b/website/src/components/PitchCode.astro
@@ -40,7 +40,7 @@ const highlightedHtml = await codeToHtml(code, {
 <section class="section rule-top pitch-code-section">
   <div class="container-edit section-inner">
     <p class="section-label">Example</p>
-    <h2 class="display-section">GCP resources in Dart</h2>
+    <h2 class="display-section">Cloud infrastructure in Dart</h2>
     <p class="pitch-code-lead">
       Cloud SQL, IAM, and a multi-container Cloud Run service with a
       <code>cloud-sql-proxy</code> sidecar&nbsp;&mdash; a
@@ -52,11 +52,11 @@ const highlightedHtml = await codeToHtml(code, {
       <div class="pitch-code-wrap" set:html={highlightedHtml} />
     </div>
     <p class="pitch-code-meta">
-      <code>terradart_google</code> ships typed factories for the
-      <strong>GA</strong> HashiCorp <code>google</code> provider catalog.
-      Beta-only types live in <code>terradart_google_beta</code>
-      (128 resource factories). The
-      full factory list with runnable examples is on
+      Curated packages wrap official Terraform providers:
+      <code>terradart_google</code> (GA catalog, 1793 entries),
+      <code>terradart_google_beta</code> (128 beta-only factories),
+      <code>terradart_appwrite</code>, and <code>terradart_cloudflare</code>.
+      The full factory list with runnable examples is on
       <a href="/docs/coverage/" class="link-mark">Coverage</a>; complete stacks live in the
       <a
         href="https://github.com/nozomi-koborinai/terradart/tree/main/cookbook"

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -9,7 +9,7 @@ interface Props {
 const {
   title = "TerraDart — Type-safe IaC for Dart",
   description =
-    "Google Cloud infrastructure as Dart — generate *.tf.json for the terraform apply pipeline you already run.",
+    "Cloud infrastructure as Dart — generate *.tf.json for the terraform apply pipeline you already run.",
 } = Astro.props;
 
 const url = Astro.site

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -38,7 +38,7 @@ import Footer from "../components/Footer.astro";
     <Comparison
       eyebrow="Compare"
       heading="Where TerraDart fits"
-      intro="TerraDart fits teams already centered on <strong>Dart</strong>, already running <strong>Terraform</strong> (or a compatible pipeline) or managing GCP in the <strong>console</strong>, where the seam between infra and app code hurts."
+      intro="TerraDart fits teams already centered on <strong>Dart</strong>, already running <strong>Terraform</strong> (or a compatible pipeline) or managing infrastructure in cloud <strong>consoles</strong>, where the seam between infra and app code hurts."
       footnote="HCL has provider schema types; CDKTF bindings are typed in TypeScript and other languages. TerraDart&rsquo;s difference is <strong>Dart-native authoring</strong> without replacing your Terraform execution pipeline."
       columns={["TerraDart", "HCL", "CDKTF", "Pulumi"]}
       rows={[
@@ -51,7 +51,7 @@ import Footer from "../components/Footer.astro";
           cells: ["Yes", "Yes", "Yes", "Different model"],
         },
         {
-          label: "Curated Dart factories for GCP",
+          label: "Curated Dart factories",
           cells: ["Yes", "No", "No", "No"],
         },
         {
@@ -73,7 +73,7 @@ import Footer from "../components/Footer.astro";
           steps={[
             {
               title: "Author in Dart",
-              body: "Subclass Stack with curated google_* factories from terradart_google.",
+              body: "Subclass Stack with curated factories from provider packages.",
             },
             {
               title: "Generate Terraform JSON",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Update landing page (LP) copy across `website/src/` to align with the multi-provider monorepo architecture:

- **Hero & Meta (`Hero.astro`, `Layout.astro`, `astro.config.mjs`)**: Updated descriptions from "Google Cloud / GCP" to "cloud infrastructure", highlighting provider-neutral Dart authoring.
- **PitchCode Section (`PitchCode.astro`)**: Updated section title to "Cloud infrastructure in Dart" and expanded the meta note to list all curated provider packages (`terradart_google`, `terradart_google_beta`, `terradart_appwrite`, `terradart_cloudflare`).
- **Comparison & Pipeline (`index.astro`, `Footer.astro`)**: Refined comparison labels and pipeline steps to refer to provider packages generally.

## Verification

- `dart tool/check_docs_consistency.dart` passed.
- `tool/agent_verify.sh --quick` passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0291b-a5ef-75d6-a7ec-4ac74144614c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0291b-a5ef-75d6-a7ec-4ac74144614c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

