### PR TITLE
ci(executors): judge PRs from main and wait for merge state before merging

### DIFF
--- a/.cursor/agents/schema-bump-postprocess.md
+++ b/.cursor/agents/schema-bump-postprocess.md
@@ -104,10 +104,14 @@ it as a stalled handoff.
 
 `bump-merge.yml` reacts to `bump-approved` and independently re-verifies
 before squash-merging: branch pattern `chore/schema-bump-*`, same-repo head,
-every changed file inside `tool/bump_allowed_paths.yaml`, required checks
-green. Merging stays disarmed unless the `BUMP_MERGE_ENABLED` repository
-variable is `true`. A `bump-escalated` PR is maintainer work — humans may
-add commits, then re-label or merge manually.
+every changed file inside `tool/bump_allowed_paths.yaml` (checked with the
+ledger and checker from `main`, never from the PR), required checks green,
+and GitHub's merge state (a required check still queued behind the example
+matrix is waited for). It merges exactly the head it verified — a push after
+the label makes the merge refuse and comment; re-label to re-verify. Every
+non-merge outcome is a PR comment. Merging stays disarmed unless the
+`BUMP_MERGE_ENABLED` repository variable is `true`. A `bump-escalated` PR is
+maintainer work — humans may add commits, then re-label or merge manually.
 
 ## Hard rules
 

--- a/.cursor/agents/wave-shipper.md
+++ b/.cursor/agents/wave-shipper.md
@@ -219,13 +219,20 @@ sense when you know them:
 - `wave-open.yml` (PAT-authenticated so its label fires the executor) turns a
   `[wave-ready]` marker push into a ready PR + the `wave-approved` label,
   generating the PR body from your commit messages. A marker-less push only
-  creates/keeps a draft backup PR.
+  creates/keeps a draft backup PR. Every marker push re-applies the label,
+  so a repair round's `[wave-ready]` push re-runs the executor against the
+  new head.
 - `wave-merge.yml` independently re-verifies before merging: every changed
   file inside `tool/wave_allowed_paths.yaml` (`MIGRATING.md` / `CHANGELOG.md`
   / pubspecs / workflows are outside it, so only additive Waves auto-merge;
   the root pubspec is content-gated to workspace-member additions) and
-  required checks green. Live apply-smoke is retired; example verification
-  is synth + `terraform validate`.
+  required checks green. The ledger and checker come from `main`, never from
+  your branch. After required checks it also waits for GitHub's merge state
+  (a required check still queued behind the example matrix is waited for)
+  and merges exactly the head it verified; a push after the label makes the
+  merge refuse and comment, and your next `[wave-ready]` push re-verifies.
+  Every non-merge outcome is a PR comment. Live apply-smoke is retired;
+  example verification is synth + `terraform validate`.
 - If the branch is BEHIND at merge time, the executor updates it and
   re-dispatches itself once (depth-capped).
 - Merging stays disarmed unless the `WAVE_MERGE_ENABLED` repository variable

--- a/.github/workflows/bump-merge.yml
+++ b/.github/workflows/bump-merge.yml
@@ -64,11 +64,11 @@ jobs:
     steps:
       # On pull_request_target the default ref is the BASE branch. Keep it
       # that way: the ledger and checker must never come from the PR. Full
-      # (blobless) history so the pinned head can be diffed against main.
+      # history so the pinned head can be diffed against main offline (no
+      # blob filter: an on-demand blob fetch is one more way to fail).
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          filter: blob:none
 
       - uses: dart-lang/setup-dart@v1
         with:

--- a/.github/workflows/bump-merge.yml
+++ b/.github/workflows/bump-merge.yml
@@ -159,7 +159,9 @@ jobs:
 
       - name: Wait for merge state
         id: merge_state
-        if: steps.verify.outputs.verdict == 'pass' && steps.checks.outputs.exit == '0'
+        # success() is the implicit default, spelled out: this must never run
+        # after an earlier step errored.
+        if: ${{ success() && steps.verify.outputs.verdict == 'pass' && steps.checks.outputs.exit == '0' }}
         env:
           GH_TOKEN: ${{ secrets.SCHEMA_BUMP_PAT }}
           PR: ${{ steps.pr.outputs.number }}
@@ -207,6 +209,7 @@ jobs:
           HEAD_SHA: ${{ steps.verify.outputs.head_sha }}
           CHECKS_EXIT: ${{ steps.checks.outputs.exit }}
           STATE: ${{ steps.merge_state.outputs.state }}
+          STATE_OUTCOME: ${{ steps.merge_state.outcome }}
           DRY_RUN: ${{ steps.pr.outputs.dry_run }}
         run: |
           set -euo pipefail
@@ -216,6 +219,12 @@ jobs:
           fi
           if [ "$CHECKS_EXIT" != "0" ]; then
             gh pr comment "$PR" --body "**bump-merge:** NOT merging — required checks did not finish green (gh pr checks exit ${CHECKS_EXIT})."
+            exit 1
+          fi
+          # Outputs alone are not enough: a gate step that errored after
+          # writing an output must still block the merge.
+          if [ "$STATE_OUTCOME" != "success" ]; then
+            gh pr comment "$PR" --body "**bump-merge:** NOT merging — the merge-state wait did not complete (${STATE_OUTCOME:-skipped}); see the workflow log."
             exit 1
           fi
           case "$STATE" in

--- a/.github/workflows/bump-merge.yml
+++ b/.github/workflows/bump-merge.yml
@@ -13,9 +13,11 @@ name: bump-merge
 # from the BASE branch (main), never from the PR under judgment. Under
 # plain pull_request the PR supplied its own ledger and checker, so one
 # push could widen the scope it was judged by. The job never checks out
