### PR TITLE
feat(hcl): add terradart_hcl — HCL parser, tf.json decoder and TfModule model (#657)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [terradart_core, terradart_codegen, terradart_google, terradart_google_beta, terradart_appwrite, terradart_cloudflare, terradart_agent, terradart_coverage]
+        package: [terradart_core, terradart_codegen, terradart_google, terradart_google_beta, terradart_appwrite, terradart_cloudflare, terradart_agent, terradart_coverage, terradart_hcl]
     steps:
       - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1
@@ -70,7 +70,7 @@ jobs:
       # CLI. wrap CLI output is the authoritative format for generated wrappers
       # and is guarded by the `wrap_check` job (`terradart wrap --check`).
       - if: matrix.package == 'terradart_core'
-        run: dart format --output=none --set-exit-if-changed packages/terradart_core/ packages/terradart_codegen/ packages/terradart_agent/ packages/terradart_coverage/
+        run: dart format --output=none --set-exit-if-changed packages/terradart_core/ packages/terradart_codegen/ packages/terradart_agent/ packages/terradart_coverage/ packages/terradart_hcl/
       - if: matrix.package == 'terradart_core'
         run: dart analyze packages/ tool/ --fatal-infos --fatal-warnings
       - if: matrix.package == 'terradart_core'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ TerraDart is a Dart-first infrastructure-as-code project that synthesizes Terraf
 - `terradart_cloudflare` for curated Cloudflare factories (`cloudflare/cloudflare`, filled at the current pin).
 - `terradart_agent` for the MCP catalog server.
 - `terradart_codegen` for maintainer generation commands such as `wrap`, `wrap-init`, and `wrap-promote`.
+- `terradart_hcl` for the HCL / `*.tf.json` front-end (`parseHcl`, `decodeTfJson`, `TfModule`) that `terradart-migrate` reads existing Terraform through (#80).
 
 Read `CONTEXT.md` before design work. It defines project-specific terms such as Curated factory, Beta-only factory, Maintainer generation pipeline, Merged IR, Wrapper override, Agent guide, and Local notes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Per-package changelogs live alongside each package and are the system of record 
 
 ## Unreleased
 
+- New package **`terradart_hcl`** — pure Dart HCL parser, `*.tf.json` decoder and `TfModule` model (the input side of `terradart-migrate`, #657).
+
 ## [0.27.0] - 2026-08-30
 
 Lockstep release across the workspace. **Breaking** — synth now rejects a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,8 @@ dart format --output=none --set-exit-if-changed \
   packages/terradart_core/ \
   packages/terradart_codegen/ \
   packages/terradart_agent/ \
-  packages/terradart_coverage/
+  packages/terradart_coverage/ \
+  packages/terradart_hcl/
 ```
 
 **Do not run `dart format` over the whole repo.** `terradart_google`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ See [terradart.dev](https://terradart.dev) for documentation, guides, and API re
 | [`terradart_agent`](packages/terradart_agent) | MCP server (`terradart-mcp`) exposing the curated factory catalog to AI agents. | *(unlisted)* |
 | [`terradart_codegen`](packages/terradart_codegen) | Maintainer generation tooling and CLI (`terradart wrap`). | [![pub](https://img.shields.io/pub/v/terradart_codegen.svg)](https://pub.dev/packages/terradart_codegen) |
 | [`terradart_hcl`](packages/terradart_hcl) | Pure Dart HCL / `*.tf.json` front-end and Terraform module model — the input side of `terradart-migrate`. | *(unlisted)* |
-| [`terradart_hcl`](packages/terradart_hcl) | HCL / `*.tf.json` front-end (parser, decoder, `TfModule`) for `terradart-migrate`. | *(unlisted)* |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ See [terradart.dev](https://terradart.dev) for documentation, guides, and API re
 | [`terradart_cloudflare`](packages/terradart_cloudflare) | Curated factory wrappers for Cloudflare edge infrastructure (`cloudflare/cloudflare`). | [![pub](https://img.shields.io/pub/v/terradart_cloudflare.svg)](https://pub.dev/packages/terradart_cloudflare) |
 | [`terradart_agent`](packages/terradart_agent) | MCP server (`terradart-mcp`) exposing the curated factory catalog to AI agents. | *(unlisted)* |
 | [`terradart_codegen`](packages/terradart_codegen) | Maintainer generation tooling and CLI (`terradart wrap`). | [![pub](https://img.shields.io/pub/v/terradart_codegen.svg)](https://pub.dev/packages/terradart_codegen) |
+| [`terradart_hcl`](packages/terradart_hcl) | Pure Dart HCL / `*.tf.json` front-end and Terraform module model — the input side of `terradart-migrate`. | *(unlisted)* |
+| [`terradart_hcl`](packages/terradart_hcl) | HCL / `*.tf.json` front-end (parser, decoder, `TfModule`) for `terradart-migrate`. | *(unlisted)* |
 
 ---
 

--- a/packages/terradart_hcl/CHANGELOG.md
+++ b/packages/terradart_hcl/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## 0.27.0 - unreleased
+
+Initial package (issue #657, part of the `terradart-migrate` epic #80).
+
+- `parseHcl` — HCL native-syntax parser: blocks with ordered, repeatable
+  entries, attributes, one-line blocks, quoted-string and heredoc templates
+  (`${}` interpolations, `%{}` directives, `<<-` flush indentation), comments
+  kept on the entries they precede, and a source range on every node.
+- Shallow expressions: literals, tuples, objects, traversals and templates
+  are parsed exactly; every other expression (function calls, operators,
+  conditionals, `for`, splats) is kept verbatim as `RawExpr` with balanced
+  brackets.
+- `decodeTfJson` — Terraform JSON syntax (`*.tf.json`) decoder producing the
+  same `HclFile` shape.
+- `TfModule` — the Terraform module model (terraform settings, providers,
+  variables, locals, outputs, resources, data sources, module calls, opaque
+  blocks) built from either front-end; `loadTfModule` reads a directory.
+- `HclWriter` — serializes files and expressions back to HCL, preserving
+  block order and repeats.

--- a/packages/terradart_hcl/LICENSE
+++ b/packages/terradart_hcl/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Nozomi Koborinai
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/terradart_hcl/README.md
+++ b/packages/terradart_hcl/README.md
@@ -1,0 +1,64 @@
+# terradart_hcl
+
+[![Dart SDK](https://img.shields.io/badge/Dart-%E2%89%A53.10-blue.svg)](https://dart.dev)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/nozomi-koborinai/terradart/blob/main/LICENSE)
+
+A pure Dart front-end for Terraform configurations: an HCL native-syntax
+parser, a `*.tf.json` decoder, and a shared module model (`TfModule`) that
+both produce. It is the input side of `terradart-migrate` (the HCL → Dart
+migrator, [#80](https://github.com/nozomi-koborinai/terradart/issues/80)) and
+depends on no other TerraDart package.
+
+## What it does
+
+- **Lossless structure.** Block bodies are ordered lists of entries, so
+  repeated blocks (`container {}` ×2, `env {}` ×3, `lifecycle_rule {}` ×2)
+  survive exactly as written. Every node carries a `SourceRange`, and comments
+  are kept on the entry they precede, so a caller can copy any block back out
+  verbatim.
+- **Shallow expressions.** Literals, tuples, objects, traversals
+  (`google_pubsub_topic.t.name`, `var.x`, `local.y[0]`) and templates
+  (`"${var.a}-x"`, heredocs) are parsed exactly. Everything else — function
+  calls, operators, conditionals, `for`, splats — is kept as `RawExpr` with
+  its verbatim source and balanced brackets. Migration needs classification,
+  not evaluation, so the full HCL expression grammar is deliberately not
+  implemented.
+- **Two front-ends, one model.** `parseHcl` and `decodeTfJson` both yield an
+  `HclFile`; `TfModule.fromFiles` reads the Terraform structure (terraform
+  settings, providers, variables, locals, outputs, resources, data sources,
+  module calls, and `moved` / `import` / `check` / `removed` kept opaque) from
+  either.
+- **Serializer.** `HclWriter` renders a file or expression back to HCL; parse →
+  write → parse is structurally identical.
+
+## Usage
+
+```dart
+import 'package:terradart_hcl/terradart_hcl.dart';
+
+final file = parseHcl(source, fileName: 'main.tf');
+for (final block in file.body.blocksOf('resource')) {
+  print('${block.labels[0].text}.${block.labels[1].text}');
+}
+
+final module = TfModule.fromFiles([file]);
+for (final r in module.resources) {
+  final name = r.body.attribute('name')?.value; // an Expr
+  print('${r.type}.${r.name}: ${name is LiteralExpr ? name.value : name}');
+}
+```
+
+## Conformance
+
+`test/specsuite_test.dart` runs every case of the
+[hashicorp/hcl specsuite](https://github.com/hashicorp/hcl/tree/main/specsuite)
+through the parser: cases the suite expects to succeed must parse, and the
+heredoc / literal cases are checked against the suite's expected values. The
+suite is fetched with a shallow `git clone` into `.dart_tool/hcl_specsuite`
+on first run (it is not vendored); set `TERRADART_HCL_SPECSUITE` to point at
+an existing checkout, or `TERRADART_HCL_SPECSUITE_SKIP=1` to skip the test
+offline.
+
+## Status
+
+Alpha, like the rest of TerraDart. Not published to pub.dev yet.

--- a/packages/terradart_hcl/analysis_options.yaml
+++ b/packages/terradart_hcl/analysis_options.yaml
@@ -1,0 +1,26 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+  errors:
+    invalid_use_of_internal_member: error
+    unused_import: error
+    unused_local_variable: error
+    dead_code: error
+
+linter:
+  rules:
+    - always_declare_return_types
+    - avoid_dynamic_calls
+    - avoid_print
+    - prefer_const_constructors
+    - prefer_const_declarations
+    - prefer_final_locals
+    - prefer_relative_imports
+    - require_trailing_commas
+    - sort_constructors_first
+    - unawaited_futures
+    - use_super_parameters

--- a/packages/terradart_hcl/lib/src/ast.dart
+++ b/packages/terradart_hcl/lib/src/ast.dart
@@ -1,0 +1,476 @@
+/// Syntax tree for HCL native syntax (and the same shape decoded from
+/// Terraform JSON).
+///
+/// The tree is *structural*: bodies keep their entries in source order,
+/// repeated blocks stay repeated, and every node carries a [SourceRange] so
+/// callers can copy any construct back out of the original text. Expressions
+/// are parsed *shallowly* — see [Expr].
+library;
+
+import 'source.dart';
+
+/// Any syntax node.
+sealed class HclNode {
+  const HclNode();
+
+  SourceRange get range;
+}
+
+/// A `#`, `//` or `/* */` comment, kept with its delimiters.
+final class Comment {
+  const Comment(this.text, this.range, {required this.isBlock});
+
+  /// The comment text including its delimiters (`# foo`, `/* bar */`).
+  final String text;
+  final SourceRange range;
+
+  /// True for `/* */` comments.
+  final bool isBlock;
+
+  @override
+  String toString() => text;
+}
+
+// ---------------------------------------------------------------------------
+// Expressions
+// ---------------------------------------------------------------------------
+
+/// An attribute value.
+///
+/// Only the shapes a migration needs to *classify* are parsed exactly:
+/// [LiteralExpr], [TemplateExpr], [TraversalExpr], [TupleExpr] and
+/// [ObjectExpr]. Anything else — function calls, operators, conditionals,
+/// `for` expressions, splats, parenthesised expressions — is a [RawExpr]
+/// holding the verbatim source with balanced brackets. Nothing is evaluated.
+sealed class Expr extends HclNode {
+  const Expr();
+
+  /// The string this expression denotes when it is a plain string literal
+  /// (a quoted string or heredoc without interpolations), else `null`.
+  String? get constantString => null;
+}
+
+/// A primitive literal: a string (from a quoted string without
+/// interpolation), a number, a boolean, or `null`.
+final class LiteralExpr extends Expr {
+  const LiteralExpr(this.value, this.range, {this.source});
+
+  /// `String`, `num`, `bool` or `null`.
+  final Object? value;
+
+  @override
+  final SourceRange range;
+
+  /// The literal's original text (`3.14159265358979323846264338327950288`)
+  /// so numbers that do not fit a Dart `double` still round-trip. `null`
+  /// for literals that did not come from source text.
+  final String? source;
+
+  bool get isString => value is String;
+  bool get isNumber => value is num;
+  bool get isBool => value is bool;
+  bool get isNull => value == null;
+
+  @override
+  String? get constantString => value is String ? value! as String : null;
+
+  @override
+  String toString() => 'Literal($value)';
+}
+
+/// One piece of a [TemplateExpr].
+sealed class TemplatePart extends HclNode {
+  const TemplatePart();
+}
+
+/// Literal text between interpolations, with escapes already decoded.
+final class TemplateLiteral extends TemplatePart {
+  const TemplateLiteral(this.text, this.range);
+
+  final String text;
+
+  @override
+  final SourceRange range;
+
+  @override
+  String toString() => 'Text(${text.replaceAll('\n', r'\n')})';
+}
+
+/// A `${ expr }` interpolation. [stripLeft] / [stripRight] record the `~`
+/// whitespace-strip markers (`${~ expr ~}`).
+final class TemplateInterpolation extends TemplatePart {
+  const TemplateInterpolation(
+    this.expr,
+    this.range, {
+    this.stripLeft = false,
+    this.stripRight = false,
+  });
+
+  final Expr expr;
+
+  @override
+  final SourceRange range;
+  final bool stripLeft;
+  final bool stripRight;
+
+  @override
+  String toString() => 'Interp($expr)';
+}
+
+/// A `%{ ... }` template directive (`if`, `else`, `endif`, `for`, `endfor`),
+/// kept as its verbatim [content] — a migrator treats a template with
+/// directives as opaque.
+final class TemplateDirective extends TemplatePart {
+  const TemplateDirective(
+    this.content,
+    this.range, {
+    this.stripLeft = false,
+    this.stripRight = false,
+  });
+
+  /// The text between `%{` and `}`, trimmed (`if var.x`, `endfor`).
+  final String content;
+
+  @override
+  final SourceRange range;
+  final bool stripLeft;
+  final bool stripRight;
+
+  @override
+  String toString() => 'Directive($content)';
+}
+
+/// A quoted string with interpolations or directives, or any heredoc.
+final class TemplateExpr extends Expr {
+  const TemplateExpr(
+    this.parts,
+    this.range, {
+    this.delimiter,
+    this.flush = false,
+    this.rawBody,
+  });
+
+  final List<TemplatePart> parts;
+
+  @override
+  final SourceRange range;
+
+  /// The heredoc marker (`EOT`), or `null` for a quoted string.
+  final String? delimiter;
+
+  /// True for a `<<-` heredoc (common leading whitespace removed).
+  final bool flush;
+
+  /// The heredoc body exactly as written (before flush stripping), so the
+  /// writer can reproduce it; `null` for quoted strings.
+  final String? rawBody;
+
+  bool get isHeredoc => delimiter != null;
+
+  /// True when the template has no interpolations or directives.
+  bool get isConstant => parts.every((p) => p is TemplateLiteral);
+
+  @override
+  String? get constantString =>
+      isConstant ? parts.map((p) => (p as TemplateLiteral).text).join() : null;
+
+  @override
+  String toString() => 'Template(${parts.join(', ')})';
+}
+
+/// One step of a [TraversalExpr].
+sealed class TraversalStep extends HclNode {
+  const TraversalStep();
+}
+
+/// `.name`
+final class AttrStep extends TraversalStep {
+  const AttrStep(this.name, this.range);
+
+  final String name;
+
+  @override
+  final SourceRange range;
+
+  @override
+  String toString() => '.$name';
+}
+
+/// `[0]` or `["key"]` with a literal index.
+final class IndexStep extends TraversalStep {
+  const IndexStep(this.index, this.range);
+
+  final LiteralExpr index;
+
+  @override
+  final SourceRange range;
+
+  @override
+  String toString() => '[${index.value}]';
+}
+
+/// A reference: `var.x`, `local.y`, `google_pubsub_topic.t.name`,
+/// `data.google_project.p.number`, `module.m.out`, `each.key`,
+/// `count.index`, `path.module`, `terraform.workspace`, `self.id`.
+///
+/// Only `.attr` and literal `[index]` steps are represented; a splat
+/// (`.*`, `[*]`) or a computed index turns the whole expression into a
+/// [RawExpr].
+final class TraversalExpr extends Expr {
+  const TraversalExpr(this.root, this.steps, this.range);
+
+  final String root;
+  final List<TraversalStep> steps;
+
+  @override
+  final SourceRange range;
+
+  /// `root.a.b` rendered without index steps — handy for classification.
+  String get dottedPath => [
+    root,
+    for (final s in steps)
+      if (s is AttrStep) s.name,
+  ].join('.');
+
+  @override
+  String toString() => 'Traversal($root${steps.join()})';
+}
+
+/// `[a, b, c]`
+final class TupleExpr extends Expr {
+  const TupleExpr(this.elements, this.range, {this.multiLine = false});
+
+  final List<Expr> elements;
+
+  @override
+  final SourceRange range;
+
+  /// True when the source spread the elements over several lines.
+  final bool multiLine;
+
+  @override
+  String toString() => 'Tuple(${elements.join(', ')})';
+}
+
+/// One `key = value` (or `key: value`) item of an [ObjectExpr].
+final class ObjectItem extends HclNode {
+  const ObjectItem(this.key, this.value, this.range, {this.colon = false});
+
+  /// A [LiteralExpr] string for identifier and quoted keys, a [RawExpr]
+  /// for a parenthesised `(expr)` key.
+  final Expr key;
+  final Expr value;
+
+  @override
+  final SourceRange range;
+
+  /// True when written `key: value`.
+  final bool colon;
+
+  /// The key text when it is a plain string.
+  String? get keyName => key.constantString;
+
+  @override
+  String toString() => '$key = $value';
+}
+
+/// `{ k = v, ... }`
+final class ObjectExpr extends Expr {
+  const ObjectExpr(this.items, this.range, {this.multiLine = false});
+
+  final List<ObjectItem> items;
+
+  @override
+  final SourceRange range;
+
+  /// True when the source spread the items over several lines.
+  final bool multiLine;
+
+  /// The first item whose key is [name], if any.
+  ObjectItem? item(String name) {
+    for (final i in items) {
+      if (i.keyName == name) return i;
+    }
+    return null;
+  }
+
+  @override
+  String toString() => 'Object(${items.join(', ')})';
+}
+
+/// Any expression the shallow parser does not model: kept verbatim.
+final class RawExpr extends Expr {
+  const RawExpr(this.source, this.range);
+
+  /// The exact source text, with balanced brackets.
+  final String source;
+
+  @override
+  final SourceRange range;
+
+  @override
+  String toString() => 'Raw($source)';
+}
+
+// ---------------------------------------------------------------------------
+// Structure
+// ---------------------------------------------------------------------------
+
+/// An entry of a [Body]: an [Attribute] or a [Block].
+sealed class BodyEntry extends HclNode {
+  const BodyEntry();
+
+  /// Comments on the lines directly before this entry.
+  List<Comment> get leadingComments;
+}
+
+/// `name = value`
+final class Attribute extends BodyEntry {
+  const Attribute(
+    this.name,
+    this.value,
+    this.range, {
+    required this.nameRange,
+    this.leadingComments = const [],
+    this.trailingComment,
+  });
+
+  final String name;
+  final Expr value;
+
+  @override
+  final SourceRange range;
+
+  /// The range of [name] alone.
+  final SourceRange nameRange;
+
+  @override
+  final List<Comment> leadingComments;
+
+  /// A comment on the same line, after the value.
+  final Comment? trailingComment;
+
+  @override
+  String toString() => '$name = $value';
+}
+
+/// One label of a [Block]: `"name"` (quoted) or `name` (identifier).
+final class BlockLabel {
+  const BlockLabel(this.text, this.range, {required this.quoted});
+
+  final String text;
+  final SourceRange range;
+  final bool quoted;
+
+  @override
+  String toString() => quoted ? '"$text"' : text;
+}
+
+/// `type "label" ... { body }`
+final class Block extends BodyEntry {
+  const Block(
+    this.type,
+    this.labels,
+    this.body,
+    this.range, {
+    required this.typeRange,
+    this.oneLine = false,
+    this.leadingComments = const [],
+    this.trailingComment,
+  });
+
+  final String type;
+  final List<BlockLabel> labels;
+  final Body body;
+
+  @override
+  final SourceRange range;
+
+  /// The range of [type] alone.
+  final SourceRange typeRange;
+
+  /// True for `a { b = "c" }` written on a single line.
+  final bool oneLine;
+
+  @override
+  final List<Comment> leadingComments;
+
+  /// A comment on the same line as the closing brace.
+  final Comment? trailingComment;
+
+  /// Label texts, quoted or not.
+  List<String> get labelTexts => [for (final l in labels) l.text];
+
+  @override
+  String toString() => 'Block($type ${labels.join(' ')})';
+}
+
+/// The ordered contents of a file or block.
+final class Body extends HclNode {
+  const Body(this.entries, this.range, {this.trailingComments = const []});
+
+  final List<BodyEntry> entries;
+
+  @override
+  final SourceRange range;
+
+  /// Comments after the last entry (before the closing brace / end of file).
+  final List<Comment> trailingComments;
+
+  Iterable<Attribute> get attributes => entries.whereType<Attribute>();
+  Iterable<Block> get blocks => entries.whereType<Block>();
+
+  /// The first attribute named [name], if any.
+  Attribute? attribute(String name) {
+    for (final e in entries) {
+      if (e is Attribute && e.name == name) return e;
+    }
+    return null;
+  }
+
+  /// All blocks of [type], in order.
+  List<Block> blocksOf(String type) => [
+    for (final e in entries)
+      if (e is Block && e.type == type) e,
+  ];
+
+  /// The first block of [type], if any.
+  Block? block(String type) {
+    for (final e in entries) {
+      if (e is Block && e.type == type) return e;
+    }
+    return null;
+  }
+
+  bool get isEmpty => entries.isEmpty;
+}
+
+/// A parsed file (native syntax or JSON syntax).
+final class HclFile extends HclNode {
+  const HclFile(
+    this.body, {
+    required this.source,
+    this.fileName,
+    this.comments = const [],
+    this.isJson = false,
+  });
+
+  final Body body;
+
+  /// The original text, so [SourceRange.textIn] works for every node.
+  final String source;
+  final String? fileName;
+
+  /// Every comment in the file, in source order (the same objects the
+  /// entries reference as leading / trailing comments).
+  final List<Comment> comments;
+
+  /// True when decoded from `*.tf.json` (nodes then have no source ranges).
+  final bool isJson;
+
+  @override
+  SourceRange get range => body.range;
+
+  /// The source text of [node].
+  String textOf(HclNode node) => node.range.textIn(source);
+}

--- a/packages/terradart_hcl/lib/src/diagnostics.dart
+++ b/packages/terradart_hcl/lib/src/diagnostics.dart
@@ -1,0 +1,31 @@
+import 'source.dart';
+
+/// One parse error with the range it points at.
+final class HclDiagnostic {
+  const HclDiagnostic(this.message, this.range, {this.fileName});
+
+  final String message;
+  final SourceRange range;
+  final String? fileName;
+
+  @override
+  String toString() {
+    final where = fileName == null ? '' : '$fileName:';
+    return '$where${range.start}: $message';
+  }
+}
+
+/// Thrown by the parser / decoder when the input is not valid HCL or
+/// Terraform JSON. Carries every diagnostic collected before giving up.
+final class HclParseException implements Exception {
+  HclParseException(this.diagnostics)
+    : assert(diagnostics.isNotEmpty, 'at least one diagnostic');
+
+  final List<HclDiagnostic> diagnostics;
+
+  HclDiagnostic get first => diagnostics.first;
+
+  @override
+  String toString() =>
+      'HclParseException: ${diagnostics.map((d) => d.toString()).join('; ')}';
+}

--- a/packages/terradart_hcl/lib/src/dump.dart
+++ b/packages/terradart_hcl/lib/src/dump.dart
@@ -1,0 +1,72 @@
+import 'ast.dart';
+
+/// A compact, position-free rendering of a node, for tests and debugging:
+/// two files that dump identically are structurally identical (comments
+/// excluded).
+String dumpHcl(HclNode node) {
+  final buf = StringBuffer();
+  _Dumper(buf).write(node, 0);
+  return buf.toString();
+}
+
+final class _Dumper {
+  _Dumper(this.buf);
+
+  final StringBuffer buf;
+
+  void _line(int indent, String text) {
+    buf.write('  ' * indent);
+    buf.writeln(text);
+  }
+
+  void write(HclNode n, int indent) {
+    switch (n) {
+      case HclFile(:final body):
+        write(body, indent);
+      case Body(:final entries):
+        for (final e in entries) {
+          write(e, indent);
+        }
+      case Attribute(:final name, :final value):
+        _line(indent, '$name = ${expr(value)}');
+      case Block(:final type, :final labels, :final body, :final oneLine):
+        final head = [
+          type,
+          for (final l in labels) l.quoted ? '"${l.text}"' : l.text,
+        ].join(' ');
+        _line(indent, '$head {${oneLine ? ' (one-line)' : ''}');
+        write(body, indent + 1);
+        _line(indent, '}');
+      case Expr():
+        _line(indent, expr(n));
+      case TemplatePart() || TraversalStep() || ObjectItem():
+        _line(indent, n.toString());
+    }
+  }
+
+  String expr(Expr e) => switch (e) {
+    LiteralExpr(:final value) => value is String ? _quote(value) : '$value',
+    TemplateExpr(:final parts, :final delimiter, :final flush) =>
+      '${delimiter == null ? 'template' : 'heredoc<<${flush ? '-' : ''}$delimiter'}'
+          '[${parts.map(_part).join('')}]',
+    TraversalExpr(:final root, :final steps) =>
+      'ref(${[root, for (final s in steps) switch (s) {
+          AttrStep(:final name) => '.$name',
+          IndexStep(:final index) => '[${expr(index)}]',
+        }].join()})',
+    TupleExpr(:final elements) => '[${elements.map(expr).join(', ')}]',
+    ObjectExpr(:final items) =>
+      '{${items.map((i) => '${expr(i.key)} = ${expr(i.value)}').join(', ')}}',
+    RawExpr(:final source) => 'raw(${source.replaceAll(RegExp(r'\s+'), ' ')})',
+  };
+
+  String _part(TemplatePart p) => switch (p) {
+    TemplateLiteral(:final text) => _quote(text),
+    TemplateInterpolation(:final expr, :final stripLeft, :final stripRight) =>
+      '\${${stripLeft ? '~' : ''}${this.expr(expr)}${stripRight ? '~' : ''}}',
+    TemplateDirective(:final content) => '%{$content}',
+  };
+
+  static String _quote(String s) =>
+      '"${s.replaceAll(r'\', r'\\').replaceAll('"', r'\"').replaceAll('\n', r'\n').replaceAll('\t', r'\t')}"';
+}

