### PR TITLE
fix(tool): let agent_verify --quick run on a checkout with no tf-out

### DIFF
--- a/tool/agent_verify.sh
+++ b/tool/agent_verify.sh
@@ -187,7 +187,15 @@ dart tool/check_mm_upstream_fingerprint.dart
 
 echo ">> apply_smoke_test (selection, no GCP)"
 chmod +x tool/apply_smoke_test.sh
-tool/apply_smoke_test.sh
+if [[ "$QUICK" == "1" ]] && ! compgen -G "examples/*/tf-out" > /dev/null; then
+  # The cost gate (test 9) inspects synthesized tf-out and fails closed when
+  # there is none. --quick skips the synth that creates it, so on a fresh
+  # checkout the gate would fail for the wrong reason; the full gate always
+  # runs it right after synth.
+  echo ">> apply_smoke_test: SKIPPED (--quick, no examples/*/tf-out yet — the full gate runs the cost gate after synth)"
+else
+  tool/apply_smoke_test.sh
+fi
 
 if [[ "$QUICK" == "0" ]]; then
   echo ">> smoke_quickstart"


### PR DESCRIPTION
## Why

`tool/agent_verify.sh --quick` is what both runbooks tell agents to iterate with, and it failed on any checkout without synthesized examples: the cost gate (`apply_smoke_test.sh` test 9) inspects `examples/*/tf-out` and fails closed on zero directories, while `--quick` skips the synth pass that creates them. A fresh clone (every cloud-agent VM, every new contributor) got `cost gate inspected 0 tf-outs` instead of a verdict.

## What

Under `--quick`, skip the `apply_smoke_test` stage only when no `examples/*/tf-out` exists, and print why. With tf-out present the quick gate still runs the cost gate; the full gate is unchanged and always runs it right after synth.

## Verification

Moved all 122 `tf-out` directories aside:

- before the fix, `tool/apply_smoke_test.sh` failed with `cost gate inspected 0 tf-outs`;
- after the fix, `tool/agent_verify.sh --quick` passed and printed the skip line;
- with tf-out restored, `tool/agent_verify.sh --quick` ran `apply_smoke_test: OK` as before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes local/CI-adjacent verification script branching; no runtime, auth, or data-path impact.
> 
> **Overview**
> **`tool/agent_verify.sh --quick`** no longer always invokes **`apply_smoke_test.sh`**. When quick mode is on and there are no **`examples/*/tf-out`** directories (typical on a fresh clone, where quick skips synth), the script **skips** the apply smoke stage and prints an explicit reason instead of hitting the cost gate’s **fail-closed “0 tf-outs”** error.
> 
> If **`tf-out`** already exists, quick mode still runs **`apply_smoke_test`** unchanged. The **full** gate is untouched and continues to synth first, then run the cost gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd9f0077d2a8351a061bf279177a9ef088fc237a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->