### PR TITLE
feat(agent): migrate_module, the HCL → Dart migrator over MCP (#667)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ GoogleCloudRunV2Service(
 
 ## AI Agent MCP Server (`terradart-mcp`)
 
-**Alpha.** [`terradart-mcp`](packages/terradart_agent/) is an MCP server that exposes the curated factory **catalog** to coding agents (Claude Code, Cursor, Claude Desktop). Five read-only tools — `list_barrels`, `list_resources`, `get_resource_schema`, `get_quickstart`, and `check_coverage` — help agents author correct Dart without guessing factory names. It does **not** run Terraform or touch GCP.
+**Alpha.** [`terradart-mcp`](packages/terradart_agent/) is an MCP server that exposes the curated factory **catalog** — and the migrator — to coding agents (Claude Code, Cursor, Claude Desktop). Six tools — `list_barrels`, `list_resources`, `get_resource_schema`, `get_quickstart`, `check_coverage`, and `migrate_module` — help agents author correct Dart without guessing factory names, and translate an existing Terraform module into a Stack. Every one of them answers from the text you pass and the catalog compiled into the binary: it does **not** run Terraform, write files, or touch GCP.
 
 ```sh
 brew install nozomi-koborinai/tap/terradart-mcp

--- a/packages/terradart_agent/README.md
+++ b/packages/terradart_agent/README.md
@@ -5,7 +5,7 @@
 
 `terradart-mcp` — a [Model Context Protocol](https://modelcontextprotocol.io) server that exposes the curated factory catalog of [TerraDart](https://terradart.dev) to AI coding agents.
 
-It reads the static catalog compiled into [`terradart_google`](https://pub.dev/packages/terradart_google) (`package:terradart_google/catalog.dart`) and surfaces it as five read-only MCP tools so agents can discover constructor signatures, nested types, quickstart snippets, and coverage gaps without guessing factory names.
+It reads the static catalog compiled into [`terradart_google`](https://pub.dev/packages/terradart_google) (`package:terradart_google/catalog.dart`) and surfaces it as six MCP tools so agents can discover constructor signatures, nested types, quickstart snippets, and coverage gaps without guessing factory names — and translate an existing Terraform module into a `Stack` with `migrate_module`, the migrator (`terradart_migrate`) over MCP.
 
 Built on [`genkit`](https://pub.dev/packages/genkit) + [`genkit_mcp`](https://pub.dev/packages/genkit_mcp). Ships as a single `terradart-mcp` binary (not published to pub.dev).
 
@@ -52,6 +52,7 @@ Full walkthroughs: [terradart.dev — terradart-mcp](https://terradart.dev/docs/
 | `get_resource_schema` | Constructor params and nested types for one factory |
 | `get_quickstart` | Ready-made `Stack` template for a resource |
 | `check_coverage` | Coverage report for `terraform show -json` input, against all four provider catalogs |
+| `migrate_module` | One Terraform module's text (HCL or `.tf.json`) → a `Stack`, a sidecar of what stays in Terraform, and a report |
 
 The catalog currently holds 1798 entries (1337 curated resource factories + 461 data sources) across 132 service barrels.
 

--- a/packages/terradart_agent/lib/src/server.dart
+++ b/packages/terradart_agent/lib/src/server.dart
@@ -8,6 +8,7 @@ import 'tools/get_quickstart.dart';
 import 'tools/get_resource_schema.dart';
 import 'tools/list_barrels.dart';
 import 'tools/list_resources.dart';
+import 'tools/migrate_module.dart';
 
 /// A JSON-Schema `object` input wrapped as a [SchemanticType] so it can be
 /// passed to [Genkit.defineTool]'s `inputSchema`.
@@ -34,13 +35,19 @@ SchemanticType<Map<String, dynamic>> _objectSchema({
 
 /// Builds the `terradart-mcp` MCP server.
 ///
-/// Registers five read-only tools (`list_resources`, `list_barrels`,
-/// `get_resource_schema`, `get_quickstart`, `check_coverage`) on a fresh
-/// [Genkit] instance and exposes them over the Model Context Protocol via
-/// genkit_mcp. The first four project TerraDart's curated `terradartCatalog`
-/// (from `package:terradart_google`) into agent-friendly JSON; `check_coverage`
-/// analyses `terraform show -json` output against every provider package's
-/// catalog (via `terradart_coverage`) and reports coverage metrics.
+/// Registers six tools (`list_resources`, `list_barrels`,
+/// `get_resource_schema`, `get_quickstart`, `check_coverage`,
+/// `migrate_module`) on a fresh [Genkit] instance and exposes them over the
+/// Model Context Protocol via genkit_mcp. The first four project TerraDart's
+/// curated `terradartCatalog` (from `package:terradart_google`) into
+/// agent-friendly JSON; `check_coverage` analyses `terraform show -json`
+/// output against every provider package's catalog (via `terradart_coverage`)
+/// and reports coverage metrics; `migrate_module` translates a Terraform
+/// module's own text into a TerraDart package (via `terradart_migrate`).
+///
+/// Every tool answers from what the caller passed and what is compiled into
+/// the binary: none of them reads a file, runs `terraform`, or reaches the
+/// network.
 Future<GenkitMcpServer> buildTerradartMcpServer() async {
   final ai = Genkit();
 
@@ -155,6 +162,79 @@ Future<GenkitMcpServer> buildTerradartMcpServer() async {
       required: ['tf_json'],
     ),
     fn: (input, _) async => checkCoverage(input['tf_json'] as String),
+  );
+
+  ai.defineTool<Map<String, dynamic>, Object>(
+    name: 'migrate_module',
+    description:
+        'Translate one Terraform module to TerraDart Dart. Pass the whole '
+        'config text as the "source" arg — HCL or .tf.json — and get back the '
+        'generated Stack ("dart_source"), the package files around it, the '
+        'sidecar of what stays in Terraform, and a report naming every block '
+        'either way with a reason. Resource addresses are preserved, so '
+        '`terraform plan` reports no changes once the sidecar is in place. '
+        'Nothing is read from disk and no terraform runs.',
+    inputSchema: _objectSchema(
+      properties: {
+        'source': $Schema.string(
+          description:
+              'The Terraform configuration text: the contents of a .tf file '
+              '(HCL) or a .tf.json file.',
+        ),
+        'name': $Schema.string(
+          description:
+              'Names the module: the Stack class is its PascalCase form with '
+              '"Stack" appended, the package its snake_case form. Defaults '
+              'to "main".',
+        ),
+        'syntax': $Schema.string(
+          description:
+              'How to read "source": "hcl", "json", or "auto" (the default, '
+              'which reads a leading "{" as .tf.json).',
+          enumValues: const ['auto', 'hcl', 'json'],
+        ),
+        'allow_todo': $Schema.boolean(
+          description:
+              'Write a TODO comment per untranslated block into the Stack '
+              'instead of a sidecar. The plan then differs until the TODOs '
+              'are ported. Defaults to false.',
+        ),
+      },
+      required: ['source'],
+    ),
+    fn: (input, _) async {
+      // The arguments come from an agent, so a wrong type is answered the
+      // same way an unparseable source is — with an error object, not a
+      // failed MCP call.
+      final source = input['source'];
+      if (source is! String) {
+        return <String, Object?>{
+          'error': source == null
+              ? 'missing required argument "source"'
+              : '"source" must be the Terraform config as a string',
+        };
+      }
+      final syntax = input['syntax'];
+      final parsed = syntax == null
+          ? MigrateSyntax.auto
+          : (syntax is String ? MigrateSyntax.byName(syntax) : null);
+      if (parsed == null) {
+        return <String, Object?>{
+          'error':
+              'unknown syntax "$syntax": expected one of '
+              '${MigrateSyntax.values.map((s) => s.name).join(', ')}',
+        };
+      }
+      return migrateModuleSource(
+        source,
+        name: switch (input['name']) {
+          final String n => n,
+          _ => 'main',
+        },
+        syntax: parsed,
+        allowTodo: input['allow_todo'] == true,
+      );
+    },
   );
 
   return createMcpServer(ai, McpServerOptions(name: 'terradart'));

--- a/packages/terradart_agent/lib/src/tools/migrate_module.dart
+++ b/packages/terradart_agent/lib/src/tools/migrate_module.dart
@@ -1,0 +1,102 @@
+import 'package:terradart_hcl/terradart_hcl.dart';
+import 'package:terradart_migrate/terradart_migrate.dart';
+
+/// The Terraform syntax [migrateModuleSource] reads the source as.
+enum MigrateSyntax {
+  /// `.tf` — native HCL.
+  hcl,
+
+  /// `.tf.json` — the JSON configuration syntax.
+  json,
+
+  /// JSON when the source opens a brace, HCL otherwise. A `.tf.json` file is
+  /// always one JSON object; an HCL body never starts with `{`.
+  auto;
+
+  static MigrateSyntax? byName(String name) {
+    for (final s in MigrateSyntax.values) {
+      if (s.name == name) return s;
+    }
+    return null;
+  }
+}
+
+/// A Dart package name: what `pubspec.yaml` and the Stack's library both
+/// need the module name to become.
+final _packageName = RegExp(r'^[a-z_][a-z0-9_]*$');
+
+/// Migrates one Terraform module's [source] text to a TerraDart package.
+///
+/// [source] is a whole Terraform configuration — HCL or `*.tf.json`, per
+/// [syntax] — as text; nothing is read from disk and no `terraform` runs.
+/// [name] names the module: the Stack class is its PascalCase form with
+/// `Stack` appended, the generated package its snake_case form. With
+/// [allowTodo] a block that stays in Terraform becomes a `TODO` comment in
+/// the Stack instead of a sidecar entry (`terradart-migrate --allow-todo`).
+///
+/// Returns the generated Dart, the sidecar of what stays in Terraform, and
+/// the report of every block either way — always a JSON object, so MCP
+/// clients that reject a bare array in `structuredContent` accept it. A
+/// source that does not parse comes back as `{'error': ..., 'diagnostics':
+/// [...]}` rather than throwing, so the agent sees the message.
+Map<String, Object?> migrateModuleSource(
+  String source, {
+  String name = 'main',
+  MigrateSyntax syntax = MigrateSyntax.auto,
+  bool allowTodo = false,
+}) {
+  if (source.trim().isEmpty) {
+    return {
+      'error': 'source is empty: pass the text of a .tf or .tf.json file',
+    };
+  }
+  final moduleName = name.trim();
+  final packageName = moduleName.isEmpty ? '' : packageNameFor(moduleName);
+  if (!_packageName.hasMatch(packageName)) {
+    return {
+      'error':
+          'name "$name" is not a Dart package name: it must start with a '
+          'letter or underscore and hold only letters, digits and underscores '
+          'once lower-cased',
+    };
+  }
+  final isJson = switch (syntax) {
+    MigrateSyntax.json => true,
+    MigrateSyntax.hcl => false,
+    MigrateSyntax.auto => source.trimLeft().startsWith('{'),
+  };
+
+  final TfModule module;
+  try {
+    module = isJson
+        ? TfModule.fromTfJson(source, fileName: 'main.tf.json')
+        : TfModule.fromHcl(source, fileName: 'main.tf');
+  } on HclParseException catch (e) {
+    return {
+      'error':
+          'source is not valid ${isJson ? 'Terraform JSON' : 'HCL'}: '
+          '${e.first.message}',
+      'diagnostics': [for (final d in e.diagnostics) d.toString()],
+    };
+  }
+
+  final result = migrateModule(module, name: moduleName, allowTodo: allowTodo);
+  final sidecar = result.sidecar;
+  return {
+    'migrated': result.hasStack,
+    'package_name': result.packageName,
+    'stack_class': result.stackClass,
+    'stack_file': 'lib/${result.stackFile}.dart',
+    // Empty when nothing in the module translates: then the sidecar is the
+    // whole answer, and the report says why of every block.
+    'dart_source': result.stackSource,
+    'infra_source': result.files['bin/infra.dart'] ?? '',
+    'pubspec': result.files['pubspec.yaml'] ?? '',
+    // File name → content, for the directory the Stack synthesizes into
+    // (`tf-out/`): what stays in Terraform, verbatim.
+    'sidecar': sidecar?.files ?? const <String, String>{},
+    'sidecar_placements': sidecar?.placements ?? const <String, String>{},
+    'report': result.report.toJson(),
+    'report_text': result.report.renderText(),
+  };
+}

--- a/packages/terradart_agent/pubspec.yaml
+++ b/packages/terradart_agent/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
   terradart_core: ^0.27.0
   terradart_google: ^0.27.0
   terradart_coverage: ^0.27.0
+  terradart_hcl: ^0.27.0
+  terradart_migrate: ^0.27.0
   genkit: ^0.14.1
   genkit_mcp: ^0.2.1
   schemantic: ^0.2.0

--- a/packages/terradart_agent/test/server_test.dart
+++ b/packages/terradart_agent/test/server_test.dart
@@ -3,16 +3,16 @@ import 'package:terradart_agent/terradart_agent.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('buildTerradartMcpServer exposes the 5 catalog tools', () async {
+  test('buildTerradartMcpServer exposes the 6 tools', () async {
     final GenkitMcpServer server = await buildTerradartMcpServer();
     final resp = await server.handleRequest(<String, dynamic>{
       'jsonrpc': '2.0',
       'method': 'tools/list',
       'id': 1,
     });
-    final tools = ((resp!['result'] as Map<String, Object?>)['tools'] as List)
-        .map((t) => (t as Map<String, Object?>)['name'] as String)
-        .toList();
+    final listed = ((resp!['result'] as Map<String, Object?>)['tools'] as List)
+        .cast<Map<String, Object?>>();
+    final tools = listed.map((t) => t['name'] as String).toList();
     expect(
       tools,
       containsAll(<String>[
@@ -21,8 +21,20 @@ void main() {
         'get_resource_schema',
         'get_quickstart',
         'check_coverage',
+        'migrate_module',
       ]),
     );
+    // The listing is what an agent reads to know what to pass, so the real
+    // parameter names are declared, not an opaque object.
+    final migrate = listed.firstWhere((t) => t['name'] == 'migrate_module');
+    final schema = migrate['inputSchema'] as Map<String, Object?>;
+    expect((schema['properties'] as Map<String, Object?>).keys, {
+      'source',
+      'name',
+      'syntax',
+      'allow_todo',
+    });
+    expect(schema['required'], ['source']);
   });
 
   test('tools/call returns object structuredContent with real data', () async {
@@ -85,6 +97,31 @@ void main() {
       'scenario': 'cloud-run-webhook',
     });
     expect(quickstart['structuredContent'], isA<Map<String, Object?>>());
+
+    // The migrator's answer is an object too, and it carries the Dart it
+    // generated rather than a description of it.
+    final migrated = await call('migrate_module', {
+      'source':
+          'resource "google_storage_bucket" "assets" {\n'
+          '  name     = "a"\n'
+          '  location = "US"\n'
+          '}\n',
+      'name': 'demo',
+    });
+    expect(migrated['isError'], isNot(true));
+    expect(migrated['structuredContent'], isA<Map<String, Object?>>());
+    final out = migrated['structuredContent'] as Map<String, Object?>;
+    expect(out['migrated'], isTrue);
+    expect(out['dart_source'], contains('final class DemoStack extends Stack'));
+
+    // A source that does not parse is an answer, not a failed call: the
+    // agent reads the reason and fixes what it passed.
+    final broken = await call('migrate_module', {'source': 'resource "x" {'});
+    expect(broken['isError'], isNot(true));
+    expect(
+      (broken['structuredContent'] as Map<String, Object?>)['error'],
+      contains('not valid HCL'),
+    );
 
     // Argument-free call to an optional-param tool must NOT error
     // (regression guard for the null-safe parse fix).

--- a/packages/terradart_agent/test/tools/migrate_module_test.dart
+++ b/packages/terradart_agent/test/tools/migrate_module_test.dart
@@ -1,0 +1,181 @@
+import 'dart:io';
+
+import 'package:terradart_agent/src/tools/migrate_module.dart';
+import 'package:test/test.dart';
+
+// `migrate_module` (#667): the migrator, over MCP. The module arrives as
+// text and leaves as Dart, a sidecar and a report — nothing is read from
+// disk. The pubsub fixture is `terradart_migrate`'s own, so the tool is
+// tested against the module the migrator's tests translate.
+const _pubsubFixture =
+    '../terradart_migrate/test/fixtures/pubsub_quickstart.tf.json';
+
+const _bucketHcl = '''
+resource "google_storage_bucket" "assets" {
+  name     = "a"
+  location = "US"
+}
+''';
+
+void main() {
+  group('migrate_module: the pubsub fixture', () {
+    final source = File(_pubsubFixture).readAsStringSync();
+    final out = migrateModuleSource(source, name: 'orders');
+
+    test('the whole module becomes Dart', () {
+      expect(out['error'], isNull, reason: '${out['error']}');
+      expect(out['migrated'], isTrue);
+      final report = out['report'] as Map<String, Object?>;
+      expect(report['complete'], isTrue);
+      expect(report['kept'], isEmpty);
+      expect(report['packages'], ['terradart_google']);
+      expect(
+        (report['migrated'] as List).map(
+          (m) => (m as Map<String, Object?>)['address'],
+        ),
+        containsAll([
+          'google_pubsub_topic.orders',
+          'google_pubsub_subscription.orders_push',
+          'data.google_project.current',
+          'output.ORDERS_TOPIC_NAME',
+        ]),
+      );
+    });
+
+    test('the Dart is a Stack named after the module', () {
+      expect(out['stack_class'], 'OrdersStack');
+      expect(out['stack_file'], 'lib/orders_stack.dart');
+      expect(out['package_name'], 'orders');
+      final dart = out['dart_source'] as String;
+      expect(dart, contains('final class OrdersStack extends Stack {'));
+      expect(dart, contains("import 'package:terradart_google/pubsub.dart';"));
+      expect(dart, contains('GooglePubsubTopic('));
+      expect(dart, contains("localName: r'orders'"));
+    });
+
+    test('the package around it comes too', () {
+      expect(out['pubspec'], contains('name: orders'));
+      expect(out['pubspec'], contains('terradart_google:'));
+      expect(out['infra_source'], contains("OrdersStack().writeTo(r'tf-out')"));
+    });
+
+    test('nothing stays in Terraform, so there is no sidecar', () {
+      expect(out['sidecar'], isEmpty);
+      expect(out['sidecar_placements'], isEmpty);
+      expect(out['report_text'], contains('kept in Terraform: 0'));
+    });
+
+    test('the tf.json syntax is read without being named', () {
+      // `auto` reads the leading brace as Terraform JSON; naming it `hcl`
+      // is the caller's mistake, and it is reported as one.
+      expect(
+        migrateModuleSource(source, syntax: MigrateSyntax.json)['migrated'],
+        isTrue,
+      );
+      final wrong = migrateModuleSource(source, syntax: MigrateSyntax.hcl);
+      expect(wrong['error'], contains('not valid HCL'));
+      expect(wrong['diagnostics'], isNotEmpty);
+    });
+  });
+
+  group('migrate_module: HCL', () {
+    test('a .tf module translates the same way', () {
+      final out = migrateModuleSource(_bucketHcl);
+      expect(out['error'], isNull);
+      expect(out['migrated'], isTrue);
+      expect(out['stack_class'], 'MainStack');
+      expect(out['stack_file'], 'lib/main_stack.dart');
+      expect(out['dart_source'], contains('GoogleStorageBucket('));
+      expect(out['dart_source'], contains("localName: r'assets'"));
+    });
+
+    test('what has no factory stays in Terraform, with a reason', () {
+      final out = migrateModuleSource('''
+$_bucketHcl
+resource "unknown_thing" "x" {
+  name = "x"
+}
+''');
+      expect(out['migrated'], isTrue);
+      final sidecar = out['sidecar'] as Map<String, Object?>;
+      expect(sidecar, isNotEmpty);
+      expect(sidecar.values.join(), contains('resource "unknown_thing" "x"'));
+      expect(
+        out['sidecar_placements'],
+        containsPair('unknown_thing.x', isA<String>()),
+      );
+      final kept = (out['report'] as Map<String, Object?>)['kept'] as List;
+      expect(
+        (kept.single as Map<String, Object?>)['reason'],
+        contains('no curated factory'),
+      );
+    });
+
+    test('--allow-todo puts the leftover in the Stack instead', () {
+      final out = migrateModuleSource('''
+$_bucketHcl
+resource "unknown_thing" "x" {
+  name = "x"
+}
+''', allowTodo: true);
+      expect(out['sidecar'], isEmpty);
+      expect(out['dart_source'], contains('TODO'));
+      expect(out['dart_source'], contains('unknown_thing.x'));
+    });
+
+    test('a module where nothing translates has no Stack at all', () {
+      final out = migrateModuleSource('''
+resource "unknown_thing" "x" {
+  name = "x"
+}
+''');
+      expect(out['migrated'], isFalse);
+      expect(out['dart_source'], isEmpty);
+      expect(out['sidecar'], isNotEmpty);
+    });
+  });
+
+  group('migrate_module: what comes back as an error, not a throw', () {
+    test('a source that does not parse', () {
+      final out = migrateModuleSource('resource "x" {');
+      expect(out['error'], contains('not valid HCL'));
+      expect(out['diagnostics'], isA<List<String>>());
+      expect(out['dart_source'], isNull);
+    });
+
+    test('an empty source', () {
+      expect(migrateModuleSource('   \n')['error'], contains('empty'));
+    });
+
+    test('a name that is not a Dart package name', () {
+      for (final name in const ['', '   ']) {
+        expect(
+          migrateModuleSource(_bucketHcl, name: name)['error'],
+          contains('package name'),
+          reason: '"\$name"',
+        );
+      }
+    });
+
+    test('a name the migrator can sanitize is sanitized, not refused', () {
+      // The name reaches a pubspec and a class declaration, so nothing of
+      // what an agent passes survives into either verbatim.
+      for (final entry in const {
+        '../escape': 'escape',
+        '9lives': 'm_9lives',
+        'a b': 'a_b',
+      }.entries) {
+        final out = migrateModuleSource(_bucketHcl, name: entry.key);
+        expect(out['error'], isNull, reason: entry.key);
+        expect(out['package_name'], entry.value, reason: entry.key);
+      }
+    });
+
+    test('a name Dart accepts once lower-cased is kept', () {
+      final out = migrateModuleSource(_bucketHcl, name: 'My-Infra');
+      expect(out['error'], isNull);
+      expect(out['package_name'], 'my_infra');
+      expect(out['stack_class'], 'MyInfraStack');
+    });
+  });
+}

--- a/website/src/content/docs/docs/agent/clients.md
+++ b/website/src/content/docs/docs/agent/clients.md
@@ -15,7 +15,7 @@ The shared shape of the config across MCP clients is just:
 }
 ```
 
-The server registers itself under the name `terradart`, and exposes the five read-only tools described in the [Tools reference](/docs/agent/tools-reference/).
+The server registers itself under the name `terradart`, and exposes the six tools described in the [Tools reference](/docs/agent/tools-reference/).
 
 ## Claude Code
 

--- a/website/src/content/docs/docs/agent/index.md
+++ b/website/src/content/docs/docs/agent/index.md
@@ -1,9 +1,11 @@
 ---
 title: terradart-mcp
-description: An MCP server that exposes TerraDart's curated Google Cloud catalog to coding agents.
+description: An MCP server that exposes TerraDart's curated Google Cloud catalog — and its HCL migrator — to coding agents.
 ---
 
 `terradart-mcp` is a [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that exposes TerraDart's curated Google Cloud factory **catalog** to coding agents. The catalog covers 1798 entries (1337 curated resource factories + 461 data sources) across 132 service barrels (`agent`, `compute`, `container`, `pubsub`, `cloud_run`, `alloydb`, `redis`, `iap`, `firestore`, and more). With the server connected, an agent can look up the exact constructor signatures, nested types, and ready-made `Stack` templates it needs to author correct TerraDart Dart code — instead of guessing factory names from memory.
+
+It also carries the migrator: `migrate_module` takes a Terraform module's own text and hands back the `Stack` it becomes, so an agent looking at an existing `.tf` file can answer "what does this look like in TerraDart?" from the same connection.
 
 It is built with [genkit_mcp](https://pub.dev/packages/genkit_mcp) (Genkit's MCP server library) and ships as a single compiled binary. Coding agents connect via Claude Code, Claude Desktop, or Cursor; a Genkit Dart app can host the server as an MCP client too ([Connecting clients](/docs/agent/clients/#genkit-dart)).
 
@@ -12,7 +14,7 @@ It is built with [genkit_mcp](https://pub.dev/packages/genkit_mcp) (Genkit's MCP
 ```mermaid
 graph LR
   agent["coding agent<br/>(Claude Code / Cursor / Claude Desktop)"]
-  mcp["terradart-mcp<br/>list_barrels · list_resources<br/>get_resource_schema · get_quickstart<br/>check_coverage"]
+  mcp["terradart-mcp<br/>list_barrels · list_resources<br/>get_resource_schema · get_quickstart<br/>check_coverage · migrate_module"]
   catalog["static catalog in terradart_google<br/>1798 entries · 132 service barrels"]
   agent -->|stdio JSON-RPC MCP| mcp
   mcp -->|reads in-process| catalog
@@ -22,11 +24,12 @@ The agent speaks JSON-RPC over stdio. `terradart-mcp` answers each tool call by 
 
 ## What it does NOT do
 
-`terradart-mcp` is **read-only catalog metadata**. It only answers questions about TerraDart's curated factories. It does **not**:
+Every tool answers from what the caller passed and what is compiled into the binary. `terradart-mcp` does **not**:
 
 - run `terraform` (no `plan`, no `apply`);
 - touch Google Cloud, your project, or any credentials;
-- write, synthesize, or apply infrastructure;
+- read or write any file on your machine — `migrate_module` takes the module as text in the call and returns the generated Dart as text in the result, and writes nothing anywhere;
+- synthesize or apply infrastructure;
 - need network access to do its job.
 
 If an agent wants to actually synthesize and apply a stack, that still happens the normal way — see [How it works](/docs/how-it-works/). `terradart-mcp` exists purely so the agent writes the right Dart in the first place.
@@ -35,5 +38,5 @@ If an agent wants to actually synthesize and apply a stack, that still happens t
 
 - [Install](/docs/agent/install/) — Homebrew or a direct binary download.
 - [Connecting clients](/docs/agent/clients/) — Claude Code, Claude Desktop, Cursor, and Genkit Dart.
-- [Tools reference](/docs/agent/tools-reference/) — the 5 tools, with request/response examples.
+- [Tools reference](/docs/agent/tools-reference/) — the 6 tools, with request/response examples.
 - [Recipes](/docs/agent/recipes/) — prompt patterns for discovery, schema lookup, scaffolding, and plan review.

--- a/website/src/content/docs/docs/agent/recipes.md
+++ b/website/src/content/docs/docs/agent/recipes.md
@@ -35,4 +35,14 @@ When you already have a proposed stack (or a design sketch), use the catalog to 
 
 > **Prompt:** "Here's my planned TerraDart stack: a Pub/Sub topic, a push subscription, and a Cloud Run service that consumes it. Verify every resource and parameter against the TerraDart catalog before I implement it."
 
-The agent resolves each resource with `get_resource_schema`, flags anything that returns `found: false` (with suggestions), and confirms the constructor parameters exist — turning "looks plausible" into "compiles against the curated API."
+The agent resolves each resource with `get_resource_schema`, flags anything that returns `found: false` (with suggestions), and confirms the constructor parameters exist — turning "looks plausible" into "compiles against the curated API.
+
+## Migrating an existing module
+
+When you have a `.tf` file open and want to know what it becomes in TerraDart, hand the agent the file. It calls `migrate_module` with the text as `source` and gets back the `Stack`, the sidecar of anything with no curated factory yet, and a report listing every block either way.
+
+> **Prompt:** "Convert this `main.tf` to TerraDart, and tell me what wouldn't convert."
+
+The agent calls `migrate_module` with `{ "source": "<the file>", "name": "orders" }`, writes `dart_source` into `lib/orders_stack.dart`, and reads `report.kept` to explain what stayed in Terraform and why. Resource addresses are preserved, so the plan reports *No changes* once the `sidecar` files sit beside the Stack's synth output.
+
+For a whole tree — child modules, environments, `moved` blocks, re-running as the catalog grows — reach for the [`terradart-migrate` CLI](/docs/migrate-from-hcl/) instead; the tool is its single-module slice, for text the agent already has."

--- a/website/src/content/docs/docs/agent/tools-reference.md
+++ b/website/src/content/docs/docs/agent/tools-reference.md
@@ -1,9 +1,9 @@
 ---
 title: Tools reference
-description: The five read-only tools exposed by terradart-mcp, with request/response examples.
+description: The six tools exposed by terradart-mcp, with request/response examples.
 ---
 
-`terradart-mcp` exposes five read-only tools over MCP. All five are invoked with the standard MCP `tools/call` method. The envelope looks like this:
+`terradart-mcp` exposes six tools over MCP. All six are invoked with the standard MCP `tools/call` method. The envelope looks like this:
 
 ```json
 {
@@ -184,3 +184,76 @@ Returns a coverage report for an existing Terraform plan or state JSON. Pass the
 ```
 
 The report is read-only analysis. It does not run Terraform, read local files, or contact Google Cloud.
+
+## `migrate_module`
+
+Translates one Terraform module into a TerraDart package: `terradart-migrate`, over MCP. Pass the module's own configuration text as `source` — a `.tf` file's HCL or a `.tf.json` file's JSON — and the tool answers with the generated `Stack`, the package files around it, the sidecar holding whatever has no curated factory yet, and a report naming every block either way.
+
+Resource addresses are preserved, so `terraform plan` against the existing state reports no changes once the sidecar sits beside the Stack's `main.tf.json`. Nothing is read from disk and no `terraform` runs: the module arrives as text in the call and leaves as text in the result.
+
+| Argument | Required | Meaning |
+| :--- | :--- | :--- |
+| `source` | yes | The whole Terraform configuration as text — HCL or `.tf.json`. |
+| `name` | no | Names the module. The Stack class is its PascalCase form with `Stack` appended, the package its snake_case form. Defaults to `main`. |
+| `syntax` | no | `auto` (default), `hcl`, or `json`. `auto` reads a leading `{` as `.tf.json`. |
+| `allow_todo` | no | Write a `TODO` comment per untranslated block into the Stack instead of a sidecar. The plan then differs until the TODOs are ported. Defaults to `false`. |
+
+**Input**
+
+```json
+{
+  "source": "resource \"google_pubsub_topic\" \"orders\" {\n  name = \"orders-prod\"\n}\n\nresource \"acme_widget\" \"w\" {\n  size = 3\n}\n",
+  "name": "orders"
+}
+```
+
+**Output** — the Stack in `dart_source`, the leftover in `sidecar`, the accounting in `report` (abridged here; `infra_source` and `pubspec` carry `bin/infra.dart` and `pubspec.yaml`):
+
+```json
+{
+  "migrated": true,
+  "package_name": "orders",
+  "stack_class": "OrdersStack",
+  "stack_file": "lib/orders_stack.dart",
+  "dart_source": "final class OrdersStack extends Stack {\n  OrdersStack() : super(providers: [const GoogleProvider()]) {\n    add(\n      GooglePubsubTopic(\n        localName: r'orders',\n        name: TfArg.literal(r'orders-prod'),\n      ),\n    );\n  }\n}\n",
+  "infra_source": "…",
+  "pubspec": "…",
+  "sidecar": {
+    "terradart_leftover.tf": "# terradart-migrate: no curated factory for resource type \"acme_widget\" (request curation)\nresource \"acme_widget\" \"w\" {\n  size = 3\n}\n"
+  },
+  "sidecar_placements": { "acme_widget.w": "terradart_leftover.tf" },
+  "report": {
+    "module": "orders",
+    "stackClass": "OrdersStack",
+    "complete": false,
+    "migrated": [
+      { "address": "provider.google" },
+      { "address": "google_pubsub_topic.orders", "dartName": "orders" }
+    ],
+    "kept": [
+      {
+        "address": "acme_widget.w",
+        "reason": "no curated factory for resource type \"acme_widget\" (request curation)"
+      }
+    ],
+    "warnings": [],
+    "packages": ["terradart_google"],
+    "providers": ["google"],
+    "expanded": []
+  },
+  "report_text": "terradart-migrate: orders → OrdersStack\n…"
+}
+```
+
+`sidecar` maps file name to content for the directory the Stack synthesizes into (`tf-out/`), and `sidecar_placements` says which file each kept address landed in. When nothing in the module translates, `migrated` is `false`, `dart_source` is empty, and the sidecar is the whole answer.
+
+**Output** — on a source that does not parse:
+
+```json
+{
+  "error": "source is not valid HCL: expected \"}\" to close the single-line block",
+  "diagnostics": ["main.tf:1:15: expected \"}\" to close the single-line block"]
+}
+```
+
+For a whole tree of modules rather than one file — child modules, environments, `moved` blocks, a re-runnable sidecar — use the [`terradart-migrate` CLI](/docs/migrate-from-hcl/) instead; this tool is the single-module slice of it, for an agent that already has the text in hand.

--- a/website/src/content/docs/docs/status.md
+++ b/website/src/content/docs/docs/status.md
@@ -46,7 +46,7 @@ Beta is the alpha change policy **proven against real external usage**. We will 
 
 - [ ] **External quickstart**: someone outside the core team completes the README path once; feedback captured in an issue or discussion.
 - [ ] **Real apply dogfood** via the [cookbook](https://github.com/nozomi-koborinai/terradart/tree/main/cookbook): at least one non-trivial recipe documents a successful `terraform apply`.
-- [ ] **`terradart-mcp`**: [Agent install](/docs/agent/install/) verified on a clean machine (Homebrew or release binary + five tools).
+- [ ] **`terradart-mcp`**: [Agent install](/docs/agent/install/) verified on a clean machine (Homebrew or release binary + six tools).
 - [ ] **`terradart-migrate`**: [Migrating from HCL](/docs/migrate-from-hcl/) verified on a clean machine (Homebrew or release binary), with one real Terraform tree that migrates and plans with *No changes*.
 
 Toward **1.0.0** (does not block beta):


### PR DESCRIPTION
Closes #667.

`terradart-mcp` could tell an agent what TerraDart covers, but not what an existing Terraform module becomes. An agent looking at a `.tf` file had to either guess the translation from `get_resource_schema` calls or ask the user to run the CLI. The migrator's own library API has been stable since #661, so this wraps it: **`migrate_module` takes the module as text and answers with the Stack it becomes.**

## The tool

**Input** — `source` (a `.tf` file's HCL or a `.tf.json` file's JSON), read by `syntax` (`auto` by default, which reads a leading `{` as Terraform JSON), plus an optional `name` for the Stack class and package, and `allow_todo` mirroring the CLI flag.

**Output** — one JSON object:

| Key | Contents |
| :--- | :--- |
| `dart_source` | The generated Stack |
| `infra_source` / `pubspec` | The two package files around it |
| `sidecar` / `sidecar_placements` | What stays in Terraform, and which file each kept address landed in |
| `report` / `report_text` | Every block either way, with a reason |

Resource addresses are preserved, so `terraform plan` reports no changes once the sidecar is in place.

The tool is a pure text-to-text translation: nothing is read from disk, no `terraform` runs, and the module never leaves the call. Argument types and a source that does not parse come back as `{"error": ..., "diagnostics": [...]}` rather than failing the MCP call, so the agent reads the reason and fixes what it sent — the same posture `check_coverage` takes.

For a whole tree — child modules, environments, `moved` blocks, `--update` — the `terradart-migrate` CLI is still the answer; this is its single-module slice, for text the agent already has.

## Acceptance (#667)

- **Tool listed in `tools/list`** — `server_test.dart` asserts all six tools, plus `migrate_module`'s real parameter names in the listed `inputSchema` (`source` / `name` / `syntax` / `allow_todo`, `source` required) so an agent knows what to pass. The compiled binary was also driven over stdio to confirm `tools/list` and `tools/call` end to end.
- **Tested against the pubsub fixture** — `terradart_migrate`'s own `pubsub_quickstart.tf.json`, referenced across packages rather than copied (the repo's existing convention). All 15 blocks translate, nothing is kept, no sidecar.

## Changes

- **New** `packages/terradart_agent/lib/src/tools/migrate_module.dart` — `MigrateSyntax` and `migrateModuleSource`, wrapping `migrateModule`.
- `packages/terradart_agent/lib/src/server.dart` — registers the tool; the doc comment now covers six tools and states that none of them reads a file, runs `terraform`, or reaches the network.
- `packages/terradart_agent/pubspec.yaml` — adds `terradart_migrate` and `terradart_hcl` (both already in the workspace; `terradart_coverage` already pulled the four provider catalogs, so `dart_style` and `path` are the only genuinely new transitive deps).
- **New** `packages/terradart_agent/test/tools/migrate_module_test.dart` (14 tests) and an extended `test/server_test.dart`.
- Docs: a `## migrate_module` section in the tools reference written from real output, a migration recipe, and the "five read-only tools" wording updated to six across `index.md`, `clients.md`, `status.md` and both READMEs. Since this tool *generates* Dart, `index.md`'s "What it does NOT do" is reframed around what actually holds — every tool answers from the text you pass and the catalog compiled into the binary, and nothing is read from or written to disk.

## Verification

- `dart format --output=none --set-exit-if-changed` on the six hand-written packages, and `dart analyze packages/ tool/ examples/ --fatal-infos --fatal-warnings` — both clean.
- Tests: terradart_agent 32, terradart_migrate 173, terradart_hcl 96, terradart_coverage 51, terradart_core 312 — all pass.
- Gates: `migrate_roundtrip_gates` 121/121, `migrate_fixture_gates` (4 passes), `migrate_moved_gates`, `check_docs_consistency`, `check_example_topology` — all OK.
- `dart compile exe bin/terradart_mcp.dart` succeeds and `--version` smoke-tests, matching `release-binary.yml`.
- `bun run build` in `website/` — 17 pages built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7D7HYzZHdcT8myLr1rmvw

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7D7HYzZHdcT8myLr1rmvw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive MCP surface over in-process migration libraries; no Terraform execution, GCP access, or filesystem I/O in the server path.
> 
> **Overview**
> Adds **`migrate_module`** to `terradart-mcp`, exposing the existing `terradart_migrate` pipeline over MCP so agents can turn a single Terraform module (HCL or `.tf.json` passed as `source`) into generated Dart (`dart_source`), package scaffolding (`pubspec`, `infra_source`), a Terraform **sidecar** for uncovered blocks, and structured/text **reports** — with optional `name`, `syntax` (`auto`/`hcl`/`json`), and `allow_todo`.
> 
> Implementation is a thin wrapper (`migrate_module.dart` + registration in `server.dart`) with **`terradart_hcl`** / **`terradart_migrate`** dependencies; invalid input and bad args return JSON **`error`** objects (plus diagnostics on parse failure) instead of failing the MCP call. Tests cover the pubsub fixture, HCL/sidecar/TODO paths, and `tools/list` / `tools/call` integration.
> 
> Docs and READMEs are updated from five catalog tools to **six**, including a tools-reference section, a migration recipe, and clarified limits (text-in/text-out, no disk I/O or `terraform` runs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86b8f938ba26da2228fd6e223f60f73b286e4717. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->