-# or runs PR code: changed files come from the API, and the head SHA
-# verified here is pinned at merge time (--match-head-commit), so a push
-# after verification cannot ride an earlier verdict.
+# or runs PR code: it pins the head SHA, fetches that commit and only READS
+# its trees to diff them against main (the pulls/files API reflects the
+# live head and cannot bind a verdict to a SHA), then merges exactly that
+# SHA (--match-head-commit), so a push after verification cannot ride an
+# earlier verdict.
 #
 # Merge state: `gh pr checks --required` only sees check runs that already
 # exist. A required job queued behind `needs:` (the terraform validate
@@ -61,8 +63,12 @@ jobs:
     timeout-minutes: 45
     steps:
       # On pull_request_target the default ref is the BASE branch. Keep it
-      # that way: the ledger and checker must never come from the PR.
+      # that way: the ledger and checker must never come from the PR. Full
+      # (blobless) history so the pinned head can be diffed against main.
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: blob:none
 
       - uses: dart-lang/setup-dart@v1
         with:
@@ -119,15 +125,16 @@ jobs:
           esac
           cross=$(gh pr view "$PR" --json isCrossRepository -q .isCrossRepository)
           [ "$cross" = "false" ] || fail "cross-repository PR"
-          # Pin the head this verdict is about BEFORE listing files; the
-          # merge step refuses any other head (--match-head-commit).
+          # Pin the head this verdict is about. Every content check below is
+          # computed from THIS SHA, and the merge step refuses any other head
+          # (--match-head-commit). The pulls/files API has no commit
+          # parameter — it always reflects the live head — so it cannot bind
+          # a verdict to a SHA; diff the pinned commit against main locally.
+          # The PR's trees are only read, never checked out or executed.
           head_sha=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-          # NOT `gh pr diff --name-only`: bump PRs carry a huge schema.json
-          # diff and trip the API's 20k-line limit (HTTP 406). The files
-          # endpoint lists names without diff bodies and paginates.
-          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/files" \
-            --paginate --jq '.[].filename' > /tmp/changed.txt
+          git fetch -q origin "$head_sha"
+          git diff --no-renames --name-only "origin/main...$head_sha" > /tmp/changed.txt
           head_now=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
           [ "$head_now" = "$head_sha" ] \
             || fail "head moved during verification (${head_sha:0:7} -> ${head_now:0:7}); re-label bump-approved to re-verify"

--- a/.github/workflows/bump-merge.yml
+++ b/.github/workflows/bump-merge.yml
@@ -3,16 +3,34 @@ name: bump-merge
 # Merge executor for the schema-bump post-process agent. The agent judges
 # and labels (bump-approved); this workflow INDEPENDENTLY re-verifies —
 # branch pattern, same-repo head, changed-file scope ledger, required
-# checks — and only then squash-merges. The agent holds no merge power.
-# Staged rollout: merging is disarmed (verify + comment only) until the
-# repository variable BUMP_MERGE_ENABLED is 'true'.
+# checks, merge state — and only then squash-merges the exact head it
+# verified. The agent holds no merge power. Staged rollout: merging is
+# disarmed (verify + comment only) until the repository variable
+# BUMP_MERGE_ENABLED is 'true'.
+#
+# Trust boundary: the job runs on pull_request_target, so this file,
+# tool/check_bump_scope.dart and tool/bump_allowed_paths.yaml are taken
+# from the BASE branch (main), never from the PR under judgment. Under
+# plain pull_request the PR supplied its own ledger and checker, so one
+# push could widen the scope it was judged by. The job never checks out
+# or runs PR code: changed files come from the API, and the head SHA
+# verified here is pinned at merge time (--match-head-commit), so a push
+# after verification cannot ride an earlier verdict.
+#
+# Merge state: `gh pr checks --required` only sees check runs that already
+# exist. A required job queued behind `needs:` (the terraform validate
+# gate waits for the example matrix) is invisible until it starts, so the
+# executor also waits for GitHub's own mergeStateStatus to leave BLOCKED
+# before merging. Without that wait `gh pr merge` fails on branch
+# protection and the PR strands with no comment (PR #643, 2026-08-31).
+# Every non-merge outcome posts a comment.
 #
 # Injection hygiene: every ${{ }} value consumed by a run: step goes
 # through env: (never inline interpolation) — the verify reason embeds the
 # head branch name, which is contributor-controlled input.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
   workflow_dispatch:
     inputs:
@@ -42,6 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      # On pull_request_target the default ref is the BASE branch. Keep it
+      # that way: the ledger and checker must never come from the PR.
       - uses: actions/checkout@v6
 
       - uses: dart-lang/setup-dart@v1
@@ -99,11 +119,18 @@ jobs:
           esac
           cross=$(gh pr view "$PR" --json isCrossRepository -q .isCrossRepository)
           [ "$cross" = "false" ] || fail "cross-repository PR"
+          # Pin the head this verdict is about BEFORE listing files; the
+          # merge step refuses any other head (--match-head-commit).
+          head_sha=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
           # NOT `gh pr diff --name-only`: bump PRs carry a huge schema.json
           # diff and trip the API's 20k-line limit (HTTP 406). The files
           # endpoint lists names without diff bodies and paginates.
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/files" \
             --paginate --jq '.[].filename' > /tmp/changed.txt
+          head_now=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
+          [ "$head_now" = "$head_sha" ] \
+            || fail "head moved during verification (${head_sha:0:7} -> ${head_now:0:7}); re-label bump-approved to re-verify"
           if dart tool/check_bump_scope.dart < /tmp/changed.txt > /tmp/scope.txt 2>&1; then
             cat /tmp/scope.txt
             echo "verdict=pass" >> "$GITHUB_OUTPUT"
