### PR TITLE
chore: lockstep 0.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Per-package changelogs live alongside each package and are the system of record 
 
 ## Unreleased
 
+## [0.25.3] - 2026-08-23
+
+Lockstep release across the workspace. **No breaking changes** vs `0.25.2`.
+
 ### Added
 
 - **`terradart_appwrite`** — fill the curated catalog at the `appwrite/appwrite` `2.0.0-beta.1` pin (38 resource factories + 24 data sources). Coverage via [`appwrite_quickstart`](examples/appwrite_quickstart/) (synth + `terraform validate`; apply-smoke skip-listed). `AppwriteProjectKey` is import-only (create endpoint gone upstream) and listed in [`tool/example_debt.yaml`](tool/example_debt.yaml).
@@ -13,6 +17,11 @@ Per-package changelogs live alongside each package and are the system of record 
 ### Removed
 
 - Live GCP apply-smoke CI against `terradart-validate` (per-PR change-gate, monthly sweep, janitor) and the Monday smoke-diagnosis loop. Example verification is synth + `terraform validate` only; `tool/apply_smoke.sh` refuses live apply/destroy.
+
+### Fixed
+
+- **`terradart_cloudflare`** — ship the hand-written `catalog_entry.dart` the generated catalog imports.
+- **`terradart_codegen`** — catalog `constructorParams` includes a required data-source lookup `id`; schema-subset extract accepts `--data-sources=`.
 
 ## [0.25.2] - 2026-08-22
 

