### PR TITLE
feat(core): ship S3Backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Per-package changelogs live alongside each package and are the system of record 
 
 ## Unreleased
 
+### Added
+
+- **`terradart_core`** — `S3Backend` for `terraform { backend "s3" { ... } }`, including the S3-compatible stores people keep state in (Cloudflare R2, MinIO, Backblaze B2). `S3Backend.r2(accountId:, bucket:, key:)` presets the R2 endpoint, `region = "auto"`, path-style addressing, and the five `skip_*` flags. Previously only `GcsBackend` and `LocalBackend` shipped, so an S3/R2 stack had to bypass `Stack.writeTo()` and splice the backend into the synthesised JSON by hand.
+
 ## [0.26.0] - 2026-08-24
 
 Lockstep release across the workspace. **Breaking** — see [MIGRATING.md](MIGRATING.md).

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`S3Backend`** — `terraform { backend "s3" { ... } }` configuration, alongside the existing `GcsBackend` and `LocalBackend`. Covers S3 and the S3-compatible stores (Cloudflare R2, MinIO, Backblaze B2) via `endpoints` plus the `skip_*` flags. `S3Backend.r2(accountId:, bucket:, key:)` fills in the R2 endpoint, `region = "auto"`, path-style addressing, and all five skip flags. Optional fields are omitted from the emitted JSON when null; an explicit `false` is emitted.
+
+### Fixed
+
+- **Docs** — `Stack.backend` and `backends.dart` described S3 as living in "provider-specific packages" and named an `S3Backend` that no package shipped. Both now describe what core actually provides.
+
 ## 0.26.0 - 2026-08-24
 
 Lockstep release with `terradart_cloudflare` 0.26.0 (catalog filled at the `5.23.0` pin). No `terradart_core` API changes.

--- a/packages/terradart_core/lib/src/backends.dart
+++ b/packages/terradart_core/lib/src/backends.dart
@@ -4,10 +4,13 @@ import 'stack.dart';
 
 /// `terraform { backend "gcs" { ... } }` configuration.
 ///