@@ -123,27 +150,88 @@ jobs:
           gh pr checks "$PR" --required --watch --interval 60
           echo "exit=$?" >> "$GITHUB_OUTPUT"
 
+      - name: Wait for merge state
+        id: merge_state
+        if: steps.verify.outputs.verdict == 'pass' && steps.checks.outputs.exit == '0'
+        env:
+          GH_TOKEN: ${{ secrets.SCHEMA_BUMP_PAT }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          # Required checks still queued behind `needs:` are invisible to
+          # `gh pr checks`; branch protection still counts them. Poll until
+          # GitHub itself reports the PR mergeable (or definitively not).
+          deadline=$((SECONDS + 1200))
+          while :; do
+            # A transient API error must not end the step (and skip the
+            # comment); treat it like UNKNOWN and poll again.
+            state=$(gh pr view "$PR" --json mergeStateStatus -q .mergeStateStatus) || state=UNKNOWN
+            case "$state" in
+              CLEAN|UNSTABLE|HAS_HOOKS|BEHIND|DIRTY)
+                echo "state=$state" >> "$GITHUB_OUTPUT"
+                exit 0 ;;
+            esac
+            # BLOCKED / UNKNOWN: a late required check may have failed.
+            set +e
+            gh pr checks "$PR" --required > /dev/null 2>&1
+            rc=$?
+            set -e
+            if [ "$rc" = "1" ]; then
+              echo "state=CHECKS_FAILED" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "state=TIMEOUT_${state}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "mergeStateStatus=$state (gh pr checks rc=$rc); waiting for branch protection to settle"
+            sleep 30
+          done
+
       - name: Merge or report
+        # Runs even when an earlier step crashed (not via fail()), so a
+        # transient error still leaves a comment instead of a silent red run.
+        if: ${{ !cancelled() && steps.pr.outputs.number != '' }}
         env:
           GH_TOKEN: ${{ secrets.SCHEMA_BUMP_PAT }}
           PR: ${{ steps.pr.outputs.number }}
           VERDICT: ${{ steps.verify.outputs.verdict }}
           REASON: ${{ steps.verify.outputs.reason }}
+          HEAD_SHA: ${{ steps.verify.outputs.head_sha }}
           CHECKS_EXIT: ${{ steps.checks.outputs.exit }}
+          STATE: ${{ steps.merge_state.outputs.state }}
           DRY_RUN: ${{ steps.pr.outputs.dry_run }}
         run: |
           set -euo pipefail
           if [ "$VERDICT" != "pass" ]; then
-            gh pr comment "$PR" --body "**bump-merge:** NOT merging — ${REASON}."
+            gh pr comment "$PR" --body "**bump-merge:** NOT merging — ${REASON:-an earlier step failed before reaching a verdict; see the workflow log}."
             exit 1
           fi
           if [ "$CHECKS_EXIT" != "0" ]; then
             gh pr comment "$PR" --body "**bump-merge:** NOT merging — required checks did not finish green (gh pr checks exit ${CHECKS_EXIT})."
             exit 1
           fi
+          case "$STATE" in
+            CLEAN|UNSTABLE|HAS_HOOKS) ;;
+            BEHIND)
+              gh pr comment "$PR" --body "**bump-merge:** NOT merging — branch is BEHIND main (protection requires an up-to-date branch). Update it (\`gh pr update-branch ${PR}\`), wait for green, then re-label \`bump-approved\`."
+              exit 1 ;;
+            DIRTY)
+              gh pr comment "$PR" --body "**bump-merge:** NOT merging — merge conflict with main; human attention required."
+              exit 1 ;;
+            CHECKS_FAILED)
+              gh pr comment "$PR" --body "**bump-merge:** NOT merging — required checks are not green (a late check failed, or none are reported); see the Checks tab."
+              exit 1 ;;
+            *)
+              gh pr comment "$PR" --body "**bump-merge:** NOT merging — merge state did not settle (${STATE:-unknown}); a required check may still be queued. Re-label \`bump-approved\` once every check has reported."
+              exit 1 ;;
+          esac
           if [ "$DRY_RUN" = "true" ]; then
-            gh pr comment "$PR" --body "**bump-merge (dry run):** all verifications passed — branch pattern, same-repo head, scope ledger, required checks green. Merging is disarmed (BUMP_MERGE_ENABLED != true)."
+            gh pr comment "$PR" --body "**bump-merge (dry run):** all verifications passed — branch pattern, same-repo head, scope ledger, required checks green, merge state ${STATE}. Merging is disarmed (BUMP_MERGE_ENABLED != true)."
             exit 0
           fi
-          gh pr merge "$PR" --squash --delete-branch
-          gh pr comment "$PR" --body "**bump-merge:** verified (branch pattern, same-repo head, scope ledger, required checks green) and squash-merged."
+          if ! gh pr merge "$PR" --squash --delete-branch --match-head-commit "$HEAD_SHA"; then
+            gh pr comment "$PR" --body "**bump-merge:** NOT merging — \`gh pr merge\` was refused (the head moved after verification, or branch protection changed). Re-label \`bump-approved\` to re-verify the current head."
+            exit 1
+          fi
+          gh pr comment "$PR" --body "**bump-merge:** verified (branch pattern, same-repo head, scope ledger, required checks green, merge state ${STATE}) and squash-merged ${HEAD_SHA:0:7}."

--- a/.github/workflows/wave-merge.yml
+++ b/.github/workflows/wave-merge.yml
@@ -75,11 +75,11 @@ jobs:
     steps:
       # On pull_request_target the default ref is the BASE branch. Keep it
       # that way: the ledger and checker must never come from the PR. Full
