### PR TITLE
ci: let terraform validate use the restored provider cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,14 @@ jobs:
     if: needs.changes.outputs.examples != '[]'
     env:
       TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform-plugin-cache
+      # tf-out is regenerated every run and its .terraform.lock.hcl is
+      # gitignored, so `terraform init` never has a lock file to verify cached
+      # providers against — and without this opt-in Terraform ignores the
+      # cache and downloads ~100 MB per leg from releases.hashicorp.com. A
+      # registry hiccup then fails the whole matrix (two legs on #647,
+      # 2026-09-06: "connection reset by peer"). Validate-only, no state, so
+      # the "may break the lock file" caveat has nothing to break.
+      TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE: "1"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Why

Every `terraform validate` leg restores a ~93 MB provider cache and then downloads the providers anyway. `tf-out/` is regenerated on each run and its `.terraform.lock.hcl` is gitignored, so `terraform init` never has a lock file to verify cached packages against, and since Terraform 1.4 it refuses to use the plugin cache in that case. 122 legs × ~100 MB from `releases.hashicorp.com` per full run, and one registry hiccup fails the matrix — which is what happened on #647 on 2026-09-06 (two legs: `connection reset by peer`).

## What

Set `TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=1` on the `terraform_validate` job, Terraform's opt-in for exactly this situation. These runs are validate-only with no state or committed lock file, so the caveat in the variable's name has nothing to break. The existing cache step (keyed on the pinned provider version) now does its job.

## Verification

- `actionlint` clean.
- This PR itself runs the full example matrix (a `ci.yml` change selects every example). The first leg per runner populates the cache; subsequent runs should show `Using hashicorp/google vX from the shared cache directory` in `terraform init` instead of `Installing`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Terraform validate configuration; no application, auth, or production deploy behavior changes.
> 
> **Overview**
> The **`terraform_validate`** job now sets **`TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=1`** alongside the existing **`TF_PLUGIN_CACHE_DIR`**, so `terraform init` can use the restored provider cache instead of re-downloading providers on every matrix leg.
> 
> Because **`tf-out/`** is regenerated each run and its lock file is gitignored, Terraform otherwise skips the cache (since 1.4) and hits the registry ~100 MB per leg—making CI slower and brittle when HashiCorp’s registry flakes (e.g. #647).
> 
> These runs are validate-only with no state or committed lock file, so the opt-in’s lock-file caveat does not apply here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77be71cdc2cd9459ce265ab241f387b8e6ed3d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->