### PR TITLE
fix(core): emit compilable Dart literals and validate export names

### DIFF
--- a/packages/terradart_core/lib/src/app_export.dart
+++ b/packages/terradart_core/lib/src/app_export.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import 'dart_source.dart';
 import 'tf_ref.dart';
 
 /// IaC ↔ application seam: a value Stack can export to either pure-Dart
@@ -49,9 +50,10 @@ abstract base class AppExport {
 /// secrets use `EnvBackedExport` (compile-time `--dart-define`) or
 /// `ResourceIdExport` with `sensitive: true` (Terraform-output-only).
 ///
-/// The constructor is non-const so it can validate `value` (no newlines,
-/// which would break the `r'...'` raw-string quoting). Use `final` not
-/// `const` at the call site:
+/// The constructor is non-const so it can validate `value` (no newlines —
+/// a constant is a single-line value). Quotes, `$`, and backslashes are
+/// fine: the emitted literal is escaped so it always compiles. Use `final`
+/// not `const` at the call site:
 ///
 /// ```dart
 /// final apiVersion = StringExport('v1');
@@ -63,8 +65,7 @@ final class StringExport extends AppExport {
       throw ArgumentError.value(
         value,
         'value',
-        'StringExport value must not contain newlines (would break '
-            'raw-string quoting in generated Dart constant).',
+        'StringExport value must not contain newlines.',
       );
     }
   }
@@ -75,7 +76,7 @@ final class StringExport extends AppExport {
   final String? description;
 
   @override
-  String get dartLiteralExpression => "r'$value'";
+  String get dartLiteralExpression => dartStringLiteral(value);
 
   @override
   String get dartType => 'String';
@@ -193,7 +194,8 @@ final class ResourceAttributeExport<T> extends AppExport {
 /// variable. Never appears in Terraform outputs.
 ///
 /// Constructor is non-const because it validates `envVarName` (must be
-/// non-empty). Use `final`:
+/// non-empty and free of characters that could not appear inside the
+/// generated `String.fromEnvironment('...')` literal). Use `final`:
 ///
 /// ```dart
 /// final apiBase = EnvBackedExport(envVarName: 'API_BASE_URL');
@@ -212,7 +214,18 @@ final class EnvBackedExport extends AppExport {
         'must not be empty',
       );
     }
+    if (_unsafeInLiteral.hasMatch(envVarName)) {
+      throw ArgumentError.value(
+        envVarName,
+        'envVarName',
+        r"must not contain quotes, backslashes, `$`, or control characters",
+      );
+    }
   }
+
+  /// Characters that would break or alter the single-quoted literal the
+  /// variable name is written into.
+  static final RegExp _unsafeInLiteral = RegExp(r"['\\$\x00-\x1f\x7f]");
 
   final String envVarName;
   final String? defaultValue;
@@ -225,7 +238,8 @@ final class EnvBackedExport extends AppExport {
     if (defaultValue == null) {
       return "const String.fromEnvironment('$envVarName')";
     }
-    return "const String.fromEnvironment('$envVarName', defaultValue: r'$defaultValue')";
+    return "const String.fromEnvironment('$envVarName', "
+        "defaultValue: ${dartStringLiteral(defaultValue!)})";
   }
 
   @override