-/// v0.0.x ships GCS as the canonical "real-world" backend; other backends
-/// (S3, local, Terraform Cloud) live in caller packages and implement
-/// [StackBackend] directly. Synth's `TfJsonEncoder.terraformBlock` knows
-/// about [GcsBackend] specifically because it's the v0.0.x default.
+/// Core ships the three backends that need no provider knowledge to
+/// configure: [GcsBackend], [S3Backend], and [LocalBackend]. Anything
+/// else (Terraform Cloud, Consul, ...) implements [StackBackend] in the
+/// caller — synth's `TfJsonEncoder` has a generic path for that.
+///
+/// `TfJsonEncoder.terraformBlock` special-cases [GcsBackend] because it
+/// predates the generic path; the emitted JSON is the same either way.
 @immutable
 final class GcsBackend implements StackBackend {
   const GcsBackend({required this.bucket, this.prefix});
@@ -50,5 +53,120 @@ final class LocalBackend implements StackBackend {
   @override
   Map<String, Object?> toTfJson() => {
         if (path != null) 'path': path,
+      };
+}
+
+/// `terraform { backend "s3" { ... } }` configuration.
+///
+/// Covers S3 itself and the S3-compatible stores people actually keep
+/// Terraform state in — Cloudflare R2, MinIO, Backblaze B2. Those need
+/// a custom [endpoints] entry plus some subset of the `skip_*` flags,
+/// because the AWS SDK preflight calls they suppress do not exist
+/// outside AWS. [S3Backend.r2] fills all of it in for R2.
+///
+/// Every optional field is omitted from [toTfJson] when null, so the
+/// Terraform-side default applies rather than a value terradart chose.
+/// An explicit `false` is a value, and is emitted.
+@immutable
+final class S3Backend implements StackBackend {
+  const S3Backend({
+    required this.bucket,
+    required this.key,
+    this.region,
+    this.endpoints,
+    this.usePathStyle,
+    this.skipCredentialsValidation,
+    this.skipRegionValidation,
+    this.skipRequestingAccountId,
+    this.skipMetadataApiCheck,
+    this.skipS3Checksum,
+  });
+
+  /// Cloudflare R2 preset: the account-scoped S3 endpoint, `region =
+  /// "auto"`, path-style addressing, and the five `skip_*` flags R2
+  /// needs because it implements no AWS metadata or STS surface.
+  ///
+  /// ```dart
+  /// S3Backend.r2(
+  ///   accountId: '<cloudflare account id>',
+  ///   bucket: 'my-tfstate',
+  ///   key: 'site/terraform.tfstate',
+  /// )
+  /// ```
+  ///
+  /// Credentials come from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+  /// at apply time (an R2 API token), never from synth output.
+  factory S3Backend.r2({
+    required String accountId,
+    required String bucket,
+    required String key,
+  }) =>
+      S3Backend(
+        bucket: bucket,
+        key: key,
+        region: 'auto',
+        endpoints: {'s3': 'https://$accountId.r2.cloudflarestorage.com'},
+        usePathStyle: true,
+        skipCredentialsValidation: true,
+        skipRegionValidation: true,
+        skipRequestingAccountId: true,
+        skipMetadataApiCheck: true,
+        skipS3Checksum: true,
+      );
+
+  /// S3 bucket holding the Terraform state file.
+  final String bucket;
+
+  /// Object key of the state file inside [bucket], e.g.
+  /// `terraform/site/terraform.tfstate`. Terraform has no default here.
+  final String key;
+
+  /// Bucket region. `'auto'` for R2.
+  final String? region;
+
+  /// Service endpoint overrides, e.g.
+  /// `{'s3': 'https://<account>.r2.cloudflarestorage.com'}`. Leave null
+  /// for AWS.
+  final Map<String, String>? endpoints;
+
+  /// Path-style addressing (`https://host/bucket/key`) instead of
+  /// virtual-hosted style. Required by most S3-compatible stores.
+  final bool? usePathStyle;
+
+  /// Skip the STS credential preflight. Required off-AWS.
+  final bool? skipCredentialsValidation;
+
+  /// Skip validating [region] against the known AWS region list —
+  /// `'auto'` is not one of them.
+  final bool? skipRegionValidation;
+
+  /// Skip the STS `GetCallerIdentity` account-id lookup.
+  final bool? skipRequestingAccountId;
+
+  /// Skip the EC2 instance metadata endpoint probe.
+  final bool? skipMetadataApiCheck;
+
+  /// Skip the trailing checksum on uploads. R2 rejects it.
+  final bool? skipS3Checksum;
+
+  @override
+  String get backendType => 's3';
+
+  @override
+  Map<String, Object?> toTfJson() => {
+        'bucket': bucket,
+        'key': key,
+        if (region != null) 'region': region,
+        if (endpoints != null) 'endpoints': endpoints,
+        if (usePathStyle != null) 'use_path_style': usePathStyle,
+        if (skipCredentialsValidation != null)
+          'skip_credentials_validation': skipCredentialsValidation,
+        if (skipRegionValidation != null)
+          'skip_region_validation': skipRegionValidation,
+        if (skipRequestingAccountId != null)
+          'skip_requesting_account_id': skipRequestingAccountId,
+        if (skipMetadataApiCheck != null)
+          'skip_metadata_api_check': skipMetadataApiCheck,
+        if (skipS3Checksum != null) 'skip_s3_checksum': skipS3Checksum,
       };
 }

--- a/packages/terradart_core/lib/src/stack.dart
+++ b/packages/terradart_core/lib/src/stack.dart
@@ -7,10 +7,10 @@ import 'duplicate_resource_error.dart';
 import 'resource.dart';
 import 'synth/stack_synth.dart';
 
-/// Lightweight backend hook — concrete classes (`GcsBackend`, `S3Backend`)
-/// live in provider-specific packages. The core `Stack` only stores the
-/// value and exposes a discriminator for synth's `terraform { backend ... }`
-/// emitter.
+/// Lightweight backend hook. Core ships `GcsBackend`, `S3Backend`, and
+/// `LocalBackend`; anything else implements this interface in the caller.
+/// The `Stack` only stores the value and exposes a discriminator for
+/// synth's `terraform { backend ... }` emitter.
 abstract interface class StackBackend {
   /// Backend type tag, e.g. `'gcs'`, `'s3'`, `'local'`. Synth uses this
   /// as the JSON key under `terraform.backend.<type>`.

--- a/packages/terradart_core/lib/terradart_core.dart
+++ b/packages/terradart_core/lib/terradart_core.dart
@@ -8,7 +8,7 @@ export 'src/app_export.dart'
         ResourceAttributeExport,
         ResourceIdExport,
         StringExport;
-export 'src/backends.dart' show GcsBackend, LocalBackend;
+export 'src/backends.dart' show GcsBackend, LocalBackend, S3Backend;
 export 'src/data.dart' show Data;
 export 'src/duplicate_resource_error.dart' show DuplicateResourceError;
 export 'src/duration_helper.dart' show TerraformDurationExt;

--- a/packages/terradart_core/test/backends_test.dart
+++ b/packages/terradart_core/test/backends_test.dart
@@ -34,4 +34,104 @@ void main() {
       expect(backend.backendType, equals('gcs'));
     });
   });