-      # (blobless) history so the pinned head can be diffed against main.
+      # history so the pinned head can be diffed against main offline (no
+      # blob filter: an on-demand blob fetch is one more way to fail).
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          filter: blob:none
 
       - uses: dart-lang/setup-dart@v1
         with:
@@ -160,13 +160,23 @@ jobs:
           # listed as a workspace member; anything beyond `- examples/…`
           # additions (dependency edits, removals) must not auto-merge.
           if grep -qx 'pubspec.yaml' /tmp/changed.txt; then
-            # Same pinned SHA as the file list; `+++ `/`--- ` are the unified
-            # diff file headers, everything else starting with +/- is content.
-            if git diff "origin/main...$head_sha" -- pubspec.yaml \
-              | grep -E '^[+-]' | grep -vE '^(\+\+\+ |--- )' \
+            # Fail CLOSED. `git diff` runs on its own so its exit status is
+            # checked (inside an `if … | grep` pipeline a git error would look
+            # like "no disallowed lines" and pass). Same pinned SHA as the
+            # file list.
+            if ! git diff "origin/main...$head_sha" -- pubspec.yaml > /tmp/pubspec.diff; then
+              fail "git diff of pubspec.yaml at ${head_sha:0:7} failed"
+            fi
+            # Every line that is not a unified-diff header or a context line
+            # must be a workspace example addition; mode / rename / binary
+            # markers and any other +/- line fail. At least one addition must
+            # exist — an empty or header-only diff is not "clean".
+            if grep -vE '^(diff --git |index [0-9a-f]+\.\.[0-9a-f]+|--- |\+\+\+ |@@ | )' /tmp/pubspec.diff \
               | grep -vE '^\+  - examples/[a-z0-9_]+$' | grep -q .; then
               fail "pubspec.yaml diff contains more than workspace example additions"
             fi
+            grep -qE '^\+  - examples/[a-z0-9_]+$' /tmp/pubspec.diff \
+              || fail "pubspec.yaml is listed as changed but adds no workspace example"
             echo "pubspec.yaml diff: workspace example additions only"
           fi
           echo "verdict=pass" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/wave-merge.yml
+++ b/.github/workflows/wave-merge.yml
@@ -201,31 +201,44 @@ jobs:
           IGNORE: ${{ github.event.inputs.ignore_review_threads }}
         run: |
           set -euo pipefail
-          echo "verdict=pass" >> "$GITHUB_OUTPUT"
+          fail() {
+            echo "verdict=fail" >> "$GITHUB_OUTPUT"
+            echo "reason=$1" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
           if [ "$IGNORE" = "true" ]; then
             echo "review-thread gate skipped by dispatch input (human override)"
+            echo "verdict=pass" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           # CI green is not review clean: Bugbot findings arrive as review
           # threads, and the shipper's token cannot resolve them — but
           # Bugbot's re-review auto-resolves threads its fix push addressed,
           # so a fix-and-push loop self-heals this gate.
-          unresolved=$(gh api graphql \
+          # The pass verdict is written only after the query succeeded: a
+          # failed query is a failed gate, never a stale pass.
+          if ! unresolved=$(gh api graphql \
             -F owner="${GITHUB_REPOSITORY%%/*}" \
             -F name="${GITHUB_REPOSITORY##*/}" \
             -F pr="$PR" \
             -f query='query($owner:String!,$name:String!,$pr:Int!){repository(owner:$owner,name:$name){pullRequest(number:$pr){reviewThreads(first:100){nodes{isResolved comments(first:1){nodes{author{login}}}}}}}}' \
-            --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false and .comments.nodes[0].author.login=="cursor")] | length')
-          if [ "${unresolved:-0}" -gt 0 ]; then
-            echo "verdict=fail" >> "$GITHUB_OUTPUT"
-            echo "reason=$unresolved unresolved Bugbot finding(s) — fix and push (Bugbot's re-review auto-resolves addressed threads), or a human resolves the threads / re-dispatches with ignore_review_threads=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "no unresolved Bugbot threads"
+            --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false and .comments.nodes[0].author.login=="cursor")] | length'); then
+            fail "could not query review threads (GraphQL failed) — not merging"
           fi
+          case "$unresolved" in
+            ''|*[!0-9]*) fail "unexpected review-thread count '${unresolved}' — not merging" ;;
+          esac
+          if [ "$unresolved" -gt 0 ]; then
+            fail "$unresolved unresolved Bugbot finding(s) — fix and push (Bugbot's re-review auto-resolves addressed threads), or a human resolves the threads / re-dispatches with ignore_review_threads=true"
+          fi
+          echo "no unresolved Bugbot threads"
+          echo "verdict=pass" >> "$GITHUB_OUTPUT"
 
       - name: Wait for merge state
         id: merge_state
-        if: steps.verify.outputs.verdict == 'pass' && steps.checks.outputs.exit == '0' && steps.review.outputs.verdict == 'pass'
+        # success() is the implicit default, spelled out: this must never run
+        # after an earlier step errored.
+        if: ${{ success() && steps.verify.outputs.verdict == 'pass' && steps.checks.outputs.exit == '0' && steps.review.outputs.verdict == 'pass' }}
         env:
           GH_TOKEN: ${{ secrets.SCHEMA_BUMP_PAT }}
           PR: ${{ steps.pr.outputs.number }}
@@ -274,7 +287,9 @@ jobs:
           CHECKS_EXIT: ${{ steps.checks.outputs.exit }}
           REVIEW_VERDICT: ${{ steps.review.outputs.verdict }}
           REVIEW_REASON: ${{ steps.review.outputs.reason }}
+          REVIEW_OUTCOME: ${{ steps.review.outcome }}
           STATE: ${{ steps.merge_state.outputs.state }}