--- a/packages/terradart_hcl/lib/src/lexer.dart
+++ b/packages/terradart_hcl/lib/src/lexer.dart
@@ -1,0 +1,492 @@
+import 'diagnostics.dart';
+import 'source.dart';
+
+/// Token kinds of HCL native syntax.
+enum TokenType {
+  lbrace,
+  rbrace,
+  lbrack,
+  rbrack,
+  lparen,
+  rparen,
+  equal,
+  comma,
+  dot,
+  ellipsis,
+  colon,
+  question,
+  fatArrow,
+
+  /// `== != < <= > >= + - * / % && || !`
+  op,
+  ident,
+  number,
+
+  /// A quoted string; [Token.inner] is the text between the quotes.
+  string,
+
+  /// A heredoc; see [Token.delimiter], [Token.flush], [Token.body].
+  heredoc,
+  newline,
+  comment,
+  eof,
+}
+
+/// One lexical token with its source [range] and verbatim [text].
+final class Token {
+  const Token(
+    this.type,
+    this.text,
+    this.range, {
+    this.inner,
+    this.delimiter,
+    this.flush = false,
+    this.body,
+    this.bodyRange,
+  });
+
+  final TokenType type;
+  final String text;
+  final SourceRange range;
+
+  /// For [TokenType.string]: the raw text between the quotes (escapes and
+  /// interpolations undecoded).
+  final String? inner;
+
+  /// For [TokenType.heredoc]: the marker identifier.
+  final String? delimiter;
+
+  /// For [TokenType.heredoc]: true for the `<<-` form.
+  final bool flush;
+
+  /// For [TokenType.heredoc]: the lines between the opening line and the
+  /// closing marker, exactly as written (each ending in `\n`).
+  final String? body;
+
+  /// For [TokenType.heredoc]: the range of [body] within the file.
+  final SourceRange? bodyRange;
+
+  bool get isOp => type == TokenType.op;
+
+  @override
+  String toString() => '$type(${text.replaceAll('\n', r'\n')})@$range';
+}
+
+/// Splits HCL source into [Token]s. Whitespace is dropped; newlines and
+/// comments are tokens so the parser can decide where they matter.
+final class Lexer {
+  Lexer(
+    this.source, {
+    this.fileName,
+    this.baseOffset = 0,
+    this.baseLine = 1,
+    this.baseColumn = 1,
+  });
+
+  final String source;
+  final String? fileName;
+
+  /// When lexing a fragment (an interpolation inside a string), the
+  /// position of the fragment's first character in the enclosing file, so
+  /// every token range is file-relative.
+  final int baseOffset;
+  final int baseLine;
+  final int baseColumn;
+
+  int _pos = 0;
+  int _line = 1;
+  int _col = 1;
+  final _tokens = <Token>[];
+
+  static final RegExp _letter = RegExp(r'\p{L}', unicode: true);
+  static final RegExp _mark = RegExp(r'\p{M}', unicode: true);
+  static final RegExp _space = RegExp(r'\p{White_Space}', unicode: true);
+
+  List<Token> tokenize() {
+    while (_pos < source.length) {
+      final c = source.codeUnitAt(_pos);
+      if (c == 0x0a) {
+        _newline();
+      } else if (c == 0x20 || c == 0x09 || c == 0x0d) {
+        _advance();
+      } else if (c == 0x23 /* # */ ) {
+        _lineComment();
+      } else if (c == 0x2f /* / */ && _peekChar(1) == 0x2f) {
+        _lineComment();
+      } else if (c == 0x2f && _peekChar(1) == 0x2a /* * */ ) {
+        _blockComment();
+      } else if (c == 0x22 /* " */ ) {
+        _string();
+      } else if (c == 0x3c /* < */ && _peekChar(1) == 0x3c) {
+        _heredoc();
+      } else if (_isDigit(c)) {
+        _number();
+      } else if (_isIdStart(_pos)) {
+        _ident();
+      } else {
+        _punct();
+      }
+    }
+    _tokens.add(Token(TokenType.eof, '', SourceRange(_here(), _here())));
+    return _tokens;
+  }
+
+  // -- helpers --------------------------------------------------------------
+
+  int _peekChar(int ahead) =>
+      _pos + ahead < source.length ? source.codeUnitAt(_pos + ahead) : -1;
+
+  SourcePos _here() => SourcePos(
+    baseOffset + _pos,
+    baseLine + _line - 1,
+    _line == 1 ? baseColumn + _col - 1 : _col,
+  );
+
+  void _advance([int n = 1]) {
+    for (var i = 0; i < n; i++) {
+      if (source.codeUnitAt(_pos) == 0x0a) {
+        _line++;
+        _col = 1;
+      } else {
+        _col++;
+      }
+      _pos++;
+    }
+  }
+
+  void _emit(TokenType type, SourcePos start, {String? text}) {
+    final end = _here();
+    _tokens.add(
+      Token(
+        type,
+        text ?? source.substring(start.offset - baseOffset, _pos),
+        SourceRange(start, end),
+      ),
+    );
+  }
+
+  Never _fail(String message, SourcePos start) {
+    throw HclParseException([
+      HclDiagnostic(message, SourceRange(start, _here()), fileName: fileName),
+    ]);
+  }
+
+  static bool _isDigit(int c) => c >= 0x30 && c <= 0x39;
+
+  bool _isIdStart(int at) {
+    final c = source.codeUnitAt(at);
+    if (c == 0x5f /* _ */ ) return true;
+    if ((c >= 0x41 && c <= 0x5a) || (c >= 0x61 && c <= 0x7a)) return true;
+    if (c < 0x80) return false;
+    return _letter.hasMatch(_charAt(at));
+  }
+
+  bool _isIdContinue(int at) {
+    final c = source.codeUnitAt(at);
+    if (c == 0x2d /* - */ || _isDigit(c)) return true;
+    if (_isIdStart(at)) return true;
+    if (c < 0x80) return false;
+    return _mark.hasMatch(_charAt(at));
+  }
+
+  /// The character at [at], as a string (a surrogate pair when needed).
+  String _charAt(int at) {
+    final c = source.codeUnitAt(at);
+    if (c >= 0xd800 && c <= 0xdbff && at + 1 < source.length) {
+      return source.substring(at, at + 2);
+    }
+    return String.fromCharCode(c);
+  }
+
+  /// Number of leading whitespace *characters* of [line] (Unicode
+  /// White_Space, so tabs and em spaces each count once).
+  static int leadingWhitespace(String line) {
+    var n = 0;
+    for (final r in line.runes) {
+      if (r == 0x20 ||
+          r == 0x09 ||
+          (r > 0x7f && _space.hasMatch(String.fromCharCode(r)))) {
+        n++;
+      } else {
+        break;
+      }
+    }
+    return n;
+  }
+
+  // -- scanners --------------------------------------------------------------
+
+  void _newline() {
+    final start = _here();
+    _advance();
+    _emit(TokenType.newline, start);
+  }
+
+  void _lineComment() {
+    final start = _here();
+    while (_pos < source.length && source.codeUnitAt(_pos) != 0x0a) {
+      _advance();
+    }
+    // Drop a trailing carriage return from CRLF files.
+    var text = source.substring(start.offset - baseOffset, _pos);
+    if (text.endsWith('\r')) text = text.substring(0, text.length - 1);
+    _emit(TokenType.comment, start, text: text);
+  }
+
+  void _blockComment() {
+    final start = _here();
+    _advance(2);
+    while (true) {
+      if (_pos >= source.length) _fail('unterminated block comment', start);
+      if (source.codeUnitAt(_pos) == 0x2a && _peekChar(1) == 0x2f) {
+        _advance(2);
+        break;
+      }
+      _advance();
+    }
+    _emit(TokenType.comment, start);
+  }
+
+  void _number() {
+    final start = _here();
+    while (_pos < source.length && _isDigit(source.codeUnitAt(_pos))) {
+      _advance();
+    }
+    if (_pos < source.length &&
+        source.codeUnitAt(_pos) == 0x2e &&
+        _isDigit(_peekChar(1))) {
+      _advance();
+      while (_pos < source.length && _isDigit(source.codeUnitAt(_pos))) {
+        _advance();
+      }
+    }
+    final e = _pos < source.length ? source.codeUnitAt(_pos) : -1;
+    if (e == 0x65 || e == 0x45) {
+      var ahead = 1;
+      final sign = _peekChar(1);
+      if (sign == 0x2b || sign == 0x2d) ahead = 2;
+      if (_isDigit(_peekChar(ahead))) {
+        _advance(ahead);
+        while (_pos < source.length && _isDigit(source.codeUnitAt(_pos))) {
+          _advance();
+        }
+      }
+    }
+    _emit(TokenType.number, start);
+  }
+
+  void _ident() {
+    final start = _here();
+    _advance(_charAt(_pos).length);
+    while (_pos < source.length && _isIdContinue(_pos)) {
+      _advance(_charAt(_pos).length);
+    }
+    _emit(TokenType.ident, start);
+  }
+
+  void _string() {
+    final start = _here();
+    _advance(); // opening quote
+    final innerStart = _pos;
+    while (true) {
+      if (_pos >= source.length) _fail('unterminated string', start);
+      final c = source.codeUnitAt(_pos);
+      if (c == 0x5c /* \ */ ) {
+        if (_pos + 1 >= source.length) _fail('unterminated string', start);
+        _advance(2);
+      } else if (c == 0x22) {
+        break;
+      } else if (c == 0x0a) {
+        _fail('newline in string literal', start);
+      } else if ((c == 0x24 /* $ */ || c == 0x25 /* % */ ) &&
+          _peekChar(1) == c &&
+          _peekChar(2) == 0x7b) {
+        _advance(3); // `$${` / `%%{` escape
+      } else if ((c == 0x24 || c == 0x25) && _peekChar(1) == 0x7b) {
+        _advance(2);
+        _skipInterpolation(start);
+      } else {
+        _advance();
+      }
+    }
+    final inner = source.substring(innerStart, _pos);
+    _advance(); // closing quote
+    final end = _here();
+    _tokens.add(
+      Token(
+        TokenType.string,
+        source.substring(start.offset - baseOffset, _pos),
+        SourceRange(start, end),
+        inner: inner,
+      ),
+    );
+  }
+
+  /// Skips to the `}` closing an interpolation / directive opened just
+  /// before [_pos], tracking nested braces and nested quoted strings.
+  void _skipInterpolation(SourcePos start) {
+    var depth = 1;
+    while (true) {
+      if (_pos >= source.length) _fail('unterminated interpolation', start);
+      final c = source.codeUnitAt(_pos);
+      if (c == 0x22) {
+        _skipNestedString(start);
+      } else if (c == 0x7b) {
+        depth++;
+        _advance();
+      } else if (c == 0x7d) {
+        depth--;
+        _advance();
+        if (depth == 0) return;
+      } else {
+        _advance();
+      }
+    }
+  }
+
+  void _skipNestedString(SourcePos start) {
+    _advance(); // opening quote
+    while (true) {
+      if (_pos >= source.length) _fail('unterminated string', start);
+      final c = source.codeUnitAt(_pos);
+      if (c == 0x5c) {
+        _advance(2);
+      } else if (c == 0x22) {
+        _advance();
+        return;
+      } else if ((c == 0x24 || c == 0x25) &&
+          _peekChar(1) == c &&
+          _peekChar(2) == 0x7b) {
+        _advance(3);
+      } else if ((c == 0x24 || c == 0x25) && _peekChar(1) == 0x7b) {
+        _advance(2);
+        _skipInterpolation(start);
+      } else {
+        _advance();
+      }
+    }
+  }
+
+  void _heredoc() {
+    final start = _here();
+    _advance(2); // <<
+    var flush = false;
+    if (_pos < source.length && source.codeUnitAt(_pos) == 0x2d) {
+      flush = true;
+      _advance();
+    }
+    while (_pos < source.length &&
+        (source.codeUnitAt(_pos) == 0x20 || source.codeUnitAt(_pos) == 0x09)) {
+      _advance();
+    }
+    if (_pos >= source.length || !_isIdStart(_pos)) {
+      _fail('heredoc marker expected after <<', start);
+    }
+    final markerStart = _pos;
+    while (_pos < source.length && _isIdContinue(_pos)) {
+      _advance(_charAt(_pos).length);
+    }
+    final delimiter = source.substring(markerStart, _pos);
+    while (_pos < source.length &&
+        (source.codeUnitAt(_pos) == 0x20 ||
+            source.codeUnitAt(_pos) == 0x09 ||
+            source.codeUnitAt(_pos) == 0x0d)) {
+      _advance();
+    }
+    if (_pos >= source.length || source.codeUnitAt(_pos) != 0x0a) {
+      _fail('newline expected after heredoc marker', start);
+    }
+    _advance(); // the newline that starts the body
+    final bodyStartPos = _here();
+    final bodyStart = _pos;
+    // Scan line by line for the closing marker.
+    while (true) {
+      if (_pos >= source.length) {
+        _fail('unterminated heredoc (missing closing "$delimiter")', start);
+      }
+      final lineStart = _pos;
+      var lineEnd = source.indexOf('\n', lineStart);
+      if (lineEnd < 0) lineEnd = source.length;
+      var line = source.substring(lineStart, lineEnd);
+      if (line.endsWith('\r')) line = line.substring(0, line.length - 1);
+      if (line.trim() == delimiter) {
+        final body = source.substring(bodyStart, lineStart);
+        final bodyRange = SourceRange(bodyStartPos, _here());
+        // Position after the marker (before its newline).
+        final markerOffset = lineStart + line.indexOf(delimiter);
+        _advance(markerOffset - _pos + delimiter.length);
+        final end = _here();
+        _tokens.add(
+          Token(
+            TokenType.heredoc,
+            source.substring(start.offset - baseOffset, _pos),
+            SourceRange(start, end),
+            delimiter: delimiter,
+            flush: flush,
+            body: body,
+            bodyRange: bodyRange,
+          ),
+        );
+        return;
+      }
+      // Consume the line and its newline.
+      _advance(lineEnd - _pos);
+      if (_pos < source.length) _advance();
+    }
+  }
+
+  void _punct() {
+    final start = _here();
+    final c = source.codeUnitAt(_pos);
+    final n = _peekChar(1);
+    final n2 = _peekChar(2);
+    TokenType? type;
+    var len = 1;
+    if (c == 0x2e && n == 0x2e && n2 == 0x2e) {
+      type = TokenType.ellipsis;
+      len = 3;
+    } else if (c == 0x3d && n == 0x3e) {
+      type = TokenType.fatArrow;
+      len = 2;
+    } else if ((c == 0x3d || c == 0x21 || c == 0x3c || c == 0x3e) &&
+        n == 0x3d) {
+      type = TokenType.op; // == != <= >=
+      len = 2;
+    } else if ((c == 0x26 && n == 0x26) || (c == 0x7c && n == 0x7c)) {
+      type = TokenType.op; // && ||
+      len = 2;
+    } else {
+      type = switch (c) {
+        0x7b => TokenType.lbrace,
+        0x7d => TokenType.rbrace,
+        0x5b => TokenType.lbrack,
+        0x5d => TokenType.rbrack,
+        0x28 => TokenType.lparen,
+        0x29 => TokenType.rparen,
+        0x3d => TokenType.equal,
+        0x2c => TokenType.comma,
+        0x2e => TokenType.dot,
+        0x3a => TokenType.colon,
+        0x3f => TokenType.question,
+        0x2b ||
+        0x2d ||
+        0x2a ||
+        0x2f ||
+        0x25 ||
+        0x3c ||
+        0x3e ||
+        0x21 => TokenType.op,
+        _ => null,
+      };
+    }
+    if (type == null) {
+      _advance(_charAt(_pos).length);
+      _fail(
+        'unexpected character "${_charAt(start.offset - baseOffset)}"',
+        start,
+      );
+    }
+    _advance(len);
+    _emit(type, start);
+  }
+}

