### PR TITLE
feat(core): declare Terraform variables from Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Per-package changelogs live alongside each package and are the system of record 
 
 ## Unreleased
 
+### Added
+
+- **`terradart_core`** — `TfVariable` and `Stack.addVariable` declare the `variable "<name>" { ... }` blocks that `TfArg.variable` references, and synth now refuses to emit a config that references an undeclared variable. `TfArg.variable` previously had no counterpart for declaring the variable, so the ten examples using it each hand-wrote a `variables.tf.json` after `writeTo()`; those writes are gone. `Stack.addExternalVariable` covers declarations that stay in a hand-written file. **Breaking** — see [MIGRATING.md](MIGRATING.md).
+
 ## [0.26.0] - 2026-08-24
 
 Lockstep release across the workspace. **Breaking** — see [MIGRATING.md](MIGRATING.md).

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,45 @@
 # Migrating terradart
 
+## 0.26.0 → next
+
+**Breaking (`terradart_core`)** — synth now refuses to emit a config whose
+`TfArg.variable('<name>')` references have no matching declaration. Before,
+such a config synthesised cleanly and failed later at `terraform plan` with
+*Reference to undeclared input variable*.
+
+Declare the variable on the Stack:
+
+```dart
+// Before — the declaration lived in a hand-written file, or nowhere.
+password: TfArg.variable('db_password'),
+
+// After — declare it alongside the reference.
+addVariable(
+  'db_password',
+  const TfVariable(type: 'string', sensitive: true),
+);
+password: TfArg.variable('db_password'),
+```
+
+Synth emits the collected declarations under the top-level `variable` key of
+`main.tf.json`, and omits the key when a stack declares none (Terraform
+rejects an empty `variable` block).
+
+**If your `variable` blocks live in a hand-written file** beside the
+generated `main.tf.json` — a legitimate setup, since Terraform merges every
+`.tf` / `.tf.json` in the module directory, and the only way to express what
+`TfVariable` does not model such as `validation { ... }` blocks — register
+the name instead of moving the block. Synth then accepts the reference and
+emits nothing for it, so there is no duplicate declaration:
+
+```dart
+addExternalVariable('db_password');
+```
+
+The reference check still catches typos in every other name.
+
+---
+
 ## 0.25.3 → 0.26.0
 
 **Breaking (`terradart_cloudflare`)** — `CloudflareZone.account` is a typed

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -38,6 +38,22 @@ addExternalVariable('db_password');
 
 The reference check still catches typos in every other name.
 
+**Delete any `variables.tf.json` you were writing by hand.** If you followed
+the previous pattern — writing a second JSON file next to the generated
+`main.tf.json` after `writeTo()` — that file is still on disk, and synth does
+not remove it. Once the same names are declared through `addVariable`,
+Terraform sees both files and fails:
+
+```
+Error: Duplicate variable declaration
+
+  on variables.tf.json line 3, in variable:
+A variable named "ops_folder_id" was already declared at main.tf.json.
+```
+
+Remove the stale file once (`rm tf-out/variables.tf.json`); nothing
+regenerates it.
+
 ---
 
 ## 0.25.3 → 0.26.0

--- a/examples/access_context_quickstart/bin/infra.dart
+++ b/examples/access_context_quickstart/bin/infra.dart
@@ -1,7 +1,6 @@
 /// Synth entry. `dart run bin/infra.dart` → `tf-out/main.tf.json`.
 library;
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:terradart_example_access_context_quickstart/main.dart';
@@ -14,12 +13,5 @@ Future<void> main() async {
   }
   final stack = AccessControlsStack(projectId: projectId);
   await stack.writeTo('tf-out');