+          STATE_OUTCOME: ${{ steps.merge_state.outcome }}
           DRY_RUN: ${{ steps.pr.outputs.dry_run }}
           DEPTH: ${{ github.event.inputs.depth }}
           IGNORE: ${{ github.event.inputs.ignore_review_threads }}
@@ -290,7 +305,13 @@ jobs:
             exit 1
           fi
           if [ "$REVIEW_VERDICT" != "pass" ]; then
-            gh pr comment "$PR" --body "**wave-merge:** NOT merging — ${REVIEW_REASON}."
+            gh pr comment "$PR" --body "**wave-merge:** NOT merging — ${REVIEW_REASON:-the review-thread gate reached no verdict; see the workflow log}."
+            exit 1
+          fi
+          # Outputs alone are not enough: a gate step that errored after
+          # writing an output must still block the merge.
+          if [ "$REVIEW_OUTCOME" != "success" ] || [ "$STATE_OUTCOME" != "success" ]; then
+            gh pr comment "$PR" --body "**wave-merge:** NOT merging — a gate step did not complete (review-thread gate: ${REVIEW_OUTCOME:-skipped}, merge-state wait: ${STATE_OUTCOME:-skipped}); see the workflow log."
             exit 1
           fi
           case "$STATE" in

--- a/.github/workflows/wave-merge.yml
+++ b/.github/workflows/wave-merge.yml
@@ -14,9 +14,10 @@ name: wave-merge
 # from the BASE branch (main), never from the PR under judgment. Under
 # plain pull_request the PR supplied its own ledger and checker, so one
 # push could widen the scope it was judged by. The job never checks out
-# or runs PR code: changed files and the root-pubspec hunk come from the
-# API, and the head SHA verified here is pinned at merge time
-# (--match-head-commit), so a push after verification cannot ride an
+# or runs PR code: it pins the head SHA, fetches that commit and only READS
+# its trees to diff them against main (the pulls/files API reflects the
+# live head and cannot bind a verdict to a SHA), then merges exactly that
+# SHA (--match-head-commit), so a push after verification cannot ride an
 # earlier verdict.
 #
 # Merge state: `gh pr checks --required` only sees check runs that already
@@ -73,8 +74,12 @@ jobs:
     timeout-minutes: 45
     steps:
       # On pull_request_target the default ref is the BASE branch. Keep it
-      # that way: the ledger and checker must never come from the PR.
+      # that way: the ledger and checker must never come from the PR. Full
+      # (blobless) history so the pinned head can be diffed against main.
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: blob:none
 
       - uses: dart-lang/setup-dart@v1
         with:
@@ -131,12 +136,16 @@ jobs:
           esac
           cross=$(gh pr view "$PR" --json isCrossRepository -q .isCrossRepository)
           [ "$cross" = "false" ] || fail "cross-repository PR"
-          # Pin the head this verdict is about BEFORE listing files; the
-          # merge step refuses any other head (--match-head-commit).
+          # Pin the head this verdict is about. Every content check below is
+          # computed from THIS SHA, and the merge step refuses any other head
+          # (--match-head-commit). The pulls/files API has no commit
+          # parameter — it always reflects the live head — so it cannot bind
+          # a verdict to a SHA; diff the pinned commit against main locally.
+          # The PR's trees are only read, never checked out or executed.
           head_sha=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/files" \
-            --paginate --jq '.[].filename' > /tmp/changed.txt
+          git fetch -q origin "$head_sha"
+          git diff --no-renames --name-only "origin/main...$head_sha" > /tmp/changed.txt
           head_now=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
           [ "$head_now" = "$head_sha" ] \
             || fail "head moved during verification (${head_sha:0:7} -> ${head_now:0:7}); re-label wave-approved to re-verify"
@@ -151,15 +160,10 @@ jobs:
           # listed as a workspace member; anything beyond `- examples/…`
           # additions (dependency edits, removals) must not auto-merge.
           if grep -qx 'pubspec.yaml' /tmp/changed.txt; then
-            # Take the hunk from the API instead of fetching PR git objects:
-            # the executor never touches PR code, and a shallow checkout has
-            # no merge base to diff against anyway.
-            gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/files" --paginate \
-              --jq '.[] | select(.filename == "pubspec.yaml") | .patch // empty' \
-              > /tmp/pubspec.patch
-            [ -s /tmp/pubspec.patch ] \
-              || fail "pubspec.yaml changed but the API returned no patch for it"
-            if grep -E '^[+-]' /tmp/pubspec.patch \
+            # Same pinned SHA as the file list; `+++ `/`--- ` are the unified
+            # diff file headers, everything else starting with +/- is content.
+            if git diff "origin/main...$head_sha" -- pubspec.yaml \
+              | grep -E '^[+-]' | grep -vE '^(\+\+\+ |--- )' \
               | grep -vE '^\+  - examples/[a-z0-9_]+$' | grep -q .; then
               fail "pubspec.yaml diff contains more than workspace example additions"
             fi

--- a/.github/workflows/wave-merge.yml
+++ b/.github/workflows/wave-merge.yml
@@ -3,10 +3,29 @@ name: wave-merge
 # Merge executor for the wave-shipper agent. The agent implements a Wave
 # from the curation backlog and labels the PR (wave-approved); this
 # workflow INDEPENDENTLY re-verifies — branch pattern, same-repo head,