+
+  group('S3Backend', () {
+    test('backendType is "s3"', () {
+      const backend =
+          S3Backend(bucket: 'my-state', key: 'app/terraform.tfstate');
+      expect(backend.backendType, equals('s3'));
+    });
+
+    test('toTfJson emits only bucket and key when nothing else is set', () {
+      const backend =
+          S3Backend(bucket: 'my-state', key: 'app/terraform.tfstate');
+      expect(
+        backend.toTfJson(),
+        equals(<String, Object?>{
+          'bucket': 'my-state',
+          'key': 'app/terraform.tfstate',
+        }),
+      );
+    });
+
+    test('toTfJson omits every null optional', () {
+      const backend = S3Backend(
+        bucket: 'my-state',
+        key: 'app/terraform.tfstate',
+        region: 'ap-northeast-1',
+      );
+      expect(backend.toTfJson().keys, equals(['bucket', 'key', 'region']));
+    });
+
+    test('toTfJson emits every field that is set', () {
+      const backend = S3Backend(
+        bucket: 'my-state',
+        key: 'app/terraform.tfstate',
+        region: 'auto',
+        endpoints: {'s3': 'https://example.invalid'},
+        usePathStyle: true,
+        skipCredentialsValidation: true,
+        skipRegionValidation: true,
+        skipRequestingAccountId: true,
+        skipMetadataApiCheck: true,
+        skipS3Checksum: true,
+      );
+      expect(
+        backend.toTfJson(),
+        equals(<String, Object?>{
+          'bucket': 'my-state',
+          'key': 'app/terraform.tfstate',
+          'region': 'auto',
+          'endpoints': {'s3': 'https://example.invalid'},
+          'use_path_style': true,
+          'skip_credentials_validation': true,
+          'skip_region_validation': true,
+          'skip_requesting_account_id': true,
+          'skip_metadata_api_check': true,
+          'skip_s3_checksum': true,
+        }),
+      );
+    });
+
+    test('false flags are emitted, not treated as unset', () {
+      const backend = S3Backend(
+        bucket: 'my-state',
+        key: 'app/terraform.tfstate',
+        usePathStyle: false,
+      );
+      expect(backend.toTfJson()['use_path_style'], isFalse);
+    });
+
+    test('r2 builds the Cloudflare R2 endpoint and flag set', () {
+      final backend = S3Backend.r2(
+        accountId: 'abc123',
+        bucket: 'my-state',
+        key: 'site/terraform.tfstate',
+      );
+      expect(backend.backendType, equals('s3'));
+      expect(
+        backend.toTfJson(),
+        equals(<String, Object?>{
+          'bucket': 'my-state',
+          'key': 'site/terraform.tfstate',
+          'region': 'auto',
+          'endpoints': {'s3': 'https://abc123.r2.cloudflarestorage.com'},
+          'use_path_style': true,
+          'skip_credentials_validation': true,
+          'skip_region_validation': true,
+          'skip_requesting_account_id': true,
+          'skip_metadata_api_check': true,
+          'skip_s3_checksum': true,
+        }),
+      );
+    });
+
+    test('implements StackBackend interface', () {
+      const StackBackend backend = S3Backend(
+        bucket: 'my-state',
+        key: 'app/terraform.tfstate',
+      );
+      expect(backend.backendType, equals('s3'));
+    });
+  });
 }

