### PR TITLE
ci(relay): allow PR comments and append a provenance footer

### DIFF
--- a/.github/workflows/escalation-relay.yml
+++ b/.github/workflows/escalation-relay.yml
@@ -12,8 +12,12 @@ name: escalation-relay
 # Everything after the marker (including further message lines) is posted
 # VERBATIM — transport only, never interpreted or rewritten
 # (tool/loop_health_report.dart counts escalation comments by their
-# escalation(...) prefix). One exception to pure transport, for safety
-# rather than judgment: a trailer line
+# escalation(...) prefix). The only addition is a provenance FOOTER (relay
+# branch, pusher, run link) appended after the text, so a reader can tell a
+# relayed agent message from a comment a human or an executor wrote — the
+# footer is appended, never prepended, so body-prefix matching stays
+# intact. One exception to pure transport, for safety rather than
+# judgment: a trailer line
 #
 #   Relay-Label: <name>
 #
@@ -47,6 +51,10 @@ on:
 permissions:
   contents: write # delete the relay branch after posting
   issues: write # comment on / label the target issue
+  # `[agent-relay #N]` may target a pull request; commenting on a PR needs
+  # this scope too (two bump reports were lost to HTTP 403 without it —
+  # runs 33344067483 and 32673553201).
+  pull-requests: write
 
 concurrency:
   group: escalation-relay-${{ github.ref }}
@@ -146,6 +154,9 @@ jobs:
           BODY: ${{ steps.msg.outputs.body }}
           ISSUE: ${{ steps.msg.outputs.issue }}
           LABEL: ${{ steps.msg.outputs.label }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELAY_REF: ${{ github.ref_name }}
+          RELAY_ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
           # Re-validate at the privileged boundary — do not trust step
@@ -179,7 +190,19 @@ jobs:
               exit 1
             fi
           fi
-          gh issue comment "$n" --repo "$GITHUB_REPOSITORY" --body "$BODY"
+          # Provenance footer (appended, never prepended — see header).
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          if [ "$EVENT_NAME" = "push" ]; then
+            origin="relayed from \`$RELAY_REF\`, pushed by $RELAY_ACTOR"
+          else
+            origin="relayed via workflow_dispatch by $RELAY_ACTOR"
+          fi
+          body_file=$(mktemp)
+          {
+            printf '%s\n\n' "$BODY"
+            printf '<sub>escalation-relay: %s · [run](%s)</sub>\n' "$origin" "$run_url"
+          } > "$body_file"
+          gh issue comment "$n" --repo "$GITHUB_REPOSITORY" --body-file "$body_file"
           if [ -n "$LABEL" ]; then
             gh issue edit "$n" --repo "$GITHUB_REPOSITORY" --add-label "$LABEL"
           fi


### PR DESCRIPTION
## Why

`[agent-relay #N]` may target a pull request, but the relay job only had `issues: write`. Both bump-agent reports aimed at their PR failed with HTTP 403 (`addComment`: runs 33344067483 and 32673553201) and the relay branch was deleted anyway, so the reports were lost.

## What

- Grant `pull-requests: write` so PR-targeted relays post.
- Append a provenance footer (relay branch, pusher, run link) after the verbatim text so a reader can tell a relayed agent message from a comment a human or an executor wrote. Appended rather than prepended, so `tool/loop_health_report.dart`'s prefix match on `escalation(wave):` keeps working.

## Verification

- `actionlint` clean.
- The relay's own tests are end-to-end via `workflow_dispatch`; nothing in `tool/` reads the footer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CI workflow permission and comment formatting only; no application auth or data-path changes.
> 
> **Overview**
> Fixes **lost agent relay messages** when `[agent-relay #N]` targets a pull request by granting **`pull-requests: write`** (comments were failing with HTTP 403 while the relay branch was still deleted).
> 
> Relayed comments now **append a small provenance footer** (relay branch or `workflow_dispatch`, actor, Actions run link) after the verbatim agent text, documented in the workflow header. The footer is **never prepended**, so tools like `loop_health_report.dart` that match comment bodies with **`startsWith('escalation(wave):')`** keep working. Posting uses **`--body-file`** to combine body and footer safely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a767d6b8000f2d8f9cc10e8e76a84196ac5ffd97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->