-# the Wave scope ledger (additive-only by construction), and required
-# checks — and only then squash-merges. The agent holds no merge power.
-# Staged rollout: merging is disarmed (verify + comment only) until the
-# repository variable WAVE_MERGE_ENABLED is 'true'.
+# the Wave scope ledger (additive-only by construction), required checks,
+# unresolved Bugbot threads, merge state — and only then squash-merges the
+# exact head it verified. The agent holds no merge power. Staged rollout:
+# merging is disarmed (verify + comment only) until the repository
+# variable WAVE_MERGE_ENABLED is 'true'.
+#
+# Trust boundary: the job runs on pull_request_target, so this file,
+# tool/check_bump_scope.dart and tool/wave_allowed_paths.yaml are taken
+# from the BASE branch (main), never from the PR under judgment. Under
+# plain pull_request the PR supplied its own ledger and checker, so one
+# push could widen the scope it was judged by. The job never checks out
+# or runs PR code: changed files and the root-pubspec hunk come from the
+# API, and the head SHA verified here is pinned at merge time
+# (--match-head-commit), so a push after verification cannot ride an
+# earlier verdict.
+#
+# Merge state: `gh pr checks --required` only sees check runs that already
+# exist. A required job queued behind `needs:` (the terraform validate
+# gate waits for the example matrix) is invisible until it starts, so the
+# executor also waits for GitHub's own mergeStateStatus to leave BLOCKED
+# before merging. Without that wait `gh pr merge` fails on branch
+# protection and the PR strands with no comment (PR #643, 2026-08-31).
+# Every non-merge outcome posts a comment.
 #
 # Live GCP apply-smoke is retired. Example verification is synth +
 # terraform validate (CI + agent_verify), not terraform apply.
@@ -15,7 +34,7 @@ name: wave-merge
 # through env: (never inline interpolation).
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
   workflow_dispatch:
     inputs:
@@ -53,6 +72,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      # On pull_request_target the default ref is the BASE branch. Keep it
+      # that way: the ledger and checker must never come from the PR.
       - uses: actions/checkout@v6
 
       - uses: dart-lang/setup-dart@v1
@@ -110,8 +131,15 @@ jobs:
           esac
           cross=$(gh pr view "$PR" --json isCrossRepository -q .isCrossRepository)
           [ "$cross" = "false" ] || fail "cross-repository PR"
+          # Pin the head this verdict is about BEFORE listing files; the
+          # merge step refuses any other head (--match-head-commit).
+          head_sha=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/files" \
             --paginate --jq '.[].filename' > /tmp/changed.txt
+          head_now=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
+          [ "$head_now" = "$head_sha" ] \
+            || fail "head moved during verification (${head_sha:0:7} -> ${head_now:0:7}); re-label wave-approved to re-verify"
           if dart tool/check_bump_scope.dart --ledger tool/wave_allowed_paths.yaml \
               < /tmp/changed.txt > /tmp/scope.txt 2>&1; then
             cat /tmp/scope.txt
@@ -123,10 +151,15 @@ jobs:
           # listed as a workspace member; anything beyond `- examples/…`
           # additions (dependency edits, removals) must not auto-merge.
           if grep -qx 'pubspec.yaml' /tmp/changed.txt; then
-            head_sha=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
-            git fetch -q origin main "$head_sha"
-            if git diff "origin/main...$head_sha" -- pubspec.yaml \
-              | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
+            # Take the hunk from the API instead of fetching PR git objects:
+            # the executor never touches PR code, and a shallow checkout has
+            # no merge base to diff against anyway.
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/files" --paginate \
+              --jq '.[] | select(.filename == "pubspec.yaml") | .patch // empty' \
+              > /tmp/pubspec.patch
+            [ -s /tmp/pubspec.patch ] \
+              || fail "pubspec.yaml changed but the API returned no patch for it"
+            if grep -E '^[+-]' /tmp/pubspec.patch \
               | grep -vE '^\+  - examples/[a-z0-9_]+$' | grep -q .; then
               fail "pubspec.yaml diff contains more than workspace example additions"
             fi
@@ -176,15 +209,58 @@ jobs:
             echo "no unresolved Bugbot threads"
           fi
 
+      - name: Wait for merge state
+        id: merge_state
+        if: steps.verify.outputs.verdict == 'pass' && steps.checks.outputs.exit == '0' && steps.review.outputs.verdict == 'pass'
+        env:
+          GH_TOKEN: ${{ secrets.SCHEMA_BUMP_PAT }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          # Required checks still queued behind `needs:` are invisible to
+          # `gh pr checks`; branch protection still counts them. Poll until
+          # GitHub itself reports the PR mergeable (or definitively not).
+          deadline=$((SECONDS + 1200))
+          while :; do
+            # A transient API error must not end the step (and skip the
+            # comment); treat it like UNKNOWN and poll again.
+            state=$(gh pr view "$PR" --json mergeStateStatus -q .mergeStateStatus) || state=UNKNOWN
+            case "$state" in
+              CLEAN|UNSTABLE|HAS_HOOKS|BEHIND|DIRTY)
+                echo "state=$state" >> "$GITHUB_OUTPUT"
+                exit 0 ;;
+            esac
+            # BLOCKED / UNKNOWN: a late required check may have failed.
+            set +e
+            gh pr checks "$PR" --required > /dev/null 2>&1
+            rc=$?
+            set -e
+            if [ "$rc" = "1" ]; then
+              echo "state=CHECKS_FAILED" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "state=TIMEOUT_${state}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "mergeStateStatus=$state (gh pr checks rc=$rc); waiting for branch protection to settle"
+            sleep 30
+          done
+
       - name: Merge or report
+        # Runs even when an earlier step crashed (not via fail()), so a
+        # transient error still leaves a comment instead of a silent red run.
+        if: ${{ !cancelled() && steps.pr.outputs.number != '' }}
         env:
           GH_TOKEN: ${{ secrets.SCHEMA_BUMP_PAT }}
           PR: ${{ steps.pr.outputs.number }}
           VERDICT: ${{ steps.verify.outputs.verdict }}
           REASON: ${{ steps.verify.outputs.reason }}
