### PR TITLE
chore: lockstep 0.26.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to file. terradart is **alpha** on
-        **0.25.x** today. Single-maintainer;
+        **0.26.x** today. Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         **PII note**: synthesized `.tf.json`, error output, and schema excerpts

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to file. terradart is **alpha** on
-        **0.25.x** today. Single-maintainer;
+        **0.26.x** today. Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         Feature requests are welcome — no timeline promises, but they help

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for taking the time to ask. terradart is **alpha** on
-        **0.25.x** today. Single-maintainer;
+        **0.26.x** today. Single-maintainer;
         triage is best-effort. See https://terradart.dev/docs/status/
 
         Docs: https://terradart.dev/docs/getting-started/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Per-package changelogs live alongside each package and are the system of record 
 
 ## Unreleased
 
+## [0.26.0] - 2026-08-24
+
+Lockstep release across the workspace. **Breaking** — see [MIGRATING.md](MIGRATING.md).
+
 ### Added
 
 - **`terradart_cloudflare`** — fill the curated catalog at the
@@ -14,11 +18,21 @@ Per-package changelogs live alongside each package and are the system of record 
   Coverage via [`cloudflare_dns_quickstart`](examples/cloudflare_dns_quickstart/)
   and [`cloudflare_leftover_quickstart`](examples/cloudflare_leftover_quickstart/)
   (synth + `terraform validate`; apply-smoke skip-listed).
+- `CloudflareDnsRecord` typed `data` / `settings` / `private_routing` slots
+  (previously omitted from the curated constructor).
 
-### Breaking (next minor)
+### Breaking
 
 - `CloudflareZone.account`: `TfArg<Map<String, dynamic>>` → `ZoneAccount`.
