### PR TITLE
ci: key the terraform provider cache on the run so it can refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,8 +269,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-          # Keyed on the pinned provider version; a provider bump invalidates it.
-          key: tfplugins-${{ runner.os }}-${{ hashFiles('packages/terradart_google/lib/src/_provider_meta.dart') }}
+          # A cache entry is immutable per key, and synth writes the floating
+          # constraint `~> 7.0`, so `terraform init` resolves the NEWEST
+          # provider release while a key derived from the pinned metadata
+          # never changed: the entry went stale on the first upstream release
+          # and every leg then restored it, missed, downloaded, and could not
+          # save ("Cache hit occurred on the primary key, not saving"). Key on
+          # the run instead: each run saves what it downloaded (the first leg
+          # to finish wins), and the next run restores the newest entry via
+          # the prefix, so a provider release costs one run of downloads.
+          key: tfplugins-${{ runner.os }}-${{ github.run_id }}
           restore-keys: tfplugins-${{ runner.os }}-
       - name: Ensure plugin cache dir exists
         run: mkdir -p "$TF_PLUGIN_CACHE_DIR"


### PR DESCRIPTION
## Why

#652 turned on `TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE`, but its own run still downloaded `hashicorp/google v7.46.1` on every leg. The post-step log of the last leg explains it: `Cache hit occurred on the primary key tfplugins-Linux-<hash>, not saving cache.`

The key hashed `_provider_meta.dart`, whose constraint is the floating `~> 7.0`. `terraform init` therefore resolves the newest provider release, while the key never changes — and a cache entry is immutable per key. So the entry went stale on the first upstream release after it was created, and every leg since then restored it, missed, downloaded, and could not save.

## What

Key the provider cache on `github.run_id` and keep the OS prefix as the restore key. Each run saves what it downloaded (the first leg to finish wins; the others see "another job may be creating this cache"), and the next run restores the newest entry. A provider release now costs one run of downloads instead of every run. Old entries age out under GitHub's cache eviction.

## Verification

- `actionlint` clean.
- This PR's run populates the first entry; the following run on `main` (or any later PR) should show `Using hashicorp/google v7.46.1 from the shared cache directory` in `terraform init`. I will check that after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change to cache keying; no application, auth, or runtime behavior changes.
> 
> **Overview**
> Fixes **stale Terraform provider caching** in the `terraform_validate` matrix job. The cache **primary key** no longer hashes `_provider_meta.dart` (which stays stable under the floating `~> 7.0` constraint while `terraform init` keeps resolving newer `hashicorp/google` releases). It now uses **`tfplugins-${{ runner.os }}-${{ github.run_id }}`**, with the same **`tfplugins-${{ runner.os }}-`** restore prefix.
> 
> Each CI run can **save** the providers it actually downloaded (first matrix leg wins), and the next run **restores the newest** matching entry instead of repeatedly hitting an immutable stale key that blocked saves (`Cache hit occurred on the primary key, not saving`). After an upstream provider release, downloads should happen for **one run**, not every leg every run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 359c45a29fa1dbc971cdc27b3a9f6ff0b9f4c265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->