+          HEAD_SHA: ${{ steps.verify.outputs.head_sha }}
           CHECKS_EXIT: ${{ steps.checks.outputs.exit }}
           REVIEW_VERDICT: ${{ steps.review.outputs.verdict }}
           REVIEW_REASON: ${{ steps.review.outputs.reason }}
+          STATE: ${{ steps.merge_state.outputs.state }}
           DRY_RUN: ${{ steps.pr.outputs.dry_run }}
           DEPTH: ${{ github.event.inputs.depth }}
           IGNORE: ${{ github.event.inputs.ignore_review_threads }}
@@ -192,7 +268,7 @@ jobs:
           set -euo pipefail
           [ "$IGNORE" = "true" ] || IGNORE=false
           if [ "$VERDICT" != "pass" ]; then
-            gh pr comment "$PR" --body "**wave-merge:** NOT merging — ${REASON}."
+            gh pr comment "$PR" --body "**wave-merge:** NOT merging — ${REASON:-an earlier step failed before reaching a verdict; see the workflow log}."
             exit 1
           fi
           if [ "$CHECKS_EXIT" != "0" ]; then
@@ -203,25 +279,42 @@ jobs:
             gh pr comment "$PR" --body "**wave-merge:** NOT merging — ${REVIEW_REASON}."
             exit 1
           fi
+          case "$STATE" in
+            CLEAN|UNSTABLE|HAS_HOOKS) ;;
+            BEHIND)
+              if [ "$DRY_RUN" = "true" ]; then
+                gh pr comment "$PR" --body "**wave-merge (dry run):** verifications passed but the branch is BEHIND main; an armed run would update it and re-dispatch itself. Merging is disarmed (WAVE_MERGE_ENABLED != true)."
+                exit 0
+              fi
+              d="${DEPTH:-0}"
+              case "$d" in *[!0-9]*|"") d=0 ;; esac
+              if [ "$d" -ge 2 ]; then
+                gh pr comment "$PR" --body "**wave-merge:** NOT merging — branch keeps falling BEHIND after ${d} update attempts; human attention required."
+                exit 1
+              fi
+              gh pr update-branch "$PR"
+              # Forward the human override — a BEHIND redispatch must not
+              # silently drop ignore_review_threads back to its default.
+              gh workflow run wave-merge.yml -f pr="$PR" -f dry_run=false \
+                -f depth="$((d + 1))" -f ignore_review_threads="$IGNORE"
+              gh pr comment "$PR" --body "**wave-merge:** branch was BEHIND — updated it and re-dispatched myself (depth $((d + 1))) to re-verify against the new head."
+              exit 0 ;;
+            DIRTY)
+              gh pr comment "$PR" --body "**wave-merge:** NOT merging — merge conflict with main; human attention required."
+              exit 1 ;;
+            CHECKS_FAILED)
+              gh pr comment "$PR" --body "**wave-merge:** NOT merging — required checks are not green (a late check failed, or none are reported); see the Checks tab."
+              exit 1 ;;
+            *)
+              gh pr comment "$PR" --body "**wave-merge:** NOT merging — merge state did not settle (${STATE:-unknown}); a required check may still be queued. Re-label \`wave-approved\` once every check has reported."
+              exit 1 ;;
+          esac
           if [ "$DRY_RUN" = "true" ]; then
-            gh pr comment "$PR" --body "**wave-merge (dry run):** all verifications passed — branch pattern, same-repo head, Wave scope ledger, required checks green, and no unresolved Bugbot threads. Merging is disarmed (WAVE_MERGE_ENABLED != true)."
+            gh pr comment "$PR" --body "**wave-merge (dry run):** all verifications passed — branch pattern, same-repo head, Wave scope ledger, required checks green, no unresolved Bugbot threads, merge state ${STATE}. Merging is disarmed (WAVE_MERGE_ENABLED != true)."
             exit 0
           fi
-          state=$(gh pr view "$PR" --json mergeStateStatus -q .mergeStateStatus)
-          if [ "$state" = "BEHIND" ]; then
-            d="${DEPTH:-0}"
-            case "$d" in *[!0-9]*|"") d=0 ;; esac
-            if [ "$d" -ge 2 ]; then
-              gh pr comment "$PR" --body "**wave-merge:** NOT merging — branch keeps falling BEHIND after ${d} update attempts; human attention required."
-              exit 1
-            fi
-            gh pr update-branch "$PR"
-            # Forward the human override — a BEHIND redispatch must not
-            # silently drop ignore_review_threads back to its default.
-            gh workflow run wave-merge.yml -f pr="$PR" -f dry_run=false \
-              -f depth="$((d + 1))" -f ignore_review_threads="$IGNORE"
-            gh pr comment "$PR" --body "**wave-merge:** branch was BEHIND — updated it and re-dispatched myself (depth $((d + 1))) to re-verify against the new head."
-            exit 0
+          if ! gh pr merge "$PR" --squash --delete-branch --match-head-commit "$HEAD_SHA"; then
+            gh pr comment "$PR" --body "**wave-merge:** NOT merging — \`gh pr merge\` was refused (the head moved after verification, or branch protection changed). Re-label \`wave-approved\` to re-verify the current head."
+            exit 1
           fi
-          gh pr merge "$PR" --squash --delete-branch
-          gh pr comment "$PR" --body "**wave-merge:** verified (branch pattern, same-repo head, scope ledger, required checks, no unresolved Bugbot threads) and squash-merged."
+          gh pr comment "$PR" --body "**wave-merge:** verified (branch pattern, same-repo head, scope ledger, required checks, no unresolved Bugbot threads, merge state ${STATE}) and squash-merged ${HEAD_SHA:0:7}."

