### PR TITLE
ci(wave-merge): re-dispatch with GITHUB_TOKEN and comment when BEHIND handling fails

### DIFF
--- a/.github/workflows/wave-merge.yml
+++ b/.github/workflows/wave-merge.yml
@@ -26,7 +26,8 @@ name: wave-merge
 # executor also waits for GitHub's own mergeStateStatus to leave BLOCKED
 # before merging. Without that wait `gh pr merge` fails on branch
 # protection and the PR strands with no comment (PR #643, 2026-08-31).
-# Every non-merge outcome posts a comment.
+# Every non-merge outcome posts a comment, including a failed BEHIND
+# update or re-dispatch.
 #
 # Live GCP apply-smoke is retired. Example verification is synth +
 # terraform validate (CI + agent_verify), not terraform apply.
@@ -58,6 +59,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # The BEHIND re-dispatch uses GITHUB_TOKEN: workflow_dispatch is one of
+  # the two events a GITHUB_TOKEN-created event still triggers, and the PAT
+  # has no actions scope (HTTP 403 on PR #643, 2026-09-05).
+  actions: write
 
 concurrency:
   group: wave-merge-${{ github.event.pull_request.number || github.event.inputs.pr }}
@@ -293,6 +298,7 @@ jobs:
           DRY_RUN: ${{ steps.pr.outputs.dry_run }}
           DEPTH: ${{ github.event.inputs.depth }}
           IGNORE: ${{ github.event.inputs.ignore_review_threads }}
+          DISPATCH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           [ "$IGNORE" = "true" ] || IGNORE=false
@@ -327,11 +333,19 @@ jobs:
                 gh pr comment "$PR" --body "**wave-merge:** NOT merging — branch keeps falling BEHIND after ${d} update attempts; human attention required."
                 exit 1
               fi
-              gh pr update-branch "$PR"
+              if ! gh pr update-branch "$PR"; then
+                gh pr comment "$PR" --body "**wave-merge:** NOT merging — branch is BEHIND main and \`gh pr update-branch\` failed; update it by hand and re-label \`wave-approved\`."
+                exit 1
+              fi
               # Forward the human override — a BEHIND redispatch must not
               # silently drop ignore_review_threads back to its default.
-              gh workflow run wave-merge.yml -f pr="$PR" -f dry_run=false \
-                -f depth="$((d + 1))" -f ignore_review_threads="$IGNORE"
+              # GITHUB_TOKEN (actions: write) dispatches; the PAT cannot.
+              if ! GH_TOKEN="$DISPATCH_TOKEN" gh workflow run wave-merge.yml \
+                -f pr="$PR" -f dry_run=false \
+                -f depth="$((d + 1))" -f ignore_review_threads="$IGNORE"; then
+                gh pr comment "$PR" --body "**wave-merge:** branch was BEHIND — updated it, but re-dispatching myself failed; re-label \`wave-approved\` once the new head's checks are green."
+                exit 1
+              fi
               gh pr comment "$PR" --body "**wave-merge:** branch was BEHIND — updated it and re-dispatched myself (depth $((d + 1))) to re-verify against the new head."
               exit 0 ;;
             DIRTY)


### PR DESCRIPTION
## Why

The first run of the hardened executor on PR #643 (run 33976022922) took the BEHIND path: `gh pr update-branch` succeeded, then `gh workflow run wave-merge.yml …` failed with HTTP 403 because `SCHEMA_BUMP_PAT` has no `actions` scope. The dispatch ran under `set -e` ahead of the comment, so the PR was left without any comment. This re-dispatch path predates #644 and had never been exercised in production.

## What

- Dispatch the re-run with `GITHUB_TOKEN` (`actions: write` added to the job permissions). `workflow_dispatch` is one of the two events that a GITHUB_TOKEN-created event still triggers, so no PAT scope change is needed.
- Post a comment when `gh pr update-branch` or the re-dispatch fails, so a failed BEHIND recovery is visible on the PR.

## Verification

- `actionlint` clean (the SC2016 info in the GraphQL step is pre-existing).
- #643 was recovered by re-labeling after the branch update (run 33976257000 merged it); this PR fixes the automatic path for next time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes automated merge executor behavior and expands workflow token permissions, but only for the BEHIND re-dispatch path—not application auth or data handling.
> 
> **Overview**
> Fixes the **wave-merge** BEHIND recovery path so a successful branch update no longer dies on a **403** when re-queueing itself, and so failures are visible on the PR instead of a silent red run.
> 
> The workflow now grants **`actions: write`** and re-dispatches **`wave-merge.yml`** with **`GITHUB_TOKEN`** (via `DISPATCH_TOKEN`), because **`SCHEMA_BUMP_PAT`** cannot trigger **`workflow_dispatch`**. **`gh pr update-branch`** and the re-dispatch are wrapped in explicit failure checks that post **wave-merge** comments with next steps (manual update or re-label **`wave-approved`**). Header comments are updated to document that BEHIND update/re-dispatch failures also get comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0b79393648c005c53be3926f5191a05cf637e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->