--- a/packages/terradart_core/lib/src/dart_source.dart
+++ b/packages/terradart_core/lib/src/dart_source.dart
@@ -1,0 +1,94 @@
+// Helpers for the Dart and Terraform source that synth writes: a string
+// literal that always compiles, and identifier checks for the names that
+// become `static const` members and `output` blocks.
+
+/// Dart's reserved words, which can never be used as identifiers. Built-in
+/// identifiers such as `get`, `static`, or `await` are legal member names
+/// and are deliberately not listed.
+const Set<String> dartReservedWords = {
+  'assert',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'default',
+  'do',
+  'else',
+  'enum',
+  'extends',
+  'false',
+  'final',
+  'finally',
+  'for',
+  'if',
+  'in',
+  'is',
+  'new',
+  'null',
+  'rethrow',
+  'return',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'var',
+  'void',
+  'while',
+  'with',
+};
+
+final RegExp _dartIdentifier = RegExp(r'^[A-Za-z_][A-Za-z0-9_]*$');
+final RegExp _terraformIdentifier = RegExp(r'^[A-Za-z_][A-Za-z0-9_-]*$');
+
+/// Whether [name] can be declared as a Dart member (`static const T name`).
+///
+/// `$` is legal in Dart identifiers but rejected here: an export key doubles
+/// as the default Terraform `output` name, where `$` is not allowed.
+bool isDartIdentifier(String name) =>
+    _dartIdentifier.hasMatch(name) && !dartReservedWords.contains(name);
+
+/// Whether [name] is a valid Terraform `output` block name.
+bool isTerraformIdentifier(String name) => _terraformIdentifier.hasMatch(name);
+
+/// A Dart string literal whose value is exactly [value].
+///
+/// Prefers the raw form `r'...'` (what synth has always emitted) whenever the
+/// value contains no single quote and no control character — a raw string
+/// cannot express a quote or a line break, and invisible characters do not
+/// belong in generated source unescaped. Otherwise it falls back to a
+/// single-quoted literal with `\`, `'`, `$`, and control characters escaped,
+/// so the generated constants file compiles for any input.
+String dartStringLiteral(String value) {
+  final needsEscape =
+      value.contains("'") || value.codeUnits.any((c) => c < 0x20 || c == 0x7f);
+  if (!needsEscape) return "r'$value'";
+  final buf = StringBuffer("'");
+  for (final rune in value.runes) {
+    switch (rune) {
+      case 0x5c:
+        buf.write(r'\\');
+      case 0x27:
+        buf.write(r"\'");
+      case 0x24:
+        buf.write(r'\$');
+      case 0x0a:
+        buf.write(r'\n');
+      case 0x0d:
+        buf.write(r'\r');
+      case 0x09:
+        buf.write(r'\t');
+      default:
+        if (rune < 0x20 || rune == 0x7f) {
+          buf.write('\\u{${rune.toRadixString(16)}}');
+        } else {
+          buf.writeCharCode(rune);
+        }
+    }
+  }
+  buf.write("'");
+  return buf.toString();
+}

--- a/packages/terradart_core/lib/src/synth/output_emitter.dart
+++ b/packages/terradart_core/lib/src/synth/output_emitter.dart
@@ -1,4 +1,5 @@
 import 'package:terradart_core/src/app_export.dart';
+import 'package:terradart_core/src/dart_source.dart';
 import 'package:terradart_core/src/stack.dart';
 import 'package:terradart_core/src/synth/literal_resolver.dart';
 import 'package:terradart_core/src/tf_ref.dart';