--- a/.github/workflows/wave-open.yml
+++ b/.github/workflows/wave-open.yml
@@ -4,7 +4,8 @@ name: wave-open
 # cannot create PRs or apply labels (403, verified 2026-07-04..06). A push
 # to wave/** whose HEAD commit message contains [wave-ready] gets a ready
 # PR + the wave-approved label (firing the wave-merge executor); a push
-# without the marker gets a draft PR (backup only). Auth uses
+# without the marker gets a draft PR (backup only). Every marker push
+# re-applies the label, so repair rounds re-run the executor. Auth uses
 # SCHEMA_BUMP_PAT: labels applied by
 # GITHUB_TOKEN would not trigger wave-merge's labeled event.
 
@@ -76,6 +77,12 @@ jobs:
           fi
 
           if [ "$ready" = "true" ]; then
+            # Adding a label that is already present emits no `labeled`
+            # event, so a repair round's second [wave-ready] push would never
+            # re-run wave-merge (PR #634 stranded this way on 2026-08-25 and
+            # needed a manual merge). Remove first so the add is a fresh
+            # event; `unlabeled` triggers nothing.
+            gh pr edit "$number" --remove-label wave-approved > /dev/null 2>&1 || true
             gh pr edit "$number" --add-label wave-approved
             echo "ready: PR #$number labeled wave-approved"
           else


### PR DESCRIPTION
## Why

Two safety assumptions of the autonomous merge path did not hold:

1. **The executor judged a PR with the PR's own ledger and checker.** `bump-merge` and `wave-merge` ran on `pull_request: [labeled]` and checked out the PR head, so `tool/check_bump_scope.dart`, the `*_allowed_paths.yaml` ledgers and the workflow file itself came from the branch under judgment. Since a `[wave-ready]` push *is* the approval, one push could widen the scope it was judged by, and a workflow edit could reach `SCHEMA_BUMP_PAT`.
2. **"Required checks green" was decided before a required check existed.** `gh pr checks --required --watch` only sees check runs that already exist. `terraform validate gate` is queued behind the example matrix, so the wait returned green while the gate had not started; `gh pr merge` was then refused by branch protection and the step died under `set -e` before commenting. PR #643 sat OPEN with `wave-approved` for five days (run 33451353060). `bump-merge` had the same code.

## What

- Both executors run on `pull_request_target` and read the ledger / checker / workflow from `main`. They pin the head SHA, fetch that commit on a full-history checkout of `main`, and compute the changed-file list and the root-pubspec hunk with `git diff origin/main...<pinned SHA>` (the pulls/files API always reflects the live head and cannot bind a verdict to a SHA). The pubspec gate fails closed: a git error, an empty diff, or any non-header line that is not a workspace example addition refuses the verdict. The PR's trees are only read, never checked out or executed, and the merge pins the same SHA with `--match-head-commit`. A head that moves during verification fails the verdict.
- After required checks, a bounded poll on `mergeStateStatus` until it leaves `BLOCKED` / `UNKNOWN`; a late required-check failure is detected; `BEHIND` / `DIRTY` / timeout / refused merge all post a comment. The final step also runs when an earlier step crashed, so no outcome is silent. Gate outputs are written only after their check succeeded, and the merge step additionally requires the gate steps' `outcome` to be `success`, so an errored gate can never be mistaken for a pass.
- `wave-open` removes `wave-approved` before re-adding it: adding a label that is already present emits no `labeled` event, so a repair round's second `[wave-ready]` push never re-ran the executor (PR #634 needed a manual merge after its repair round).
- Runbooks (`schema-bump-postprocess.md`, `wave-shipper.md`) describe the new behaviour.

## Verification

- `actionlint` clean on all three workflows (the one remaining SC2016 info in `wave-merge.yml` is pre-existing on `main`).
- YAML parses. `tool/agent_verify.sh` not run: no Dart or `tool/` code changed.

## After merge

PR #643 is mergeable (only its own failed `verify + merge` check is red). Remove and re-add `wave-approved`, or `gh workflow run wave-merge.yml -f pr=643 -f dry_run=false`, to run the fixed executor against it.

## Follow-ups (separate PRs)

- `escalation-relay.yml` lacks `pull-requests: write`, so `[agent-relay #<pr>]` comments on PRs fail (run 33344067483).
- Runbook contradictions on token capabilities, branch naming and editable `tool/*.dart`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes trust boundaries and merge automation for PAT-powered workflows (`pull_request_target`, pinned SHA merges); mistakes could block legitimate merges or affect merge safety on labeled PRs.
> 
> **Overview**
> Hardens the **bump-merge** and **wave-merge** auto-merge executors so verdicts cannot be widened by PR content and merges do not strand without a PR comment.
> 
> Both workflows now run on **`pull_request_target`**, keep checkout on **main**, and evaluate scope with **`tool/check_bump_scope.dart`** and the allowed-paths ledgers from the base branch only. They **pin the PR head SHA**, build the changed-file list via **`git diff origin/main...<sha>`** (instead of the live pulls/files API), refuse if the head moves during verification, and squash-merge with **`--match-head-commit`**. **wave-merge** tightens the root **`pubspec.yaml`** gate (fail-closed diff handling) and treats failed Bugbot thread GraphQL as a failed gate.
> 
> After **`gh pr checks --required`**, a new step **polls `mergeStateStatus`** until branch protection settles (queued required jobs behind `needs:`), with explicit handling for BEHIND/DIRTY/check failures/timeouts. The final **Merge or report** step runs on more outcomes and **always comments** on non-merge paths, including refused merges and crashed earlier steps.
> 
> **wave-open** **removes then re-adds `wave-approved`** on each `[wave-ready]` push so repair rounds re-fire the labeled executor. Agent runbooks document the updated pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c61de5902668b7494f35899bfddbf2cb9c331476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->