--- a/cookbook/firebase-app-backend/pubspec.yaml
+++ b/cookbook/firebase-app-backend/pubspec.yaml
@@ -9,9 +9,9 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
-  terradart_google_beta: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
+  terradart_google_beta: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/firestore-seeded-data/pubspec.yaml
+++ b/cookbook/firestore-seeded-data/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/lunch-concierge/infra/pubspec.yaml
+++ b/cookbook/lunch-concierge/infra/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/remote-backend/pubspec.yaml
+++ b/cookbook/remote-backend/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/single-project-app/pubspec.yaml
+++ b/cookbook/single-project-app/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/access_context_quickstart/pubspec.yaml
+++ b/examples/access_context_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/api_security_quickstart/pubspec.yaml
+++ b/examples/api_security_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/apigee_quickstart/pubspec.yaml
+++ b/examples/apigee_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/app_engine_quickstart/pubspec.yaml
+++ b/examples/app_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/apphub_quickstart/pubspec.yaml
+++ b/examples/apphub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/appwrite_quickstart/pubspec.yaml
+++ b/examples/appwrite_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_appwrite: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_appwrite: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/artifact_registry_quickstart/pubspec.yaml
+++ b/examples/artifact_registry_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/beta_leftover_quickstart/pubspec.yaml
+++ b/examples/beta_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google_beta: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google_beta: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/beta_service_identity_quickstart/pubspec.yaml
+++ b/examples/beta_service_identity_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google_beta: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google_beta: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/biglake_quickstart/pubspec.yaml
+++ b/examples/biglake_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_datapolicyv2_quickstart/pubspec.yaml
+++ b/examples/bigquery_datapolicyv2_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_quickstart/pubspec.yaml
+++ b/examples/bigquery_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigtable_quickstart/pubspec.yaml
+++ b/examples/bigtable_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ces_quickstart/pubspec.yaml
+++ b/examples/ces_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/chronicle_quickstart/pubspec.yaml
+++ b/examples/chronicle_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_asset_quickstart/pubspec.yaml
+++ b/examples/cloud_asset_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_build_quickstart/pubspec.yaml
+++ b/examples/cloud_build_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_functions_quickstart/pubspec.yaml
+++ b/examples/cloud_functions_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_quickstart/pubspec.yaml
+++ b/examples/cloud_run_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_v1_quickstart/pubspec.yaml
+++ b/examples/cloud_run_v1_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_scheduler_quickstart/pubspec.yaml
+++ b/examples/cloud_scheduler_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_sql_quickstart/pubspec.yaml
+++ b/examples/cloud_sql_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_tasks_quickstart/pubspec.yaml
+++ b/examples/cloud_tasks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/clouddeploy_quickstart/pubspec.yaml
+++ b/examples/clouddeploy_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloudflare_dns_quickstart/pubspec.yaml
+++ b/examples/cloudflare_dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_cloudflare: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_cloudflare: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/colab_quickstart/pubspec.yaml
+++ b/examples/colab_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_cloud_armor_tier_quickstart/pubspec.yaml
+++ b/examples/compute_cloud_armor_tier_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_default_network_tier_quickstart/pubspec.yaml
+++ b/examples/compute_default_network_tier_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_instance_settings_quickstart/pubspec.yaml
+++ b/examples/compute_instance_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_lb_quickstart/pubspec.yaml
+++ b/examples/compute_lb_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_preview_feature_quickstart/pubspec.yaml
+++ b/examples/compute_preview_feature_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_quickstart/pubspec.yaml
+++ b/examples/compute_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_rollout_quickstart/pubspec.yaml
+++ b/examples/compute_rollout_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_route_quickstart/pubspec.yaml
+++ b/examples/compute_route_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_snapshot_settings_quickstart/pubspec.yaml
+++ b/examples/compute_snapshot_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_vpn_gateway_quickstart/pubspec.yaml
+++ b/examples/compute_vpn_gateway_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/config_deployment_quickstart/pubspec.yaml
+++ b/examples/config_deployment_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/contact_center_insights_quickstart/pubspec.yaml
+++ b/examples/contact_center_insights_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/container_analysis_quickstart/pubspec.yaml
+++ b/examples/container_analysis_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_catalog_quickstart/pubspec.yaml
+++ b/examples/data_catalog_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_lineage_quickstart/pubspec.yaml
+++ b/examples/data_lineage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_source_leftover_quickstart/pubspec.yaml
+++ b/examples/data_source_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataform_quickstart/pubspec.yaml
+++ b/examples/dataform_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataplex_quickstart/pubspec.yaml
+++ b/examples/dataplex_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataproc_autoscaling_quickstart/pubspec.yaml
+++ b/examples/dataproc_autoscaling_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataproc_metastore_quickstart/pubspec.yaml
+++ b/examples/dataproc_metastore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/deferred_leftover_quickstart/pubspec.yaml
+++ b/examples/deferred_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/developer_connect_quickstart/pubspec.yaml
+++ b/examples/developer_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_es_quickstart/pubspec.yaml
+++ b/examples/dialogflow_es_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_quickstart/pubspec.yaml
+++ b/examples/dialogflow_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/discovery_engine_quickstart/pubspec.yaml
+++ b/examples/discovery_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dlp_quickstart/pubspec.yaml
+++ b/examples/dlp_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dns_quickstart/pubspec.yaml
+++ b/examples/dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/document_ai_quickstart/pubspec.yaml
+++ b/examples/document_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/endpoints_quickstart/pubspec.yaml
+++ b/examples/endpoints_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/eventarc_quickstart/pubspec.yaml
+++ b/examples/eventarc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/filestore_quickstart/pubspec.yaml
+++ b/examples/filestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_check_quickstart/pubspec.yaml
+++ b/examples/firebase_app_check_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_hosting_quickstart/pubspec.yaml
+++ b/examples/firebase_app_hosting_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_data_connect_quickstart/pubspec.yaml
+++ b/examples/firebase_data_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_remote_config_quickstart/pubspec.yaml
+++ b/examples/firebase_remote_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebaserules_quickstart/pubspec.yaml
+++ b/examples/firebaserules_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_document_quickstart/pubspec.yaml
+++ b/examples/firestore_document_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_quickstart/pubspec.yaml
+++ b/examples/firestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gemini_quickstart/pubspec.yaml
+++ b/examples/gemini_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_hub_feature_quickstart/pubspec.yaml
+++ b/examples/gke_hub_feature_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_hub_quickstart/pubspec.yaml
+++ b/examples/gke_hub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_quickstart/pubspec.yaml
+++ b/examples/gke_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/healthcare_quickstart/pubspec.yaml
+++ b/examples/healthcare_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iam_quickstart/pubspec.yaml
+++ b/examples/iam_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iap_settings_quickstart/pubspec.yaml
+++ b/examples/iap_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iap_tunnel_quickstart/pubspec.yaml
+++ b/examples/iap_tunnel_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/identity_platform_quickstart/pubspec.yaml
+++ b/examples/identity_platform_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/integrations_quickstart/pubspec.yaml
+++ b/examples/integrations_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_autokey_quickstart/pubspec.yaml
+++ b/examples/kms_autokey_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_quickstart/pubspec.yaml
+++ b/examples/kms_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/license_manager_quickstart/pubspec.yaml
+++ b/examples/license_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/migration_center_quickstart/pubspec.yaml
+++ b/examples/migration_center_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/model_armor_quickstart/pubspec.yaml
+++ b/examples/model_armor_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/monitoring_quickstart/pubspec.yaml
+++ b/examples/monitoring_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ncc_hub_quickstart/pubspec.yaml
+++ b/examples/ncc_hub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/netapp_metadata_quickstart/pubspec.yaml
+++ b/examples/netapp_metadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_connectivity_quickstart/pubspec.yaml
+++ b/examples/network_connectivity_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_management_vpc_flow_logs_quickstart/pubspec.yaml
+++ b/examples/network_management_vpc_flow_logs_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_backend_auth_quickstart/pubspec.yaml
+++ b/examples/network_security_backend_auth_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_dns_threat_quickstart/pubspec.yaml
+++ b/examples/network_security_dns_threat_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_gateway_policy_quickstart/pubspec.yaml
+++ b/examples/network_security_gateway_policy_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_lists_quickstart/pubspec.yaml
+++ b/examples/network_security_lists_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_tls_quickstart/pubspec.yaml
+++ b/examples/network_security_tls_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_ull_quickstart/pubspec.yaml
+++ b/examples/network_security_ull_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_services_mesh_quickstart/pubspec.yaml
+++ b/examples/network_services_mesh_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/notebooks_quickstart/pubspec.yaml
+++ b/examples/notebooks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/observability_quickstart/pubspec.yaml
+++ b/examples/observability_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ops_quickstart/pubspec.yaml
+++ b/examples/ops_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_autonomous_database_quickstart/pubspec.yaml
+++ b/examples/oracle_autonomous_database_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_db_system_quickstart/pubspec.yaml
+++ b/examples/oracle_db_system_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_exadata_quickstart/pubspec.yaml
+++ b/examples/oracle_exadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_goldengate_quickstart/pubspec.yaml
+++ b/examples/oracle_goldengate_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/org_leftover_quickstart/pubspec.yaml
+++ b/examples/org_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/parameter_manager_quickstart/pubspec.yaml
+++ b/examples/parameter_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/privileged_access_manager_quickstart/pubspec.yaml
+++ b/examples/privileged_access_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/project_iam_audit_config_quickstart/pubspec.yaml
+++ b/examples/project_iam_audit_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/public_ca_quickstart/pubspec.yaml
+++ b/examples/public_ca_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/pubsub_quickstart/pubspec.yaml
+++ b/examples/pubsub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/scc_quickstart/pubspec.yaml
+++ b/examples/scc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/secret_manager_quickstart/pubspec.yaml
+++ b/examples/secret_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/service_directory_quickstart/pubspec.yaml
+++ b/examples/service_directory_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/sourcerepo_quickstart/pubspec.yaml
+++ b/examples/sourcerepo_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/spanner_instance_config_quickstart/pubspec.yaml
+++ b/examples/spanner_instance_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_intelligence_quickstart/pubspec.yaml
+++ b/examples/storage_intelligence_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_quickstart/pubspec.yaml
+++ b/examples/storage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_transfer_quickstart/pubspec.yaml
+++ b/examples/storage_transfer_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/tags_quickstart/pubspec.yaml
+++ b/examples/tags_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/transcoder_quickstart/pubspec.yaml
+++ b/examples/transcoder_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/usage_export_quickstart/pubspec.yaml
+++ b/examples/usage_export_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vector_quickstart/pubspec.yaml
+++ b/examples/vector_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vertex_ai_quickstart/pubspec.yaml
+++ b/examples/vertex_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vm_compliance_quickstart/pubspec.yaml
+++ b/examples/vm_compliance_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/wif_trust_domain_quickstart/pubspec.yaml
+++ b/examples/wif_trust_domain_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/workflows_quickstart/pubspec.yaml
+++ b/examples/workflows_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/terradart_agent/CHANGELOG.md
+++ b/packages/terradart_agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.3 - 2026-08-23
+
+Lockstep release with `terradart_appwrite` 0.25.3. MCP catalog is unchanged (GA `hashicorp/google` only). No MCP protocol or tool changes.
+
 ## 0.25.2 - 2026-08-22
 
 Lockstep release with `terradart_cloudflare` 0.25.2. MCP catalog is unchanged (GA `hashicorp/google` only). No MCP protocol or tool changes.