@@ -76,7 +77,7 @@ class OutputEmitter {
         // base class declares it nullable so we read via the concrete type.
         dartConstants.add(
           DartConstantSpec(
-            name: key,
+            name: _dartConstantName(key),
             dartType: export.dartType,
             rhs: export.dartLiteralExpression,
             doc: export.description,
@@ -93,9 +94,9 @@ class OutputEmitter {
         if (canDartLiteral) {
           dartConstants.add(
             DartConstantSpec(
-              name: key,
+              name: _dartConstantName(key),
               dartType: export.dartType,
-              rhs: "r'$lit'",
+              rhs: dartStringLiteral(lit),
               doc: export.description,
             ),
           );
@@ -108,7 +109,7 @@ class OutputEmitter {
         if (mustOutput) {
           terraformOutputs.add(
             TerraformOutputSpec(
-              name: export.terraformOutputName ?? key,
+              name: _terraformOutputName(export.terraformOutputName ?? key),
               value: export.ref.interpolation,
               sensitive: export.sensitive,
               description: export.description,
@@ -130,7 +131,7 @@ class OutputEmitter {
           final rhs = _runEncoder(export, litRaw, addr, attrName);
           dartConstants.add(
             DartConstantSpec(
-              name: key,
+              name: _dartConstantName(key),
               dartType: export.dartType,
               rhs: rhs,
               doc: export.description,
@@ -142,7 +143,7 @@ class OutputEmitter {
         if (mustOutput) {
           terraformOutputs.add(
             TerraformOutputSpec(
-              name: export.terraformOutputName ?? key,
+              name: _terraformOutputName(export.terraformOutputName ?? key),
               value: export.ref.interpolation,
               sensitive: export.sensitive,
               description: export.description,
@@ -155,7 +156,7 @@ class OutputEmitter {
       if (export is EnvBackedExport) {
         dartConstants.add(
           DartConstantSpec(
-            name: key,
+            name: _dartConstantName(key),
             dartType: export.dartType,
             rhs: export.dartLiteralExpression,
             doc: export.description,
@@ -176,6 +177,27 @@ class OutputEmitter {
     return OutputEmissionResult(
       dartConstants: dartConstants,
       terraformOutputs: terraformOutputs,
+    );
+  }
+
+  /// The export key becomes `static const <type> <key>` in the generated
+  /// constants file, so it must be a Dart identifier — checked here, where
+  /// the file would otherwise be written and fail to compile later.
+  static String _dartConstantName(String key) {
+    if (isDartIdentifier(key)) return key;
+    throw StateError(
+      'AppExport "$key" is emitted as a Dart constant, but "$key" is not a '
+      'valid Dart identifier (letters, digits, and underscores; not a '
+      'reserved word). Rename the export, or make it Terraform-output-only.',
+    );
+  }
+
+  /// Terraform `output` names allow letters, digits, `_`, and `-`.
+  static String _terraformOutputName(String name) {
+    if (isTerraformIdentifier(name)) return name;
+    throw StateError(
+      'Terraform output name "$name" is not a valid identifier (letters, '
+      'digits, underscores, and hyphens; must not start with a digit).',
     );
   }
 

--- a/packages/terradart_core/test/app_export_test.dart
+++ b/packages/terradart_core/test/app_export_test.dart
@@ -60,9 +60,9 @@ void main() {
       expect(e.description, isNull);
     });
 
-    test('preserves single quotes via raw string', () {
+    test('escapes single quotes instead of emitting a broken raw string', () {
       final e = StringExport("user's-topic");
-      expect(e.dartLiteralExpression, equals("r'user's-topic'"));
+      expect(e.dartLiteralExpression, equals(r"'user\'s-topic'"));
     });
 
     test('rejects values containing newlines (would break raw string)', () {
@@ -198,6 +198,27 @@ void main() {
     test('rejects empty envVarName', () {
       expect(
         () => EnvBackedExport(envVarName: ''),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('escapes a defaultValue containing a single quote', () {
+      final e = EnvBackedExport(envVarName: 'GREETING', defaultValue: "it's");
+      expect(
+        e.dartLiteralExpression,
+        equals(
+          r"const String.fromEnvironment('GREETING', defaultValue: 'it\'s')",
+        ),
+      );
+    });
+
+    test('rejects an envVarName that would break the generated literal', () {
+      expect(
+        () => EnvBackedExport(envVarName: "A'B"),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => EnvBackedExport(envVarName: r'A$B'),
         throwsA(isA<ArgumentError>()),
       );
     });

--- a/packages/terradart_core/test/dart_source_test.dart
+++ b/packages/terradart_core/test/dart_source_test.dart
@@ -1,0 +1,62 @@
+import 'package:terradart_core/src/dart_source.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('dartStringLiteral', () {
+    test('uses a raw string when the value has no quote or newline', () {
+      expect(dartStringLiteral('orders-prod'), equals("r'orders-prod'"));
+      expect(dartStringLiteral(r'a\b$c'), equals(r"r'a\b$c'"));
+      expect(dartStringLiteral(''), equals("r''"));
+    });
+
+    test('escapes a single quote in a non-raw string', () {
+      expect(dartStringLiteral("user's-topic"), equals(r"'user\'s-topic'"));
+    });
+
+    test('escapes backslash and dollar once it leaves raw form', () {
+      expect(
+        dartStringLiteral(r"it's $5 \ done"),
+        equals(r"'it\'s \$5 \\ done'"),
+      );
+    });
+
+    test('escapes newline, carriage return, and tab', () {
+      expect(dartStringLiteral('a\nb\rc\td'), equals(r"'a\nb\rc\td'"));
+    });
+
+    test('escapes other control characters as a unicode escape', () {
+      final value = 'a${String.fromCharCode(1)}b';
+      expect(dartStringLiteral(value), equals(r"'a\u{1}b'"));
+    });
+  });
+
+  group('isDartIdentifier', () {
+    test('accepts plain identifiers', () {
+      expect(isDartIdentifier('ordersTopicId'), isTrue);
+      expect(isDartIdentifier('_x1'), isTrue);
+    });
+
+    test('rejects reserved words, hyphens, dollars, digits first, empty', () {
+      expect(isDartIdentifier('class'), isFalse);
+      expect(isDartIdentifier('null'), isFalse);
+      expect(isDartIdentifier('orders-topic'), isFalse);
+      expect(isDartIdentifier(r'a$b'), isFalse);
+      expect(isDartIdentifier('1abc'), isFalse);
+      expect(isDartIdentifier(''), isFalse);
+    });
+  });
+
+  group('isTerraformIdentifier', () {
+    test('accepts letters, digits, underscore, hyphen', () {
+      expect(isTerraformIdentifier('orders-topic_id'), isTrue);
+      expect(isTerraformIdentifier('_x'), isTrue);
+    });
+
+    test('rejects digits first, spaces, dollars, empty', () {
+      expect(isTerraformIdentifier('1abc'), isFalse);
+      expect(isTerraformIdentifier('a b'), isFalse);
+      expect(isTerraformIdentifier(r'a$b'), isFalse);
+      expect(isTerraformIdentifier(''), isFalse);
+    });
+  });
+}

--- a/packages/terradart_core/test/synth/dart_constants_emitter_test.dart
+++ b/packages/terradart_core/test/synth/dart_constants_emitter_test.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:terradart_core/src/dart_source.dart';
 import 'package:terradart_core/src/synth/dart_constants_emitter.dart';
 import 'package:terradart_core/src/synth/output_emitter.dart';
 import 'package:test/test.dart';
@@ -118,6 +121,43 @@ abstract final class OrdersStackExports {
           '  static const Uri apiUri = Uri.parse(r\'https://example.com\');',
         ),
       );
+    });
+  });
+
+  group('DartConstantsEmitter output compiles', () {
+    test('a value with quotes, dollars, and backslashes passes dart analyze',
+        () async {
+      final out = DartConstantsEmitter.emit(
+        stackName: 'TrickyStack',
+        constants: [
+          DartConstantSpec(
+            name: 'greeting',
+            dartType: 'String',
+            rhs: dartStringLiteral(r"it's $5 \ done"),
+          ),
+          DartConstantSpec(
+            name: 'plain',
+            dartType: 'String',
+            rhs: dartStringLiteral('orders-prod'),
+          ),
+        ],
+      );
+      final dir = await Directory.systemTemp.createTemp('terradart_constants_');
+      try {
+        final file = File('${dir.path}/tricky.app.dart');
+        await file.writeAsString(out);
+        final result = await Process.run(
+          Platform.resolvedExecutable,
+          ['analyze', '--fatal-infos', file.path],
+        );
+        expect(
+          result.exitCode,
+          0,
+          reason: 'dart analyze failed:\n${result.stdout}\n${result.stderr}',
+        );
+      } finally {
+        await dir.delete(recursive: true);
+      }
     });
   });
 }

--- a/packages/terradart_core/test/synth/output_emitter_test.dart
+++ b/packages/terradart_core/test/synth/output_emitter_test.dart
@@ -285,4 +285,93 @@ void main() {
       expect(res.dartConstants.single.doc, equals('API version'));
     });
   });
+
+  group('OutputEmitter emits valid names and compilable literals', () {
+    OutputEmissionResult run(TestStack stack) => OutputEmitter.run(
+          stack: stack,
+          resolver: LiteralResolver.fromStack(stack),
+        );
+
+    test('escapes a resolved literal containing a single quote', () {
+      final stack = TestStack();
+      final topic = stack.add(
+        FakePubsubTopic(
+          localName: 'orders',
+          argMap: const {'name': TfArgLiteral<String>("user's-topic")},
+        ),
+      );
+      stack.addExport(
+        'ordersTopicName',
+        ResourceIdExport(TfRef.attribute<String>(topic, 'name')),
+      );
+      expect(run(stack).dartConstants.single.rhs, equals(r"'user\'s-topic'"));
+    });
+
+    test('rejects a Dart-constant export whose key is not a Dart identifier',
+        () {
+      final stack = TestStack();
+      stack.addExport('orders-topic', StringExport('v1'));
+      expect(
+        () => run(stack),
+        throwsA(
+          isA<StateError>()
+              .having((e) => e.message, 'message', contains('orders-topic')),
+        ),
+      );
+    });
+
+    test('rejects a Dart-constant export whose key is a reserved word', () {
+      final stack = TestStack();
+      stack.addExport('class', StringExport('v1'));
+      expect(() => run(stack), throwsA(isA<StateError>()));
+    });
+
+    test('allows a hyphenated key when the export is Terraform-output-only',
+        () {
+      final stack = TestStack();
+      final topic = stack.add(
+        FakePubsubTopic(
+          localName: 'orders',
+          argMap: const {'name': TfArgLiteral<String>('orders-prod')},
+        ),
+      );
+      // `id` has no literal in argMap, so no Dart constant is emitted.
+      stack.addExport(
+        'orders-topic-id',
+        ResourceIdExport(
+          TfRef.attribute<String>(topic, 'id'),
+          emitTerraformOutput: true,
+        ),
+      );
+      final res = run(stack);
+      expect(res.dartConstants, isEmpty);
+      expect(res.terraformOutputs.single.name, equals('orders-topic-id'));
+    });
+
+    test('rejects a terraformOutputName that is not a Terraform identifier',
+        () {
+      final stack = TestStack();
+      final topic = stack.add(
+        FakePubsubTopic(
+          localName: 'orders',
+          argMap: const {'name': TfArgLiteral<String>('orders-prod')},
+        ),
+      );
+      stack.addExport(
+        'ordersTopicId',
+        ResourceIdExport(
+          TfRef.attribute<String>(topic, 'id'),
+          emitTerraformOutput: true,
+          terraformOutputName: 'orders topic',
+        ),
+      );
+      expect(
+        () => run(stack),
+        throwsA(
+          isA<StateError>()
+              .having((e) => e.message, 'message', contains('orders topic')),
+        ),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Why

Synth wrote every exported string as `r'$value'` with no escaping. A value containing a single quote produced an unterminated string literal in the generated constants file, and `app_export_test.dart` pinned that broken output (`r'user's-topic'`) as the expected result. `EnvBackedExport` had the same hole for `defaultValue`, and nothing checked that an export key is a legal Dart identifier or that a Terraform output name is a legal Terraform identifier, so a bad key surfaced only when the generated file failed to compile or `terraform validate` failed.

## What

- `dartStringLiteral()` (new `lib/src/dart_source.dart`): keeps the raw form `r'...'` whenever the value has no quote and no control character (byte-for-byte what synth emitted before), otherwise emits a single-quoted literal with `\`, `'`, `$`, and control characters escaped. Used by `StringExport`, `EnvBackedExport.defaultValue`, and the resolved-literal path in `OutputEmitter`.
- `OutputEmitter` rejects, with a `StateError` naming the export, a key that is not a Dart identifier when a Dart constant is emitted for it (reserved words included), and a Terraform output name that is not a Terraform identifier. A hyphenated key stays legal for a Terraform-output-only export.
- `EnvBackedExport` rejects a variable name containing quotes, backslashes, `$`, or control characters.
- Tests: unit tests for the helper and the identifier checks, the flipped `StringExport` expectation, `OutputEmitter` cases for each rule, and an end-to-end test that runs `dart analyze` on an emitted constants file with a hostile value.

All 19 export keys used across `examples/` are plain identifiers, so no example changes.

## Verification

- `dart test` in `terradart_core`: 247 passed. `dart analyze --fatal-infos` clean, `dart format` clean.
- `tool/agent_verify.sh` (full gate): OK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core synth output and export validation; mis-escaping or overly strict name checks could break existing stacks, though behavior for typical identifiers is unchanged.
> 
> **Overview**
> Fixes synth codegen that always wrapped strings in `r'...'`, which **broke compilation** when values contained single quotes (and had the same gap for `EnvBackedExport` defaults).
> 
> Adds **`dartStringLiteral()`** in new `dart_source.dart`: still emits raw strings when safe, otherwise escapes quotes, `$`, backslashes, and control characters. **`StringExport`**, **`EnvBackedExport`**, and **`OutputEmitter`**’s resolved literal path now use it. **`EnvBackedExport`** also rejects `envVarName` values that would corrupt the generated `String.fromEnvironment('...')` literal.
> 
> **`OutputEmitter`** now fails fast with **`StateError`** when an export key isn’t a valid Dart identifier for emitted constants (reserved words included) or a Terraform output name isn’t a valid Terraform identifier; hyphenated keys remain OK for Terraform-output-only exports.
> 
> Tests cover the helper, identifier rules, updated expectations, and an integration check that **`dart analyze`** passes on emitted constants with hostile string content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e013ea512bfa72bc7afe8df5912d207d283c5958. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->