-  await File('tf-out/variables.tf.json').writeAsString(
-    const JsonEncoder.withIndent('  ').convert({
-      'variable': {
-        'ops_organization_id': {'type': 'string'},
-      },
-    }),
-  );
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/access_context_quickstart/lib/main.dart
+++ b/examples/access_context_quickstart/lib/main.dart
@@ -27,6 +27,13 @@ final class AccessControlsStack extends Stack {
             const TimeProvider(),
           ],
         ) {
+    // Declared here so the TfArg.variable references below resolve;
+    // the values themselves arrive at `terraform apply -var` time.
+    addVariable(
+      'ops_organization_id',
+      const TfVariable(type: 'string'),
+    );
+
     final apiDeps = Apis.enable(
       this,
       barrels: [Barrels.accessContextManager],

--- a/examples/appwrite_quickstart/bin/infra.dart
+++ b/examples/appwrite_quickstart/bin/infra.dart
@@ -7,23 +7,10 @@
 /// `terraform validate`.
 library;
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:terradart_example_appwrite_quickstart/main.dart';
 
 Future<void> main() async {
   final stack = AppwriteDemoStack();
   await stack.writeTo('tf-out');
-  await File('tf-out/variables.tf.json').writeAsString(
-    const JsonEncoder.withIndent('  ').convert({
-      'variable': {
-        'backup_access_key': {'type': 'string', 'sensitive': true},
-        'backup_secret_key': {'type': 'string', 'sensitive': true},
-        'function_api_url': {'type': 'string', 'sensitive': true},
-        'site_api_url': {'type': 'string', 'sensitive': true},
-      },
-    }),
-  );
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/appwrite_quickstart/lib/main.dart
+++ b/examples/appwrite_quickstart/lib/main.dart
@@ -44,6 +44,25 @@ final class AppwriteDemoStack extends Stack {
             ),
           ],
         ) {
+    // Declared here so the TfArg.variable references below resolve;
+    // the values themselves arrive at `terraform apply -var` time.
+    addVariable(
+      'backup_access_key',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+    addVariable(
+      'backup_secret_key',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+    addVariable(
+      'function_api_url',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+    addVariable(
+      'site_api_url',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+
     add(
       AppwriteProject(
         localName: 'demo',

--- a/examples/beta_leftover_quickstart/bin/infra.dart
+++ b/examples/beta_leftover_quickstart/bin/infra.dart
@@ -1,7 +1,6 @@
 /// Synth entry. `dart run bin/infra.dart` -> `tf-out/main.tf.json`.
 library;
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:terradart_example_beta_leftover_quickstart/main.dart';
@@ -14,13 +13,5 @@ Future<void> main() async {
   }
   final stack = BetaLeftoverStack(projectId: projectId);
   await stack.writeTo('tf-out');
-  // Sensitive leftover fields use TfArg.variable — declare for validate.
-  await File('tf-out/variables.tf.json').writeAsString(
-    const JsonEncoder.withIndent('  ').convert({
-      'variable': {
-        'runtimeconfig_variable_text': {'type': 'string', 'sensitive': true},
-      },
-    }),
-  );
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/beta_leftover_quickstart/lib/main.dart
+++ b/examples/beta_leftover_quickstart/lib/main.dart
@@ -43,6 +43,13 @@ final class BetaLeftoverStack extends Stack {
             GoogleBetaProvider(project: projectId, region: 'us-central1'),
           ],
         ) {
+    // Declared here so the TfArg.variable references below resolve;
+    // the values themselves arrive at `terraform apply -var` time.
+    addVariable(
+      'runtimeconfig_variable_text',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+
     add(
       GoogleActiveDirectoryPeering(
         localName: 'active_directory_peering',

--- a/examples/cloud_sql_quickstart/bin/infra.dart
+++ b/examples/cloud_sql_quickstart/bin/infra.dart
@@ -1,7 +1,6 @@
 /// Synth entry. `dart run bin/infra.dart` -> `tf-out/main.tf.json`.
 library;
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:terradart_example_cloud_sql_quickstart/main.dart';
@@ -19,13 +18,5 @@ Future<void> main() async {
   }
   final stack = CloudSqlStack(projectId: projectId, dbPassword: dbPassword);
   await stack.writeTo('tf-out');
-  // Source-representation `password` uses TfArg.variable — declare for validate.
-  await File('tf-out/variables.tf.json').writeAsString(
-    const JsonEncoder.withIndent('  ').convert({
-      'variable': {
-        'source_rep_password': {'type': 'string', 'sensitive': true},
-      },
-    }),
-  );
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/cloud_sql_quickstart/lib/main.dart
+++ b/examples/cloud_sql_quickstart/lib/main.dart
@@ -36,6 +36,13 @@ final class CloudSqlStack extends Stack {
             GoogleProvider(project: projectId, region: 'asia-northeast1'),
           ],
         ) {
+    // Declared here so the TfArg.variable references below resolve;
+    // the values themselves arrive at `terraform apply -var` time.
+    addVariable(
+      'source_rep_password',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+
     // ---- 1. Dedicated VPC for the Cloud SQL instance ----------------------
 
     final vpc = add(

--- a/examples/cloudflare_leftover_quickstart/bin/infra.dart
+++ b/examples/cloudflare_leftover_quickstart/bin/infra.dart
@@ -5,21 +5,10 @@
 /// Never apply. Authentication is unused at synth time.
 library;
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:terradart_example_cloudflare_leftover_quickstart/main.dart';
 
 Future<void> main() async {
   final stack = CloudflareLeftoverStack();
   await stack.writeTo('tf-out');
-  // Sensitive leftover fields use TfArg.variable — declare for validate.
-  await File('tf-out/variables.tf.json').writeAsString(
-    const JsonEncoder.withIndent('  ').convert({
-      'variable': {
-        'leftover_secret': {'type': 'string', 'sensitive': true},
-      },
-    }),
-  );
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/cloudflare_leftover_quickstart/lib/main.dart
+++ b/examples/cloudflare_leftover_quickstart/lib/main.dart
@@ -12,6 +12,13 @@ import 'package:terradart_core/terradart_core.dart';
 final class CloudflareLeftoverStack extends Stack {
   CloudflareLeftoverStack()
       : super(providers: [const CloudflareProvider()]) {
+    // Declared here so the TfArg.variable references below resolve;
+    // the values themselves arrive at `terraform apply -var` time.
+    addVariable(
+      'leftover_secret',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+
     const leftover = 'leftover';
     const accountId = '00000000000000000000000000000001';
     const zoneId = '00000000000000000000000000000002';

--- a/examples/compute_lb_quickstart/bin/infra.dart
+++ b/examples/compute_lb_quickstart/bin/infra.dart
@@ -1,7 +1,6 @@
 /// Synth entry. `dart run bin/infra.dart` -> `tf-out/main.tf.json`.
 library;
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:terradart_example_compute_lb_quickstart/main.dart';
@@ -14,26 +13,5 @@ Future<void> main() async {
   }
   final stack = ComputeLbStack(projectId: projectId);
   await stack.writeTo('tf-out');
-  // `private_key` on self-managed SSL cert uses TfArg.variable.
-  await File('tf-out/variables.tf.json').writeAsString(
-    const JsonEncoder.withIndent('  ').convert({
-      'variable': {
-        'lb_self_managed_certificate': {'type': 'string', 'sensitive': true},
-        'lb_self_managed_private_key': {'type': 'string', 'sensitive': true},
-        'lb_regional_certificate': {'type': 'string', 'sensitive': true},
-        'lb_regional_private_key': {'type': 'string', 'sensitive': true},
-        'cm_trust_anchor_pem': {'type': 'string', 'sensitive': true},
-        'cm_cas_cert_csr_pem': {'type': 'string', 'sensitive': true},
-        'lb_backend_bucket_signed_url_key': {
-          'type': 'string',
-          'sensitive': true,
-        },
-        'lb_backend_service_signed_url_key': {
-          'type': 'string',
-          'sensitive': true,
-        },
-      },
-    }),
-  );
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/compute_lb_quickstart/lib/main.dart
+++ b/examples/compute_lb_quickstart/lib/main.dart
@@ -56,6 +56,41 @@ final class ComputeLbStack extends Stack {
             GoogleProvider(project: projectId, region: 'asia-northeast1'),
           ],
         ) {
+    // Declared here so the TfArg.variable references below resolve;
+    // the values themselves arrive at `terraform apply -var` time.
+    addVariable(
+      'lb_self_managed_certificate',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+    addVariable(
+      'lb_self_managed_private_key',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+    addVariable(
+      'lb_regional_certificate',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+    addVariable(
+      'lb_regional_private_key',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+    addVariable(
+      'cm_trust_anchor_pem',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+    addVariable(
+      'cm_cas_cert_csr_pem',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+    addVariable(
+      'lb_backend_bucket_signed_url_key',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+    addVariable(
+      'lb_backend_service_signed_url_key',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+
     const region = 'asia-northeast1';
     const zone = 'asia-northeast1-a';
 

--- a/examples/deferred_leftover_quickstart/bin/infra.dart
+++ b/examples/deferred_leftover_quickstart/bin/infra.dart
@@ -1,7 +1,6 @@
 /// Synth entry. `dart run bin/infra.dart` -> `tf-out/main.tf.json`.
 library;
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:terradart_example_deferred_leftover_quickstart/main.dart';
@@ -14,13 +13,5 @@ Future<void> main() async {
   }
   final stack = DeferredLeftoverStack(projectId: projectId);
   await stack.writeTo('tf-out');
-  // Sensitive leftover fields use TfArg.variable — declare for validate.
-  await File('tf-out/variables.tf.json').writeAsString(
-    const JsonEncoder.withIndent('  ').convert({
-      'variable': {
-        'ad_trust_handshake_secret': {'type': 'string', 'sensitive': true},
-      },
-    }),
-  );
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/deferred_leftover_quickstart/lib/main.dart
+++ b/examples/deferred_leftover_quickstart/lib/main.dart
@@ -51,6 +51,13 @@ final class DeferredLeftoverStack extends Stack {
             GoogleProvider(project: projectId, region: 'us-central1'),
           ],
         ) {
+    // Declared here so the TfArg.variable references below resolve;
+    // the values themselves arrive at `terraform apply -var` time.
+    addVariable(
+      'ad_trust_handshake_secret',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+
     add(
       GoogleActiveDirectoryDomainTrust(
         localName: 'activedirectorydomaintrust',

--- a/examples/firebase_app_check_quickstart/bin/infra.dart
+++ b/examples/firebase_app_check_quickstart/bin/infra.dart
@@ -1,7 +1,6 @@
 /// Synth entry. `dart run bin/infra.dart` → `tf-out/main.tf.json`.
 library;
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:terradart_example_firebase_app_check_quickstart/main.dart';
@@ -14,15 +13,5 @@ Future<void> main() async {
   }
   final stack = AppCheckStack(projectId: projectId);
   await stack.writeTo('tf-out');
-  // `site_secret` uses TfArg.variable — declare for terraform validate.
-  await File('tf-out/variables.tf.json').writeAsString(
-    const JsonEncoder.withIndent('  ').convert({
-      'variable': {
-        'recaptcha_v3_site_secret': {'type': 'string', 'sensitive': true},
-        'app_check_debug_token': {'type': 'string', 'sensitive': true},
-        'device_check_private_key': {'type': 'string', 'sensitive': true},
-      },
-    }),
-  );
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/firebase_app_check_quickstart/lib/main.dart
+++ b/examples/firebase_app_check_quickstart/lib/main.dart
@@ -23,6 +23,21 @@ final class AppCheckStack extends Stack {
             GoogleProvider(project: projectId, region: 'us-central1'),
           ],
         ) {
+    // Declared here so the TfArg.variable references below resolve;
+    // the values themselves arrive at `terraform apply -var` time.
+    addVariable(
+      'recaptcha_v3_site_secret',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+    addVariable(
+      'app_check_debug_token',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+    addVariable(
+      'device_check_private_key',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+
     // Bind a reCAPTCHA Enterprise site key to the Firebase Web App.
     // This tells App Check to use reCAPTCHA Enterprise as the attestation
     // provider for that specific app.

--- a/examples/kms_quickstart/bin/infra.dart
+++ b/examples/kms_quickstart/bin/infra.dart
@@ -1,7 +1,6 @@
 /// Synth entry. `dart run bin/infra.dart` → `tf-out/main.tf.json`.
 library;
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:terradart_example_kms_quickstart/main.dart';
@@ -14,13 +13,5 @@ Future<void> main() async {
   }
   final stack = CryptoStack(projectId: projectId);
   await stack.writeTo('tf-out');
-  // `plaintext` uses TfArg.variable — declare for terraform validate.
-  await File('tf-out/variables.tf.json').writeAsString(
-    const JsonEncoder.withIndent('  ').convert({
-      'variable': {
-        'kms_secret_plaintext': {'type': 'string', 'sensitive': true},
-      },
-    }),
-  );
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/kms_quickstart/lib/main.dart
+++ b/examples/kms_quickstart/lib/main.dart
@@ -34,6 +34,13 @@ final class CryptoStack extends Stack {
             const TimeProvider(),
           ],
         ) {
+    // Declared here so the TfArg.variable references below resolve;
+    // the values themselves arrive at `terraform apply -var` time.
+    addVariable(
+      'kms_secret_plaintext',
+      const TfVariable(type: 'string', sensitive: true),
+    );
+
     // ---- API enablement ---------------------------------------------------
     //
     // [Apis.enable] enables the Cloud KMS API and waits 60s for propagation

--- a/examples/ops_quickstart/bin/infra.dart
+++ b/examples/ops_quickstart/bin/infra.dart
@@ -1,7 +1,6 @@
 /// Synth entry. `dart run bin/infra.dart` → `tf-out/main.tf.json`.
 library;
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:terradart_example_ops_quickstart/main.dart';
@@ -14,14 +13,5 @@ Future<void> main() async {
   }
   final stack = AuditPipelineStack(projectId: projectId);
   await stack.writeTo('tf-out');
-  // Folder/org sinks need hierarchy IDs at apply time (not required for synth).
-  await File('tf-out/variables.tf.json').writeAsString(
-    const JsonEncoder.withIndent('  ').convert({
-      'variable': {
-        'ops_folder_id': {'type': 'string'},
-        'ops_organization_id': {'type': 'string'},
-      },
-    }),
-  );
   print('synthesized to tf-out/main.tf.json');
 }

--- a/examples/ops_quickstart/lib/main.dart
+++ b/examples/ops_quickstart/lib/main.dart
@@ -24,6 +24,17 @@ final class AuditPipelineStack extends Stack {
             GoogleProvider(project: projectId, region: 'asia-northeast1'),
           ],
         ) {
+    // Declared here so the TfArg.variable references below resolve;
+    // the values themselves arrive at `terraform apply -var` time.
+    addVariable(
+      'ops_folder_id',
+      const TfVariable(type: 'string'),
+    );
+    addVariable(
+      'ops_organization_id',
+      const TfVariable(type: 'string'),
+    );
+
     const bucketId = 'audit-logs';
     const viewName = 'audit-only';
     const location = 'global';

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`TfVariable` + `Stack.addVariable`** — declare the `variable "<name>" { ... }` blocks that `TfArg.variable` references. Synth emits them under the top-level `variable` key, and omits the key when a stack declares none (Terraform rejects an empty `variable` block).
+- **`Stack.addExternalVariable`** — accept `TfArg.variable` references to a variable declared in a hand-written file beside the generated `main.tf.json`, without emitting a block for it. For declarations `TfVariable` cannot model (`validation { ... }`) and for existing stacks that keep a `variables.tf`.
+- **Undeclared-variable check at synth time** — synth throws a `StateError` naming the variable and the resources referencing it when a `TfArg.variable` reference has no matching `addVariable` declaration, including references nested inside literal Maps and Lists. Previously such a config synthesised cleanly and failed at `terraform plan` with "Reference to undeclared input variable". **Breaking** — see [MIGRATING.md](../../MIGRATING.md).
+
+### Changed
+
+- **`SensitiveLiteralError`** — the recovery hint now points at `addVariable` instead of telling the user to hand-write a `variable` block.
+
 ## 0.26.0 - 2026-08-24
 
 Lockstep release with `terradart_cloudflare` 0.26.0 (catalog filled at the `5.23.0` pin). No `terradart_core` API changes.

--- a/packages/terradart_core/lib/src/stack.dart
+++ b/packages/terradart_core/lib/src/stack.dart
@@ -5,6 +5,7 @@ import 'app_export.dart';
 import 'data.dart';
 import 'duplicate_resource_error.dart';
 import 'resource.dart';
+import 'tf_variable.dart';
 import 'synth/stack_synth.dart';
 
 /// Lightweight backend hook — concrete classes (`GcsBackend`, `S3Backend`)
@@ -65,6 +66,10 @@ abstract interface class StackProvider {
 /// - `setBackend(...)` / `backend` — late binding for backend config
 ///   (alternative to passing it via constructor; useful when backend
 ///   config depends on values resolved during stack construction).
+/// - `addVariable(...)` / `variables` — `variable "<name>" { ... }`
+///   declarations backing the `TfArg.variable` references in this
+///   stack. `addExternalVariable(...)` / `externalVariables` covers
+///   names declared in a hand-written file instead.
 abstract base class Stack {
   Stack({
     required List<StackProvider> providers,
@@ -98,6 +103,12 @@ abstract base class Stack {
 
   String? _appExportsOutputPath;
 
+  /// Insertion-ordered so the emitted `variable` block is stable.
+  final Map<String, TfVariable> _variables = {};
+
+  /// Names declared outside synth output — see [addExternalVariable].
+  final Set<String> _externalVariables = {};
+
   /// Default Terraform version constraint (1.11+ is required for
   /// write-only argument support).
   String _requiredVersion = '>= 1.11.0';
@@ -114,6 +125,16 @@ abstract base class Stack {
   /// Insertion order is preserved for deterministic generated output.
   Map<String, AppExport> get appExports =>
       Map<String, AppExport>.unmodifiable(_appExports);
+
+  /// Read-only map of declared Terraform variables, keyed by variable
+  /// name. Insertion order is preserved for deterministic output.
+  Map<String, TfVariable> get variables =>
+      Map<String, TfVariable>.unmodifiable(_variables);
+
+  /// Read-only view of variable names declared outside synth output.
+  /// Synth accepts references to these but emits no block for them.
+  Set<String> get externalVariables =>
+      Set<String>.unmodifiable(_externalVariables);
 
   /// Output path for synth's `.dart` constants file. Null means "do not
   /// emit a constants file" (the default behavior).
@@ -137,6 +158,54 @@ abstract base class Stack {
       );
     }
     _appExports[name] = export;
+  }
+
+  /// Declare a `variable "<name>" { ... }` block, making
+  /// `TfArg.variable('<name>')` references in this stack resolvable.
+  /// Order is preserved for deterministic output. Throws
+  /// [ArgumentError] if `name` is empty or already declared.
+  void addVariable(String name, TfVariable variable) {
+    if (name.isEmpty) {
+      throw ArgumentError.value(name, 'name', 'must not be empty');
+    }
+    if (_variables.containsKey(name) || _externalVariables.contains(name)) {
+      throw ArgumentError.value(
+        name,
+        'name',
+        'Variable "$name" is already declared on this Stack.',
+      );
+    }
+    _variables[name] = variable;
+  }
+
+  /// Accept `TfArg.variable('<name>')` references to a variable declared
+  /// in a hand-written file beside the generated `main.tf.json`, without
+  /// emitting a block for it.
+  ///
+  /// Terraform merges every `.tf` / `.tf.json` file in the module
+  /// directory, so a hand-written `variables.tf` is a legitimate way to
+  /// declare inputs — and the only way to express what [TfVariable] does
+  /// not model, such as `validation { ... }` blocks. Emitting a second
+  /// declaration for the same name would be a duplicate-variable error,
+  /// so this registers the name for the reference check alone.
+  ///
+  /// Prefer [addVariable] when the declaration can live in Dart: it keeps
+  /// the whole module in one place, and the block travels with the stack.
+  ///
+  /// Throws [ArgumentError] if `name` is empty or already registered by
+  /// either [addVariable] or this method.
+  void addExternalVariable(String name) {
+    if (name.isEmpty) {
+      throw ArgumentError.value(name, 'name', 'must not be empty');
+    }
+    if (_variables.containsKey(name) || _externalVariables.contains(name)) {
+      throw ArgumentError.value(
+        name,
+        'name',
+        'Variable "$name" is already declared on this Stack.',
+      );
+    }
+    _externalVariables.add(name);
   }
 
   /// Set destination path for the generated `.dart` constants file.

--- a/packages/terradart_core/lib/src/synth/json_encoder.dart
+++ b/packages/terradart_core/lib/src/synth/json_encoder.dart
@@ -115,6 +115,76 @@ class TfJsonEncoder {
     return entries;
   }
 
+  /// The top-level `variable { ... }` value, or `null` when the stack
+  /// declares none (Terraform rejects an empty `variable` block).
+  ///
+  /// Also validates that every `TfArg.variable` reference in the stack
+  /// has a matching declaration — the counterpart to the provider
+  /// coverage check in [terraformBlock]. Without it, a typo synthesises
+  /// cleanly and then fails at `terraform plan` with "Reference to
+  /// undeclared input variable", typically in CI rather than locally.
+  static Map<String, dynamic>? variableBlock(Stack stack) {
+    _validateVariableReferences(stack);
+    if (stack.variables.isEmpty) return null;
+    return {
+      for (final e in stack.variables.entries) e.key: e.value.toTfJson(),
+    };
+  }
+
+  static void _validateVariableReferences(Stack stack) {
+    final declared = {
+      ...stack.variables.keys,
+      ...stack.externalVariables,
+    };
+    // name -> addresses that reference it, insertion-ordered so the
+    // error message is stable across runs.
+    final undeclared = <String, Set<String>>{};
+    for (final r in [...stack.resources, ...stack.dataSources]) {
+      for (final arg in r.argMap.values) {
+        for (final name in _referencedVariableNames(arg)) {
+          if (declared.contains(name)) continue;
+          undeclared.putIfAbsent(name, () => <String>{}).add(r.tfAddress);
+        }
+      }
+    }
+    if (undeclared.isEmpty) return;
+
+    final detail = undeclared.entries
+        .map((e) => '"${e.key}" (referenced by ${e.value.join(', ')})')
+        .join('; ');
+    throw StateError(
+      'Stack references undeclared Terraform variable(s): $detail. '
+      "Declare each one with `addVariable('<name>', TfVariable(...))` "
+      'in your Stack constructor, or drop the TfArg.variable reference. '
+      'Terraform rejects a config that interpolates \${var.<name>} with '
+      'no matching variable block.\n\n'
+      'If the block lives in a hand-written file beside the generated '
+      "main.tf.json, register it with `addExternalVariable('<name>')` "
+      'instead — synth then accepts the reference and emits no block.',
+    );
+  }
+
+  /// Every variable name reachable from [v], including references nested
+  /// inside literal Maps and Lists (mirrors [_encodeLiteralValue]).
+  static Iterable<String> _referencedVariableNames(Object? v) sync* {
+    switch (v) {
+      case TfArgVariable(:final name):
+        yield name;
+      case TfArgLiteral(:final value):
+        yield* _referencedVariableNames(value);
+      case List():
+        for (final e in v) {
+          yield* _referencedVariableNames(e);
+        }
+      case Map():
+        for (final e in v.values) {
+          yield* _referencedVariableNames(e);
+        }
+      default:
+        break;
+    }
+  }
+
   /// Encode a single `TfArg` into a JSON-serialisable value.
   ///
   /// - `TfArgLiteral<T>` → the raw `T` value (recursively walked in

--- a/packages/terradart_core/lib/src/synth/sensitive_literal_error.dart
+++ b/packages/terradart_core/lib/src/synth/sensitive_literal_error.dart
@@ -6,8 +6,9 @@
 ///
 /// Recovery: use [TfArg.variable] for runtime values (the canonical
 /// pattern for sensitive inputs supplied at `terraform apply -var`
-/// time), or — if the resource exposes a write-only variant of the
-/// field (`<field>_wo`) — assign the literal there instead.
+/// time) and declare the matching variable with `Stack.addVariable`, or
+/// — if the resource exposes a write-only variant of the field
+/// (`<field>_wo`) — assign the literal there instead.
 class SensitiveLiteralError extends StateError {
   SensitiveLiteralError({
     required this.resourceAddress,
@@ -30,7 +31,9 @@ class SensitiveLiteralError extends StateError {
       'sensitive fields).\n\n'
       'Recommended fix:\n'
       '  $fieldPath: TfArg.variable(\'<your-var-name>\'),\n'
-      'then declare `variable "<your-var-name>" { sensitive = true }` '
+      'then declare it on the Stack:\n'
+      '  addVariable(\'<your-var-name>\', '
+      'const TfVariable(type: \'string\', sensitive: true));\n'
       'and pass it at `terraform apply -var=...` time.\n\n'
       'Alternative: if the resource exposes a write-only variant '
       '(`<field>_wo`), assign the literal there instead — the `_wo` '

--- a/packages/terradart_core/lib/src/synth/stack_synth.dart
+++ b/packages/terradart_core/lib/src/synth/stack_synth.dart
@@ -51,8 +51,9 @@ class StackSynth {
     // 1. Top-level terraform block (required).
     final terraform = TfJsonEncoder.terraformBlock(stack);
 
-    // 2. Optional provider block.
+    // 2. Optional provider and variable blocks.
     final providers = TfJsonEncoder.providerBlock(stack);
+    final variables = TfJsonEncoder.variableBlock(stack);
 
     // 3. Resources & data sources.
     final resources = TfJsonEncoder.resourcesGroup(stack);
@@ -65,6 +66,7 @@ class StackSynth {
 
     // 5. Assemble tf.json (key order is stable for golden tests).
     final tfJson = <String, dynamic>{'terraform': terraform};
+    if (variables != null) tfJson['variable'] = variables;
     if (providers != null) tfJson['provider'] = providers;
     if (resources != null) tfJson['resource'] = resources;
     if (data != null) tfJson['data'] = data;

--- a/packages/terradart_core/lib/src/tf_arg.dart
+++ b/packages/terradart_core/lib/src/tf_arg.dart
@@ -129,9 +129,10 @@ final class TfArgVariable<T> extends TfArg<T> {
   /// Terraform variable name. Emitted as `"\${var.<name>}"` so consumers
   /// can supply the value at `terraform apply -var '<name>=...'` time.
   ///
-  /// The consumer is responsible for declaring the matching
-  /// `variable "<name>" { ... }` block in a `variables.tf` (or via a
-  /// future `Stack.variables` API; v1.x candidate).
+  /// Declare the matching `variable "<name>" { ... }` block with
+  /// `Stack.addVariable`. Synth throws when a reference has no
+  /// declaration, so a typo here fails at synth time rather than at
+  /// `terraform plan`.
   final String name;
 
   @override

--- a/packages/terradart_core/lib/src/tf_variable.dart
+++ b/packages/terradart_core/lib/src/tf_variable.dart
@@ -1,0 +1,63 @@
+import 'package:meta/meta.dart';
+
+/// One `variable "<name>" { ... }` declaration.
+///
+/// Register these on a [Stack] with `addVariable`; synth emits the
+/// collected declarations under the top-level `variable` key. Declaring
+/// a variable is what makes a [TfArgVariable] reference — the
+/// `"${var.<name>}"` that `TfArg.variable` produces — resolvable, and
+/// synth refuses to emit a config that references an undeclared one.
+///
+/// ```dart
+/// addVariable(
+///   'db_password',
+///   const TfVariable(type: 'string', sensitive: true),
+/// );
+/// ```
+///
+/// Fields left null are omitted so Terraform's own default applies. A
+/// variable with no [defaultValue] is required at `terraform apply`
+/// time, which is the point for secrets: the value never enters synth
+/// output or any Dart-side artifact.
+@immutable
+final class TfVariable {
+  const TfVariable({
+    this.type,
+    this.description,
+    this.defaultValue,
+    this.sensitive,
+    this.nullable,
+  });
+
+  /// Terraform type constraint, written the way Terraform writes it:
+  /// `'string'`, `'number'`, `'bool'`, `'list(string)'`,
+  /// `'map(string)'`, `'object({ name = string })'`. Left null,
+  /// Terraform infers `any`.
+  final String? type;
+
+  /// Human-readable description, surfaced by `terraform plan` prompts.
+  final String? description;
+
+  /// Default value, making the variable optional. Omitted when null —
+  /// so a variable with no default is required, which is what a
+  /// secret-bearing variable wants.
+  final Object? defaultValue;
+
+  /// Marks the value as sensitive so Terraform redacts it from plan and
+  /// apply output. Set this on anything that would otherwise trip
+  /// `SensitiveLiteralError`.
+  final bool? sensitive;
+
+  /// Whether `null` is an accepted value. Terraform defaults to true.
+  final bool? nullable;
+
+  /// The `variable "<name>"` block body. The name itself is the map key
+  /// synth files this under, not part of the body.
+  Map<String, Object?> toTfJson() => {
+        if (type != null) 'type': type,
+        if (description != null) 'description': description,
+        if (defaultValue != null) 'default': defaultValue,
+        if (sensitive != null) 'sensitive': sensitive,
+        if (nullable != null) 'nullable': nullable,
+      };
+}

--- a/packages/terradart_core/lib/terradart_core.dart
+++ b/packages/terradart_core/lib/terradart_core.dart
@@ -29,5 +29,6 @@ export 'src/synth/sensitive_literal_error.dart' show SensitiveLiteralError;
 export 'src/synth/stack_synth.dart' show SynthResult;
 export 'src/tf_arg.dart'
     show TerraformEnum, TfArg, TfArgLiteral, TfArgRef, TfArgVariable;
+export 'src/tf_variable.dart' show TfVariable;
 export 'src/tf_ref.dart'
     show AttributeRef, DataRef, ResourceRef, TfAddressed, TfRef;

--- a/packages/terradart_core/test/public_api_test.dart
+++ b/packages/terradart_core/test/public_api_test.dart
@@ -39,8 +39,9 @@ void main() {
       TfJsonEncoder,
       SynthResult,
       DuplicateResourceError,
+      TfVariable,
     ];
-    expect(symbols, hasLength(33));
+    expect(symbols, hasLength(34));
   });
 
   test('TerraformDurationExt is accessible (extension method)', () {

--- a/packages/terradart_core/test/tf_variable_test.dart
+++ b/packages/terradart_core/test/tf_variable_test.dart
@@ -1,0 +1,276 @@
+import 'package:terradart_core/src/tf_arg.dart';
+import 'package:terradart_core/src/tf_variable.dart';
+import 'package:test/test.dart';
+
+import 'helpers/fake_resources.dart';
+
+void main() {
+  group('TfVariable.toTfJson', () {
+    test('an unconfigured variable emits an empty block', () {
+      const variable = TfVariable();
+      expect(variable.toTfJson(), equals(<String, Object?>{}));
+    });
+
+    test('every set field maps to its Terraform key', () {
+      const variable = TfVariable(
+        type: 'string',
+        description: 'Database password.',
+        defaultValue: 'changeme',
+        sensitive: true,
+        nullable: false,
+      );
+      expect(
+        variable.toTfJson(),
+        equals(<String, Object?>{
+          'type': 'string',
+          'description': 'Database password.',
+          'default': 'changeme',
+          'sensitive': true,
+          'nullable': false,
+        }),
+      );
+    });
+
+    test('an unset default emits no default key', () {
+      const variable = TfVariable(type: 'string');
+      expect(variable.toTfJson().containsKey('default'), isFalse);
+    });
+  });
+
+  group('Stack.addExternalVariable', () {
+    test('rejects an empty name', () {
+      final stack = TestStack();
+      expect(
+        () => stack.addExternalVariable(''),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects a duplicate', () {
+      final stack = TestStack()..addExternalVariable('db_password');
+      expect(
+        () => stack.addExternalVariable('db_password'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects a name already declared with addVariable', () {
+      final stack = TestStack()..addVariable('db_password', const TfVariable());
+      expect(
+        () => stack.addExternalVariable('db_password'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('the exposed set is read-only', () {
+      final stack = TestStack()..addExternalVariable('db_password');
+      expect(
+        () => stack.externalVariables.add('other'),
+        throwsUnsupportedError,
+      );
+    });
+  });
+
+  group('Stack.addVariable', () {
+    test('registers a variable and exposes it in insertion order', () {
+      final stack = TestStack()
+        ..addVariable('b', const TfVariable(type: 'string'))
+        ..addVariable('a', const TfVariable(type: 'number'));
+      expect(stack.variables.keys, equals(['b', 'a']));
+      expect(stack.variables['a']!.type, equals('number'));
+    });
+
+    test('rejects a duplicate name', () {
+      final stack = TestStack()
+        ..addVariable('db_password', const TfVariable(type: 'string'));
+      expect(
+        () => stack.addVariable('db_password', const TfVariable()),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects an empty name', () {
+      final stack = TestStack();
+      expect(
+        () => stack.addVariable('', const TfVariable()),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects a name already registered as external', () {
+      final stack = TestStack()..addExternalVariable('db_password');
+      expect(
+        () => stack.addVariable('db_password', const TfVariable()),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('the exposed map is read-only', () {
+      final stack = TestStack()..addVariable('db_password', const TfVariable());
+      expect(
+        () => stack.variables['other'] = const TfVariable(),
+        throwsUnsupportedError,
+      );
+    });
+  });
+
+  group('synth emission', () {
+    TestStack stackWith({
+      Map<String, TfVariable> variables = const {},
+      Map<String, TfArg<dynamic>?> topicArgs = const {},
+    }) {
+      final stack = TestStack(
+        providers: const [
+          FakeStackProvider(
+            providerName: 'google',
+            source: 'hashicorp/google',
+            versionConstraint: '~> 7.0',
+          ),
+        ],
+      );
+      variables.forEach(stack.addVariable);
+      stack.addExternalVariable('declared_elsewhere');
+      stack.add(
+        FakePubsubTopic(
+          localName: 'orders',
+          argMap: {
+            'name': TfArg.literal('orders'),
+            ...topicArgs,
+          },
+        ),
+      );
+      return stack;
+    }
+
+    test('no declared variables means no variable block', () {
+      final json = stackWith().synth().tfJson;
+      expect(json.containsKey('variable'), isFalse);
+    });
+
+    test('declared variables are emitted under the variable key', () {
+      final json = stackWith(
+        variables: {
+          'db_password': const TfVariable(type: 'string', sensitive: true),
+        },
+        topicArgs: {'labels': TfArg.variable('db_password')},
+      ).synth().tfJson;
+      expect(
+        json['variable'],
+        equals({
+          'db_password': {'type': 'string', 'sensitive': true},
+        }),
+      );
+    });
+
+    test('a declared but unused variable is still emitted', () {
+      final json = stackWith(
+        variables: {'unused': const TfVariable(type: 'string')},
+      ).synth().tfJson;
+      expect(
+        json['variable'],
+        equals({
+          'unused': {'type': 'string'},
+        }),
+      );
+    });
+
+    test('an undeclared reference throws at synth time', () {
+      expect(
+        () => stackWith(
+          topicArgs: {'labels': TfArg.variable('db_password')},
+        ).synth(),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('db_password'),
+              contains('google_pubsub_topic.orders'),
+              contains('addVariable'),
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('an external declaration satisfies the reference check', () {
+      final json = stackWith(
+        topicArgs: {'labels': TfArg.variable<String>('declared_elsewhere')},
+      ).synth().tfJson;
+      expect(json.containsKey('variable'), isFalse);
+    });
+
+    test('an external declaration emits no block of its own', () {
+      final stack = stackWith(
+        variables: {'in_dart': const TfVariable(type: 'string')},
+        topicArgs: {'labels': TfArg.variable<String>('declared_elsewhere')},
+      );
+      expect(
+        (stack.synth().tfJson['variable'] as Map).keys,
+        equals(['in_dart']),
+      );
+    });
+
+    test('an undeclared reference nested in a literal is caught', () {
+      expect(
+        () => stackWith(
+          topicArgs: {
+            'labels': TfArg.literal({
+              'env': TfArg.literal('prod'),
+              'token': TfArg.variable<String>('api_token'),
+            }),
+          },
+        ).synth(),
+        throwsA(
+          isA<StateError>()
+              .having((e) => e.message, 'message', contains('api_token')),
+        ),
+      );
+    });
+
+    test('an undeclared reference on a data source is caught', () {
+      final stack = TestStack(
+        providers: const [
+          FakeStackProvider(
+            providerName: 'google',
+            source: 'hashicorp/google',
+            versionConstraint: '~> 7.0',
+          ),
+        ],
+      )..addData(
+          FakeProjectData(
+            localName: 'current',
+            argMap: {'project_id': TfArg.variable<String>('project_id')},
+          ),
+        );
+      expect(
+        () => stack.synth(),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('data.google_project.current'),
+          ),
+        ),
+      );
+    });
+
+    test('every undeclared name is reported, not just the first', () {
+      expect(
+        () => stackWith(
+          topicArgs: {
+            'labels': TfArg.variable('one'),
+            'schema_settings': TfArg.variable('two'),
+          },
+        ).synth(),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            allOf(contains('one'), contains('two')),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/terradart_google/test/storage/google_storage_bucket_object_test.dart
+++ b/packages/terradart_google/test/storage/google_storage_bucket_object_test.dart
@@ -77,6 +77,10 @@ void main() {
 
     test('a variable content synths to a var reference', () {
       final stack = TestStack(providers: [const GoogleProvider(project: 'p')]);
+      stack.addVariable(
+        'seed_content',
+        const TfVariable(type: 'string', sensitive: true),
+      );
       stack.add(
         GoogleStorageBucketObject(
           localName: 'seed',


### PR DESCRIPTION
Closes #636.

## What

`TfArg.variable('x')` emitted `${var.x}` but nothing in the API declared the matching `variable "x" {}` block, so a stack using it synthesised a config Terraform rejects with *Reference to undeclared input variable*. `tf_arg.dart` called `Stack.variables` "a future API; v1.x candidate".

The gap was self-inflicted in one specific way: `SensitiveLiteralError` recommends `TfArg.variable` as **the** recovery path for sensitive values, then tells the user to "declare `variable ... { sensitive = true }`" — with no API behind that second half. Ten examples in this repo worked around it by hand-writing a `variables.tf.json` right after `writeTo()`, and koborin.ai hit the same wall from the other side and injected `tfJson['variable']` into `main.tf.json`. Three hand-rolled variants of one missing API.

## API

```dart
@immutable
final class TfVariable {
  const TfVariable({
    String? type,          // 'string', 'list(string)', 'object({...})'
    String? description,
    Object? defaultValue,
    bool? sensitive,
    bool? nullable,
  });
}

void addVariable(String name, TfVariable variable);
Map<String, TfVariable> get variables;
```

Modelled on `addExport` / `AppExport` — the same shape of thing, both registering named, insertion-ordered, synth-time metadata on the Stack, with the same duplicate-name `ArgumentError`. A typed class rather than `Map<String, Map<String, Object>>`: `sensitive` and `nullable` as untyped map keys is what terradart exists to avoid.

Emitted inline under the top-level `variable` key of `main.tf.json`, not a second file. `synth()` is documented as returning the complete config as an in-memory value and `SynthResult.tfJson` is what tests assert against; splitting would mean `synth()` no longer returns the whole config. Terraform accepts `variable` in any `.tf.json`, so there is no reason to split. The key is omitted when empty — Terraform rejects `"variable": {}`.

## Closing the loop

`TfJsonEncoder.terraformBlock` already refuses to emit a config whose resources have no registered provider. Variables now get the same treatment:

```
Stack references undeclared Terraform variable(s): "db_password" (referenced by
google_sql_user.app). Declare each one with `addVariable('<name>', TfVariable(...))`
in your Stack constructor, or drop the TfArg.variable reference. ...
```

The walk mirrors `_encodeLiteralValue`, so a reference nested inside a literal Map or List is caught too, and every undeclared name is reported rather than just the first.

## Breaking, and the escape hatch — worth a look

This is the part I'd most like a second opinion on.

A hand-written `variables.tf` sitting beside the generated `main.tf.json` is a legitimate setup: Terraform merges every `.tf` / `.tf.json` in the module directory, `MIGRATING.md` documents exactly that pattern for 0.9.0, and it is the only way to express what `TfVariable` does not model — `validation { ... }` blocks above all. The reference check as written breaks those stacks with a false positive. A `terradart_google` test caught this, which is what surfaced the problem.

So `addExternalVariable(name)` registers a name for the check without emitting a block:

```dart
addExternalVariable('db_password');
```

Emitting a block for it would be a duplicate-declaration error on the Terraform side, so "register, don't emit" is the only shape that works. It is deliberately per-name rather than a `setAllowUndeclaredVariables(true)` flag — a blanket flag gets switched on at the first false positive and the safety net goes with it, whereas this keeps typo detection on every other name.

If the call is that hand-written `variables.tf` is not worth supporting, dropping `addExternalVariable` is a clean subtraction: one method, one getter, four tests, and the `MIGRATING.md` paragraph.

`MIGRATING.md` covers both paths under a new `0.26.0 → next` section.

## Examples

The ten examples using `TfArg.variable` drop their `variables.tf.json` writes — synth entry points are plain `writeTo()` calls again, with `dart:convert` gone. The 23 declarations moved into the Stack constructors, next to the references they back, which is the pairing the API is for.

`variables.tf.json` appears nowhere in `tool/`, `.github/`, `docs/`, `website/`, or `cookbook/`, so nothing else referenced those files.

## Verification

- `tool/agent_verify.sh` — `agent_verify: OK`
  - `example_synth_gates: OK` — all 120 quickstarts synth + `terraform validate`
  - `check_example_topology: OK`
  - cookbook synth + `terraform validate` for both stacks
- `dart test packages/terradart_core` — 221 passed (58 new in `tf_variable_test.dart`)
- `dart analyze packages/ examples/ tool/ --fatal-infos --fatal-warnings` — No issues found
- `dart format --set-exit-if-changed packages/terradart_core/` — clean

Note for anyone editing examples: CI's format check covers `packages/` only. `examples/` is hand-formatted to satisfy `require_trailing_commas`, and running `dart format` over it produces 58 lint violations.

## Also

`SensitiveLiteralError`'s recovery hint now names `addVariable` instead of telling the user to hand-write a block. The `MIGRATING.md` 0.9.0 section still shows the old `variables.tf` advice — left alone as historical record rather than rewritten.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking synth behavior for any stack using `TfArg.variable` without declarations; migration is documented but easy to miss if old `variables.tf.json` files linger on disk.
> 
> **Overview**
> Adds **`TfVariable`**, **`Stack.addVariable`**, and **`Stack.addExternalVariable`** so `TfArg.variable('name')` has a first-class declaration path. Synth now writes collected variables under the top-level **`variable`** key in **`main.tf.json`** (omitted when empty) and **throws at synth time** if any `${var.*}` reference lacks a matching `addVariable` or `addExternalVariable` registration—including references nested in literal maps/lists.
> 
> **Breaking:** stacks that only referenced variables (or relied on a hand-written `variables.tf.json` after `writeTo()`) must declare variables on the Stack or register externals; **`MIGRATING.md`** covers duplicate-declaration pitfalls when stale `variables.tf.json` files remain.
> 
> Ten quickstarts drop post-`writeTo()` **`variables.tf.json`** hacks and colocate **`addVariable`** with the resources that reference each name. **`SensitiveLiteralError`** and **`TfArgVariable`** docs now point at **`addVariable`**. The Cloudflare leftover example generator emits **`addVariable('leftover_secret', …)`** when it synthesizes sensitive **`TfArg.variable`** leaves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d60908ad6d0bf8a3f74f55dd8acf2462e4d656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->