--- a/packages/terradart_agent/lib/src/version.dart
+++ b/packages/terradart_agent/lib/src/version.dart
@@ -1,4 +1,4 @@
 /// The terradart-mcp binary version, kept in lockstep with pubspec.yaml's
 /// `version:` field by `tool/bump_version.sh`. The lockstep is guarded by
 /// test/version_test.dart so the two can never silently drift.
-const String packageVersion = '0.25.2';
+const String packageVersion = '0.25.3';

--- a/packages/terradart_agent/pubspec.yaml
+++ b/packages/terradart_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_agent
 description: terradart-mcp — MCP server exposing the curated GCP factory catalog of TerraDart.
-version: 0.25.2
+version: 0.25.3
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -16,9 +16,9 @@ executables:
   terradart-mcp: terradart_mcp
 
 dependencies:
-  terradart_core: ^0.25.2
-  terradart_google: ^0.25.2
-  terradart_coverage: ^0.25.2
+  terradart_core: ^0.25.3
+  terradart_google: ^0.25.3
+  terradart_coverage: ^0.25.3
   genkit: ^0.14.1
   genkit_mcp: ^0.2.1
   schemantic: ^0.2.0

--- a/packages/terradart_appwrite/CHANGELOG.md
+++ b/packages/terradart_appwrite/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.25.3 - 2026-08-23
 
 - Fill the curated catalog at the `appwrite/appwrite` `2.0.0-beta.1` pin:
   every remaining resource factory and data source (38 resources + 24

--- a/packages/terradart_appwrite/pubspec.yaml
+++ b/packages/terradart_appwrite/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_appwrite
 description: Curated factory wrappers for Appwrite resources (official appwrite/appwrite Terraform provider) for Dart-first Terraform stacks.
-version: 0.25.2
+version: 0.25.3
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
+  terradart_core: ^0.25.3
   meta: ^1.15.0
 
 dev_dependencies:

--- a/packages/terradart_cloudflare/CHANGELOG.md
+++ b/packages/terradart_cloudflare/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.25.3 - 2026-08-23
+
+- Ship the hand-written `catalog_entry.dart` the generated catalog imports.
+  No factory or provider changes.
+
 ## 0.25.2
 
 - Initial release: `CloudflareProvider` (secret-free by design — the

--- a/packages/terradart_cloudflare/pubspec.yaml
+++ b/packages/terradart_cloudflare/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_cloudflare
 description: Curated factory wrappers for Cloudflare resources (official cloudflare/cloudflare Terraform provider) for Dart-first Terraform stacks.
-version: 0.25.2
+version: 0.25.3
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
+  terradart_core: ^0.25.3
   meta: ^1.15.0
 
 dev_dependencies:

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.3 - 2026-08-23
+
+`extract_schema_subset` accepts `--data-sources=` (and `--resources-from` unions fixture data sources). Catalog `constructorParams` for data sources now includes a required lookup `id`, matching the emitted constructor. No user-facing CLI flag changes.
+
 ## 0.25.2 - 2026-08-22
 
 Plugin-framework schema support: `SchemaJsonParser` normalizes `nested_type` object attributes into the nested-block IR (first consumer: the cloudflare 5.23.0 fixture); computed-only object attributes are excluded from constructors. No user-facing CLI flag changes.

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart maintainer tooling — parses Terraform provider schema JSON and Magic Modules YAML and emits curated factory wrappers via terradart wrap. Ships the terradart CLI.
-version: 0.25.2
+version: 0.25.3
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -33,7 +33,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.25.2
+  terradart_core: ^0.25.3
 
 dev_dependencies:
   http: ^1.0.0

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.3 - 2026-08-23
+
+Lockstep release with `terradart_appwrite` 0.25.3 (catalog filled at the `2.0.0-beta.1` pin). No `terradart_core` API changes.
+
 ## 0.25.2 - 2026-08-22
 
 Lockstep release with `terradart_cloudflare` 0.25.2 (initial release). No `terradart_core` API changes.

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.25.2
+version: 0.25.3
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_coverage/CHANGELOG.md
+++ b/packages/terradart_coverage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.3 - 2026-08-23
+
+Lockstep release with `terradart_appwrite` 0.25.3. No functional changes in this package.
+
 ## 0.25.2 - 2026-08-22
 
 Lockstep release with `terradart_cloudflare` 0.25.2. No functional changes in this package.

--- a/packages/terradart_coverage/pubspec.yaml
+++ b/packages/terradart_coverage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_coverage
 description: Read-only Terraform coverage checker — reports how much of a Terraform config is covered by curated terradart_google factories.
-version: 0.25.2
+version: 0.25.3
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -15,7 +15,7 @@ executables:
   terradart-coverage: terradart_coverage
 
 dependencies:
-  terradart_google: ^0.25.2
+  terradart_google: ^0.25.3
   args: ^2.5.0
 
 dev_dependencies:

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.3 - 2026-08-23
+
+Lockstep release. **No breaking changes** vs `0.25.2`. No `terradart_google` API changes — the new curated surface ships in `terradart_appwrite`.
+
 ## 0.25.2 - 2026-08-22
 
 Lockstep release. **No breaking changes** vs `0.25.1`. No `terradart_google` API changes — the new curated surface ships in `terradart_cloudflare`.

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: Curated factory wrappers for Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.
-version: 0.25.2
+version: 0.25.3
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -22,11 +22,11 @@ false_secrets:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
+  terradart_core: ^0.25.3
   meta: ^1.15.0
 
 dev_dependencies:
-  terradart_codegen: ^0.25.2
+  terradart_codegen: ^0.25.3
   path: ^1.9.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/packages/terradart_google_beta/CHANGELOG.md
+++ b/packages/terradart_google_beta/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.3 - 2026-08-23
+
+Lockstep release with the TerraDart workspace. No factory or provider changes.
+
 ## 0.25.2 - 2026-08-22
 
 - Add an in-package `example/main.dart` (pub.dev pana example check). No

--- a/packages/terradart_google_beta/pubspec.yaml
+++ b/packages/terradart_google_beta/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google_beta
 description: Curated factory wrappers for beta-only Google Cloud resources (hashicorp/google-beta) for Dart-first Terraform stacks.
-version: 0.25.2
+version: 0.25.3
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.2
+  terradart_core: ^0.25.3
   meta: ^1.15.0
 
 dev_dependencies:

--- a/tool/bump_version.sh
+++ b/tool/bump_version.sh
@@ -148,10 +148,10 @@ echo "  Cookbook recipe pubspecs:"
 COOKBOOK_COUNT=0
 for f in cookbook/*/pubspec.yaml cookbook/*/*/pubspec.yaml; do
   [ -f "$f" ] || continue
-  sed_inplace "s#^( *terradart_(core|google)): \\^${OLD_RE}\$#\\1: ^${NEW}#" "$f"
+  sed_inplace "s#^( *terradart_(core|google|google_beta|appwrite|cloudflare)): \\^${OLD_RE}\$#\\1: ^${NEW}#" "$f"
   COOKBOOK_COUNT=$((COOKBOOK_COUNT + 1))
 done
-echo "    - scanned $COOKBOOK_COUNT cookbook pubspecs for terradart_{core,google}: ^$NEW"
+echo "    - scanned $COOKBOOK_COUNT cookbook pubspecs for terradart_{core,google,google_beta,appwrite,cloudflare}: ^$NEW"
 
 # 4. Markdown caret samples (README + website getting-started).
 #    Two distinct patterns:
@@ -293,27 +293,29 @@ STALE=$(
     website/src/content/docs/docs/getting-started.md \
     packages/terradart_codegen/README.md 2>/dev/null
   grep -nE "packageVersion = '${OLD_RE}'" packages/terradart_agent/lib/src/version.dart 2>/dev/null
-  grep -nE "\\^${OLD_MINOR_RE}\\.x" \
-    CONTRIBUTING.md SECURITY.md 2>/dev/null
-  grep -nE "\\*\\*${OLD_MINOR_RE}\\.x\\*\\* (today|\\()" \
-    CONTRIBUTING.md SECURITY.md \
-    .github/ISSUE_TEMPLATE/bug.yml \
-    .github/ISSUE_TEMPLATE/feature.yml \
-    .github/ISSUE_TEMPLATE/question.yml 2>/dev/null
-  grep -nE "\\*\\*${OLD_MINOR_RE}\\.x\\*\\* line" \
-    website/src/content/docs/docs/getting-started.md 2>/dev/null
-  grep -nE "\\^${OLD_MINOR_RE}\\.x" \
-    README.md website/src/content/docs/docs/getting-started.md \
-    packages/terradart_core/README.md \
-    packages/terradart_google/README.md \
-    packages/terradart_codegen/README.md 2>/dev/null
-  grep -nE "pre-1\\.0 \\(${OLD_MINOR_RE}\\.x\\)" README.md 2>/dev/null
-  grep -nE "\\b${OLD_MINOR_RE}\\.x\\b" \
-    README.md CONTRIBUTING.md \
-    website/src/content/docs/docs/index.md \
-    website/src/content/docs/docs/status.md \
-    website/src/content/docs/docs/getting-started.md \
-    website/src/content/docs/docs/why-terradart.md 2>/dev/null
+  if [ "$OLD_MINOR" != "$NEW_MINOR" ]; then
+    grep -nE "\\^${OLD_MINOR_RE}\\.x" \
+      CONTRIBUTING.md SECURITY.md 2>/dev/null
+    grep -nE "\\*\\*${OLD_MINOR_RE}\\.x\\*\\* (today|\\()" \
+      CONTRIBUTING.md SECURITY.md \
+      .github/ISSUE_TEMPLATE/bug.yml \
+      .github/ISSUE_TEMPLATE/feature.yml \
+      .github/ISSUE_TEMPLATE/question.yml 2>/dev/null
+    grep -nE "\\*\\*${OLD_MINOR_RE}\\.x\\*\\* line" \
+      website/src/content/docs/docs/getting-started.md 2>/dev/null
+    grep -nE "\\^${OLD_MINOR_RE}\\.x" \
+      README.md website/src/content/docs/docs/getting-started.md \
+      packages/terradart_core/README.md \
+      packages/terradart_google/README.md \
+      packages/terradart_codegen/README.md 2>/dev/null
+    grep -nE "pre-1\\.0 \\(${OLD_MINOR_RE}\\.x\\)" README.md 2>/dev/null
+    grep -nE "\\b${OLD_MINOR_RE}\\.x\\b" \
+      README.md CONTRIBUTING.md \
+      website/src/content/docs/docs/index.md \
+      website/src/content/docs/docs/status.md \
+      website/src/content/docs/docs/getting-started.md \
+      website/src/content/docs/docs/why-terradart.md 2>/dev/null
+  fi
 )
 set -e
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Lockstep release across the workspace. **No breaking changes** vs `0.25.2`.

- **`terradart_appwrite` 0.25.3** — fill the `appwrite/appwrite` `2.0.0-beta.1` catalog (#629): 38 resource factories + 24 data sources. `AppwriteProjectKey` is import-only and listed in `tool/example_debt.yaml`.
- **`terradart_codegen` 0.25.3** — `--data-sources=` on schema-subset extract; catalog `constructorParams` includes required data-source lookup `id`.
- **`terradart_cloudflare` 0.25.3** — ship the hand-written `catalog_entry.dart` (#623).
- **Removed** — live GCP apply-smoke CI (#624). Example verification is synth + `terraform validate` only.
- Everything else moves in lockstep with no functional change.

`tool/bump_version.sh` now bumps cookbook `terradart_google_beta` carets and skips the `0.N.x` stale check on same-minor patch bumps.

After merge + green CI, maintainer tag (do not tag from this PR):

```bash
git tag -a v0.25.3 -m "Release v0.25.3"
git push origin v0.25.3
```

Then create the GitHub release (`v0.25.3` title only) from the notes below. Close #76 after pub.dev shows 0.25.3.

## Draft GitHub release notes

```markdown
Lockstep release across `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_google_beta`, `terradart_appwrite`, `terradart_cloudflare`, `terradart_agent`, and `terradart_coverage`. **No breaking changes** vs `0.25.2`.

## Highlights

- **`terradart_appwrite` catalog filled** at the `appwrite/appwrite` `2.0.0-beta.1` pin: **38 resource factories + 24 data sources**. Coverage via [`appwrite_quickstart`](https://github.com/nozomi-koborinai/terradart/tree/main/examples/appwrite_quickstart) (synth + `terraform validate`). `AppwriteProjectKey` is import-only (mint in the Console, then `terraform import`).
- **Docs / site** — multi-provider README and website copy (#625–#628); GA+Beta Firebase cookbook recipe.
- **Live GCP apply-smoke retired** — example quality is synth + `terraform validate` only.

## Upgrade

    dependencies:
      terradart_core: ^0.25.3
      terradart_google: ^0.25.3
      terradart_appwrite: ^0.25.3

Docs: [Getting started](https://terradart.dev/docs/getting-started/) · [Status](https://terradart.dev/docs/status/)

## What's Changed

* fix(cloudflare): ship catalog_entry.dart by @nozomi-koborinai in https://github.com/nozomi-koborinai/terradart/pull/623
* ci: retire live GCP apply-smoke by @nozomi-koborinai in https://github.com/nozomi-koborinai/terradart/pull/624
* docs: restructure root README for multi-package monorepo by @nozomi-koborinai in https://github.com/nozomi-koborinai/terradart/pull/625
* docs: standardize and enrich package READMEs across monorepo by @nozomi-koborinai in https://github.com/nozomi-koborinai/terradart/pull/626
* docs: align website docs with multi-provider architecture and add GA+Beta Firebase cookbook recipe by @nozomi-koborinai in https://github.com/nozomi-koborinai/terradart/pull/627
* docs(website): update landing page copy to reflect multi-provider architecture by @nozomi-koborinai in https://github.com/nozomi-koborinai/terradart/pull/628
* feat(appwrite): fill the 2.0.0-beta.1 catalog by @nozomi-koborinai in https://github.com/nozomi-koborinai/terradart/pull/629
* chore: lockstep 0.25.3 by @nozomi-koborinai in https://github.com/nozomi-koborinai/terradart/pull/630

**Full Changelog**: https://github.com/nozomi-koborinai/terradart/compare/v0.25.2...v0.25.3
```

## Test plan

- [x] `tool/bump_version.sh 0.25.3`
- [x] `dart tool/check_docs_consistency.dart`
- [x] `dart analyze` core/codegen/google/appwrite
- [x] package CHANGELOGs contain `## 0.25.3`
- [x] `dart pub publish --dry-run` for `terradart_core` (warning: dirty tree only)
- [x] `tool/agent_verify.sh` (`agent_verify: OK`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02e85-838e-70fe-97a9-6f7a92953de7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02e85-838e-70fe-97a9-6f7a92953de7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

