### PR TITLE
ci: add a single aggregate `ci gate` and stop validate from passing on a skipped matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,25 +328,85 @@ jobs:
   terraform_validate_gate:
     name: terraform validate gate
     runs-on: ubuntu-latest
-    needs: [changes, terraform_validate]
+    needs: [changes, test, terraform_validate]
     if: always()
-    # Stable, always-present check that aggregates the dynamic validate matrix.
-    # Branch protection requires THIS (not the per-example jobs), so a PR that
-    # validates a subset — or none — still presents a green required check.
+    # Stable, always-present check that aggregates the dynamic validate matrix,
+    # so a PR that validates a subset — or none — still presents a green
+    # check. `skipped` is a pass ONLY when nothing was selected: the matrix is
+    # also skipped when `test` fails (it `needs: test`), and that must not
+    # read as "validated".
     steps:
       - name: Aggregate terraform validate result
         env:
           CHANGES: ${{ needs.changes.result }}
+          TESTS: ${{ needs.test.result }}
           RESULT: ${{ needs.terraform_validate.result }}
           SELECTED: ${{ needs.changes.outputs.examples }}
         run: |
           echo "selected examples: $SELECTED"
-          echo "changes job: $CHANGES / terraform_validate: $RESULT"
+          echo "changes: $CHANGES / test: $TESTS / terraform_validate: $RESULT"
           if [ "$CHANGES" != 'success' ]; then
             echo "::error::example-selection job did not succeed ($CHANGES)"
             exit 1
           fi
+          if [ "$TESTS" != 'success' ]; then
+            echo "::error::package tests did not succeed ($TESTS), so the validate matrix never ran"
+            exit 1
+          fi
           case "$RESULT" in
-            success|skipped) echo "gate: PASS"; exit 0 ;;
+            success) echo "gate: PASS"; exit 0 ;;
+            skipped)
+              if [ "$SELECTED" = '[]' ]; then
+                echo "gate: PASS (no example selected)"; exit 0
+              fi
+              echo "::error::terraform validate was skipped although examples were selected"
+              exit 1 ;;
             *) echo "::error::terraform validate did not pass (result=$RESULT)"; exit 1 ;;
           esac
+
+  ci_gate:
+    name: ci gate
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - test
+      - apply_smoke_selection_test
+      - wrap_check
+      - override_gates
+      - publish_dry_run
+      - wrap_init_check
+      - wrap_promote_check
+      - terraform_validate_gate
+    if: always()
+    # The one check branch protection should require. Requiring individual
+    # job names let the required set drift: the cost gate
+    # (apply_smoke_selection_test), four of the eight package test legs, and
+    # the publish dry-runs were never required, so a PR with any of them red
+    # — or still pending — could auto-merge. Every job must be `success`;
+    # `skipped` counts as failure because a job skipped by a failed
+    # dependency has not proven anything.
+    steps:
+      - name: Require every CI job to succeed
+        env:
+          RESULTS: |
+            select examples=${{ needs.changes.result }}
+            test=${{ needs.test.result }}
+            apply_smoke.sh selection test=${{ needs.apply_smoke_selection_test.result }}
+            terradart wrap --check=${{ needs.wrap_check.result }}
+            override gates=${{ needs.override_gates.result }}
+            pub publish --dry-run=${{ needs.publish_dry_run.result }}
+            terradart wrap-init smoke=${{ needs.wrap_init_check.result }}
+            terradart wrap-promote smoke=${{ needs.wrap_promote_check.result }}
+            terraform validate gate=${{ needs.terraform_validate_gate.result }}
+        run: |
+          fail=0
+          while IFS='=' read -r job result; do
+            [ -n "$job" ] || continue
+            if [ "$result" = 'success' ]; then
+              echo "ok    $job"
+            else
+              echo "::error::$job: $result"
+              fail=1
+            fi
+          done <<< "$RESULTS"
+          [ "$fail" = '0' ] && echo "ci gate: PASS" || exit 1


### PR DESCRIPTION
## Why

Branch protection on `main` requires nine individual job names, and the set has drifted from what CI actually runs. Never required: the cost gate (`apply_smoke.sh selection test`), four of the eight package test legs (`google_beta`, `appwrite`, `cloudflare`, `coverage`), and the `pub publish --dry-run` jobs. The executors wait on `gh pr checks --required`, so a PR with any of those red — or still pending — can auto-merge; #645 merged with the cost gate still pending.

`terraform validate gate` had a related hole: it accepted a `skipped` matrix unconditionally, but the matrix is also skipped when `test` fails (it `needs: test`), so a failing test leg could read as "validated".

## What

- New `ci gate` job: `needs` every job in `ci.yml`, `if: always()`, and passes only when every result is `success`. `skipped` counts as failure, because a job skipped by a failed dependency has proven nothing. It prints one line per job so a red gate says which job.
- `terraform validate gate` now also `needs: test`, requires it to be `success`, and accepts a skipped matrix only when the selection was empty.

## After merge (maintainer, branch protection UI or API)

Replace the required status checks on `main` with:

- `ci gate` (this workflow)
- `docs consistency + pubsub smoke` (docs-consistency.yml)
- `type from title` (pr-labeler.yml)

and remove the nine per-job contexts (`test (terradart_core|codegen|google|google_beta)`, `terradart wrap --check`, `terradart wrap-init smoke`, `terradart wrap-promote smoke`, `override gates (lint, enum gaps, MM fingerprint)`, `terraform validate gate`). `ci gate` must have reported once on `main` before it can be picked from the UI list; merging this PR produces that run.

## Verification

- `actionlint` clean; YAML parses with the new job.
- This PR's own run shows the `ci gate` check aggregating all jobs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gating and branch-protection semantics; misconfiguration could block merges or leave holes until required checks are updated to `ci gate`.
> 
> **Overview**
> **Closes a branch-protection gap** where required checks could drift from what CI actually runs, letting PRs auto-merge with red or pending jobs (e.g. cost gate, some test matrix legs, publish dry-runs).
> 
> Adds a **`ci gate`** job that depends on every job in this workflow, runs with `if: always()`, and passes only when each dependency is **`success`**—**`skipped` is treated as failure** so dependency-skipped jobs do not count as green. Failures print one line per job for quick diagnosis.
> 
> **Tightens `terraform validate gate`**: it now **`needs: test`**, fails if package tests did not succeed, and treats a **skipped** validate matrix as pass **only** when no examples were selected (`[]`), not when the matrix was skipped because tests failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0210a5e571b43a84c39004ec5688eae46f8a367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->