--- a/packages/terradart_core/test/public_api_test.dart
+++ b/packages/terradart_core/test/public_api_test.dart
@@ -30,6 +30,7 @@ void main() {
       ResourceAttributeExport,
       EnvBackedExport,
       GcsBackend,
+      S3Backend,
       LiteralResolver,
       OutputEmitter,
       OutputEmissionResult,
@@ -40,7 +41,7 @@ void main() {
       SynthResult,
       DuplicateResourceError,
     ];
-    expect(symbols, hasLength(33));
+    expect(symbols, hasLength(34));
   });
 
   test('TerraformDurationExt is accessible (extension method)', () {

--- a/packages/terradart_core/test/synth/json_encoder_test.dart
+++ b/packages/terradart_core/test/synth/json_encoder_test.dart
@@ -76,6 +76,60 @@ void main() {
       );
     });
 
+    test('S3 backend is included when configured', () {
+      final stack = TestStack(
+        providers: const [
+          FakeStackProvider(
+            providerName: 'google',
+            source: 'hashicorp/google',
+            versionConstraint: '~> 7.0',
+          ),
+        ],
+        backend: const S3Backend(
+          bucket: 'tfstate-orders',
+          key: 'envs/prod/terraform.tfstate',
+          region: 'ap-northeast-1',
+        ),
+      );
+      final block = TfJsonEncoder.terraformBlock(stack);
+      expect(
+        block['backend'],
+        equals({
+          's3': {
+            'bucket': 'tfstate-orders',
+            'key': 'envs/prod/terraform.tfstate',
+            'region': 'ap-northeast-1',
+          },
+        }),
+      );
+    });
+
+    test('S3 backend for R2 emits the endpoint and skip flags', () {
+      final stack = TestStack(
+        providers: const [
+          FakeStackProvider(
+            providerName: 'google',
+            source: 'hashicorp/google',
+            versionConstraint: '~> 7.0',
+          ),
+        ],
+        backend: S3Backend.r2(
+          accountId: 'abc123',
+          bucket: 'tfstate-orders',
+          key: 'site/terraform.tfstate',
+        ),
+      );
+      final backend =
+          (TfJsonEncoder.terraformBlock(stack)['backend'] as Map)['s3'] as Map;
+      expect(
+        backend['endpoints'],
+        equals({'s3': 'https://abc123.r2.cloudflarestorage.com'}),
+      );
+      expect(backend['region'], equals('auto'));
+      expect(backend['use_path_style'], isTrue);
+      expect(backend['skip_s3_checksum'], isTrue);
+    });
+
     test('GCS backend without prefix omits the field', () {
       final stack = TestStack(
         providers: const [


### PR DESCRIPTION
Closes #635.

## What

`terradart_core` shipped `GcsBackend` and `LocalBackend` but no `S3Backend`, so any stack keeping state in S3 — or in the S3-compatible stores people actually use, Cloudflare R2, MinIO, Backblaze B2 — could not use `Stack.writeTo()` at all. The backend had to be spliced into the synthesised JSON by hand, which also drops the AppExport output-path guard `writeTo()` performs.

The docs made this worse by naming the missing class: `stack.dart` said concrete backends "live in provider-specific packages (`GcsBackend`, `S3Backend`)", and `backends.dart` repeated the policy — but `LocalBackend` is already in core, so the policy no longer described the code. Both are corrected.

## API

```dart
const S3Backend({
  required String bucket,
  required String key,
  String? region,
  Map<String, String>? endpoints,
  bool? usePathStyle,
  bool? skipCredentialsValidation,
  bool? skipRegionValidation,
  bool? skipRequestingAccountId,
  bool? skipMetadataApiCheck,
  bool? skipS3Checksum,
});

factory S3Backend.r2({
  required String accountId,
  required String bucket,
  required String key,
});
```

Only `bucket` and `key` are required. Every other field is omitted from `toTfJson()` when null so Terraform's own default applies rather than one terradart picked — matching `GcsBackend.prefix`. An explicit `false` is a value and is emitted.

`S3Backend.r2` collapses the R2 case to three arguments: the endpoint URL, `region = "auto"`, path-style addressing, and all five `skip_*` flags are mechanical for R2, and they are exactly the part that is easy to get wrong and hard to notice — a missing `use_path_style` fails only at `terraform init`.

It is a `factory` rather than a `const` constructor. A const map literal cannot interpolate a constructor parameter (`Non-constant map literal is not a constant expression`), and the R2 account id comes from the environment in every real usage, so `const` would never apply anyway.

## Why core, not a provider package

The `backend "s3"` block is not provider-specific — the same block serves AWS, R2, MinIO, and Backblaze, and R2 needs no Cloudflare provider knowledge, only `endpoints` plus the flags. It sits beside `LocalBackend`, which is already here.

## No plumbing change

`TfJsonEncoder._encodeBackend` already has a generic fallback over `backendType` / `toTfJson()`. Verified before writing this by implementing `R2Backend implements StackBackend` in a consumer repo: it round-trips and `writeTo()` works. So this is a missing class, not missing plumbing, and `_encodeBackend` is untouched.

## Verification

- `tool/agent_verify.sh` — `agent_verify: OK`
- `dart test packages/terradart_core` — 209 passed
- `dart analyze --fatal-infos --fatal-warnings` — No issues found
- `dart format` — clean

New tests: 7 in `backends_test.dart` (type tag, required-only emission, null omission, full emission, `false` is not "unset", the R2 preset, interface conformance) and 2 in `json_encoder_test.dart` (the block reaches `terraform.backend.s3` through synth, and the R2 preset survives encoding). `public_api_test.dart` symbol count 33 → 34.

## Where this came from

Migrating koborin.ai to Cloudflare Workers with state in R2. The site's synth entry point had grown a 46-line helper whose only real job was writing this block; everything else it did was a reimplementation of `writeTo()`. The same helper had existed through the earlier GCP era against `backend "gcs"`, so the escape hatch was load-bearing across a full provider migration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and documentation fixes; remote state config is emitted as before via the existing generic backend encoder, with no changes to synth plumbing.
> 
> **Overview**
> **`terradart_core`** now ships **`S3Backend`** so stacks using S3 or S3-compatible remote state (R2, MinIO, B2) can set `Stack.backend` and use **`Stack.writeTo()`** instead of hand-splicing `terraform.backend.s3` into synth output.
> 
> The type implements `StackBackend` with required `bucket`/`key`, optional region, custom `endpoints`, path-style addressing, and the five `skip_*` flags; **`S3Backend.r2(accountId:, bucket:, key:)`** presets Cloudflare R2 (endpoint, `region = "auto"`, path-style, all skip flags). Null optionals are omitted from `toTfJson()`; explicit `false` is still emitted. **`S3Backend`** is exported from the public barrel; **`stack.dart`** / **`backends.dart`** docs no longer claim S3 lives only in provider packages.
> 
> Synth encoding is unchanged—the existing generic `backendType` / `toTfJson()` path is covered by new **`backends_test`** and **`json_encoder_test`** cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d85c65f4bf8e5ba131e0497649593ae13d7f346c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->