--- a/packages/terradart_hcl/lib/src/loader.dart
+++ b/packages/terradart_hcl/lib/src/loader.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'ast.dart';
+import 'parser.dart';
+import 'tf_json.dart';
+import 'tf_module.dart';
+
+/// Reads every `*.tf` and `*.tf.json` file directly under [directory]
+/// (sorted by name, like Terraform) into one [TfModule].
+///
+/// `*_override.tf` files are read as ordinary files — this model does not
+/// apply override merging.
+TfModule loadTfModule(Directory directory) =>
+    TfModule.fromFiles(loadTfFiles(directory));
+
+/// The parsed files of [directory], sorted by file name.
+List<HclFile> loadTfFiles(Directory directory) {
+  final files =
+      directory
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.tf') || f.path.endsWith('.tf.json'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+  return [
+    for (final f in files)
+      f.path.endsWith('.json')
+          ? decodeTfJson(f.readAsStringSync(), fileName: f.path)
+          : parseHcl(f.readAsStringSync(), fileName: f.path),
+  ];
+}

--- a/packages/terradart_hcl/lib/src/parser.dart
+++ b/packages/terradart_hcl/lib/src/parser.dart
@@ -449,6 +449,9 @@ final class _Parser {
         end = next.range.end;
         _i += 2;
       } else if (_t.type == TokenType.lbrack) {
+        // `[` is never the last token, but `foo[` at EOF has only `eof`
+        // after it: fall back to the raw scanner, which reports it.
+        if (_i + 2 >= tokens.length) return null;
         final open = _t;
         final idx = tokens[_i + 1];
         final close = tokens[_i + 2];

--- a/packages/terradart_hcl/lib/src/parser.dart
+++ b/packages/terradart_hcl/lib/src/parser.dart
@@ -1,0 +1,991 @@
+import 'ast.dart';
+import 'diagnostics.dart';
+import 'lexer.dart';
+import 'source.dart';
+
+/// Parses HCL native syntax into an [HclFile].
+///
+/// Throws [HclParseException] on the first syntax error. Structure is
+/// parsed fully (blocks, one-line blocks, attributes, comments); expression
+/// parsing is shallow — see [Expr].
+HclFile parseHcl(String source, {String? fileName}) {
+  final tokens = Lexer(source, fileName: fileName).tokenize();
+  return _Parser(source, tokens, fileName: fileName).parseFile();
+}
+
+/// Parses a standalone expression (`var.x`, `"${a}-b"`, `[1, 2]`, ...).
+Expr parseHclExpression(String source, {String? fileName}) {
+  final tokens = Lexer(source, fileName: fileName).tokenize();
+  return _Parser(
+    source,
+    tokens,
+    fileName: fileName,
+  ).parseStandaloneExpression();
+}
+
+/// Builds the expression for a string whose escapes are already decoded
+/// (a `*.tf.json` string value): `${ }` interpolations and `%{ }`
+/// directives are parsed, `$${` / `%%{` are the literal escapes, and
+/// backslashes are plain characters. Returns a [LiteralExpr] when the text
+/// has no template markers.
+Expr templateFromDecodedString(String text, {String? fileName}) {
+  final parts = _TemplateParser(
+    text,
+    fileName: fileName,
+    escapes: false,
+    baseOffset: 0,
+    baseLine: 0,
+    baseColumn: 0,
+    positions: false,
+  ).parse();
+  if (parts.isEmpty) return const LiteralExpr('', SourceRange.none);
+  if (parts.length == 1 && parts.single is TemplateLiteral) {
+    return LiteralExpr(
+      (parts.single as TemplateLiteral).text,
+      SourceRange.none,
+    );
+  }
+  return TemplateExpr(parts, SourceRange.none);
+}
+
+/// Removes the common leading whitespace of a `<<-` heredoc body: the
+/// smallest number of leading whitespace *characters* over the non-blank
+/// lines is dropped from every line (matching hashicorp/hcl).
+String stripFlushIndent(String body) {
+  final lines = body.split('\n');
+  int? min;
+  for (final line in lines) {
+    if (line.trim().isEmpty) continue;
+    final n = Lexer.leadingWhitespace(line);
+    if (min == null || n < min) min = n;
+  }
+  if (min == null || min == 0) return body;
+  final out = <String>[];
+  for (final line in lines) {
+    final runes = line.runes.toList();
+    final drop = runes.length < min ? runes.length : min;
+    // Only whitespace is dropped, even on shorter blank lines.
+    var k = 0;
+    while (k < drop &&
+        Lexer.leadingWhitespace(String.fromCharCode(runes[k])) == 1) {
+      k++;
+    }
+    out.add(String.fromCharCodes(runes.sublist(k)));
+  }
+  return out.join('\n');
+}
+
+/// Where an expression appears, which decides what ends it.
+enum _Ctx {
+  /// An attribute value: ends at the newline (or a comment / `}` / EOF).
+  attribute,
+
+  /// A tuple element: newlines are insignificant; `,` or `]` ends it.
+  tuple,
+
+  /// An object item value: `,`, a newline, a comment or `}` ends it.
+  object,
+}
+
+final class _Parser {
+  _Parser(this.source, this.tokens, {this.fileName, this.offsetBase = 0});
+
+  final String source;
+  final List<Token> tokens;
+  final String? fileName;
+
+  /// File offset of `source[0]` — non-zero when [source] is an
+  /// interpolation fragment whose token ranges are file-relative.
+  final int offsetBase;
+  int _i = 0;
+  final _comments = <Comment>[];
+
+  Token get _t => tokens[_i];
+
+  Never _fail(String message, SourceRange range) {
+    throw HclParseException([
+      HclDiagnostic(message, range, fileName: fileName),
+    ]);
+  }
+
+  Never _failAt(String message, Token t) => _fail(message, t.range);
+
+  Comment _comment(Token t) {
+    final c = Comment(t.text, t.range, isBlock: t.text.startsWith('/*'));
+    _comments.add(c);
+    return c;
+  }
+
+  // -- structure ------------------------------------------------------------
+
+  HclFile parseFile() {
+    final body = _parseBody(blockStart: null);
+    if (_t.type != TokenType.eof) _failAt('unexpected "${_t.text}"', _t);
+    return HclFile(
+      body,
+      source: source,
+      fileName: fileName,
+      comments: List.unmodifiable(_comments),
+    );
+  }
+
+  Expr parseStandaloneExpression() {
+    _skipNewlinesAndComments();
+    final expr = _parseExpr(_Ctx.tuple);
+    _skipNewlinesAndComments();
+    if (_t.type != TokenType.eof) {
+      _failAt('unexpected "${_t.text}" after expression', _t);
+    }
+    return expr;
+  }
+
+  /// Parses entries until the closing brace (when [blockStart] is set) or
+  /// end of file.
+  Body _parseBody({required Token? blockStart}) {
+    final start = _t.range.start;
+    final entries = <BodyEntry>[];
+    var pending = <Comment>[];
+    while (true) {
+      final t = _t;
+      switch (t.type) {
+        case TokenType.newline:
+          _i++;
+        case TokenType.comment:
+          pending.add(_comment(t));
+          _i++;
+        case TokenType.rbrace:
+          if (blockStart == null) _failAt('unexpected "}"', t);
+          return Body(
+            entries,
+            SourceRange(start, t.range.start),
+            trailingComments: pending,
+          );
+        case TokenType.eof:
+          if (blockStart != null) {
+            _fail(
+              'unclosed block "${blockStart.text}" (missing "}")',
+              blockStart.range,
+            );
+          }
+          return Body(
+            entries,
+            SourceRange(start, t.range.start),
+            trailingComments: pending,
+          );
+        case TokenType.ident:
+          entries.add(_parseEntry(pending));
+          pending = <Comment>[];
+        default:
+          _failAt(
+            'expected an argument or block definition, found "${t.text}"',
+            t,
+          );
+      }
+    }
+  }
+
+  BodyEntry _parseEntry(List<Comment> leading) {
+    final nameTok = _t;
+    _i++;
+    if (_t.type == TokenType.equal) {
+      return _parseAttributeRest(nameTok, leading, inOneLineBlock: false);
+    }
+    return _parseBlockRest(nameTok, leading);
+  }
+
+  Attribute _parseAttributeRest(
+    Token nameTok,
+    List<Comment> leading, {
+    required bool inOneLineBlock,
+  }) {
+    _i++; // '='
+    final value = _parseExpr(_Ctx.attribute);
+    Comment? trailing;
+    if (!inOneLineBlock) {
+      if (_t.type == TokenType.comment) {
+        trailing = _comment(_t);
+        _i++;
+      }
+      switch (_t.type) {
+        case TokenType.newline:
+          _i++;
+        case TokenType.eof:
+          break;
+        case TokenType.comma:
+          _failAt('each argument must be on its own line', _t);
+        default:
+          _failAt('missing newline after argument', _t);
+      }
+    }
+    return Attribute(
+      nameTok.text,
+      value,
+      SourceRange(nameTok.range.start, value.range.end),
+      nameRange: nameTok.range,
+      leadingComments: leading,
+      trailingComment: trailing,
+    );
+  }
+
+  Block _parseBlockRest(Token typeTok, List<Comment> leading) {
+    final labels = <BlockLabel>[];
+    while (_t.type == TokenType.ident || _t.type == TokenType.string) {
+      final t = _t;
+      if (t.type == TokenType.string) {
+        final expr = _templateFromString(t);
+        final text = expr.constantString;
+        if (text == null) {
+          _failAt('a block label must be a plain string', t);
+        }
+        labels.add(BlockLabel(text, t.range, quoted: true));
+      } else {
+        labels.add(BlockLabel(t.text, t.range, quoted: false));
+      }
+      _i++;
+    }
+    if (_t.type != TokenType.lbrace) {
+      _failAt(
+        labels.isEmpty
+            ? 'expected "=" or "{" after "${typeTok.text}"'
+            : 'expected "{" to open the "${typeTok.text}" block',
+        _t,
+      );
+    }
+    _i++; // '{'
+    final Body body;
+    final bool oneLine;
+    if (_t.type == TokenType.newline) {
+      _i++;
+      body = _parseBody(blockStart: typeTok);
+      oneLine = false;
+    } else {
+      body = _parseOneLineBody();
+      oneLine = true;
+    }
+    final closeTok = _t; // '}' guaranteed by the body parsers
+    _i++;
+    Comment? trailing;
+    if (_t.type == TokenType.comment) {
+      trailing = _comment(_t);
+      _i++;
+    }
+    switch (_t.type) {
+      case TokenType.newline:
+        _i++;
+      case TokenType.eof:
+        break;
+      default:
+        _failAt('missing newline after block definition', _t);
+    }
+    return Block(
+      typeTok.text,
+      labels,
+      body,
+      SourceRange(typeTok.range.start, closeTok.range.end),
+      typeRange: typeTok.range,
+      oneLine: oneLine,
+      leadingComments: leading,
+      trailingComment: trailing,
+    );
+  }
+
+  /// `{ }` or `{ name = expr }` on the opening line.
+  Body _parseOneLineBody() {
+    final start = _t.range.start;
+    final entries = <BodyEntry>[];
+    if (_t.type == TokenType.ident) {
+      final nameTok = _t;
+      _i++;
+      if (_t.type != TokenType.equal) {
+        _fail(
+          'a single-line block definition cannot contain another block '
+          'definition',
+          nameTok.range,
+        );
+      }
+      entries.add(_parseAttributeRest(nameTok, const [], inOneLineBlock: true));
+      if (_t.type == TokenType.comma || _t.type == TokenType.ident) {
+        _failAt(
+          'only one argument is allowed in a single-line block definition',
+          _t,
+        );
+      }
+    }
+    if (_t.type == TokenType.newline) {
+      _failAt(
+        'the closing brace for a single-line block definition must be on '
+        'the same line',
+        _t,
+      );
+    }
+    if (_t.type != TokenType.rbrace) {
+      _failAt('expected "}" to close the single-line block', _t);
+    }
+    return Body(entries, SourceRange(start, _t.range.start));
+  }
+
+  // -- expressions ----------------------------------------------------------
+
+  void _skipNewlinesAndComments() {
+    while (_t.type == TokenType.newline || _t.type == TokenType.comment) {
+      if (_t.type == TokenType.comment) _comment(_t);
+      _i++;
+    }
+  }
+
+  /// Parses one expression in context [ctx].
+  Expr _parseExpr(_Ctx ctx) {
+    if (ctx == _Ctx.tuple) _skipNewlinesAndComments();
+    final startIndex = _i;
+    final simple = _tryParseSimple();
+    if (simple != null && _atTerminator(ctx)) return simple;
+    if (simple != null &&
+        ctx == _Ctx.attribute &&
+        (_t.type == TokenType.ident ||
+            _t.type == TokenType.string ||
+            _t.type == TokenType.number)) {
+      _failAt('missing newline after argument', _t);
+    }
+    _i = startIndex;
+    return _parseRaw(ctx);
+  }
+
+  /// Whether token type [t] ends an expression in [ctx] (at bracket depth
+  /// zero).
+  static bool _terminates(TokenType t, _Ctx ctx) => switch (ctx) {
+    _Ctx.attribute => switch (t) {
+      TokenType.newline ||
+      TokenType.comment ||
+      TokenType.eof ||
+      TokenType.rbrace => true,
+      _ => false,
+    },
+    _Ctx.tuple => switch (t) {
+      TokenType.comma ||
+      TokenType.rbrack ||
+      TokenType.rbrace ||
+      TokenType.rparen ||
+      TokenType.eof => true,
+      _ => false,
+    },
+    _Ctx.object => switch (t) {
+      TokenType.comma ||
+      TokenType.newline ||
+      TokenType.comment ||
+      TokenType.rbrace ||
+      TokenType.eof => true,
+      _ => false,
+    },
+  };
+
+  bool _atTerminator(_Ctx ctx) {
+    var j = _i;
+    if (ctx == _Ctx.tuple) {
+      // Peek past insignificant newlines / comments without consuming.
+      while (tokens[j].type == TokenType.newline ||
+          tokens[j].type == TokenType.comment) {
+        j++;
+      }
+    }
+    return _terminates(tokens[j].type, ctx);
+  }
+
+  /// Literal, template, traversal, tuple or object — or `null` when the
+  /// upcoming tokens are not one of those shapes.
+  Expr? _tryParseSimple() {
+    final t = _t;
+    switch (t.type) {
+      case TokenType.number:
+        _i++;
+        return _number(t.text, t.range);
+      case TokenType.op:
+        if (t.text == '-' && tokens[_i + 1].type == TokenType.number) {
+          final n = tokens[_i + 1];
+          _i += 2;
+          return _number('-${n.text}', SourceRange(t.range.start, n.range.end));
+        }
+        return null;
+      case TokenType.string:
+        _i++;
+        return _templateFromString(t);
+      case TokenType.heredoc:
+        _i++;
+        return _templateFromHeredoc(t);
+      case TokenType.ident:
+        return _tryParseTraversal();
+      case TokenType.lbrack:
+        return _tryParseTuple();
+      case TokenType.lbrace:
+        return _tryParseObject();
+      default:
+        return null;
+    }
+  }
+
+  Expr? _tryParseTraversal() {
+    final root = _t;
+    switch (root.text) {
+      case 'true':
+        _i++;
+        return LiteralExpr(true, root.range, source: root.text);
+      case 'false':
+        _i++;
+        return LiteralExpr(false, root.range, source: root.text);
+      case 'null':
+        _i++;
+        return LiteralExpr(null, root.range, source: root.text);
+    }
+    _i++;
+    if (_t.type == TokenType.lparen) return null; // function call
+    final steps = <TraversalStep>[];
+    var end = root.range.end;
+    while (true) {
+      if (_t.type == TokenType.dot) {
+        final next = tokens[_i + 1];
+        if (next.type != TokenType.ident) return null; // splat, legacy index
+        steps.add(
+          AttrStep(next.text, SourceRange(_t.range.start, next.range.end)),
+        );
+        end = next.range.end;
+        _i += 2;
+      } else if (_t.type == TokenType.lbrack) {
+        final open = _t;
+        final idx = tokens[_i + 1];
+        final close = tokens[_i + 2];
+        if (close.type != TokenType.rbrack) return null;
+        final LiteralExpr index;
+        if (idx.type == TokenType.number) {
+          index = _number(idx.text, idx.range);
+        } else if (idx.type == TokenType.string) {
+          final e = _templateFromString(idx);
+          if (e is! LiteralExpr) return null;
+          index = e;
+        } else {
+          return null;
+        }
+        steps.add(
+          IndexStep(index, SourceRange(open.range.start, close.range.end)),
+        );
+        end = close.range.end;
+        _i += 3;
+      } else {
+        break;
+      }
+    }
+    return TraversalExpr(root.text, steps, SourceRange(root.range.start, end));
+  }
+
+  Expr? _tryParseTuple() {
+    final open = _t;
+    _i++;
+    _skipNewlinesAndComments();
+    if (_t.type == TokenType.ident && _t.text == 'for') return null;
+    final elements = <Expr>[];
+    while (true) {
+      _skipNewlinesAndComments();
+      if (_t.type == TokenType.rbrack) break;
+      if (_t.type == TokenType.eof) {
+        _failAt('unterminated tuple (missing "]")', open);
+      }
+      elements.add(_parseExpr(_Ctx.tuple));
+      _skipNewlinesAndComments();
+      if (_t.type == TokenType.comma) {
+        _i++;
+        continue;
+      }
+      if (_t.type == TokenType.rbrack) break;
+      if (_t.type == TokenType.eof) {
+        _failAt('unterminated tuple (missing "]")', open);
+      }
+      _failAt('expected "," or "]" in tuple, found "${_t.text}"', _t);
+    }
+    final close = _t;
+    _i++;
+    return TupleExpr(
+      elements,
+      SourceRange(open.range.start, close.range.end),
+      multiLine: close.range.start.line != open.range.start.line,
+    );
+  }
+
+  Expr? _tryParseObject() {
+    final open = _t;
+    _i++;
+    _skipNewlinesAndComments();
+    if (_t.type == TokenType.ident && _t.text == 'for') return null;
+    final items = <ObjectItem>[];
+    while (true) {
+      _skipNewlinesAndComments();
+      if (_t.type == TokenType.rbrace) break;
+      if (_t.type == TokenType.eof) {
+        _failAt('unterminated object (missing "}")', open);
+      }
+      final keyTok = _t;
+      final Expr key;
+      switch (keyTok.type) {
+        case TokenType.ident:
+          key = LiteralExpr(keyTok.text, keyTok.range, source: keyTok.text);
+          _i++;
+        case TokenType.string:
+          final e = _templateFromString(keyTok);
+          key = e is LiteralExpr ? e : RawExpr(keyTok.text, keyTok.range);
+          _i++;
+        case TokenType.lparen:
+          key = _parseRaw(_Ctx.tuple, singleBracketed: true);
+        default:
+          _failAt('expected an object key, found "${keyTok.text}"', keyTok);
+      }
+      final colon = _t.type == TokenType.colon;
+      if (!colon && _t.type != TokenType.equal) {
+        _failAt('expected "=" or ":" after object key, found "${_t.text}"', _t);
+      }
+      _i++;
+      final value = _parseExpr(_Ctx.object);
+      items.add(
+        ObjectItem(
+          key,
+          value,
+          SourceRange(keyTok.range.start, value.range.end),
+          colon: colon,
+        ),
+      );
+      var separated = false;
+      if (_t.type == TokenType.comma) {
+        _i++;
+        separated = true;
+      }
+      while (_t.type == TokenType.newline || _t.type == TokenType.comment) {
+        if (_t.type == TokenType.comment) _comment(_t);
+        _i++;
+        separated = true;
+      }
+      if (_t.type == TokenType.rbrace) break;
+      if (!separated) {
+        _failAt(
+          'expected "," or newline between object items, found "${_t.text}"',
+          _t,
+        );
+      }
+    }
+    final close = _t;
+    _i++;
+    return ObjectExpr(
+      items,
+      SourceRange(open.range.start, close.range.end),
+      multiLine: close.range.start.line != open.range.start.line,
+    );
+  }
+
+  /// Consumes tokens verbatim until the expression ends in [ctx], keeping
+  /// brackets balanced. With [singleBracketed] the raw expression is
+  /// exactly one bracketed group starting at the current token (an object
+  /// key `(expr)`).
+  RawExpr _parseRaw(_Ctx ctx, {bool singleBracketed = false}) {
+    final first = _t;
+    var depth = 0;
+    Token? last;
+    while (true) {
+      final t = _t;
+      if (depth == 0 &&
+          last != null &&
+          !singleBracketed &&
+          _terminates(t.type, ctx)) {
+        break;
+      }
+      switch (t.type) {
+        case TokenType.eof:
+          if (last == null) _failAt('expected an expression', t);
+          _failAt('unbalanced brackets in expression', first);
+        case TokenType.lbrace || TokenType.lbrack || TokenType.lparen:
+          depth++;
+        case TokenType.rbrace || TokenType.rbrack || TokenType.rparen:
+          if (depth == 0) {
+            if (last == null) _failAt('expected an expression', t);
+            _failAt('unbalanced "${t.text}" in expression', t);
+          }
+          depth--;
+        case TokenType.newline:
+          if (depth == 0 && last == null) {
+            if (ctx == _Ctx.tuple) {
+              _i++;
+              continue;
+            }
+            _failAt('expected an expression', t);
+          }
+        case TokenType.comment:
+          _comment(t);
+        case TokenType.comma:
+          if (depth == 0 && ctx == _Ctx.attribute) {
+            _failAt('each argument must be on its own line', t);
+          }
+        case TokenType.equal:
+          if (depth == 0 && ctx == _Ctx.attribute) {
+            _failAt('unexpected "=" in expression', t);
+          }
+        default:
+          break;
+      }
+      last = t;
+      _i++;
+      if (singleBracketed && depth == 0) break;
+    }
+    final range = SourceRange(first.range.start, last.range.end);
+    return RawExpr(
+      source.substring(
+        first.range.start.offset - offsetBase,
+        last.range.end.offset - offsetBase,
+      ),
+      range,
+    );
+  }
+
+  LiteralExpr _number(String text, SourceRange range) {
+    final value = num.tryParse(text) ?? double.parse(text);
+    return LiteralExpr(value, range, source: text);
+  }
+
+  // -- templates ------------------------------------------------------------
+
+  Expr _templateFromString(Token t) {
+    final inner = t.inner!;
+    final start = t.range.start;
+    final parts = _TemplateParser(
+      inner,
+      fileName: fileName,
+      escapes: true,
+      baseOffset: start.offset + 1,
+      baseLine: start.line,
+      baseColumn: start.column + 1,
+      positions: true,
+    ).parse();
+    if (parts.isEmpty) return LiteralExpr('', t.range, source: t.text);
+    if (parts.length == 1 && parts.single is TemplateLiteral) {
+      return LiteralExpr(
+        (parts.single as TemplateLiteral).text,
+        t.range,
+        source: t.text,
+      );
+    }
+    return TemplateExpr(parts, t.range);
+  }
+
+  TemplateExpr _templateFromHeredoc(Token t) {
+    final raw = t.body!;
+    final body = t.flush ? stripFlushIndent(raw) : raw;
+    final bodyStart = t.bodyRange!.start;
+    final parts = _TemplateParser(
+      body,
+      fileName: fileName,
+      escapes: false,
+      baseOffset: bodyStart.offset,
+      baseLine: bodyStart.line,
+      baseColumn: bodyStart.column,
+      // Flush stripping shifts columns; positions stay approximate then.
+      positions: !t.flush,
+    ).parse();
+    return TemplateExpr(
+      parts,
+      t.range,
+      delimiter: t.delimiter,
+      flush: t.flush,
+      rawBody: raw,
+    );
+  }
+}
+
+/// Splits template text into literal / interpolation / directive parts.
+final class _TemplateParser {
+  _TemplateParser(
+    this.text, {
+    required this.fileName,
+    required this.escapes,
+    required this.baseOffset,
+    required this.baseLine,
+    required this.baseColumn,
+    required this.positions,
+  });
+
+  final String text;
+  final String? fileName;
+
+  /// Decode backslash escapes (quoted strings) or not (heredocs, JSON).
+  final bool escapes;
+  final int baseOffset;
+  final int baseLine;
+  final int baseColumn;
+
+  /// False when the text does not map onto the file (no ranges).
+  final bool positions;
+
+  final _parts = <TemplatePart>[];
+  final _buf = StringBuffer();
+  int _bufStart = 0;
+  int _line = 0;
+  int _col = 0;
+
+  SourcePos _pos(int index) {
+    if (!positions) return SourcePos.none;
+    // Recompute line / column for [index] from the start of the text.
+    var line = baseLine;
+    var col = baseColumn;
+    for (var k = 0; k < index; k++) {
+      if (text.codeUnitAt(k) == 0x0a) {
+        line++;
+        col = 1;
+      } else {
+        col++;
+      }
+    }
+    _line = line;
+    _col = col;
+    return SourcePos(baseOffset + index, _line, _col);
+  }
+
+  SourceRange _range(int from, int to) =>
+      positions ? SourceRange(_pos(from), _pos(to)) : SourceRange.none;
+
+  Never _fail(String message, int at) {
+    throw HclParseException([
+      HclDiagnostic(message, _range(at, at + 1), fileName: fileName),
+    ]);
+  }
+
+  List<TemplatePart> parse() {
+    var i = 0;
+    while (i < text.length) {
+      final c = text.codeUnitAt(i);
+      if (escapes && c == 0x5c /* \ */ ) {
+        i = _escape(i);
+        continue;
+      }
+      if (c == 0x24 /* $ */ || c == 0x25 /* % */ ) {
+        if (i + 2 < text.length &&
+            text.codeUnitAt(i + 1) == c &&
+            text.codeUnitAt(i + 2) == 0x7b) {
+          _buf.writeCharCode(c);
+          _buf.write('{');
+          i += 3;
+          continue;
+        }
+        if (i + 1 < text.length && text.codeUnitAt(i + 1) == 0x7b) {
+          _flushLiteral(i);
+          final end = _findClose(i + 2);
+          var inner = text.substring(i + 2, end);
+          var stripLeft = false;
+          var stripRight = false;
+          if (inner.startsWith('~')) {
+            stripLeft = true;
+            inner = inner.substring(1);
+          }
+          if (inner.endsWith('~')) {
+            stripRight = true;
+            inner = inner.substring(0, inner.length - 1);
+          }
+          final range = _range(i, end + 1);
+          if (c == 0x24) {
+            _parts.add(
+              TemplateInterpolation(
+                _innerExpression(inner, i + 2 + (stripLeft ? 1 : 0)),
+                range,
+                stripLeft: stripLeft,
+                stripRight: stripRight,
+              ),
+            );
+          } else {
+            _parts.add(
+              TemplateDirective(
+                inner.trim(),
+                range,
+                stripLeft: stripLeft,
+                stripRight: stripRight,
+              ),
+            );
+          }
+          i = end + 1;
+          _bufStart = i;
+          continue;
+        }
+      }
+      _buf.writeCharCode(c);
+      i++;
+    }
+    _flushLiteral(text.length);
+    return _parts;
+  }
+
+  void _flushLiteral(int end) {
+    if (_buf.isEmpty) return;
+    _parts.add(TemplateLiteral(_buf.toString(), _range(_bufStart, end)));
+    _buf.clear();
+  }
+
+  Expr _innerExpression(String inner, int innerIndex) {
+    final lexer = positions
+        ? Lexer(
+            inner,
+            fileName: fileName,
+            baseOffset: baseOffset + innerIndex,
+            baseLine: _pos(innerIndex).line,
+            baseColumn: _pos(innerIndex).column,
+          )
+        : Lexer(inner, fileName: fileName);
+    final tokens = lexer.tokenize();
+    final expr = _Parser(
+      inner,
+      tokens,
+      fileName: fileName,
+      offsetBase: positions ? baseOffset + innerIndex : 0,
+    ).parseStandaloneExpression();
+    return positions ? expr : _withoutPositions(expr);
+  }
+
+  /// Interpolations of JSON strings carry no file positions.
+  static Expr _withoutPositions(Expr e) => switch (e) {
+    LiteralExpr(:final value, :final source) => LiteralExpr(
+      value,
+      SourceRange.none,
+      source: source,
+    ),
+    TraversalExpr(:final root, :final steps) => TraversalExpr(root, [
+      for (final s in steps)
+        switch (s) {
+          AttrStep(:final name) => AttrStep(name, SourceRange.none),
+          IndexStep(:final index) => IndexStep(
+            LiteralExpr(index.value, SourceRange.none, source: index.source),
+            SourceRange.none,
+          ),
+        },
+    ], SourceRange.none),
+    TupleExpr(:final elements, :final multiLine) => TupleExpr(
+      [for (final x in elements) _withoutPositions(x)],
+      SourceRange.none,
+      multiLine: multiLine,
+    ),
+    ObjectExpr(:final items, :final multiLine) => ObjectExpr(
+      [
+        for (final it in items)
+          ObjectItem(
+            _withoutPositions(it.key),
+            _withoutPositions(it.value),
+            SourceRange.none,
+            colon: it.colon,
+          ),
+      ],
+      SourceRange.none,
+      multiLine: multiLine,
+    ),
+    TemplateExpr(
+      :final parts,
+      :final delimiter,
+      :final flush,
+      :final rawBody,
+    ) =>
+      TemplateExpr(
+        [
+          for (final p in parts)
+            switch (p) {
+              TemplateLiteral(:final text) => TemplateLiteral(
+                text,
+                SourceRange.none,
+              ),
+              TemplateInterpolation(
+                :final expr,
+                :final stripLeft,
+                :final stripRight,
+              ) =>
+                TemplateInterpolation(
+                  _withoutPositions(expr),
+                  SourceRange.none,
+                  stripLeft: stripLeft,
+                  stripRight: stripRight,
+                ),
+              TemplateDirective(
+                :final content,
+                :final stripLeft,
+                :final stripRight,
+              ) =>
+                TemplateDirective(
+                  content,
+                  SourceRange.none,
+                  stripLeft: stripLeft,
+                  stripRight: stripRight,
+                ),
+            },
+        ],
+        SourceRange.none,
+        delimiter: delimiter,
+        flush: flush,
+        rawBody: rawBody,
+      ),
+    RawExpr(:final source) => RawExpr(source, SourceRange.none),
+  };
+
+  /// Index of the `}` closing the interpolation whose content starts at
+  /// [from], honouring nested braces and quoted strings.
+  int _findClose(int from) {
+    var depth = 1;
+    var i = from;
+    while (i < text.length) {
+      final c = text.codeUnitAt(i);
+      if (c == 0x22) {
+        i = _skipQuoted(i + 1);
+        continue;
+      }
+      if (c == 0x7b) depth++;
+      if (c == 0x7d) {
+        depth--;
+        if (depth == 0) return i;
+      }
+      i++;
+    }
+    _fail('unterminated template interpolation', from - 2);
+  }
+
+  int _skipQuoted(int i) {
+    while (i < text.length) {
+      final c = text.codeUnitAt(i);
+      if (c == 0x5c) {
+        i += 2;
+      } else if (c == 0x22) {
+        return i + 1;
+      } else if ((c == 0x24 || c == 0x25) &&
+          i + 1 < text.length &&
+          text.codeUnitAt(i + 1) == 0x7b) {
+        i = _findClose(i + 2) + 1;
+      } else {
+        i++;
+      }
+    }
+    _fail('unterminated string in template interpolation', i);
+  }
+
+  int _escape(int i) {
+    if (i + 1 >= text.length) _fail('dangling backslash in string', i);
+    final e = text.codeUnitAt(i + 1);
+    switch (e) {
+      case 0x6e:
+        _buf.write('\n');
+      case 0x72:
+        _buf.write('\r');
+      case 0x74:
+        _buf.write('\t');
+      case 0x22:
+        _buf.write('"');
+      case 0x5c:
+        _buf.write(r'\');
+      case 0x75 || 0x55:
+        final len = e == 0x75 ? 4 : 8;
+        if (i + 2 + len > text.length) _fail('invalid unicode escape', i);
+        final hex = text.substring(i + 2, i + 2 + len);
+        final code = int.tryParse(hex, radix: 16);
+        if (code == null) {
+          _fail('invalid unicode escape "\\${String.fromCharCode(e)}$hex"', i);
+        }
+        _buf.writeCharCode(code);
+        return i + 2 + len;
+      default:
+        _fail('invalid escape sequence "\\${String.fromCharCode(e)}"', i);
+    }
+    return i + 2;
+  }
+}

--- a/packages/terradart_hcl/lib/src/source.dart
+++ b/packages/terradart_hcl/lib/src/source.dart
@@ -1,0 +1,65 @@
+/// A position in a source file: zero-based byte [offset] plus one-based
+/// [line] and [column] (UTF-16 code units, like Dart's own error messages).
+final class SourcePos implements Comparable<SourcePos> {
+  const SourcePos(this.offset, this.line, this.column);
+
+  /// The position used for nodes that have no source text, such as blocks
+  /// decoded from `*.tf.json`.
+  static const none = SourcePos(-1, 0, 0);
+
+  final int offset;
+  final int line;
+  final int column;
+
+  bool get isNone => offset < 0;
+
+  @override
+  int compareTo(SourcePos other) => offset.compareTo(other.offset);
+
+  @override
+  bool operator ==(Object other) =>
+      other is SourcePos && other.offset == offset;
+
+  @override
+  int get hashCode => offset.hashCode;
+
+  @override
+  String toString() => '$line:$column';
+}
+
+/// A half-open span `[start, end)` of a source file.
+final class SourceRange {
+  const SourceRange(this.start, this.end);
+
+  /// The range of nodes without source text (see [SourcePos.none]).
+  static const none = SourceRange(SourcePos.none, SourcePos.none);
+
+  final SourcePos start;
+  final SourcePos end;
+
+  bool get isNone => start.isNone;
+
+  /// The text this range covers in [source].
+  String textIn(String source) =>
+      isNone ? '' : source.substring(start.offset, end.offset);
+
+  /// The smallest range covering both this and [other].
+  SourceRange union(SourceRange other) {
+    if (isNone) return other;
+    if (other.isNone) return this;
+    return SourceRange(
+      start.offset <= other.start.offset ? start : other.start,
+      end.offset >= other.end.offset ? end : other.end,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is SourceRange && other.start == start && other.end == end;
+
+  @override
+  int get hashCode => Object.hash(start, end);
+
+  @override
+  String toString() => isNone ? '<none>' : '$start-$end';
+}

--- a/packages/terradart_hcl/lib/src/tf_json.dart
+++ b/packages/terradart_hcl/lib/src/tf_json.dart
@@ -10,8 +10,9 @@ import 'source.dart';
 ///
 /// The Terraform-level structure is fixed, so it maps to blocks without a
 /// schema: `resource` / `data` values are `{type: {name: body}}`,
-/// `variable` / `output` / `module` / `provider` values are `{name: body}`,
-/// `terraform` / `moved` / `import` / `removed` / `check` values are a body,
+/// `variable` / `output` / `module` / `provider` / `check` values are
+/// `{name: body}`, `terraform` / `moved` / `import` / `removed` values are a
+/// body,
 /// and `locals` is a body of attributes. Wherever Terraform allows a list
 /// of bodies (repeated `provider` configurations, several `resource` entries
 /// of the same address) each element becomes its own block.
@@ -61,8 +62,14 @@ final class _TfJsonDecoder {
   final String? fileName;
 
   static const _twoLabels = {'resource', 'data'};
-  static const _oneLabel = {'variable', 'output', 'module', 'provider'};
-  static const _noLabel = {'terraform', 'moved', 'import', 'removed', 'check'};
+  static const _oneLabel = {
+    'variable',
+    'output',
+    'module',
+    'provider',
+    'check',
+  };
+  static const _noLabel = {'terraform', 'moved', 'import', 'removed'};
 
   Never _fail(String message) {
     throw HclParseException([

--- a/packages/terradart_hcl/lib/src/tf_json.dart
+++ b/packages/terradart_hcl/lib/src/tf_json.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+
+import 'ast.dart';
+import 'diagnostics.dart';
+import 'parser.dart';
+import 'source.dart';
+
+/// Decodes a Terraform JSON configuration (`*.tf.json`) into the same
+/// [HclFile] shape [parseHcl] produces.
+///
+/// The Terraform-level structure is fixed, so it maps to blocks without a
+/// schema: `resource` / `data` values are `{type: {name: body}}`,
+/// `variable` / `output` / `module` / `provider` values are `{name: body}`,
+/// `terraform` / `moved` / `import` / `removed` / `check` values are a body,
+/// and `locals` is a body of attributes. Wherever Terraform allows a list
+/// of bodies (repeated `provider` configurations, several `resource` entries
+/// of the same address) each element becomes its own block.
+///
+/// Inside a body every key is an attribute: JSON objects become
+/// [ObjectExpr], arrays [TupleExpr], and strings are parsed as templates
+/// (`"${var.x}-y"` → [TemplateExpr]). Nodes decoded from JSON carry
+/// [SourceRange.none].
+HclFile decodeTfJson(String json, {String? fileName}) {
+  final Object? root;
+  try {
+    root = jsonDecode(json);
+  } on FormatException catch (e) {
+    throw HclParseException([
+      HclDiagnostic(
+        'invalid JSON: ${e.message}',
+        SourceRange.none,
+        fileName: fileName,
+      ),
+    ]);
+  }
+  if (root is! Map<String, dynamic>) {
+    throw HclParseException([
+      HclDiagnostic(
+        'a Terraform JSON file must be a JSON object',
+        SourceRange.none,
+        fileName: fileName,
+      ),
+    ]);
+  }
+  final decoder = _TfJsonDecoder(fileName);
+  final entries = <BodyEntry>[];
+  for (final e in root.entries) {
+    entries.addAll(decoder.topLevel(e.key, e.value));
+  }
+  return HclFile(
+    Body(entries, SourceRange.none),
+    source: json,
+    fileName: fileName,
+    isJson: true,
+  );
+}
+
+final class _TfJsonDecoder {
+  _TfJsonDecoder(this.fileName);
+
+  final String? fileName;
+
+  static const _twoLabels = {'resource', 'data'};
+  static const _oneLabel = {'variable', 'output', 'module', 'provider'};
+  static const _noLabel = {'terraform', 'moved', 'import', 'removed', 'check'};
+
+  Never _fail(String message) {
+    throw HclParseException([
+      HclDiagnostic(message, SourceRange.none, fileName: fileName),
+    ]);
+  }
+
+  List<BodyEntry> topLevel(String key, Object? value) {
+    if (_twoLabels.contains(key)) {
+      final byType = _object(value, 'top-level "$key"');
+      return [
+        for (final t in byType.entries)
+          for (final n in _object(t.value, '"$key" type "${t.key}"').entries)
+            for (final body in _bodies(n.value, '$key.${t.key}.${n.key}'))
+              _block(key, [t.key, n.key], body),
+      ];
+    }
+    if (_oneLabel.contains(key)) {
+      final byName = _object(value, 'top-level "$key"');
+      return [
+        for (final n in byName.entries)
+          for (final body in _bodies(n.value, '$key.${n.key}'))
+            _block(key, [n.key], body),
+      ];
+    }
+    if (key == 'locals') {
+      return [
+        for (final body in _bodies(value, 'locals'))
+          _block('locals', const [], body),
+      ];
+    }
+    if (_noLabel.contains(key) ||
+        value is Map<String, dynamic> ||
+        value is List) {
+      return [
+        for (final body in _bodies(value, key)) _block(key, const [], body),
+      ];
+    }
+    return [_attribute(key, value)];
+  }
+
+  Map<String, dynamic> _object(Object? value, String what) {
+    if (value is Map<String, dynamic>) return value;
+    _fail('$what must be a JSON object');
+  }
+
+  /// A body, or each body of a list of bodies.
+  List<Map<String, dynamic>> _bodies(Object? value, String what) {
+    if (value is Map<String, dynamic>) return [value];
+    if (value is List) {
+      return [
+        for (final v in value)
+          if (v is Map<String, dynamic>)
+            v
+          else
+            _fail('$what: every list element must be a JSON object'),
+      ];
+    }
+    _fail('$what must be a JSON object or a list of objects');
+  }
+
+  Block _block(String type, List<String> labels, Map<String, dynamic> body) =>
+      Block(
+        type,
+        [for (final l in labels) BlockLabel(l, SourceRange.none, quoted: true)],
+        Body([
+          for (final e in body.entries) _attribute(e.key, e.value),
+        ], SourceRange.none),
+        SourceRange.none,
+        typeRange: SourceRange.none,
+      );
+
+  Attribute _attribute(String name, Object? value) => Attribute(
+    name,
+    expr(value),
+    SourceRange.none,
+    nameRange: SourceRange.none,
+  );
+
+  Expr expr(Object? value) => switch (value) {
+    null => const LiteralExpr(null, SourceRange.none, source: 'null'),
+    String() => templateFromDecodedString(value, fileName: fileName),
+    num() => LiteralExpr(value, SourceRange.none, source: _numberText(value)),
+    bool() => LiteralExpr(value, SourceRange.none, source: value.toString()),
+    List() => TupleExpr([for (final v in value) expr(v)], SourceRange.none),
+    Map<String, dynamic>() => ObjectExpr(
+      [
+        for (final e in value.entries)
+          ObjectItem(
+            LiteralExpr(e.key, SourceRange.none, source: e.key),
+            expr(e.value),
+            SourceRange.none,
+          ),
+      ],
+      SourceRange.none,
+      multiLine: value.isNotEmpty,
+    ),
+    _ => _fail('unsupported JSON value ${value.runtimeType}'),
+  };
+
+  static String _numberText(num n) {
+    if (n is int) return n.toString();
+    final d = n as double;
+    if (d == d.roundToDouble() && d.abs() < 1e15) return d.toInt().toString();
+    return d.toString();
+  }
+}

--- a/packages/terradart_hcl/lib/src/tf_module.dart
+++ b/packages/terradart_hcl/lib/src/tf_module.dart
@@ -209,11 +209,41 @@ final class TerraformBlock extends TfBlock {
 
   Expr? get requiredVersion => argument('required_version');
 
-  /// `backend "type" { ... }`, if any.
-  Block? get backend => body.block('backend');
+  /// `backend "type" { ... }`, if any — also from the JSON form
+  /// `"backend": {"type": { ... }}`, which is surfaced as an equivalent
+  /// synthesized [Block] (no source range).
+  Block? get backend {
+    final b = body.block('backend');
+    if (b != null) return b;
+    final v = body.attribute('backend')?.value;
+    if (v is! ObjectExpr || v.items.length != 1) return null;
+    final item = v.items.single;
+    final type = item.keyName;
+    final settings = item.value;
+    if (type == null || settings is! ObjectExpr) return null;
+    return Block(
+      'backend',
+      [BlockLabel(type, item.key.range, quoted: true)],
+      bodyFromObject(settings),
+      v.range,
+      typeRange: SourceRange.none,
+    );
+  }
 
-  /// `cloud { ... }`, if any.
-  Block? get cloud => body.block('cloud');
+  /// `cloud { ... }`, if any — also from the JSON form `"cloud": { ... }`.
+  Block? get cloud {
+    final b = body.block('cloud');
+    if (b != null) return b;
+    final v = body.attribute('cloud')?.value;
+    if (v is! ObjectExpr) return null;
+    return Block(
+      'cloud',
+      const [],
+      bodyFromObject(v),
+      v.range,
+      typeRange: SourceRange.none,
+    );
+  }
 
   /// `required_providers { name = {...} }` as name → expression.
   Map<String, Expr> get requiredProviders {

--- a/packages/terradart_hcl/lib/src/tf_module.dart
+++ b/packages/terradart_hcl/lib/src/tf_module.dart
@@ -1,0 +1,318 @@
+import 'ast.dart';
+import 'diagnostics.dart';
+import 'parser.dart';
+import 'source.dart';
+import 'tf_json.dart';
+
+/// A Terraform module: the top-level structure of one or more files, from
+/// either front-end ([parseHcl] or [decodeTfJson]).
+///
+/// Blocks keep their [Block] node and the [HclFile] they came from, so a
+/// caller can copy any of them back out verbatim (`sourceText`). Nothing is
+/// evaluated or merged: `*_override.tf` files are read like any other file,
+/// and duplicate addresses are kept as written.
+final class TfModule {
+  TfModule.fromFiles(List<HclFile> files) : files = List.unmodifiable(files) {
+    for (final file in files) {
+      for (final entry in file.body.entries) {
+        _add(file, entry);
+      }
+    }
+  }
+
+  /// Parses [source] as HCL native syntax.
+  factory TfModule.fromHcl(String source, {String? fileName}) =>
+      TfModule.fromFiles([parseHcl(source, fileName: fileName)]);
+
+  /// Decodes [json] as a `*.tf.json` file.
+  factory TfModule.fromTfJson(String json, {String? fileName}) =>
+      TfModule.fromFiles([decodeTfJson(json, fileName: fileName)]);
+
+  final List<HclFile> files;
+  final terraform = <TerraformBlock>[];
+  final providers = <ProviderBlock>[];
+  final variables = <VariableBlock>[];
+  final locals = <LocalValue>[];
+  final outputs = <OutputBlock>[];
+  final resources = <ResourceBlock>[];
+  final dataSources = <DataBlock>[];
+  final moduleCalls = <ModuleCallBlock>[];
+
+  /// `moved`, `import`, `removed`, `check` and any block type this model
+  /// does not interpret, in source order.
+  final opaque = <OpaqueBlock>[];
+
+  /// Top-level attributes, which Terraform does not allow; kept so a caller
+  /// can report them.
+  final strayAttributes = <Attribute>[];
+
+  /// Blocks whose label count is wrong for their type (a `resource` with
+  /// one label, ...). They are also listed in [opaque].
+  final warnings = <HclDiagnostic>[];
+
+  void _add(HclFile file, BodyEntry entry) {
+    switch (entry) {
+      case Attribute():
+        strayAttributes.add(entry);
+      case Block(:final type, :final labels):
+        switch (type) {
+          case 'terraform' when labels.isEmpty:
+            terraform.add(TerraformBlock._(file, entry));
+          case 'provider' when labels.length == 1:
+            providers.add(ProviderBlock._(file, entry));
+          case 'variable' when labels.length == 1:
+            variables.add(VariableBlock._(file, entry));
+          case 'output' when labels.length == 1:
+            outputs.add(OutputBlock._(file, entry));
+          case 'module' when labels.length == 1:
+            moduleCalls.add(ModuleCallBlock._(file, entry));
+          case 'resource' when labels.length == 2:
+            resources.add(ResourceBlock._(file, entry));
+          case 'data' when labels.length == 2:
+            dataSources.add(DataBlock._(file, entry));
+          case 'locals' when labels.isEmpty:
+            for (final a in entry.body.attributes) {
+              locals.add(LocalValue._(file, entry, a));
+            }
+          case 'terraform' ||
+              'provider' ||
+              'variable' ||
+              'output' ||
+              'module' ||
+              'resource' ||
+              'data' ||
+              'locals':
+            warnings.add(
+              HclDiagnostic(
+                '"$type" block has ${labels.length} label(s)',
+                entry.range,
+                fileName: file.fileName,
+              ),
+            );
+            opaque.add(OpaqueBlock._(file, entry));
+          default:
+            opaque.add(OpaqueBlock._(file, entry));
+        }
+    }
+  }
+
+  /// The first `backend "type" {}` block of any `terraform {}` block.
+  Block? get backend {
+    for (final t in terraform) {
+      final b = t.backend;
+      if (b != null) return b;
+    }
+    return null;
+  }
+
+  /// `required_providers` entries (name → expression) merged over every
+  /// `terraform {}` block, in order.
+  Map<String, Expr> get requiredProviders {
+    final out = <String, Expr>{};
+    for (final t in terraform) {
+      out.addAll(t.requiredProviders);
+    }
+    return out;
+  }
+
+  /// The first `required_version` of any `terraform {}` block.
+  Expr? get requiredVersion {
+    for (final t in terraform) {
+      final v = t.requiredVersion;
+      if (v != null) return v;
+    }
+    return null;
+  }
+
+  /// `resource "type" "name"` by address (`type.name`), first wins.
+  ResourceBlock? resource(String type, String name) {
+    for (final r in resources) {
+      if (r.type == type && r.name == name) return r;
+    }
+    return null;
+  }
+
+  /// `data "type" "name"` by address, first wins.
+  DataBlock? data(String type, String name) {
+    for (final d in dataSources) {
+      if (d.type == type && d.name == name) return d;
+    }
+    return null;
+  }
+
+  VariableBlock? variable(String name) {
+    for (final v in variables) {
+      if (v.name == name) return v;
+    }
+    return null;
+  }
+
+  OutputBlock? output(String name) {
+    for (final o in outputs) {
+      if (o.name == name) return o;
+    }
+    return null;
+  }
+
+  LocalValue? local(String name) {
+    for (final l in locals) {
+      if (l.name == name) return l;
+    }
+    return null;
+  }
+}
+
+/// A top-level Terraform block together with the file it came from.
+sealed class TfBlock {
+  const TfBlock(this.file, this.block);
+
+  final HclFile file;
+  final Block block;
+
+  Body get body => block.body;
+  SourceRange get range => block.range;
+
+  /// The block exactly as written (empty for JSON-decoded files).
+  String get sourceText => file.textOf(block);
+
+  /// The body of a nested argument written either as a block
+  /// (`lifecycle { ... }`) or, in JSON syntax, as an object attribute
+  /// (`"lifecycle": { ... }`); `null` when absent.
+  Body? nestedBody(String name) {
+    final b = body.block(name);
+    if (b != null) return b.body;
+    final a = body.attribute(name);
+    final v = a?.value;
+    if (v is ObjectExpr) return bodyFromObject(v);
+    return null;
+  }
+
+  /// The attribute value named [name], if any.
+  Expr? argument(String name) => body.attribute(name)?.value;
+}
+
+/// Views an [ObjectExpr] as a [Body] of attributes (JSON nested arguments).
+Body bodyFromObject(ObjectExpr object) => Body([
+  for (final item in object.items)
+    if (item.keyName != null)
+      Attribute(
+        item.keyName!,
+        item.value,
+        item.range,
+        nameRange: item.key.range,
+      ),
+], object.range);
+
+/// `terraform { ... }`
+final class TerraformBlock extends TfBlock {
+  const TerraformBlock._(super.file, super.block);
+
+  Expr? get requiredVersion => argument('required_version');
+
+  /// `backend "type" { ... }`, if any.
+  Block? get backend => body.block('backend');
+
+  /// `cloud { ... }`, if any.
+  Block? get cloud => body.block('cloud');
+
+  /// `required_providers { name = {...} }` as name → expression.
+  Map<String, Expr> get requiredProviders {
+    final nested = nestedBody('required_providers');
+    if (nested == null) return const {};
+    return {for (final a in nested.attributes) a.name: a.value};
+  }
+}
+
+/// `provider "name" { ... }`
+final class ProviderBlock extends TfBlock {
+  const ProviderBlock._(super.file, super.block);
+
+  String get name => block.labels.single.text;
+
+  /// The `alias` argument as a string, when it is a literal.
+  String? get alias => argument('alias')?.constantString;
+}
+
+/// `variable "name" { ... }`
+final class VariableBlock extends TfBlock {
+  const VariableBlock._(super.file, super.block);
+
+  String get name => block.labels.single.text;
+  Expr? get type => argument('type');
+  Expr? get defaultValue => argument('default');
+  Expr? get description => argument('description');
+  Expr? get sensitive => argument('sensitive');
+}
+
+/// One `name = expr` inside a `locals { ... }` block.
+final class LocalValue {
+  const LocalValue._(this.file, this.block, this.attribute);
+
+  final HclFile file;
+
+  /// The enclosing `locals` block.
+  final Block block;
+  final Attribute attribute;
+
+  String get name => attribute.name;
+  Expr get value => attribute.value;
+}
+
+/// `output "name" { ... }`
+final class OutputBlock extends TfBlock {
+  const OutputBlock._(super.file, super.block);
+
+  String get name => block.labels.single.text;
+  Expr? get value => argument('value');
+  Expr? get description => argument('description');
+  Expr? get sensitive => argument('sensitive');
+}
+
+/// Arguments shared by resources, data sources and module calls.
+mixin _MetaArguments on TfBlock {
+  Expr? get count => argument('count');
+  Expr? get forEach => argument('for_each');
+  Expr? get provider => argument('provider');
+  Expr? get dependsOn => argument('depends_on');
+}
+
+/// `resource "type" "name" { ... }`
+final class ResourceBlock extends TfBlock with _MetaArguments {
+  const ResourceBlock._(super.file, super.block);
+
+  String get type => block.labels[0].text;
+  String get name => block.labels[1].text;
+  String get address => '$type.$name';
+
+  /// `lifecycle { ... }` (or the JSON object form).
+  Body? get lifecycle => nestedBody('lifecycle');
+
+  /// `dynamic "name" { ... }` blocks.
+  List<Block> get dynamicBlocks => body.blocksOf('dynamic');
+}
+
+/// `data "type" "name" { ... }`
+final class DataBlock extends TfBlock with _MetaArguments {
+  const DataBlock._(super.file, super.block);
+
+  String get type => block.labels[0].text;
+  String get name => block.labels[1].text;
+  String get address => 'data.$type.$name';
+}
+
+/// `module "name" { ... }`
+final class ModuleCallBlock extends TfBlock with _MetaArguments {
+  const ModuleCallBlock._(super.file, super.block);
+
+  String get name => block.labels.single.text;
+  Expr? get source => argument('source');
+  Expr? get version => argument('version');
+}
+
+/// A block kept verbatim: `moved`, `import`, `removed`, `check`, or an
+/// unknown / malformed block.
+final class OpaqueBlock extends TfBlock {
+  const OpaqueBlock._(super.file, super.block);
+
+  String get type => block.type;
+}

--- a/packages/terradart_hcl/lib/src/writer.dart
+++ b/packages/terradart_hcl/lib/src/writer.dart
@@ -1,0 +1,245 @@
+import 'ast.dart';
+
+/// Renders syntax nodes back to HCL native syntax.
+///
+/// Output is canonical rather than byte-identical to the input (two-space
+/// indentation, one entry per line, a blank line between blocks), but it
+/// preserves everything the tree does: entry order, repeated blocks,
+/// one-line blocks, comments, heredoc bodies and raw expression text — so
+/// `parseHcl(write(parseHcl(x)))` is structurally identical to
+/// `parseHcl(x)`.
+final class HclWriter {
+  const HclWriter({this.indent = '  '});
+
+  final String indent;
+
+  static final RegExp _identifier = RegExp(
+    r'^[\p{L}_][\p{L}\p{M}\p{N}_-]*$',
+    unicode: true,
+  );
+
+  /// The whole file.
+  String writeFile(HclFile file) {
+    final buf = StringBuffer();
+    _body(buf, file.body, 0, topLevel: true);
+    return buf.toString();
+  }
+
+  /// A body at nesting [level] (0 = top level).
+  String writeBody(Body body, {int level = 0}) {
+    final buf = StringBuffer();
+    _body(buf, body, level, topLevel: level == 0);
+    return buf.toString();
+  }
+
+  /// One entry (attribute or block) at nesting [level].
+  String writeEntry(BodyEntry entry, {int level = 0}) {
+    final buf = StringBuffer();
+    _entry(buf, entry, level);
+    return buf.toString();
+  }
+
+  /// An expression, indented for nesting [level] when it spans lines.
+  String writeExpr(Expr expr, {int level = 0}) => _expr(expr, level);
+
+  void _body(StringBuffer buf, Body body, int level, {required bool topLevel}) {
+    BodyEntry? previous;
+    for (final e in body.entries) {
+      if (topLevel && previous != null && e is Block) buf.writeln();
+      _entry(buf, e, level);
+      previous = e;
+    }
+    for (final c in body.trailingComments) {
+      _line(buf, level, c.text);
+    }
+  }
+
+  void _entry(StringBuffer buf, BodyEntry e, int level) {
+    for (final c in e.leadingComments) {
+      _line(buf, level, c.text);
+    }
+    switch (e) {
+      case Attribute(:final name, :final value, :final trailingComment):
+        final text = '$name = ${_expr(value, level)}';
+        _line(
+          buf,
+          level,
+          trailingComment == null ? text : '$text ${trailingComment.text}',
+        );
+      case Block(
+        :final type,
+        :final labels,
+        :final body,
+        :final oneLine,
+        :final trailingComment,
+      ):
+        final head = StringBuffer(type);
+        for (final l in labels) {
+          head.write(' ');
+          head.write(l.quoted ? _quote(l.text) : l.text);
+        }
+        final trailing = trailingComment == null
+            ? ''
+            : ' ${trailingComment.text}';
+        final singleAttr =
+            body.entries.length == 1 && body.entries.single is Attribute;
+        if (oneLine &&
+            body.trailingComments.isEmpty &&
+            (body.entries.isEmpty || singleAttr)) {
+          if (body.entries.isEmpty) {
+            _line(buf, level, '$head {}$trailing');
+          } else {
+            final a = body.entries.single as Attribute;
+            _line(
+              buf,
+              level,
+              '$head { ${a.name} = ${_expr(a.value, level)} }$trailing',
+            );
+          }
+          return;
+        }
+        _line(buf, level, '$head {');
+        _body(buf, body, level + 1, topLevel: false);
+        _line(buf, level, '}$trailing');
+    }
+  }
+
+  void _line(StringBuffer buf, int level, String text) {
+    buf.write(indent * level);
+    buf.writeln(text);
+  }
+
+  String _expr(Expr e, int level) => switch (e) {
+    LiteralExpr(:final value, :final source) => switch (value) {
+      String() => _quote(value),
+      num() => source ?? value.toString(),
+      bool() => value.toString(),
+      _ => 'null',
+    },
+    TemplateExpr() => _template(e, level),
+    TraversalExpr(:final root, :final steps) => [
+      root,
+      for (final s in steps)
+        switch (s) {
+          AttrStep(:final name) => '.$name',
+          IndexStep(:final index) => '[${_expr(index, level)}]',
+        },
+    ].join(),
+    TupleExpr(:final elements, :final multiLine) => _tuple(
+      elements,
+      level,
+      multiLine,
+    ),
+    ObjectExpr(:final items, :final multiLine) => _object(
+      items,
+      level,
+      multiLine,
+    ),
+    RawExpr(:final source) => source,
+  };
+
+  String _tuple(List<Expr> elements, int level, bool multiLine) {
+    if (elements.isEmpty) return '[]';
+    final needsLines = multiLine || elements.any(_isHeredoc);
+    if (!needsLines) {
+      return '[${elements.map((x) => _expr(x, level)).join(', ')}]';
+    }
+    final buf = StringBuffer('[\n');
+    for (final x in elements) {
+      buf.write(indent * (level + 1));
+      buf.write(_expr(x, level + 1));
+      buf.writeln(_isHeredoc(x) ? '\n${indent * (level + 1)},' : ',');
+    }
+    buf.write(indent * level);
+    buf.write(']');
+    return buf.toString();
+  }
+
+  String _object(List<ObjectItem> items, int level, bool multiLine) {
+    if (items.isEmpty) return '{}';
+    final needsLines = multiLine || items.any((i) => _isHeredoc(i.value));
+    String item(ObjectItem i, int lvl) =>
+        '${_key(i.key)} ${i.colon ? ':' : '='} ${_expr(i.value, lvl)}';
+    if (!needsLines) {
+      return '{ ${items.map((i) => item(i, level)).join(', ')} }';
+    }
+    final buf = StringBuffer('{\n');
+    for (final i in items) {
+      buf.write(indent * (level + 1));
+      buf.writeln(item(i, level + 1));
+    }
+    buf.write(indent * level);
+    buf.write('}');
+    return buf.toString();
+  }
+
+  String _key(Expr key) {
+    final name = key.constantString;
+    if (name != null) {
+      return _identifier.hasMatch(name) ? name : _quote(name);
+    }
+    return _expr(key, 0);
+  }
+
+  static bool _isHeredoc(Expr e) => e is TemplateExpr && e.isHeredoc;
+
+  String _template(TemplateExpr t, int level) {
+    if (t.isHeredoc) {
+      final body = t.rawBody ?? _templateBody(t, level, escapes: false);
+      final buf = StringBuffer('<<${t.flush ? '-' : ''}${t.delimiter}\n');
+      buf.write(body);
+      if (!body.endsWith('\n')) buf.write('\n');
+      // The closing marker sits at the enclosing entry's indentation.
+      buf.write(indent * level);
+      buf.write(t.delimiter);
+      return buf.toString();
+    }
+    return '"${_templateBody(t, level, escapes: true)}"';
+  }
+
+  String _templateBody(TemplateExpr t, int level, {required bool escapes}) {
+    final buf = StringBuffer();
+    for (final p in t.parts) {
+      switch (p) {
+        case TemplateLiteral(:final text):
+          buf.write(
+            escapes ? _escapeQuoted(text) : _escapeTemplateMarkers(text),
+          );
+        case TemplateInterpolation(
+          :final expr,
+          :final stripLeft,
+          :final stripRight,
+        ):
+          buf.write(
+            '\${${stripLeft ? '~' : ''}${_expr(expr, level)}${stripRight ? '~' : ''}}',
+          );
+        case TemplateDirective(
+          :final content,
+          :final stripLeft,
+          :final stripRight,
+        ):
+          buf.write(
+            '%{${stripLeft ? '~' : ''}$content${stripRight ? '~' : ''}}',
+          );
+      }
+    }
+    return buf.toString();
+  }
+
+  static String _escapeTemplateMarkers(String s) =>
+      s.replaceAll(r'${', r'$${').replaceAll('%{', '%%{');
+
+  static String _escapeQuoted(String s) => _escapeTemplateMarkers(
+    s
+        .replaceAll(r'\', r'\\')
+        .replaceAll('"', r'\"')
+        .replaceAll('\n', r'\n')
+        .replaceAll('\r', r'\r')
+        .replaceAll('\t', r'\t'),
+  );
+
+  static String _quote(String s) => '"${_escapeQuoted(s)}"';
+}
+
+/// Convenience: [HclWriter.writeFile] with default settings.
+String serializeHcl(HclFile file) => const HclWriter().writeFile(file);

--- a/packages/terradart_hcl/lib/terradart_hcl.dart
+++ b/packages/terradart_hcl/lib/terradart_hcl.dart
@@ -1,0 +1,15 @@
+/// Pure Dart HCL parser, `*.tf.json` decoder and Terraform module model —
+/// the input side of `terradart-migrate`.
+///
+/// Entry points: [parseHcl], [decodeTfJson], [TfModule.fromFiles],
+/// [loadTfModule], [HclWriter].
+library;
+
+export 'src/ast.dart';
+export 'src/diagnostics.dart';
+export 'src/loader.dart';
+export 'src/parser.dart' show parseHcl, parseHclExpression;
+export 'src/source.dart';
+export 'src/tf_json.dart';
+export 'src/tf_module.dart';
+export 'src/writer.dart';

--- a/packages/terradart_hcl/pubspec.yaml
+++ b/packages/terradart_hcl/pubspec.yaml
@@ -1,0 +1,19 @@
+name: terradart_hcl
+description: Pure Dart HCL (Terraform native syntax) parser and tf.json front-end producing a shared Terraform module model — the input side of terradart-migrate.
+version: 0.27.0
+publish_to: none
+homepage: https://github.com/nozomi-koborinai/terradart
+repository: https://github.com/nozomi-koborinai/terradart
+issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
+
+environment:
+  sdk: ^3.10.0
+
+resolution: workspace
+
+dependencies:
+  meta: ^1.16.0
+
+dev_dependencies:
+  lints: ^6.0.0
+  test: ^1.25.6

--- a/packages/terradart_hcl/test/fixtures/pubsub_quickstart.tf.json
+++ b/packages/terradart_hcl/test/fixtures/pubsub_quickstart.tf.json
@@ -1,0 +1,128 @@
+{
+  "terraform": {
+    "required_version": ">= 1.11.0",
+    "required_providers": {
+      "google": {
+        "source": "hashicorp/google",
+        "version": "~> 7.0"
+      }
+    }
+  },
+  "provider": {
+    "google": {
+      "project": "ci-test-project-id",
+      "region": "us-central1"
+    }
+  },
+  "resource": {
+    "google_pubsub_schema": {
+      "orders_proto": {
+        "name": "orders-proto",
+        "type": "PROTOCOL_BUFFER",
+        "definition": "syntax = \"proto3\"; message Order { string id = 1; }"
+      }
+    },
+    "google_service_account": {
+      "orders_publisher": {
+        "account_id": "orders-publisher",
+        "display_name": "Orders Pub/Sub publisher"
+      }
+    },
+    "google_pubsub_schema_iam_member": {
+      "orders_schema_publisher": {
+        "schema": "${google_pubsub_schema.orders_proto.id}",
+        "role": "roles/pubsub.viewer",
+        "member": "${google_service_account.orders_publisher.member}",
+        "depends_on": [
+          "google_pubsub_schema.orders_proto",
+          "google_service_account.orders_publisher"
+        ]
+      }
+    },
+    "google_pubsub_schema_iam_binding": {
+      "orders_schema_viewer_binding": {
+        "schema": "${google_pubsub_schema.orders_proto.id}",
+        "role": "roles/pubsub.viewer",
+        "members": [
+          "${google_service_account.orders_publisher.member}"
+        ],
+        "depends_on": [
+          "google_pubsub_schema.orders_proto",
+          "google_service_account.orders_publisher"
+        ]
+      }
+    },
+    "google_pubsub_schema_iam_policy": {
+      "orders_schema_viewer_policy": {
+        "schema": "${google_pubsub_schema.orders_proto.id}",
+        "policy_data": "{\"bindings\":[{\"role\":\"roles/pubsub.viewer\",\"members\":[\"serviceAccount:orders-publisher@ci-test-project-id.iam.gserviceaccount.com\"]}]}",
+        "depends_on": [
+          "google_pubsub_schema.orders_proto",
+          "google_pubsub_schema_iam_binding.orders_schema_viewer_binding"
+        ]
+      }
+    },
+    "google_pubsub_topic": {
+      "orders": {
+        "name": "orders-prod",
+        "message_retention_duration": "604800s"
+      }
+    },
+    "google_pubsub_subscription": {
+      "orders_push": {
+        "name": "orders-push",
+        "topic": "${google_pubsub_topic.orders.id}",
+        "push_config": {
+          "push_endpoint": "https://app.example.com/push"
+        },
+        "ack_deadline_seconds": 60
+      }
+    },
+    "google_pubsub_topic_iam_member": {
+      "orders_pubsub_agent": {
+        "topic": "${google_pubsub_topic.orders.name}",
+        "role": "roles/pubsub.publisher",
+        "member": "serviceAccount:service-${data.google_project.current.number}@gcp-sa-pubsub.iam.gserviceaccount.com",
+        "depends_on": [
+          "google_pubsub_topic.orders"
+        ]
+      }
+    },
+    "google_pubsub_topic_iam_binding": {
+      "orders_publisher_binding": {
+        "topic": "${google_pubsub_topic.orders.name}",
+        "role": "roles/pubsub.viewer",
+        "members": [
+          "${google_service_account.orders_publisher.member}"
+        ],
+        "depends_on": [
+          "google_pubsub_topic.orders",
+          "google_service_account.orders_publisher"
+        ]
+      }
+    },
+    "google_pubsub_topic_iam_policy": {
+      "orders_publisher_policy": {
+        "topic": "${google_pubsub_topic.orders.name}",
+        "policy_data": "{\"bindings\":[{\"role\":\"roles/pubsub.viewer\",\"members\":[\"serviceAccount:orders-publisher@ci-test-project-id.iam.gserviceaccount.com\"]}]}",
+        "depends_on": [
+          "google_pubsub_topic.orders",
+          "google_pubsub_topic_iam_binding.orders_publisher_binding"
+        ]
+      }
+    }
+  },
+  "data": {
+    "google_project": {
+      "current": {}
+    }
+  },
+  "output": {
+    "ORDERS_TOPIC_NAME": {
+      "value": "${google_pubsub_topic.orders.name}"
+    },
+    "ORDERS_TOPIC_ID": {
+      "value": "${google_pubsub_topic.orders.id}"
+    }
+  }
+}

--- a/packages/terradart_hcl/test/fixtures/repeated_blocks.tf
+++ b/packages/terradart_hcl/test/fixtures/repeated_blocks.tf
@@ -1,0 +1,131 @@
+# Stress fixture: repeated blocks at every level must survive parsing.
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+  }
+  backend "gcs" {
+    bucket = "tf-state"
+    prefix = "stress"
+  }
+}
+
+provider "google" {
+  project = var.project
+}
+
+provider "google" {
+  alias   = "eu"
+  project = var.project
+  region  = "europe-west1"
+}
+
+variable "project" {
+  type        = string
+  description = "GCP project"
+}
+
+locals {
+  labels = { env = "dev", team = "core" }
+  names  = ["a", "b", "c"]
+}
+
+resource "google_cloud_run_v2_service" "svc" {
+  name     = "svc-${var.project}"
+  location = "asia-northeast1"
+  labels   = local.labels
+
+  template {
+    containers {
+      image = "gcr.io/${var.project}/api:latest"
+      env {
+        name  = "A"
+        value = "1"
+      }
+      env {
+        name  = "B"
+        value = "2"
+      }
+      env {
+        name = "SECRET"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.s.secret_id
+            version = "latest"
+          }
+        }
+      }
+    }
+    containers {
+      image = "gcr.io/${var.project}/sidecar:latest"
+      resources {
+        limits = { cpu = "1", memory = "512Mi" }
+      }
+    }
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 3
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [client, client_version]
+  }
+}
+
+resource "google_storage_bucket" "b" {
+  name     = lower("${var.project}-assets")
+  location = "US"
+  lifecycle_rule {
+    action { type = "Delete" }
+    condition { age = 30 }
+  }
+  lifecycle_rule {
+    action {
+      type          = "SetStorageClass"
+      storage_class = "NEARLINE"
+    }
+    condition {
+      age                = 7
+      matches_storage_class = ["STANDARD"]
+    }
+  }
+  dynamic "cors" {
+    for_each = var.cors_origins
+    content {
+      origin = [cors.value]
+      method = ["GET"]
+    }
+  }
+}
+
+resource "google_secret_manager_secret" "s" {
+  secret_id = "api-key"
+  replication {
+    auto {}
+  }
+}
+
+data "google_project" "p" {}
+
+module "network" {
+  source  = "./modules/network"
+  project = var.project
+  cidrs   = [for i in range(3) : cidrsubnet("10.0.0.0/16", 8, i)]
+}
+
+output "url" {
+  value       = google_cloud_run_v2_service.svc.uri
+  description = <<-EOT
+    Service URL.
+    Multi-line description with ${var.project} inside.
+  EOT
+}
+
+moved {
+  from = google_storage_bucket.old
+  to   = google_storage_bucket.b
+}

--- a/packages/terradart_hcl/test/fixtures_test.dart
+++ b/packages/terradart_hcl/test/fixtures_test.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+
+import 'package:terradart_hcl/terradart_hcl.dart';
+import 'package:test/test.dart';
+
+int _count(String src, String pattern) =>
+    RegExp(pattern, multiLine: true).allMatches(src).length;
+
+void main() {
+  test('the repeated-block stress fixture parses losslessly', () {
+    final file = parseHcl(
+      File('test/fixtures/repeated_blocks.tf').readAsStringSync(),
+    );
+    final svc = file.body.blocksOf('resource').first;
+    final containers = svc.body.block('template')!.body.blocksOf('containers');
+    expect(containers, hasLength(2));
+    expect(containers.first.body.blocksOf('env'), hasLength(3));
+    expect(
+      containers.first.body
+          .blocksOf('env')
+          .last
+          .body
+          .block('value_source')!
+          .body
+          .block('secret_key_ref'),
+      isNotNull,
+    );
+    final bucket = file.body.blocksOf('resource')[1];
+    expect(bucket.body.blocksOf('lifecycle_rule'), hasLength(2));
+    expect(
+      bucket.body.blocksOf('dynamic').single.body.block('content'),
+      isNotNull,
+    );
+    expect(file.body.blocksOf('provider'), hasLength(2));
+  });
+
+  group('coverage fixtures parse with every top-level block intact', () {
+    final files =
+        Directory('../terradart_coverage/test/fixtures')
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where((f) => f.path.endsWith('.tf'))
+            .toList()
+          ..sort((a, b) => a.path.compareTo(b.path));
+    test('fixtures exist', () => expect(files, isNotEmpty));
+    for (final f in files) {
+      test(f.path, () {
+        final src = f.readAsStringSync();
+        final file = parseHcl(src, fileName: f.path);
+        for (final type in [
+          'resource',
+          'data',
+          'module',
+          'variable',
+          'output',
+          'provider',
+        ]) {
+          expect(
+            file.body.blocksOf(type),
+            hasLength(_count(src, '^$type ')),
+            reason: 'top-level $type blocks in ${f.path}',
+          );
+        }
+      });
+    }
+  });
+}

--- a/packages/terradart_hcl/test/lexer_test.dart
+++ b/packages/terradart_hcl/test/lexer_test.dart
@@ -1,0 +1,117 @@
+import 'package:terradart_hcl/src/lexer.dart';
+import 'package:terradart_hcl/terradart_hcl.dart';
+import 'package:test/test.dart';
+
+List<TokenType> _types(String src) =>
+    Lexer(src).tokenize().map((t) => t.type).toList();
+
+void main() {
+  group('Lexer', () {
+    test('tokenizes structure, keeping newlines and comments', () {
+      expect(_types('a = "x" # c\nb { }\n'), [
+        TokenType.ident,
+        TokenType.equal,
+        TokenType.string,
+        TokenType.comment,
+        TokenType.newline,
+        TokenType.ident,
+        TokenType.lbrace,
+        TokenType.rbrace,
+        TokenType.newline,
+        TokenType.eof,
+      ]);
+    });
+
+    test('a string with nested interpolation and quotes is one token', () {
+      final tokens = Lexer('x = "${r'${lookup(var.m, "k")}'}-y"').tokenize();
+      final str = tokens.firstWhere((t) => t.type == TokenType.string);
+      expect(str.inner, r'${lookup(var.m, "k")}-y');
+      expect(tokens.where((t) => t.type == TokenType.string), hasLength(1));
+    });
+
+    test('heredoc token carries the marker, flush flag and raw body', () {
+      final tokens = Lexer('x = <<-EOT\n  a\n   b\n  EOT\ny = 1\n').tokenize();
+      final h = tokens.firstWhere((t) => t.type == TokenType.heredoc);
+      expect(h.delimiter, 'EOT');
+      expect(h.flush, isTrue);
+      expect(h.body, '  a\n   b\n');
+      // The newline after the closing marker is a regular newline token.
+      expect(tokens[tokens.indexOf(h) + 1].type, TokenType.newline);
+      expect(tokens[tokens.indexOf(h) + 2].text, 'y');
+    });
+
+    test('numbers and operators', () {
+      final tokens = Lexer(
+        '1 1.5 1e3 1.5E-2 == != <= >= && || => ...',
+      ).tokenize();
+      expect(tokens.map((t) => t.text).where((t) => t.isNotEmpty).toList(), [
+        '1',
+        '1.5',
+        '1e3',
+        '1.5E-2',
+        '==',
+        '!=',
+        '<=',
+        '>=',
+        '&&',
+        '||',
+        '=>',
+        '...',
+      ]);
+      expect(tokens[4].type, TokenType.op);
+      expect(tokens[10].type, TokenType.fatArrow);
+      expect(tokens[11].type, TokenType.ellipsis);
+    });
+
+    test('unicode identifiers', () {
+      final tokens = Lexer('ünïcode-name_1 = 1').tokenize();
+      expect(tokens.first.type, TokenType.ident);
+      expect(tokens.first.text, 'ünïcode-name_1');
+    });
+
+    test('positions are one-based lines and columns', () {
+      final tokens = Lexer('a = 1\n  bb = 2').tokenize();
+      final bb = tokens.firstWhere((t) => t.text == 'bb');
+      expect(bb.range.start.line, 2);
+      expect(bb.range.start.column, 3);
+      expect(bb.range.start.offset, 8);
+      expect(bb.range.end.offset, 10);
+    });
+
+    test(
+      'rejects unterminated strings, heredocs, comments and stray characters',
+      () {
+        expect(
+          () => Lexer('a = "abc').tokenize(),
+          throwsA(isA<HclParseException>()),
+        );
+        expect(
+          () => Lexer('a = <<EOT\nabc\n').tokenize(),
+          throwsA(isA<HclParseException>()),
+        );
+        expect(
+          () => Lexer('/* open').tokenize(),
+          throwsA(isA<HclParseException>()),
+        );
+        expect(
+          () => Lexer('a = @').tokenize(),
+          throwsA(isA<HclParseException>()),
+        );
+        expect(
+          () => Lexer('a = "line\nbreak"').tokenize(),
+          throwsA(isA<HclParseException>()),
+        );
+      },
+    );
+
+    test(
+      'leadingWhitespace counts characters, including tabs and em spaces',
+      () {
+        expect(Lexer.leadingWhitespace('    x'), 4);
+        expect(Lexer.leadingWhitespace('\tx'), 1);
+        expect(Lexer.leadingWhitespace('   x'), 3);
+        expect(Lexer.leadingWhitespace('x'), 0);
+      },
+    );
+  });
+}

--- a/packages/terradart_hcl/test/parser_test.dart
+++ b/packages/terradart_hcl/test/parser_test.dart
@@ -302,6 +302,9 @@ b "x" {
         _parseError('unterminated object'),
       );
       expect(() => parseHcl('a =\n'), _parseError('expected an expression'));
+      expect(() => parseHcl('a = foo['), _parseError('unbalanced'));
+      expect(() => parseHcl('a = foo[0'), _parseError('unbalanced'));
+      expect(() => parseHclExpression('foo['), _parseError('unbalanced'));
       expect(() => parseHcl('a b c\n'), _parseError('expected "{"'));
       expect(() => parseHcl('a\n'), _parseError('expected "=" or "{"'));
       expect(() => parseHcl('}\n'), _parseError('unexpected "}"'));

--- a/packages/terradart_hcl/test/parser_test.dart
+++ b/packages/terradart_hcl/test/parser_test.dart
@@ -1,0 +1,332 @@
+import 'package:terradart_hcl/src/dump.dart';
+import 'package:terradart_hcl/terradart_hcl.dart';
+import 'package:test/test.dart';
+
+Expr _expr(String src) => parseHcl('x = $src\n').body.attribute('x')!.value;
+
+Matcher _parseError(String messagePart) => throwsA(
+  isA<HclParseException>().having(
+    (e) => e.first.message,
+    'message',
+    contains(messagePart),
+  ),
+);
+
+void main() {
+  group('structure', () {
+    test('attributes and blocks keep source order and repeats', () {
+      const src = '''
+resource "google_cloud_run_v2_service" "svc" {
+  name = "svc"
+  template {
+    containers {
+      env {
+        name = "A"
+      }
+      env {
+        name = "B"
+      }
+      env {
+        name = "C"
+      }
+    }
+    containers {
+      image = "x"
+    }
+  }
+}
+''';
+      final file = parseHcl(src, fileName: 'main.tf');
+      final res = file.body.blocks.single;
+      expect(res.type, 'resource');
+      expect(res.labelTexts, ['google_cloud_run_v2_service', 'svc']);
+      expect(res.labels.every((l) => l.quoted), isTrue);
+      final template = res.body.block('template')!;
+      final containers = template.body.blocksOf('containers');
+      expect(containers, hasLength(2));
+      final envs = containers.first.body.blocksOf('env');
+      expect(envs.map((e) => e.body.attribute('name')!.value.constantString), [
+        'A',
+        'B',
+        'C',
+      ]);
+      expect(file.textOf(res), src.trim());
+      expect(file.textOf(envs[1]), 'env {\n        name = "B"\n      }');
+    });
+
+    test('identifier labels and one-line blocks', () {
+      final file = parseHcl('a b c {}\nd { e = 1 }\nf {\n}\n');
+      final a = file.body.blocks.first;
+      expect(a.labelTexts, ['b', 'c']);
+      expect(a.labels.first.quoted, isFalse);
+      expect(a.oneLine, isTrue);
+      expect(a.body.isEmpty, isTrue);
+      final d = file.body.blocks.elementAt(1);
+      expect(d.oneLine, isTrue);
+      expect(
+        d.body.attribute('e')!.value,
+        isA<LiteralExpr>().having((l) => l.value, 'value', 1),
+      );
+      expect(file.body.blocks.elementAt(2).oneLine, isFalse);
+    });
+
+    test('comments attach to the entry they precede and to the same line', () {
+      const src = '''
+# file header
+
+// leading a
+a = 1 # trailing a
+
+/* leading b */
+b "x" {
+  c = 2 // trailing c
+  # dangling in b
+} # after b
+''';
+      final file = parseHcl(src);
+      final a = file.body.attributes.single;
+      expect(a.leadingComments.map((c) => c.text), [
+        '# file header',
+        '// leading a',
+      ]);
+      expect(a.trailingComment!.text, '# trailing a');
+      final b = file.body.blocks.single;
+      expect(b.leadingComments.map((c) => c.text), ['/* leading b */']);
+      expect(b.leadingComments.single.isBlock, isTrue);
+      expect(b.body.attribute('c')!.trailingComment!.text, '// trailing c');
+      expect(b.body.trailingComments.map((c) => c.text), ['# dangling in b']);
+      expect(b.trailingComment!.text, '# after b');
+      expect(file.comments, hasLength(7));
+    });
+
+    test('CRLF input', () {
+      final file = parseHcl('a = 1\r\nb {\r\n  c = "d"\r\n}\r\n');
+      expect(file.body.attribute('a')!.value.constantString, isNull);
+      expect(
+        file.body.block('b')!.body.attribute('c')!.value.constantString,
+        'd',
+      );
+    });
+
+    test('empty and comment-only files', () {
+      expect(parseHcl('').body.isEmpty, isTrue);
+      final file = parseHcl('# only a comment\n');
+      expect(file.body.isEmpty, isTrue);
+      expect(file.body.trailingComments, hasLength(1));
+    });
+  });
+
+  group('expressions', () {
+    test('literals', () {
+      expect((_expr('5') as LiteralExpr).value, 5);
+      expect((_expr('3.2') as LiteralExpr).value, 3.2);
+      expect((_expr('-1') as LiteralExpr).value, -1);
+      expect((_expr('1e3') as LiteralExpr).value, 1000);
+      expect((_expr('true') as LiteralExpr).value, true);
+      expect((_expr('null') as LiteralExpr).isNull, isTrue);
+      final big = _expr('3.14159265358979323846264338327950288') as LiteralExpr;
+      expect(big.source, '3.14159265358979323846264338327950288');
+      expect((_expr('"hello"') as LiteralExpr).value, 'hello');
+      expect((_expr(r'"a\"b\\c\n\té"') as LiteralExpr).value, 'a"b\\c\n\té');
+      expect(
+        (_expr(r'"$${not} %%{either}"') as LiteralExpr).value,
+        r'${not} %{either}',
+      );
+      expect((_expr('""') as LiteralExpr).value, '');
+    });
+
+    test('templates', () {
+      final t = _expr(r'"${var.a}-${b}"') as TemplateExpr;
+      expect(t.parts, hasLength(3));
+      expect(
+        (t.parts[0] as TemplateInterpolation).expr,
+        isA<TraversalExpr>().having((e) => e.dottedPath, 'path', 'var.a'),
+      );
+      expect((t.parts[1] as TemplateLiteral).text, '-');
+      expect(t.isConstant, isFalse);
+      expect(t.constantString, isNull);
+
+      final d = _expr(r'"%{ if var.x }a${ y }%{ endif }"') as TemplateExpr;
+      expect(d.parts.whereType<TemplateDirective>().map((p) => p.content), [
+        'if var.x',
+        'endif',
+      ]);
+
+      final strip =
+          (_expr(r'"${~ x ~}"') as TemplateExpr).parts.single
+              as TemplateInterpolation;
+      expect(strip.stripLeft, isTrue);
+      expect(strip.stripRight, isTrue);
+      expect((strip.expr as TraversalExpr).root, 'x');
+
+      final nested =
+          (_expr(r'"${lookup(var.m, "k")}"') as TemplateExpr).parts.single
+              as TemplateInterpolation;
+      expect(
+        nested.expr,
+        isA<RawExpr>().having((r) => r.source, 'source', 'lookup(var.m, "k")'),
+      );
+    });
+
+    test('heredocs', () {
+      final file = parseHcl(
+        'a = <<EOT\n  x ${r'${y}'}\n  z\n  EOT\nb = <<-EOT\n    p\n      q\n  EOT\n',
+      );
+      final a = file.body.attribute('a')!.value as TemplateExpr;
+      expect(a.isHeredoc, isTrue);
+      expect(a.delimiter, 'EOT');
+      expect(a.flush, isFalse);
+      expect(a.rawBody, '  x ${r'${y}'}\n  z\n');
+      expect((a.parts.first as TemplateLiteral).text, '  x ');
+      expect(a.parts[1], isA<TemplateInterpolation>());
+      final b = file.body.attribute('b')!.value as TemplateExpr;
+      expect(b.flush, isTrue);
+      expect(b.constantString, 'p\n  q\n');
+      expect(b.rawBody, '    p\n      q\n');
+    });
+
+    test('traversals', () {
+      expect((_expr('var.x') as TraversalExpr).dottedPath, 'var.x');
+      final t = _expr('google_pubsub_topic.t.name') as TraversalExpr;
+      expect(t.root, 'google_pubsub_topic');
+      expect(t.steps.map((s) => (s as AttrStep).name), ['t', 'name']);
+      final idx = _expr('local.l[0]["k"].v') as TraversalExpr;
+      expect(idx.steps, hasLength(4));
+      expect((idx.steps[0] as AttrStep).name, 'l');
+      expect((idx.steps[1] as IndexStep).index.value, 0);
+      expect((idx.steps[2] as IndexStep).index.value, 'k');
+      expect((idx.steps[3] as AttrStep).name, 'v');
+      expect(idx.dottedPath, 'local.l.v');
+      expect((_expr('each.key') as TraversalExpr).dottedPath, 'each.key');
+    });
+
+    test('everything else is raw with exact source', () {
+      expect((_expr('a.b.*.c') as RawExpr).source, 'a.b.*.c');
+      expect((_expr('a.b[*].c') as RawExpr).source, 'a.b[*].c');
+      expect((_expr('lower(var.x)') as RawExpr).source, 'lower(var.x)');
+      expect((_expr('a.0') as RawExpr).source, 'a.0');
+      expect((_expr('1 + 2 * 3') as RawExpr).source, '1 + 2 * 3');
+      expect((_expr('x ? "a" : "b"') as RawExpr).source, 'x ? "a" : "b"');
+      expect((_expr('!enabled') as RawExpr).source, '!enabled');
+      expect((_expr('(1)') as RawExpr).source, '(1)');
+      expect((_expr('m[var.k]') as RawExpr).source, 'm[var.k]');
+      expect((_expr('[for i in x : i]') as RawExpr).source, '[for i in x : i]');
+      expect(
+        (_expr('{ for k, v in m : k => v }') as RawExpr).source,
+        '{ for k, v in m : k => v }',
+      );
+      final multi = _expr('merge(\n  a,\n  b, # c\n)') as RawExpr;
+      expect(multi.source, 'merge(\n  a,\n  b, # c\n)');
+    });
+
+    test('tuples', () {
+      final t = _expr('[1, "a", var.x]') as TupleExpr;
+      expect(t.elements, hasLength(3));
+      expect(t.multiLine, isFalse);
+      final m = _expr('[\n  1,\n  # comment\n  2,\n]') as TupleExpr;
+      expect(m.elements.map((e) => (e as LiteralExpr).value), [1, 2]);
+      expect(m.multiLine, isTrue);
+      expect((_expr('[]') as TupleExpr).elements, isEmpty);
+      final nested = _expr('[[1], { a = 2 }]') as TupleExpr;
+      expect(nested.elements[0], isA<TupleExpr>());
+      expect(nested.elements[1], isA<ObjectExpr>());
+    });
+
+    test('objects', () {
+      final o = _expr('{ a = 1, "b" = 2, (c) = 3, d: 4 }') as ObjectExpr;
+      expect(o.items.map((i) => i.key.constantString), ['a', 'b', null, 'd']);
+      expect(
+        o.items[2].key,
+        isA<RawExpr>().having((r) => r.source, 'source', '(c)'),
+      );
+      expect(o.items[3].colon, isTrue);
+      expect(
+        o.item('b')!.value,
+        isA<LiteralExpr>().having((l) => l.value, 'value', 2),
+      );
+      final m =
+          _expr(
+                '{\n  source  = "hashicorp/google"\n  version = "~> 7.0"\n  nested = {\n    k = "v"\n  }\n}',
+              )
+              as ObjectExpr;
+      expect(m.multiLine, isTrue);
+      expect(m.items.map((i) => i.keyName), ['source', 'version', 'nested']);
+      expect(
+        (m.item('nested')!.value as ObjectExpr).item('k')!.value.constantString,
+        'v',
+      );
+      expect((_expr('{}') as ObjectExpr).items, isEmpty);
+    });
+
+    test('parseHclExpression', () {
+      expect(parseHclExpression('var.x'), isA<TraversalExpr>());
+      expect(parseHclExpression('[1,\n 2]'), isA<TupleExpr>());
+      expect(parseHclExpression('  "s"  '), isA<LiteralExpr>());
+      expect(() => parseHclExpression('1, 2'), _parseError('unexpected'));
+      // Adjacent primaries are not validated: the shallow parser keeps them raw.
+      expect(parseHclExpression('1 2'), isA<RawExpr>());
+    });
+  });
+
+  group('errors', () {
+    test('arguments must be on their own line', () {
+      expect(
+        () => parseHcl('a = "a value", b = "b value"\n'),
+        _parseError('own line'),
+      );
+      expect(() => parseHcl('a = 1 b = 2\n'), _parseError('missing newline'));
+    });
+
+    test('single-line block rules', () {
+      expect(
+        () => parseHcl('a { b = "foo", c = "bar" }\n'),
+        throwsA(isA<HclParseException>()),
+      );
+      expect(() => parseHcl('a { b = "foo"\n}\n'), _parseError('same line'));
+      expect(
+        () => parseHcl('a { b = "foo"\n  c = "bar" }\n'),
+        _parseError('same line'),
+      );
+      expect(
+        () => parseHcl('a { d {} }\n'),
+        _parseError('cannot contain another block'),
+      );
+    });
+
+    test('unclosed constructs', () {
+      expect(() => parseHcl('a {\n'), _parseError('unclosed block "a"'));
+      expect(() => parseHcl('a = (1\n'), _parseError('unbalanced'));
+      expect(() => parseHcl('a = [1, 2\n'), _parseError('unterminated tuple'));
+      expect(
+        () => parseHcl('a = {\n  b = 1\n'),
+        _parseError('unterminated object'),
+      );
+      expect(() => parseHcl('a =\n'), _parseError('expected an expression'));
+      expect(() => parseHcl('a b c\n'), _parseError('expected "{"'));
+      expect(() => parseHcl('a\n'), _parseError('expected "=" or "{"'));
+      expect(() => parseHcl('}\n'), _parseError('unexpected "}"'));
+      expect(
+        () => parseHcl('a "${r'${x}'}" {}\n'),
+        _parseError('plain string'),
+      );
+    });
+
+    test('diagnostics carry the file name and position', () {
+      try {
+        parseHcl('ok = 1\nbad = (\n', fileName: 'x.tf');
+        fail('expected an exception');
+      } on HclParseException catch (e) {
+        expect(e.first.fileName, 'x.tf');
+        expect(e.first.range.start.line, 2);
+        expect(e.toString(), contains('x.tf:2:'));
+      }
+    });
+  });
+
+  test('dumpHcl is position-free and stable', () {
+    final a = dumpHcl(parseHcl('a = 1\nb "x" { c = [1,2] }\n'));
+    final b = dumpHcl(parseHcl('\n\na   =   1\n\nb "x" { c = [1, 2] }\n'));
+    expect(a, b);
+    expect(a, 'a = 1\nb "x" { (one-line)\n  c = [1, 2]\n}\n');
+  });
+}

--- a/packages/terradart_hcl/test/specsuite_test.dart
+++ b/packages/terradart_hcl/test/specsuite_test.dart
@@ -1,0 +1,163 @@
+@Tags(['specsuite'])
+library;
+
+import 'dart:io';
+
+import 'package:terradart_hcl/terradart_hcl.dart';
+import 'package:test/test.dart';
+
+/// Locates the hashicorp/hcl specsuite `tests` directory: an explicit
+/// checkout via `TERRADART_HCL_SPECSUITE` (the hcl repo root or its
+/// `specsuite/tests` directory), else a cached shallow clone under
+/// `.dart_tool/hcl_specsuite`, made on first use. Returns `null` only when
+/// `TERRADART_HCL_SPECSUITE_SKIP` is set.
+Directory? locateSpecsuite() {
+  final env = Platform.environment;
+  if (env['TERRADART_HCL_SPECSUITE_SKIP'] == '1') return null;
+  final explicit = env['TERRADART_HCL_SPECSUITE'];
+  if (explicit != null && explicit.isNotEmpty) {
+    return _testsDir(Directory(explicit)) ??
+        (throw StateError(
+          'TERRADART_HCL_SPECSUITE=$explicit has no specsuite/tests',
+        ));
+  }
+  final cache = Directory('.dart_tool/hcl_specsuite');
+  final cached = _testsDir(cache);
+  if (cached != null) return cached;
+  final result = Process.runSync('git', [
+    'clone',
+    '--depth',
+    '1',
+    '--filter=blob:none',
+    'https://github.com/hashicorp/hcl.git',
+    cache.path,
+  ]);
+  if (result.exitCode != 0) {
+    throw StateError(
+      'could not fetch the hashicorp/hcl specsuite (git clone exit '
+      '${result.exitCode}: ${result.stderr}). Point TERRADART_HCL_SPECSUITE at '
+      'a checkout, or set TERRADART_HCL_SPECSUITE_SKIP=1 to skip offline.',
+    );
+  }
+  return _testsDir(cache) ?? (throw StateError('clone has no specsuite/tests'));
+}
+
+Directory? _testsDir(Directory root) {
+  for (final candidate in [
+    Directory('${root.path}/specsuite/tests'),
+    Directory('${root.path}/tests'),
+    root,
+  ]) {
+    if (candidate.existsSync() &&
+        candidate.listSync(recursive: true).any((f) => f.path.endsWith('.t'))) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+void main() {
+  final tests = locateSpecsuite();
+  if (tests == null) {
+    test('specsuite', () {}, skip: 'TERRADART_HCL_SPECSUITE_SKIP=1');
+    return;
+  }
+  final cases =
+      tests
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.hcl'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+  test(
+    'the suite has cases',
+    () => expect(cases.length, greaterThanOrEqualTo(10)),
+  );
+
+  group('every specsuite case', () {
+    for (final hcl in cases) {
+      final t = File('${hcl.path.substring(0, hcl.path.length - 4)}.t');
+      final expectsDiagnostics =
+          t.existsSync() &&
+          RegExp(
+            r'^diagnostics\s*\{',
+            multiLine: true,
+          ).hasMatch(t.readAsStringSync());
+      test(hcl.path.substring(tests.path.length + 1), () {
+        final src = hcl.readAsStringSync();
+        if (expectsDiagnostics) {
+          // Some diagnostics are schema errors the parser cannot see; a
+          // parse must simply not crash with anything but a parse error.
+          try {
+            parseHcl(src, fileName: hcl.path);
+          } on HclParseException {
+            // A syntax error is the expected outcome for the syntax cases.
+          }
+        } else {
+          expect(() => parseHcl(src, fileName: hcl.path), returnsNormally);
+        }
+      });
+    }
+  });
+
+  test('heredoc values match the suite expectations', () {
+    final dir = '${tests.path}/expressions';
+    final actual = parseHcl(File('$dir/heredoc.hcl').readAsStringSync());
+    final expected = parseHcl(File('$dir/heredoc.t').readAsStringSync());
+    final spec = parseHcl(File('$dir/heredoc.hcldec').readAsStringSync());
+    final variables = {
+      for (final a in spec.body.block('variables')!.body.attributes)
+        a.name: a.value.constantString,
+    };
+    String evaluate(TemplateExpr t) => [
+      for (final p in t.parts)
+        switch (p) {
+          TemplateLiteral(:final text) => text,
+          TemplateInterpolation(:final expr) =>
+            variables[(expr as TraversalExpr).root]!,
+          TemplateDirective() => throw StateError('no directives expected'),
+        },
+    ].join();
+    final result = expected.body.attribute('result')!.value as ObjectExpr;
+    var checked = 0;
+    for (final group in ['normal', 'flush']) {
+      final want = result.item(group)!.value as ObjectExpr;
+      final got = actual.body.attribute(group)!.value as ObjectExpr;
+      for (final item in want.items) {
+        final template = got.item(item.keyName!)!.value as TemplateExpr;
+        expect(
+          evaluate(template),
+          item.value.constantString,
+          reason: '$group.${item.keyName}',
+        );
+        checked++;
+      }
+    }
+    expect(checked, greaterThanOrEqualTo(15));
+  });
+
+  test('primitive literal values match the suite expectations', () {
+    final dir = '${tests.path}/expressions';
+    final actual = parseHcl(
+      File('$dir/primitive_literals.hcl').readAsStringSync(),
+    );
+    final expected = parseHcl(
+      File('$dir/primitive_literals.t').readAsStringSync(),
+    );
+    final result = expected.body.attribute('result')!.value as ObjectExpr;
+    for (final item in result.items) {
+      final got = actual.body.attribute(item.keyName!)!.value as LiteralExpr;
+      final want = item.value as LiteralExpr;
+      if (item.keyName == 'string_unicode_nonnorm') {
+        // HCL normalizes strings to NFC; this parser keeps the source code
+        // points (the migrator copies text back verbatim), so the combining
+        // tilde in the input stays a combining tilde.
+        expect(got.value, 'an\u0303os');
+        continue;
+      }
+      expect(got.value, want.value, reason: item.keyName);
+    }
+    expect(result.items, hasLength(10));
+  });
+}

--- a/packages/terradart_hcl/test/tf_json_test.dart
+++ b/packages/terradart_hcl/test/tf_json_test.dart
@@ -97,6 +97,12 @@ void main() {
         'v',
       );
       expect(file.body.blocksOf('moved'), hasLength(1));
+      expect(
+        decodeTfJson(
+          '{"check": {"health": {"assert": {"condition": true}}}}',
+        ).body.block('check')!.labelTexts,
+        ['health'],
+      );
       expect(file.body.block('custom_block')!.body.attribute('x'), isNotNull);
       expect(file.body.attribute('stray')!.value.constantString, 'value');
     });

--- a/packages/terradart_hcl/test/tf_json_test.dart
+++ b/packages/terradart_hcl/test/tf_json_test.dart
@@ -1,0 +1,152 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:terradart_hcl/src/dump.dart';
+import 'package:terradart_hcl/terradart_hcl.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final json = File(
+    'test/fixtures/pubsub_quickstart.tf.json',
+  ).readAsStringSync();
+
+  group('decodeTfJson', () {
+    test('maps the Terraform structure to blocks', () {
+      final file = decodeTfJson(json, fileName: 'main.tf.json');
+      expect(file.isJson, isTrue);
+      final raw = jsonDecode(json) as Map<String, dynamic>;
+      final resourceCount = (raw['resource'] as Map<String, dynamic>).values
+          .map((byName) => (byName as Map).length)
+          .fold<int>(0, (a, b) => a + b);
+      expect(file.body.blocksOf('resource'), hasLength(resourceCount));
+      expect(file.body.block('terraform')!.labels, isEmpty);
+      expect(file.body.block('provider')!.labelTexts, ['google']);
+      expect(
+        file.body.blocksOf('output').map((b) => b.labelTexts.single),
+        (raw['output'] as Map).keys,
+      );
+
+      final sub = file.body
+          .blocksOf('resource')
+          .firstWhere(
+            (b) =>
+                b.labelTexts.join('.') ==
+                'google_pubsub_subscription.orders_push',
+          );
+      final pushConfig = sub.body.attribute('push_config')!.value as ObjectExpr;
+      expect(
+        pushConfig.item('push_endpoint')!.value.constantString,
+        'https://app.example.com/push',
+      );
+      final topic = sub.body.attribute('topic')!.value as TemplateExpr;
+      expect(topic.parts.single, isA<TemplateInterpolation>());
+      expect(
+        ((topic.parts.single as TemplateInterpolation).expr as TraversalExpr)
+            .dottedPath,
+        'google_pubsub_topic.orders.id',
+      );
+      expect(
+        (sub.body.attribute('ack_deadline_seconds')!.value as LiteralExpr)
+            .value,
+        60,
+      );
+
+      final iam = file.body
+          .blocksOf('resource')
+          .firstWhere(
+            (b) => b.labelTexts.first == 'google_pubsub_schema_iam_member',
+          );
+      final dependsOn = iam.body.attribute('depends_on')!.value as TupleExpr;
+      expect(dependsOn.elements.map((e) => e.constantString), [
+        'google_pubsub_schema.orders_proto',
+        'google_service_account.orders_publisher',
+      ]);
+      expect(sub.range.isNone, isTrue);
+    });
+
+    test('lists of bodies, locals, escapes and scalars', () {
+      final file = decodeTfJson('''
+{
+  "provider": {"google": [{"project": "a"}, {"alias": "eu", "project": "b"}]},
+  "locals": {"n": 1, "s": "\$\${literal}", "l": [true, null, 1.5], "o": {"k": "v"}},
+  "moved": [{"from": "a.b", "to": "a.c"}],
+  "custom_block": {"x": 1},
+  "stray": "value"
+}
+''');
+      expect(
+        file.body
+            .blocksOf('provider')
+            .map((b) => b.body.attribute('project')!.value.constantString),
+        ['a', 'b'],
+      );
+      final locals = file.body.block('locals')!.body;
+      expect((locals.attribute('n')!.value as LiteralExpr).value, 1);
+      expect(locals.attribute('s')!.value.constantString, r'${literal}');
+      final l = locals.attribute('l')!.value as TupleExpr;
+      expect(l.elements.map((e) => (e as LiteralExpr).value), [
+        true,
+        null,
+        1.5,
+      ]);
+      expect(
+        (locals.attribute('o')!.value as ObjectExpr)
+            .item('k')!
+            .value
+            .constantString,
+        'v',
+      );
+      expect(file.body.blocksOf('moved'), hasLength(1));
+      expect(file.body.block('custom_block')!.body.attribute('x'), isNotNull);
+      expect(file.body.attribute('stray')!.value.constantString, 'value');
+    });
+
+    test('rejects invalid input with a diagnostic', () {
+      expect(
+        () => decodeTfJson('{'),
+        throwsA(
+          isA<HclParseException>().having(
+            (e) => e.first.message,
+            'message',
+            contains('invalid JSON'),
+          ),
+        ),
+      );
+      expect(
+        () => decodeTfJson('[]'),
+        throwsA(
+          isA<HclParseException>().having(
+            (e) => e.first.message,
+            'message',
+            contains('JSON object'),
+          ),
+        ),
+      );
+      expect(
+        () => decodeTfJson('{"resource": {"t": "oops"}}'),
+        throwsA(isA<HclParseException>()),
+      );
+      expect(
+        () => decodeTfJson('{"resource": {"t": {"n": [1]}}}'),
+        throwsA(isA<HclParseException>()),
+      );
+    });
+
+    test('JSON → module → HCL → module gives the same structure', () {
+      final fromJson = TfModule.fromTfJson(json, fileName: 'main.tf.json');
+      final hcl = serializeHcl(fromJson.files.single);
+      final fromHcl = TfModule.fromHcl(hcl, fileName: 'main.tf');
+      expect(
+        fromHcl.resources.map((r) => r.address),
+        fromJson.resources.map((r) => r.address),
+      );
+      expect(
+        fromHcl.outputs.map((o) => o.name),
+        fromJson.outputs.map((o) => o.name),
+      );
+      expect(fromHcl.providers.single.name, 'google');
+      expect(dumpHcl(fromHcl.files.single), dumpHcl(fromJson.files.single));
+      expect(fromHcl.requiredProviders.keys, ['google']);
+    });
+  });
+}

--- a/packages/terradart_hcl/test/tf_module_test.dart
+++ b/packages/terradart_hcl/test/tf_module_test.dart
@@ -98,6 +98,36 @@ void main() {
       expect(r.sourceText, isEmpty);
     });
 
+    test('terraform backend and cloud from the JSON object form', () {
+      final m = TfModule.fromTfJson(
+        '{"terraform": {"required_version": ">= 1.5", '
+        '"backend": {"gcs": {"bucket": "tf-state", "prefix": "p"}}, '
+        '"cloud": {"organization": "acme"}}}',
+      );
+      expect(m.backend!.labelTexts, ['gcs']);
+      expect(
+        m.backend!.body.attribute('bucket')!.value.constantString,
+        'tf-state',
+      );
+      expect(
+        m.terraform.single.cloud!.body
+            .attribute('organization')!
+            .value
+            .constantString,
+        'acme',
+      );
+      expect(m.requiredVersion!.constantString, '>= 1.5');
+      final none = TfModule.fromTfJson(
+        '{"terraform": {"backend": {"a": {}, "b": {}}}}',
+      );
+      expect(none.backend, isNull);
+      final hcl = TfModule.fromHcl(
+        'terraform {\n  backend "s3" {\n    bucket = "b"\n  }\n  cloud {}\n}\n',
+      );
+      expect(hcl.backend!.labelTexts, ['s3']);
+      expect(hcl.terraform.single.cloud, isNotNull);
+    });
+
     test('malformed labels are kept opaque with a warning', () {
       final m = TfModule.fromHcl(
         'resource "only_one" {}\nvariable {}\nx = 1\n',

--- a/packages/terradart_hcl/test/tf_module_test.dart
+++ b/packages/terradart_hcl/test/tf_module_test.dart
@@ -1,0 +1,154 @@
+import 'dart:io';
+
+import 'package:terradart_hcl/terradart_hcl.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final src = File('test/fixtures/repeated_blocks.tf').readAsStringSync();
+  final module = TfModule.fromHcl(src, fileName: 'repeated_blocks.tf');
+
+  group('TfModule', () {
+    test('classifies every top-level block', () {
+      expect(module.terraform, hasLength(1));
+      expect(module.providers.map((p) => p.alias), [null, 'eu']);
+      expect(module.variables.map((v) => v.name), ['project']);
+      expect(module.locals.map((l) => l.name), ['labels', 'names']);
+      expect(module.outputs.map((o) => o.name), ['url']);
+      expect(module.resources.map((r) => r.address), [
+        'google_cloud_run_v2_service.svc',
+        'google_storage_bucket.b',
+        'google_secret_manager_secret.s',
+      ]);
+      expect(module.dataSources.single.address, 'data.google_project.p');
+      expect(module.moduleCalls.single.name, 'network');
+      expect(
+        module.moduleCalls.single.source!.constantString,
+        './modules/network',
+      );
+      expect(module.opaque.map((o) => o.type), ['moved']);
+      expect(module.strayAttributes, isEmpty);
+      expect(module.warnings, isEmpty);
+    });
+
+    test('terraform settings', () {
+      expect(module.requiredVersion!.constantString, '>= 1.5');
+      expect(module.backend!.labelTexts, ['gcs']);
+      expect(
+        module.backend!.body.attribute('bucket')!.value.constantString,
+        'tf-state',
+      );
+      final google = module.requiredProviders['google'] as ObjectExpr;
+      expect(google.item('source')!.value.constantString, 'hashicorp/google');
+    });
+
+    test('resource accessors', () {
+      final svc = module.resource('google_cloud_run_v2_service', 'svc')!;
+      expect(svc.type, 'google_cloud_run_v2_service');
+      expect(svc.name, 'svc');
+      expect(svc.count, isNull);
+      expect(svc.forEach, isNull);
+      expect(svc.argument('location')!.constantString, 'asia-northeast1');
+      expect(
+        svc.lifecycle!.attribute('ignore_changes')!.value,
+        isA<TupleExpr>(),
+      );
+      expect(
+        svc.body.block('template')!.body.blocksOf('containers'),
+        hasLength(2),
+      );
+      expect(
+        svc.sourceText,
+        startsWith('resource "google_cloud_run_v2_service" "svc" {'),
+      );
+      expect(svc.sourceText, endsWith('}'));
+      expect(src.contains(svc.sourceText), isTrue);
+
+      final bucket = module.resource('google_storage_bucket', 'b')!;
+      expect(bucket.dynamicBlocks.single.labelTexts, ['cors']);
+      expect(bucket.body.blocksOf('lifecycle_rule'), hasLength(2));
+      expect(bucket.argument('name'), isA<RawExpr>());
+      expect(module.resource('nope', 'x'), isNull);
+    });
+
+    test('variables, locals and outputs', () {
+      final v = module.variable('project')!;
+      expect(
+        v.type,
+        isA<TraversalExpr>().having((t) => t.root, 'root', 'string'),
+      );
+      expect(v.description!.constantString, 'GCP project');
+      expect(v.defaultValue, isNull);
+      final labels = module.local('labels')!.value as ObjectExpr;
+      expect(labels.item('env')!.value.constantString, 'dev');
+      final url = module.output('url')!;
+      expect(url.value, isA<TraversalExpr>());
+      expect((url.description! as TemplateExpr).isHeredoc, isTrue);
+    });
+
+    test('nested arguments in JSON object form', () {
+      final m = TfModule.fromTfJson(
+        '{"resource": {"t": {"n": {"lifecycle": {"prevent_destroy": true}, "count": 2}}}}',
+      );
+      final r = m.resources.single;
+      expect(
+        (r.lifecycle!.attribute('prevent_destroy')!.value as LiteralExpr).value,
+        true,
+      );
+      expect((r.count as LiteralExpr).value, 2);
+      expect(r.sourceText, isEmpty);
+    });
+
+    test('malformed labels are kept opaque with a warning', () {
+      final m = TfModule.fromHcl(
+        'resource "only_one" {}\nvariable {}\nx = 1\n',
+      );
+      expect(m.resources, isEmpty);
+      expect(m.opaque.map((o) => o.type), ['resource', 'variable']);
+      expect(m.warnings, hasLength(2));
+      expect(m.warnings.first.message, contains('1 label'));
+      expect(m.strayAttributes.single.name, 'x');
+    });
+
+    test('several files merge in order', () {
+      final m = TfModule.fromFiles([
+        parseHcl('resource "a" "b" {}\n', fileName: 'a.tf'),
+        decodeTfJson('{"resource": {"c": {"d": {}}}}', fileName: 'c.tf.json'),
+      ]);
+      expect(m.resources.map((r) => '${r.file.fileName}:${r.address}'), [
+        'a.tf:a.b',
+        'c.tf.json:c.d',
+      ]);
+    });
+  });
+
+  group('loadTfModule', () {
+    test('reads .tf and .tf.json files sorted by name', () {
+      final dir = Directory.systemTemp.createTempSync('terradart_hcl_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      File('${dir.path}/b.tf').writeAsStringSync('resource "x" "b" {}\n');
+      File(
+        '${dir.path}/a.tf.json',
+      ).writeAsStringSync('{"resource": {"x": {"a": {}}}}');
+      File(
+        '${dir.path}/ignored.txt',
+      ).writeAsStringSync('resource "x" "no" {}\n');
+      final m = loadTfModule(dir);
+      expect(m.files, hasLength(2));
+      expect(m.resources.map((r) => r.name), ['a', 'b']);
+    });
+
+    test('loads the coverage config_tree fixture', () {
+      final m = loadTfModule(
+        Directory('../terradart_coverage/test/fixtures/config_tree/dev'),
+      );
+      expect(m.files.map((f) => f.fileName!.split('/').last), [
+        'backend.tf',
+        'main.tf',
+        'variables.tf',
+      ]);
+      expect(m.backend, isNotNull);
+      expect(m.moduleCalls, isNotEmpty);
+      expect(m.variables, isNotEmpty);
+    });
+  });
+}

--- a/packages/terradart_hcl/test/writer_test.dart
+++ b/packages/terradart_hcl/test/writer_test.dart
@@ -1,0 +1,121 @@
+import 'dart:io';
+
+import 'package:terradart_hcl/src/dump.dart';
+import 'package:terradart_hcl/terradart_hcl.dart';
+import 'package:test/test.dart';
+
+String _roundTrip(String src) => serializeHcl(parseHcl(src));
+
+void main() {
+  group('HclWriter', () {
+    test(
+      'renders attributes, blocks, labels, one-line blocks and comments',
+      () {
+        const src = '''
+# header
+a = "x" # trailing
+
+b "l1" l2 {
+  c = 1
+  d { e = true }
+  f {}
+  # dangling
+}
+''';
+        expect(_roundTrip(src), src);
+      },
+    );
+
+    test('escapes strings and template markers', () {
+      final file = parseHcl(
+        r'a = "q\"b\\c\n$${x}%%{y}"'
+        '\n',
+      );
+      expect(
+        serializeHcl(file),
+        r'a = "q\"b\\c\n$${x}%%{y}"'
+        '\n',
+      );
+      final t = parseHcl(
+        r'a = "${var.x}-${~ y ~}%{ if z }!%{ endif }"'
+        '\n',
+      );
+      expect(
+        serializeHcl(t),
+        r'a = "${var.x}-${~y~}%{if z}!%{endif}"'
+        '\n',
+      );
+    });
+
+    test('reproduces heredocs from their raw body', () {
+      const src = 'a = <<-EOT\n    p ${r'${q}'}\n      r\n  EOT\nb = 1\n';
+      expect(
+        _roundTrip(src),
+        'a = <<-EOT\n    p ${r'${q}'}\n      r\nEOT\nb = 1\n',
+      );
+      const nested = 'x {\n  a = <<EOT\n  p\n  EOT\n}\n';
+      expect(_roundTrip(nested), nested);
+    });
+
+    test('tuples and objects', () {
+      expect(_roundTrip('a = [1, "b", var.c]\n'), 'a = [1, "b", var.c]\n');
+      expect(_roundTrip('a = [\n  1,\n  2,\n]\n'), 'a = [\n  1,\n  2,\n]\n');
+      expect(
+        _roundTrip('a = { b = 1, "c d" = 2, e: 3 }\n'),
+        'a = { b = 1, "c d" = 2, e : 3 }\n',
+      );
+      expect(
+        _roundTrip('a = {\n  source = "x"\n  version = "1"\n}\n'),
+        'a = {\n  source = "x"\n  version = "1"\n}\n',
+      );
+      expect(_roundTrip('a = []\nb = {}\n'), 'a = []\nb = {}\n');
+    });
+
+    test('raw expressions are verbatim', () {
+      const src = 'a = merge(\n  local.x,\n  { b = 1 },\n)\nc = x ? 1 : 2\n';
+      expect(_roundTrip(src), src);
+    });
+
+    test('a heredoc inside a tuple stays valid HCL', () {
+      const src = 'a = [<<EOT\nx\nEOT\n, 1]\n';
+      final out = _roundTrip(src);
+      expect(dumpHcl(parseHcl(out)), dumpHcl(parseHcl(src)));
+    });
+
+    test('writeExpr and writeEntry', () {
+      const w = HclWriter();
+      expect(w.writeExpr(parseHclExpression('var.x[0]')), 'var.x[0]');
+      final file = parseHcl('b {\n  c = 1\n}\n');
+      expect(
+        w.writeEntry(file.body.blocks.single, level: 1),
+        '  b {\n    c = 1\n  }\n',
+      );
+    });
+  });
+
+  group('round trip', () {
+    final fixtures = [
+      File('test/fixtures/repeated_blocks.tf'),
+      ...Directory('../terradart_coverage/test/fixtures')
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.tf')),
+    ];
+    for (final f in fixtures) {
+      test('parse → write → parse is structurally identical: ${f.path}', () {
+        final src = f.readAsStringSync();
+        final first = parseHcl(src, fileName: f.path);
+        final written = serializeHcl(first);
+        final again = parseHcl(written, fileName: '${f.path}#written');
+        expect(dumpHcl(again), dumpHcl(first));
+        // Writing is idempotent.
+        expect(serializeHcl(again), written);
+        // Comments survive too.
+        expect(
+          again.comments.map((c) => c.text),
+          first.comments.map((c) => c.text),
+        );
+      });
+    }
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ workspace:
   - packages/terradart_cloudflare
   - packages/terradart_agent
   - packages/terradart_coverage
+  - packages/terradart_hcl
   - examples/agentic_applications_quickstart
   - examples/apigee_quickstart
   - examples/appwrite_quickstart

--- a/tool/agent_verify.sh
+++ b/tool/agent_verify.sh
@@ -73,16 +73,17 @@ else
 fi
 
 if [[ "$WITH_FORMAT" == "1" ]]; then
-  echo ">> dart format (terradart_core, terradart_codegen, terradart_agent, terradart_coverage)"
+  echo ">> dart format (terradart_core, terradart_codegen, terradart_agent, terradart_coverage, terradart_hcl)"
   dart format --output=none --set-exit-if-changed \
     packages/terradart_core/ \
     packages/terradart_codegen/ \
     packages/terradart_agent/ \
-    packages/terradart_coverage/
+    packages/terradart_coverage/ \
+    packages/terradart_hcl/
 fi
 
 if [[ "$QUICK" == "0" ]]; then
-  PACKAGES=(terradart_core terradart_codegen terradart_google terradart_google_beta terradart_appwrite terradart_cloudflare terradart_agent terradart_coverage)
+  PACKAGES=(terradart_core terradart_codegen terradart_google terradart_google_beta terradart_appwrite terradart_cloudflare terradart_agent terradart_coverage terradart_hcl)
   for pkg in "${PACKAGES[@]}"; do
     echo ">> dart test packages/$pkg"
     (cd "packages/$pkg" && dart test --reporter=expanded)

--- a/tool/bump_version.sh
+++ b/tool/bump_version.sh
@@ -98,7 +98,7 @@ sed_inplace() {
 
 # 1. `version:` field on the package pubspecs.
 echo "  Package versions:"
-for pkg in terradart_core terradart_codegen terradart_google terradart_google_beta terradart_appwrite terradart_cloudflare terradart_agent terradart_coverage; do
+for pkg in terradart_core terradart_codegen terradart_google terradart_google_beta terradart_appwrite terradart_cloudflare terradart_agent terradart_coverage terradart_hcl; do
   sed_inplace "s#^version: ${OLD_RE}\$#version: ${NEW}#" "packages/$pkg/pubspec.yaml"
   echo "    - packages/$pkg/pubspec.yaml -> $NEW"
 done


### PR DESCRIPTION
Closes #657 — Phase 2, step 4 of #80 (`terradart-migrate`); no code dependency on Phase 1. Design spec: #655, sub-issue index: #656.

## What

New pure-Dart package `packages/terradart_hcl`: the input side of `terradart-migrate`. It depends on no other TerraDart package.

- **`parseHcl`** — HCL native syntax. Block bodies are ordered entry lists, so repeated blocks (`containers` ×2, `env` ×3, `lifecycle_rule` ×2) survive as written. Every node carries a `SourceRange`; comments stay on the entry they precede (verbatim copy-back for the sidecar). Structure is parsed fully, including one-line blocks and the single-line-block / newline-after-argument rules the specsuite checks.
- **Shallow expressions.** Literals, tuples, objects, traversals (`google_pubsub_topic.t.name`, `var.x`, `local.l[0]`) and templates (quoted strings with `${}` / `%{}`, `$${` escapes, `~` strip markers, `<<` / `<<-` heredocs with the spec's flush-indent rule) are parsed exactly. Function calls, operators, conditionals, `for`, splats and computed indexes are kept as `RawExpr` with balanced brackets and verbatim source. Nothing is evaluated — migration needs classification, not evaluation.
- **`decodeTfJson`** — Terraform JSON syntax to the same `HclFile` shape (`resource` / `data` / `variable` / `output` / `module` / `provider` / `terraform` / `locals` / `moved` / `import` / `removed` / `check`; lists of bodies; strings parsed as templates).
- **`TfModule`** — terraform settings (`required_version`, `required_providers`, `backend`), providers with alias, variables, locals, outputs, resources, data sources, module calls, opaque blocks; `loadTfModule` reads a directory. Nested arguments (`lifecycle`, …) resolve from either the block form or the JSON object form.
- **`HclWriter`** — canonical HCL output; parse → write → parse is structurally identical, and JSON → module → HCL → module round-trips.

## Acceptance (from #657)

| Criterion | Result |
|---|---|
| hashicorp/hcl specsuite valid cases pass | every case the suite expects to succeed parses; the three syntax-error cases are rejected; heredoc and primitive-literal cases are checked against the suite's expected values |
| coverage fixtures + a repeated-block stress file parse losslessly | all 16 `terradart_coverage` fixture `.tf` files and `test/fixtures/repeated_blocks.tf`: top-level block counts match the source, parse → write → parse identical |
| `serialize(parse(x))` preserves block order and repeats | writer tests + the round-trip group |

The specsuite is fetched with a shallow `git clone` into `.dart_tool/hcl_specsuite` on first run (not vendored). `TERRADART_HCL_SPECSUITE` points the test at an existing checkout; `TERRADART_HCL_SPECSUITE_SKIP=1` skips it offline.

## Notes for review

- `TfModule` lives in this package rather than in `terradart_migrate` (the design doc put it in Phase 1): #657 asks for a tf.json decoder that produces *the same* `TfModule`, so the shared model has to sit here. Consequence: #660 depends on #657 as well as #658 — the index in #656 needs that one edit.
- NFC normalization is deliberately not applied to strings (HCL does): the migrator copies source text back verbatim, so the parser keeps the original code points. The specsuite's `string_unicode_nonnorm` case is handled explicitly in the test.
- The shallow parser does not validate adjacent primaries (`1 2` inside brackets parses as raw); it never claims to be a validator — Terraform still does that on the sidecar.

## Registration

Workspace `pubspec.yaml`, the CI `test` matrix and format check (`.github/workflows/ci.yml`), `tool/agent_verify.sh`, `tool/bump_version.sh`, `CONTRIBUTING.md`, `AGENTS.md`, `README.md`, root `CHANGELOG.md`. Version 0.27.0 (lockstep), `publish_to: none` for now.

## Verification

- `packages/terradart_hcl`: `dart test` 95 passed (specsuite included, both the cached-checkout and the clone path)
- `tool/agent_verify.sh --quick --format`: green (analyze incl. the new package, docs consistency, 4 `wrap --check` lanes, 4 `lint-override` lanes, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7D7HYzZHdcT8myLr1rmvw

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7D7HYzZHdcT8myLr1rmvw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive new package and CI/docs wiring only; no changes to synth, providers, or existing runtime behavior.
> 
> **Overview**
> Introduces **`terradart_hcl`**, a new standalone Dart package that will feed **`terradart-migrate`**: it parses native HCL and decodes `*.tf.json` into a shared **`HclFile` / `TfModule`** model, with **`HclWriter`** for round-tripping structure (ordered/repeated blocks, comments, shallow expressions as literals/traversals/templates or **`RawExpr`**).
> 
> The implementation includes lexer/parser, Terraform JSON mapping, directory loading via **`loadTfModule`**, broad unit tests (coverage fixtures, round-trip writer tests), and optional **hashicorp/hcl specsuite** conformance. Docs and tooling register the package in the workspace, README/AGENTS/CHANGELOG, CI test matrix and format scope, **`agent_verify.sh`**, and **`bump_version.sh`** (0.27.0, `publish_to: none`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fe150bfacab481767c59f49ba37359cceb13433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->