-  `CloudflareDnsRecord` gains typed `data` / `settings` / `private_routing`.
+
+### Changed
+
+- **`terradart_codegen`** — `skipAttribute` keeps a required `id` (plugin-framework
+  create-time / lookup keys). Synthetic optional/computed `id` is still dropped.
+- Wrap fixtures: `hashicorp/google` and `hashicorp/google-beta` pin **7.45.0**
+  ([#631](https://github.com/nozomi-koborinai/terradart/pull/631)). Generated
+  GA/beta wrappers are unchanged (`wrap --check` clean); two new `google_*`
+  names landed on the curation backlog.
 
 ## [0.25.3] - 2026-08-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing to terradart
 
-Thanks for taking time to look at this. terradart is an **alpha** single-maintainer project (0.25.x today; breaking changes land only on minor bumps — beta needs external validation, see the [path to beta](https://terradart.dev/docs/status/#path-to-beta)). Contributions are welcome on a best-effort basis.
+Thanks for taking time to look at this. terradart is an **alpha** single-maintainer project (0.26.x today; breaking changes land only on minor bumps — beta needs external validation, see the [path to beta](https://terradart.dev/docs/status/#path-to-beta)). Contributions are welcome on a best-effort basis.
 
 ## What kind of contribution?
 
 terradart ships one consumer surface:
 
-- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**1332 curated resource factories + 461 data sources** as of 0.25.x) and the beta-only catalog in [`terradart_google_beta`](packages/terradart_google_beta/README.md) (**128 resource factories**). Bug fixes, tests, and doc improvements welcome. The GA catalog is filled; new beta-only types that appear after the current provider pin still land via `terradart wrap` overrides — open an issue first to discuss scope.
+- **Curated factories** — the `google_*` factory wrappers in [`terradart_google`](packages/terradart_google/README.md) (**1332 curated resource factories + 461 data sources** as of 0.26.x) and the beta-only catalog in [`terradart_google_beta`](packages/terradart_google_beta/README.md) (**128 resource factories**). Bug fixes, tests, and doc improvements welcome. The GA catalog is filled; new beta-only types that appear after the current provider pin still land via `terradart wrap` overrides — open an issue first to discuss scope.
 
-Within a **minor** line (`^0.25.x`), no breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (the alpha change policy — see [status](https://terradart.dev/docs/status/)).
+Within a **minor** line (`^0.26.x`), no breaking public API changes. Across **minors**, breaking changes are allowed with `MIGRATING.md` coverage (the alpha change policy — see [status](https://terradart.dev/docs/status/)).
 
 Bug reports / questions / feature requests: pick a template when [opening an issue](https://github.com/nozomi-koborinai/terradart/issues/new/choose).
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,6 +1,6 @@
 # Migrating terradart
 
-## Unreleased — next minor (`0.25.x` → `0.26.x`)
+## 0.25.3 → 0.26.0
 
 **Breaking (`terradart_cloudflare`)** — `CloudflareZone.account` is a typed
 `ZoneAccount` helper instead of `TfArg<Map<String, dynamic>>`. Nested
@@ -27,8 +27,8 @@ CloudflareZone(
 (`DnsRecordSettings`), and `private_routing` slots that were previously
 omitted from the curated constructor.
 
-This lands on the next **minor** bump; `^0.25.x` patches on pub.dev stay
-compatible with the previous `TfArg<Map>` zone account.
+`^0.25.x` patches on pub.dev stay compatible with the previous
+`TfArg<Map>` zone account.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 >
 > Cloud infrastructure as real Dart code — typed, refactor-safe, drop-in for `terraform apply`.
 
-**Alpha** — no SemVer until v1.0.0, but breaking changes land only on **minor** bumps. Pin `^0.25.x`, read [`MIGRATING.md`](MIGRATING.md) before minor bumps, and see [status on terradart.dev](https://terradart.dev/docs/status/).
+**Alpha** — no SemVer until v1.0.0, but breaking changes land only on **minor** bumps. Pin `^0.26.x`, read [`MIGRATING.md`](MIGRATING.md) before minor bumps, and see [status on terradart.dev](https://terradart.dev/docs/status/).
 
 [![CI](https://github.com/nozomi-koborinai/terradart/actions/workflows/ci.yml/badge.svg)](https://github.com/nozomi-koborinai/terradart/actions/workflows/ci.yml)
 [![Dart SDK](https://img.shields.io/badge/Dart-%E2%89%A53.6-blue.svg)](https://dart.dev)
@@ -39,8 +39,8 @@ See [terradart.dev](https://terradart.dev) for documentation, guides, and API re
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.25.x
-  terradart_google: ^0.25.x
+  terradart_core: ^0.26.x
+  terradart_google: ^0.26.x
 ```
 
 ```dart
@@ -270,7 +270,7 @@ See the full factory table on [terradart.dev/docs/coverage/](https://terradart.d
 
 ## Status
 
-**Alpha**, pre-1.0 (0.25.x). No SemVer until v1.0.0, but breaking changes land only on **minor** bumps, always documented in [`MIGRATING.md`](MIGRATING.md); pin `^0.25.x` and take patches freely. Beta needs external validation — see the [path to beta](https://terradart.dev/docs/status/#path-to-beta). Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
+**Alpha**, pre-1.0 (0.26.x). No SemVer until v1.0.0, but breaking changes land only on **minor** bumps, always documented in [`MIGRATING.md`](MIGRATING.md); pin `^0.26.x` and take patches freely. Beta needs external validation — see the [path to beta](https://terradart.dev/docs/status/#path-to-beta). Expectations: [terradart.dev/docs/status/](https://terradart.dev/docs/status/).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,12 +31,12 @@ What does **not** count:
 
 ## Supported versions
 
-Pin dependencies with `^0.25.x` on [pub.dev](https://pub.dev/packages/terradart_core) today.
+Pin dependencies with `^0.26.x` on [pub.dev](https://pub.dev/packages/terradart_core) today.
 
 | Version | Status | Security fixes |
 |---|---|---|
-| **0.25.x** (alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
-| **0.11.x and older** | Unsupported | Upgrade to 0.25.x; see [MIGRATING.md](MIGRATING.md) |
+| **0.26.x** (alpha, current) | **Best-effort** | Yes, on a rolling basis — no embargo guarantees |
+| **0.11.x and older** | Unsupported | Upgrade to 0.26.x; see [MIGRATING.md](MIGRATING.md) |
 | Future beta line (TBD) | Best-effort with clearer minor-boundary policy | See [status on terradart.dev](https://terradart.dev/docs/status/) |
 
 ## Disclosure policy

--- a/cookbook/firebase-app-backend/pubspec.yaml
+++ b/cookbook/firebase-app-backend/pubspec.yaml
@@ -9,9 +9,9 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
-  terradart_google_beta: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
+  terradart_google_beta: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/firestore-seeded-data/pubspec.yaml
+++ b/cookbook/firestore-seeded-data/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/lunch-concierge/infra/pubspec.yaml
+++ b/cookbook/lunch-concierge/infra/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/remote-backend/pubspec.yaml
+++ b/cookbook/remote-backend/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/single-project-app/pubspec.yaml
+++ b/cookbook/single-project-app/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/access_context_quickstart/pubspec.yaml
+++ b/examples/access_context_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/api_security_quickstart/pubspec.yaml
+++ b/examples/api_security_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/apigee_quickstart/pubspec.yaml
+++ b/examples/apigee_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/app_engine_quickstart/pubspec.yaml
+++ b/examples/app_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/apphub_quickstart/pubspec.yaml
+++ b/examples/apphub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/appwrite_quickstart/pubspec.yaml
+++ b/examples/appwrite_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_appwrite: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_appwrite: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/artifact_registry_quickstart/pubspec.yaml
+++ b/examples/artifact_registry_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/beta_leftover_quickstart/pubspec.yaml
+++ b/examples/beta_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google_beta: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google_beta: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/beta_service_identity_quickstart/pubspec.yaml
+++ b/examples/beta_service_identity_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google_beta: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google_beta: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/biglake_quickstart/pubspec.yaml
+++ b/examples/biglake_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_datapolicyv2_quickstart/pubspec.yaml
+++ b/examples/bigquery_datapolicyv2_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_quickstart/pubspec.yaml
+++ b/examples/bigquery_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigtable_quickstart/pubspec.yaml
+++ b/examples/bigtable_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ces_quickstart/pubspec.yaml
+++ b/examples/ces_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/chronicle_quickstart/pubspec.yaml
+++ b/examples/chronicle_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_asset_quickstart/pubspec.yaml
+++ b/examples/cloud_asset_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_build_quickstart/pubspec.yaml
+++ b/examples/cloud_build_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_functions_quickstart/pubspec.yaml
+++ b/examples/cloud_functions_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_quickstart/pubspec.yaml
+++ b/examples/cloud_run_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_v1_quickstart/pubspec.yaml
+++ b/examples/cloud_run_v1_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_scheduler_quickstart/pubspec.yaml
+++ b/examples/cloud_scheduler_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_sql_quickstart/pubspec.yaml
+++ b/examples/cloud_sql_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_tasks_quickstart/pubspec.yaml
+++ b/examples/cloud_tasks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/clouddeploy_quickstart/pubspec.yaml
+++ b/examples/clouddeploy_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloudflare_dns_quickstart/pubspec.yaml
+++ b/examples/cloudflare_dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_cloudflare: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_cloudflare: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloudflare_leftover_quickstart/pubspec.yaml
+++ b/examples/cloudflare_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_cloudflare: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_cloudflare: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/colab_quickstart/pubspec.yaml
+++ b/examples/colab_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_cloud_armor_tier_quickstart/pubspec.yaml
+++ b/examples/compute_cloud_armor_tier_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_default_network_tier_quickstart/pubspec.yaml
+++ b/examples/compute_default_network_tier_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_instance_settings_quickstart/pubspec.yaml
+++ b/examples/compute_instance_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_lb_quickstart/pubspec.yaml
+++ b/examples/compute_lb_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_preview_feature_quickstart/pubspec.yaml
+++ b/examples/compute_preview_feature_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_quickstart/pubspec.yaml
+++ b/examples/compute_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_rollout_quickstart/pubspec.yaml
+++ b/examples/compute_rollout_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_route_quickstart/pubspec.yaml
+++ b/examples/compute_route_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_snapshot_settings_quickstart/pubspec.yaml
+++ b/examples/compute_snapshot_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_vpn_gateway_quickstart/pubspec.yaml
+++ b/examples/compute_vpn_gateway_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/config_deployment_quickstart/pubspec.yaml
+++ b/examples/config_deployment_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/contact_center_insights_quickstart/pubspec.yaml
+++ b/examples/contact_center_insights_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/container_analysis_quickstart/pubspec.yaml
+++ b/examples/container_analysis_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_catalog_quickstart/pubspec.yaml
+++ b/examples/data_catalog_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_lineage_quickstart/pubspec.yaml
+++ b/examples/data_lineage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_source_leftover_quickstart/pubspec.yaml
+++ b/examples/data_source_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataform_quickstart/pubspec.yaml
+++ b/examples/dataform_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataplex_quickstart/pubspec.yaml
+++ b/examples/dataplex_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataproc_autoscaling_quickstart/pubspec.yaml
+++ b/examples/dataproc_autoscaling_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataproc_metastore_quickstart/pubspec.yaml
+++ b/examples/dataproc_metastore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/deferred_leftover_quickstart/pubspec.yaml
+++ b/examples/deferred_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/developer_connect_quickstart/pubspec.yaml
+++ b/examples/developer_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_es_quickstart/pubspec.yaml
+++ b/examples/dialogflow_es_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_quickstart/pubspec.yaml
+++ b/examples/dialogflow_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/discovery_engine_quickstart/pubspec.yaml
+++ b/examples/discovery_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dlp_quickstart/pubspec.yaml
+++ b/examples/dlp_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dns_quickstart/pubspec.yaml
+++ b/examples/dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/document_ai_quickstart/pubspec.yaml
+++ b/examples/document_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/endpoints_quickstart/pubspec.yaml
+++ b/examples/endpoints_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/eventarc_quickstart/pubspec.yaml
+++ b/examples/eventarc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/filestore_quickstart/pubspec.yaml
+++ b/examples/filestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_check_quickstart/pubspec.yaml
+++ b/examples/firebase_app_check_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_hosting_quickstart/pubspec.yaml
+++ b/examples/firebase_app_hosting_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_data_connect_quickstart/pubspec.yaml
+++ b/examples/firebase_data_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_remote_config_quickstart/pubspec.yaml
+++ b/examples/firebase_remote_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebaserules_quickstart/pubspec.yaml
+++ b/examples/firebaserules_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_document_quickstart/pubspec.yaml
+++ b/examples/firestore_document_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_quickstart/pubspec.yaml
+++ b/examples/firestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gemini_quickstart/pubspec.yaml
+++ b/examples/gemini_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_hub_feature_quickstart/pubspec.yaml
+++ b/examples/gke_hub_feature_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_hub_quickstart/pubspec.yaml
+++ b/examples/gke_hub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_quickstart/pubspec.yaml
+++ b/examples/gke_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/healthcare_quickstart/pubspec.yaml
+++ b/examples/healthcare_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iam_quickstart/pubspec.yaml
+++ b/examples/iam_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iap_settings_quickstart/pubspec.yaml
+++ b/examples/iap_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iap_tunnel_quickstart/pubspec.yaml
+++ b/examples/iap_tunnel_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/identity_platform_quickstart/pubspec.yaml
+++ b/examples/identity_platform_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/integrations_quickstart/pubspec.yaml
+++ b/examples/integrations_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_autokey_quickstart/pubspec.yaml
+++ b/examples/kms_autokey_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_quickstart/pubspec.yaml
+++ b/examples/kms_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/license_manager_quickstart/pubspec.yaml
+++ b/examples/license_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/migration_center_quickstart/pubspec.yaml
+++ b/examples/migration_center_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/model_armor_quickstart/pubspec.yaml
+++ b/examples/model_armor_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/monitoring_quickstart/pubspec.yaml
+++ b/examples/monitoring_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ncc_hub_quickstart/pubspec.yaml
+++ b/examples/ncc_hub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/netapp_metadata_quickstart/pubspec.yaml
+++ b/examples/netapp_metadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_connectivity_quickstart/pubspec.yaml
+++ b/examples/network_connectivity_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_management_vpc_flow_logs_quickstart/pubspec.yaml
+++ b/examples/network_management_vpc_flow_logs_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_backend_auth_quickstart/pubspec.yaml
+++ b/examples/network_security_backend_auth_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_dns_threat_quickstart/pubspec.yaml
+++ b/examples/network_security_dns_threat_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_gateway_policy_quickstart/pubspec.yaml
+++ b/examples/network_security_gateway_policy_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_lists_quickstart/pubspec.yaml
+++ b/examples/network_security_lists_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_tls_quickstart/pubspec.yaml
+++ b/examples/network_security_tls_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_ull_quickstart/pubspec.yaml
+++ b/examples/network_security_ull_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_services_mesh_quickstart/pubspec.yaml
+++ b/examples/network_services_mesh_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/notebooks_quickstart/pubspec.yaml
+++ b/examples/notebooks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/observability_quickstart/pubspec.yaml
+++ b/examples/observability_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ops_quickstart/pubspec.yaml
+++ b/examples/ops_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_autonomous_database_quickstart/pubspec.yaml
+++ b/examples/oracle_autonomous_database_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_db_system_quickstart/pubspec.yaml
+++ b/examples/oracle_db_system_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_exadata_quickstart/pubspec.yaml
+++ b/examples/oracle_exadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_goldengate_quickstart/pubspec.yaml
+++ b/examples/oracle_goldengate_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/org_leftover_quickstart/pubspec.yaml
+++ b/examples/org_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/parameter_manager_quickstart/pubspec.yaml
+++ b/examples/parameter_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/privileged_access_manager_quickstart/pubspec.yaml
+++ b/examples/privileged_access_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/project_iam_audit_config_quickstart/pubspec.yaml
+++ b/examples/project_iam_audit_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/public_ca_quickstart/pubspec.yaml
+++ b/examples/public_ca_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/pubsub_quickstart/pubspec.yaml
+++ b/examples/pubsub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/scc_quickstart/pubspec.yaml
+++ b/examples/scc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/secret_manager_quickstart/pubspec.yaml
+++ b/examples/secret_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/service_directory_quickstart/pubspec.yaml
+++ b/examples/service_directory_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/sourcerepo_quickstart/pubspec.yaml
+++ b/examples/sourcerepo_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/spanner_instance_config_quickstart/pubspec.yaml
+++ b/examples/spanner_instance_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_intelligence_quickstart/pubspec.yaml
+++ b/examples/storage_intelligence_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_quickstart/pubspec.yaml
+++ b/examples/storage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_transfer_quickstart/pubspec.yaml
+++ b/examples/storage_transfer_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/tags_quickstart/pubspec.yaml
+++ b/examples/tags_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/transcoder_quickstart/pubspec.yaml
+++ b/examples/transcoder_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/usage_export_quickstart/pubspec.yaml
+++ b/examples/usage_export_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vector_quickstart/pubspec.yaml
+++ b/examples/vector_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vertex_ai_quickstart/pubspec.yaml
+++ b/examples/vertex_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vm_compliance_quickstart/pubspec.yaml
+++ b/examples/vm_compliance_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/wif_trust_domain_quickstart/pubspec.yaml
+++ b/examples/wif_trust_domain_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/workflows_quickstart/pubspec.yaml
+++ b/examples/workflows_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/terradart_agent/CHANGELOG.md
+++ b/packages/terradart_agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.26.0 - 2026-08-24
+
+Lockstep release with `terradart_cloudflare` 0.26.0. MCP catalog is unchanged (GA `hashicorp/google` only). No MCP protocol or tool changes.
+
 ## 0.25.3 - 2026-08-23
 
 Lockstep release with `terradart_appwrite` 0.25.3. MCP catalog is unchanged (GA `hashicorp/google` only). No MCP protocol or tool changes.

--- a/packages/terradart_agent/lib/src/version.dart
+++ b/packages/terradart_agent/lib/src/version.dart
@@ -1,4 +1,4 @@
 /// The terradart-mcp binary version, kept in lockstep with pubspec.yaml's
 /// `version:` field by `tool/bump_version.sh`. The lockstep is guarded by
 /// test/version_test.dart so the two can never silently drift.
-const String packageVersion = '0.25.3';
+const String packageVersion = '0.26.0';

--- a/packages/terradart_agent/pubspec.yaml
+++ b/packages/terradart_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_agent
 description: terradart-mcp — MCP server exposing the curated GCP factory catalog of TerraDart.
-version: 0.25.3
+version: 0.26.0
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -16,9 +16,9 @@ executables:
   terradart-mcp: terradart_mcp
 
 dependencies:
-  terradart_core: ^0.25.3
-  terradart_google: ^0.25.3
-  terradart_coverage: ^0.25.3
+  terradart_core: ^0.26.0
+  terradart_google: ^0.26.0
+  terradart_coverage: ^0.26.0
   genkit: ^0.14.1
   genkit_mcp: ^0.2.1
   schemantic: ^0.2.0

--- a/packages/terradart_appwrite/CHANGELOG.md
+++ b/packages/terradart_appwrite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.26.0 - 2026-08-24
+
+Lockstep release with the TerraDart workspace. No Appwrite factory or provider changes.
+
 ## 0.25.3 - 2026-08-23
 
 - Fill the curated catalog at the `appwrite/appwrite` `2.0.0-beta.1` pin:

--- a/packages/terradart_appwrite/README.md
+++ b/packages/terradart_appwrite/README.md
@@ -16,8 +16,8 @@ The catalog at the current provider pin is filled (every `appwrite_*` resource a
 
 ```yaml
 dependencies:
-  terradart_core: ^0.25.x
-  terradart_appwrite: ^0.25.x
+  terradart_core: ^0.26.x
+  terradart_appwrite: ^0.26.x
 ```
 
 ## Usage example

--- a/packages/terradart_appwrite/pubspec.yaml
+++ b/packages/terradart_appwrite/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_appwrite
 description: Curated factory wrappers for Appwrite resources (official appwrite/appwrite Terraform provider) for Dart-first Terraform stacks.
-version: 0.25.3
+version: 0.26.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
+  terradart_core: ^0.26.0
   meta: ^1.15.0
 
 dev_dependencies:

--- a/packages/terradart_cloudflare/CHANGELOG.md
+++ b/packages/terradart_cloudflare/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Changelog
 
-## Unreleased
+## 0.26.0 - 2026-08-24
 
 - Fill the catalog at the `cloudflare/cloudflare` `5.23.0` pin: **257
   resource factories + 446 data sources** (703 catalog entries). Nested
   plugin-framework objects are typed Dart helper classes.
-- **Breaking (next minor):** `CloudflareZone.account` is `ZoneAccount`
-  instead of `TfArg<Map<String, dynamic>>`. `CloudflareDnsRecord` gains
-  typed `data` / `settings` / `private_routing`.
+- **Breaking:** `CloudflareZone.account` is `ZoneAccount` instead of
+  `TfArg<Map<String, dynamic>>`. See [MIGRATING.md](../../MIGRATING.md).
+- `CloudflareDnsRecord` gains typed `data` / `settings` / `private_routing`.
+- Six resources take required create-time `id`: `CloudflareAiGateway`,
+  `CloudflareAiSearchInstance`, `CloudflareImage`, `CloudflareImageVariant`,
+  `CloudflareZeroTrustAccessAiControlsMcpPortal`,
+  `CloudflareZeroTrustAccessAiControlsMcpServer`.
 - Coverage: `examples/cloudflare_dns_quickstart` plus
   `examples/cloudflare_leftover_quickstart` (synth + `terraform validate`;
   apply-smoke skip-listed). Factories the leftover dummy cannot satisfy

--- a/packages/terradart_cloudflare/README.md
+++ b/packages/terradart_cloudflare/README.md
@@ -18,8 +18,8 @@ The catalog at the current provider pin is filled (every `cloudflare_*` resource
 
 ```yaml
 dependencies:
-  terradart_core: ^0.25.x
-  terradart_cloudflare: ^0.25.x
+  terradart_core: ^0.26.x
+  terradart_cloudflare: ^0.26.x
 ```
 
 ## Usage example

--- a/packages/terradart_cloudflare/pubspec.yaml
+++ b/packages/terradart_cloudflare/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_cloudflare
 description: Curated factory wrappers for Cloudflare resources (official cloudflare/cloudflare Terraform provider) for Dart-first Terraform stacks.
-version: 0.25.3
+version: 0.26.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
+  terradart_core: ^0.26.0
   meta: ^1.15.0
 
 dev_dependencies:

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
-## Unreleased
+## 0.26.0 - 2026-08-24
 
 - Plugin-framework `nested_type` attributes emit typed nested helper
   classes (not `TfArg<Map<String, dynamic>>`). Computed-only objects stay
   skipped. Data-source nested helpers use a `Data` prefix to avoid
   resource name clashes. Reserved Dart identifiers (e.g. `default`) are
-  escaped. Cloudflare `wrap --check` remains in `tool/agent_verify.sh`.
+  escaped.
+- `skipAttribute` / `skipDataSourceAttribute` keep a **required** `id`
+  (create-time / lookup key). Synthetic optional/computed `id` is still
+  dropped.
+- Wrap fixtures: `hashicorp/google` and `hashicorp/google-beta` **7.45.0**.
+  Cloudflare `wrap --check` remains in `tool/agent_verify.sh`.
 
 ## 0.25.3 - 2026-08-23
 

--- a/packages/terradart_codegen/README.md
+++ b/packages/terradart_codegen/README.md
@@ -19,7 +19,7 @@ End users depend on [`terradart_google`](https://pub.dev/packages/terradart_goog
 Activate on the same minor line as your workspace when working on the repo:
 
 ```bash
-dart pub global activate terradart_codegen ^0.25.x
+dart pub global activate terradart_codegen ^0.26.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_codegen) for the latest patch.

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart maintainer tooling — parses Terraform provider schema JSON and Magic Modules YAML and emits curated factory wrappers via terradart wrap. Ships the terradart CLI.
-version: 0.25.3
+version: 0.26.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -33,7 +33,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.25.3
+  terradart_core: ^0.26.0
 
 dev_dependencies:
   http: ^1.0.0

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.26.0 - 2026-08-24
+
+Lockstep release with `terradart_cloudflare` 0.26.0 (catalog filled at the `5.23.0` pin). No `terradart_core` API changes.
+
 ## 0.25.3 - 2026-08-23
 
 Lockstep release with `terradart_appwrite` 0.25.3 (catalog filled at the `2.0.0-beta.1` pin). No `terradart_core` API changes.

--- a/packages/terradart_core/README.md
+++ b/packages/terradart_core/README.md
@@ -33,7 +33,7 @@ For project-level documentation, see the [terradart repo README](https://github.
 
 ```yaml
 dependencies:
-  terradart_core: ^0.25.x
+  terradart_core: ^0.26.x
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch. Read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before minor bumps.

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.25.3
+version: 0.26.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_coverage/CHANGELOG.md
+++ b/packages/terradart_coverage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.26.0 - 2026-08-24
+
+Lockstep release with `terradart_cloudflare` 0.26.0. No functional changes in this package.
+
 ## 0.25.3 - 2026-08-23
 
 Lockstep release with `terradart_appwrite` 0.25.3. No functional changes in this package.

--- a/packages/terradart_coverage/pubspec.yaml
+++ b/packages/terradart_coverage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_coverage
 description: Read-only Terraform coverage checker — reports how much of a Terraform config is covered by curated terradart_google factories.
-version: 0.25.3
+version: 0.26.0
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -15,7 +15,7 @@ executables:
   terradart-coverage: terradart_coverage
 
 dependencies:
-  terradart_google: ^0.25.3
+  terradart_google: ^0.26.0
   args: ^2.5.0
 
 dev_dependencies:

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.26.0 - 2026-08-24
+
+Lockstep release. **Breaking** for `terradart_cloudflare` — see [MIGRATING.md](../../MIGRATING.md). No `terradart_google` API changes — the filled catalog and the `CloudflareZone.account` type change ship in `terradart_cloudflare`. Wrap fixture pin is `hashicorp/google` 7.45.0; generated wrappers are unchanged.
+
 ## 0.25.3 - 2026-08-23
 
 Lockstep release. **No breaking changes** vs `0.25.2`. No `terradart_google` API changes — the new curated surface ships in `terradart_appwrite`.

--- a/packages/terradart_google/README.md
+++ b/packages/terradart_google/README.md
@@ -14,8 +14,8 @@ Beta-only types live in [`terradart_google_beta`](https://pub.dev/packages/terra
 
 ```yaml
 dependencies:
-  terradart_core: ^0.25.x
-  terradart_google: ^0.25.x
+  terradart_core: ^0.26.x
+  terradart_google: ^0.26.x
 ```
 
 ## Usage example

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: Curated factory wrappers for Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.
-version: 0.25.3
+version: 0.26.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -22,11 +22,11 @@ false_secrets:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
+  terradart_core: ^0.26.0
   meta: ^1.15.0
 
 dev_dependencies:
-  terradart_codegen: ^0.25.3
+  terradart_codegen: ^0.26.0
   path: ^1.9.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/packages/terradart_google_beta/CHANGELOG.md
+++ b/packages/terradart_google_beta/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.26.0 - 2026-08-24
+
+Lockstep release with the TerraDart workspace. Schema fixture re-extracted at `hashicorp/google-beta` 7.45.0 (same resource set). No factory or provider API changes.
+
 ## 0.25.3 - 2026-08-23
 
 Lockstep release with the TerraDart workspace. No factory or provider changes.

--- a/packages/terradart_google_beta/README.md
+++ b/packages/terradart_google_beta/README.md
@@ -12,8 +12,8 @@ The **beta-only** catalog is filled (**128 resource factories**, schema pin trac
 
 ```yaml
 dependencies:
-  terradart_core: ^0.25.x
-  terradart_google_beta: ^0.25.x
+  terradart_core: ^0.26.x
+  terradart_google_beta: ^0.26.x
 ```
 
 ## Usage example

--- a/packages/terradart_google_beta/pubspec.yaml
+++ b/packages/terradart_google_beta/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google_beta
 description: Curated factory wrappers for beta-only Google Cloud resources (hashicorp/google-beta) for Dart-first Terraform stacks.
-version: 0.25.3
+version: 0.26.0
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.25.3
+  terradart_core: ^0.26.0
   meta: ^1.15.0
 
 dev_dependencies:

--- a/tool/bump_version.sh
+++ b/tool/bump_version.sh
@@ -25,6 +25,9 @@
 #   - SECURITY.md                                 (supported-versions pin + table)
 #   - packages/terradart_core/README.md           (pubspec sample caret)
 #   - packages/terradart_google/README.md         (pubspec sample carets)
+#   - packages/terradart_google_beta/README.md    (pubspec sample carets)
+#   - packages/terradart_appwrite/README.md       (pubspec sample carets)
+#   - packages/terradart_cloudflare/README.md     (pubspec sample carets)
 #   - packages/terradart_codegen/README.md        (`dart pub global activate` caret)
 #   - website/src/content/docs/docs/getting-started.md  (pubspec sample caret note + version line)
 #   - .github/ISSUE_TEMPLATE/bug.yml              (alpha banner version)
@@ -200,6 +203,9 @@ fi
 # Package READMEs: pubspec caret samples + activate caret.
 for pkg_readme in packages/terradart_core/README.md \
                   packages/terradart_google/README.md \
+                  packages/terradart_google_beta/README.md \
+                  packages/terradart_appwrite/README.md \
+                  packages/terradart_cloudflare/README.md \
                   packages/terradart_codegen/README.md; do
   if [ -f "$pkg_readme" ]; then
     sed_inplace "s#terradart_(core|codegen|google): \\^${OLD_RE}#terradart_\\1: ^${NEW}#g" "$pkg_readme"
@@ -241,6 +247,9 @@ for f in README.md \
          website/src/content/docs/docs/getting-started.md \
          packages/terradart_core/README.md \
          packages/terradart_google/README.md \
+         packages/terradart_google_beta/README.md \
+         packages/terradart_appwrite/README.md \
+         packages/terradart_cloudflare/README.md \
          packages/terradart_codegen/README.md; do
   [ -f "$f" ] || continue
   # Blanket ^X.Y.x replace (like CONTRIBUTING/SECURITY below) covers every
@@ -287,6 +296,9 @@ STALE=$(
     README.md website/src/content/docs/docs/getting-started.md \
     packages/terradart_core/README.md \
     packages/terradart_google/README.md \
+    packages/terradart_google_beta/README.md \
+    packages/terradart_appwrite/README.md \
+    packages/terradart_cloudflare/README.md \
     packages/terradart_codegen/README.md 2>/dev/null
   grep -nE "dart pub global activate terradart_codegen \\^${OLD_RE}([^0-9A-Za-z.-]|\$)" \
     README.md \
@@ -307,6 +319,9 @@ STALE=$(
       README.md website/src/content/docs/docs/getting-started.md \
       packages/terradart_core/README.md \
       packages/terradart_google/README.md \
+      packages/terradart_google_beta/README.md \
+      packages/terradart_appwrite/README.md \
+      packages/terradart_cloudflare/README.md \
       packages/terradart_codegen/README.md 2>/dev/null
     grep -nE "pre-1\\.0 \\(${OLD_MINOR_RE}\\.x\\)" README.md 2>/dev/null
     grep -nE "\\b${OLD_MINOR_RE}\\.x\\b" \

--- a/website/src/content/docs/docs/getting-started.md
+++ b/website/src/content/docs/docs/getting-started.md
@@ -3,7 +3,7 @@ title: Getting Started
 description: Install TerraDart and generate your first *.tf.json from a Stack.
 ---
 
-This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.25.x** line. TerraDart is **alpha** — breaking changes land only on **minor** bumps; see [Status & versioning](/docs/status/) for the change policy and the [path to beta](/docs/status/#path-to-beta).
+This guide matches the [README quickstart](https://github.com/nozomi-koborinai/terradart#quickstart) for the **0.26.x** line. TerraDart is **alpha** — breaking changes land only on **minor** bumps; see [Status & versioning](/docs/status/) for the change policy and the [path to beta](/docs/status/#path-to-beta).
 
 ## Prerequisites
 
@@ -18,11 +18,11 @@ Choose `terradart_core` along with the provider factory package(s) your stack re
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.25.x
-  terradart_google: ^0.25.x # for Google Cloud (GA)
-  # terradart_google_beta: ^0.25.x # for Google Cloud beta-only resources
-  # terradart_appwrite: ^0.25.x    # for Appwrite
-  # terradart_cloudflare: ^0.25.x  # for Cloudflare edge infrastructure
+  terradart_core: ^0.26.x
+  terradart_google: ^0.26.x # for Google Cloud (GA)
+  # terradart_google_beta: ^0.26.x # for Google Cloud beta-only resources
+  # terradart_appwrite: ^0.26.x    # for Appwrite
+  # terradart_cloudflare: ^0.26.x  # for Cloudflare edge infrastructure
 ```
 
 Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch, then run:
@@ -123,9 +123,9 @@ graph TB
 ```yaml
 # pubspec.yaml
 dependencies:
-  terradart_core: ^0.25.x
-  terradart_google: ^0.25.x
-  terradart_google_beta: ^0.25.x
+  terradart_core: ^0.26.x
+  terradart_google: ^0.26.x
+  terradart_google_beta: ^0.26.x
 ```
 
 ```dart

--- a/website/src/content/docs/docs/index.md
+++ b/website/src/content/docs/docs/index.md
@@ -5,7 +5,7 @@ description: Guides for TerraDart — type-safe infrastructure-as-code for Dart.
 
 Welcome to the TerraDart docs.
 
-Guides track the **0.25.x** line on pub.dev. The repo [README](https://github.com/nozomi-koborinai/terradart/blob/main/README.md) and [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) stay the deepest references; this site mirrors onboarding and release expectations.
+Guides track the **0.26.x** line on pub.dev. The repo [README](https://github.com/nozomi-koborinai/terradart/blob/main/README.md) and [examples](https://github.com/nozomi-koborinai/terradart/tree/main/examples) stay the deepest references; this site mirrors onboarding and release expectations.
 
 ## Packages
 

--- a/website/src/content/docs/docs/status.md
+++ b/website/src/content/docs/docs/status.md
@@ -3,22 +3,22 @@ title: Status & versioning
 description: Alpha expectations, the path to beta, and how TerraDart versions releases.
 ---
 
-TerraDart is **alpha** on the **0.25.x** line today. Alpha means the maintainer-side quality gates are all done (see [Alpha gates](#alpha-gates-complete)) and the [change policy](#change-policy-from-alpha-onward) below is in force; what still separates alpha from **beta** is external validation — see [Path to beta](#path-to-beta).
+TerraDart is **alpha** on the **0.26.x** line today. Alpha means the maintainer-side quality gates are all done (see [Alpha gates](#alpha-gates-complete)) and the [change policy](#change-policy-from-alpha-onward) below is in force; what still separates alpha from **beta** is external validation — see [Path to beta](#path-to-beta).
 
-There are no SemVer guarantees until **v1.0.0**, but breaking changes land only on **minor** bumps: pin with `^0.25.x`, take patch releases freely, and read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before every minor bump. Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch.
+There are no SemVer guarantees until **v1.0.0**, but breaking changes land only on **minor** bumps: pin with `^0.26.x`, take patch releases freely, and read [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) before every minor bump. Check [pub.dev](https://pub.dev/packages/terradart_core) for the latest patch.
 
 ## Release phases
 
 | Phase | Version line | What we promise |
 | --- | --- | --- |
-| **Alpha** | 0.25.x (current) | Maintainer-side gates are done (docs, CI, real-apply coverage). **No breaking changes within a minor** (`^0.N.x`); breaking changes only on minor bumps, always documented in `MIGRATING.md`. Not SemVer until 1.0.0. |
+| **Alpha** | 0.26.x (current) | Maintainer-side gates are done (docs, CI, real-apply coverage). **No breaking changes within a minor** (`^0.N.x`); breaking changes only on minor bumps, always documented in `MIGRATING.md`. Not SemVer until 1.0.0. |
 | **Beta** | TBD (needs external validation) | The same change policy, proven against real external usage — see [Path to beta](#path-to-beta). |
 | **1.0.0** | TBD | Stable SemVer for `terradart_core`, `terradart_google`, and `terradart_codegen`. |
 
 ## What to expect today (alpha)
 
 - Breaking changes to the public Dart API or the emitted Terraform JSON land only on **minor** bumps, each with a [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md) section; patch releases within `^0.N.x` are safe to take.
-- Use hosted `^0.25.x` carets on [pub.dev](https://pub.dev/packages/terradart_core) — not legacy `0.x.y-dev` pre-release tags.
+- Use hosted `^0.26.x` carets on [pub.dev](https://pub.dev/packages/terradart_core) — not legacy `0.x.y-dev` pre-release tags.
 - Only the **curated** surfaces are supported for users. The GA `hashicorp/google` catalog is filled in `terradart_google`; beta-only types ship in `terradart_google_beta` (128 resource factories). `terradart_appwrite` is filled at `2.0.0-beta.1` (38 resource factories + 24 data sources). `terradart_cloudflare` is filled at `5.23.0` (257 resource factories + 446 data sources).
 
 ## Change policy (from alpha onward)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Lockstep release across the workspace. **Breaking** vs `0.25.3` — see `MIGRATING.md`.

- **`terradart_cloudflare` 0.26.0** — fill the `cloudflare/cloudflare` `5.23.0` catalog (#632): **257 resource factories + 446 data sources**. Nested plugin-framework objects are typed helpers. `CloudflareZone.account` is `ZoneAccount` (breaking). Coverage via `cloudflare_dns_quickstart` + `cloudflare_leftover_quickstart`.
- **`terradart_codegen` 0.26.0** — emit typed helpers for plugin-framework `nested_type`; `skipAttribute` keeps a required `id`. Wrap fixtures pin `hashicorp/google` and `hashicorp/google-beta` **7.45.0** (#631); generated GA/beta wrappers unchanged.
- Everything else moves in lockstep with no functional API change.
- `tool/bump_version.sh` now also rewrites `terradart_google_beta` / `terradart_appwrite` / `terradart_cloudflare` README carets.

After merge + green CI, maintainer tag (do not tag from this PR):

```bash
git tag -a v0.26.0 -m "Release v0.26.0"
git push origin v0.26.0
```

Then create the GitHub release (`v0.26.0` title only) from the notes below. `terradart_cloudflare` first pub.dev publish is still a manual `dart pub publish` if 0.25.2/0.25.3 never landed there.

## Draft GitHub release notes

```markdown
Lockstep release across `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_google_beta`, `terradart_appwrite`, `terradart_cloudflare`, `terradart_agent`, and `terradart_coverage`. **Breaking** vs `0.25.3` — see [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md).

## Highlights

- **`terradart_cloudflare` catalog filled** at the `cloudflare/cloudflare` `5.23.0` pin: **257 resource factories + 446 data sources**. Nested plugin-framework objects are typed Dart helper classes. Coverage via [`cloudflare_dns_quickstart`](https://github.com/nozomi-koborinai/terradart/tree/main/examples/cloudflare_dns_quickstart) and [`cloudflare_leftover_quickstart`](https://github.com/nozomi-koborinai/terradart/tree/main/examples/cloudflare_leftover_quickstart) (synth + `terraform validate`).
- **Breaking:** `CloudflareZone.account` is `ZoneAccount` instead of `TfArg<Map<String, dynamic>>`.
- **Codegen:** required `id` stays on constructors; wrap fixtures at `hashicorp/google` and `hashicorp/google-beta` **7.45.0**.

## Upgrade

    dependencies:
      terradart_core: ^0.26.0
      terradart_google: ^0.26.0
      terradart_cloudflare: ^0.26.0

Docs: [Getting started](https://terradart.dev/docs/getting-started/) · [Status](https://terradart.dev/docs/status/) · [MIGRATING.md](https://github.com/nozomi-koborinai/terradart/blob/main/MIGRATING.md)

## What's Changed

* chore(schema): weekly bump 2026-08-23 by @nozomi-koborinai in https://github.com/nozomi-koborinai/terradart/pull/631
* feat(cloudflare): fill typed catalog at pin 5.23.0 by @nozomi-koborinai in https://github.com/nozomi-koborinai/terradart/pull/632
* chore: lockstep 0.26.0 by @nozomi-koborinai in https://github.com/nozomi-koborinai/terradart/pull/633

**Full Changelog**: https://github.com/nozomi-koborinai/terradart/compare/v0.25.3...v0.26.0
```

## Test plan

- [x] `tool/bump_version.sh 0.26.0`
- [x] `dart tool/check_docs_consistency.dart`
- [x] package CHANGELOGs contain `## 0.26.0`
- [x] `dart pub publish --dry-run` for `terradart_core` (warning: dirty tree only)
- [x] `tool/agent_verify.sh` (`agent_verify: OK`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02f09-6504-7597-a77a-bc1a14a60c1f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02f09-6504-7597-a77a-bc1a14a60c1f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

