### PR TITLE
fix(migrate): bare Map / List passthrough slots, and the 0.28.1 lockstep bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to terradart are documented here. The format follows [Keep a
 
 Per-package changelogs live alongside each package and are the system of record for `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_agent`, and `terradart_coverage` — this top-level file summarises cross-cutting milestones.
 
-## Unreleased
+## [0.28.1] - 2026-09-13
+
+Lockstep patch release across the workspace. **No breaking changes** vs `0.28.0`.
 
 - **`terradart_migrate`** — fix: a passthrough slot whose parameter is a bare `Map` / `List` (`advancedExtra` on `SqlDatabaseInstanceSettings`) was emitted as `TfArg.literal({...})`, so a migrated Stack carrying an `insights_config` did not compile although the report counted the resource as migrated. The emitter now honours the manifest's `wrapped` flag, shapes the payload to the parameter and types empty payloads; `cloud_sql_quickstart` exercises the path so the round-trip gate covers it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to terradart are documented here. The format follows [Keep a
 
 Per-package changelogs live alongside each package and are the system of record for `terradart_core`, `terradart_codegen`, `terradart_google`, `terradart_agent`, and `terradart_coverage` — this top-level file summarises cross-cutting milestones.
 
+## Unreleased
+
+- **`terradart_migrate`** — fix: a passthrough slot whose parameter is a bare `Map` / `List` (`advancedExtra` on `SqlDatabaseInstanceSettings`) was emitted as `TfArg.literal({...})`, so a migrated Stack carrying an `insights_config` did not compile although the report counted the resource as migrated. The emitter now honours the manifest's `wrapped` flag, shapes the payload to the parameter and types empty payloads; `cloud_sql_quickstart` exercises the path so the round-trip gate covers it.
+
 ## [0.28.0] - 2026-09-13
 
 Lockstep release across the workspace — the `terradart-migrate` epic (#80) lands: `terradart_hcl`, `terradart_migrate`, the `terradart-migrate` binary, the `migrate_module` MCP tool, and the `terradart_core` additions the migrator needed. **Breaking** — `TfArg` gains a fourth variant (`TfArgExpression`) and `StackProvider` gains `alias`; see [MIGRATING.md](MIGRATING.md).

--- a/cookbook/firebase-app-backend/pubspec.yaml
+++ b/cookbook/firebase-app-backend/pubspec.yaml
@@ -9,9 +9,9 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
-  terradart_google_beta: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
+  terradart_google_beta: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/firestore-seeded-data/pubspec.yaml
+++ b/cookbook/firestore-seeded-data/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/lunch-concierge/infra/pubspec.yaml
+++ b/cookbook/lunch-concierge/infra/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/remote-backend/pubspec.yaml
+++ b/cookbook/remote-backend/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/cookbook/single-project-app/pubspec.yaml
+++ b/cookbook/single-project-app/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/access_context_quickstart/pubspec.yaml
+++ b/examples/access_context_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/agentic_applications_quickstart/pubspec.yaml
+++ b/examples/agentic_applications_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/api_security_quickstart/pubspec.yaml
+++ b/examples/api_security_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/apigee_quickstart/pubspec.yaml
+++ b/examples/apigee_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/app_engine_quickstart/pubspec.yaml
+++ b/examples/app_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/apphub_quickstart/pubspec.yaml
+++ b/examples/apphub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/appwrite_quickstart/pubspec.yaml
+++ b/examples/appwrite_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_appwrite: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_appwrite: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/artifact_registry_quickstart/pubspec.yaml
+++ b/examples/artifact_registry_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/beta_leftover_quickstart/pubspec.yaml
+++ b/examples/beta_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google_beta: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google_beta: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/beta_service_identity_quickstart/pubspec.yaml
+++ b/examples/beta_service_identity_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google_beta: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google_beta: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/biglake_quickstart/pubspec.yaml
+++ b/examples/biglake_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_datapolicyv2_quickstart/pubspec.yaml
+++ b/examples/bigquery_datapolicyv2_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigquery_quickstart/pubspec.yaml
+++ b/examples/bigquery_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/bigtable_quickstart/pubspec.yaml
+++ b/examples/bigtable_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ces_quickstart/pubspec.yaml
+++ b/examples/ces_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/chronicle_quickstart/pubspec.yaml
+++ b/examples/chronicle_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_asset_quickstart/pubspec.yaml
+++ b/examples/cloud_asset_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_build_quickstart/pubspec.yaml
+++ b/examples/cloud_build_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_functions_quickstart/pubspec.yaml
+++ b/examples/cloud_functions_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_quickstart/pubspec.yaml
+++ b/examples/cloud_run_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_run_v1_quickstart/pubspec.yaml
+++ b/examples/cloud_run_v1_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_scheduler_quickstart/pubspec.yaml
+++ b/examples/cloud_scheduler_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_sql_quickstart/lib/main.dart
+++ b/examples/cloud_sql_quickstart/lib/main.dart
@@ -114,6 +114,20 @@ final class CloudSqlStack extends Stack {
             // VPC has multiple PSA peerings.
             allocatedIpRange: TfArg.ref(psaRange.nameRef),
           ),
+          // Query Insights is not a typed helper on the settings block; it
+          // rides through `advancedExtra`, the raw-map escape hatch keyed by
+          // the Terraform block name — which also keeps the migrator's
+          // passthrough emission under the round-trip gate.
+          advancedExtra: {
+            'insights_config': [
+              {
+                'query_insights_enabled': true,
+                'query_string_length': 1024,
+                'record_application_tags': true,
+                'record_client_address': false,
+              },
+            ],
+          },
         ),
         dependsOn: [ResourceDependency(psaConnection)],
       ),

--- a/examples/cloud_sql_quickstart/pubspec.yaml
+++ b/examples/cloud_sql_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloud_tasks_quickstart/pubspec.yaml
+++ b/examples/cloud_tasks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/clouddeploy_quickstart/pubspec.yaml
+++ b/examples/clouddeploy_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloudflare_dns_quickstart/pubspec.yaml
+++ b/examples/cloudflare_dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_cloudflare: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_cloudflare: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/cloudflare_leftover_quickstart/pubspec.yaml
+++ b/examples/cloudflare_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_cloudflare: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_cloudflare: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/colab_quickstart/pubspec.yaml
+++ b/examples/colab_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_cloud_armor_tier_quickstart/pubspec.yaml
+++ b/examples/compute_cloud_armor_tier_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_default_network_tier_quickstart/pubspec.yaml
+++ b/examples/compute_default_network_tier_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_instance_settings_quickstart/pubspec.yaml
+++ b/examples/compute_instance_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_lb_quickstart/pubspec.yaml
+++ b/examples/compute_lb_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_preview_feature_quickstart/pubspec.yaml
+++ b/examples/compute_preview_feature_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_quickstart/pubspec.yaml
+++ b/examples/compute_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_rollout_quickstart/pubspec.yaml
+++ b/examples/compute_rollout_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_route_quickstart/pubspec.yaml
+++ b/examples/compute_route_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_snapshot_settings_quickstart/pubspec.yaml
+++ b/examples/compute_snapshot_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/compute_vpn_gateway_quickstart/pubspec.yaml
+++ b/examples/compute_vpn_gateway_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/config_deployment_quickstart/pubspec.yaml
+++ b/examples/config_deployment_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/contact_center_insights_quickstart/pubspec.yaml
+++ b/examples/contact_center_insights_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/container_analysis_quickstart/pubspec.yaml
+++ b/examples/container_analysis_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_catalog_quickstart/pubspec.yaml
+++ b/examples/data_catalog_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_lineage_quickstart/pubspec.yaml
+++ b/examples/data_lineage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/data_source_leftover_quickstart/pubspec.yaml
+++ b/examples/data_source_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataform_quickstart/pubspec.yaml
+++ b/examples/dataform_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataplex_quickstart/pubspec.yaml
+++ b/examples/dataplex_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataproc_autoscaling_quickstart/pubspec.yaml
+++ b/examples/dataproc_autoscaling_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dataproc_metastore_quickstart/pubspec.yaml
+++ b/examples/dataproc_metastore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/deferred_leftover_quickstart/pubspec.yaml
+++ b/examples/deferred_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/developer_connect_quickstart/pubspec.yaml
+++ b/examples/developer_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_es_quickstart/pubspec.yaml
+++ b/examples/dialogflow_es_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dialogflow_quickstart/pubspec.yaml
+++ b/examples/dialogflow_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/discovery_engine_quickstart/pubspec.yaml
+++ b/examples/discovery_engine_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dlp_quickstart/pubspec.yaml
+++ b/examples/dlp_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/dns_quickstart/pubspec.yaml
+++ b/examples/dns_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/document_ai_quickstart/pubspec.yaml
+++ b/examples/document_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/endpoints_quickstart/pubspec.yaml
+++ b/examples/endpoints_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/eventarc_quickstart/pubspec.yaml
+++ b/examples/eventarc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/filestore_quickstart/pubspec.yaml
+++ b/examples/filestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_check_quickstart/pubspec.yaml
+++ b/examples/firebase_app_check_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_app_hosting_quickstart/pubspec.yaml
+++ b/examples/firebase_app_hosting_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_data_connect_quickstart/pubspec.yaml
+++ b/examples/firebase_data_connect_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebase_remote_config_quickstart/pubspec.yaml
+++ b/examples/firebase_remote_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firebaserules_quickstart/pubspec.yaml
+++ b/examples/firebaserules_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_document_quickstart/pubspec.yaml
+++ b/examples/firestore_document_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/firestore_quickstart/pubspec.yaml
+++ b/examples/firestore_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gemini_quickstart/pubspec.yaml
+++ b/examples/gemini_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_hub_feature_quickstart/pubspec.yaml
+++ b/examples/gke_hub_feature_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_hub_quickstart/pubspec.yaml
+++ b/examples/gke_hub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/gke_quickstart/pubspec.yaml
+++ b/examples/gke_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/healthcare_quickstart/pubspec.yaml
+++ b/examples/healthcare_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iam_quickstart/pubspec.yaml
+++ b/examples/iam_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iap_settings_quickstart/pubspec.yaml
+++ b/examples/iap_settings_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/iap_tunnel_quickstart/pubspec.yaml
+++ b/examples/iap_tunnel_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/identity_platform_quickstart/pubspec.yaml
+++ b/examples/identity_platform_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/integrations_quickstart/pubspec.yaml
+++ b/examples/integrations_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_autokey_quickstart/pubspec.yaml
+++ b/examples/kms_autokey_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/kms_quickstart/pubspec.yaml
+++ b/examples/kms_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/migration_center_quickstart/pubspec.yaml
+++ b/examples/migration_center_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/model_armor_quickstart/pubspec.yaml
+++ b/examples/model_armor_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/monitoring_quickstart/pubspec.yaml
+++ b/examples/monitoring_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ncc_hub_quickstart/pubspec.yaml
+++ b/examples/ncc_hub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/netapp_metadata_quickstart/pubspec.yaml
+++ b/examples/netapp_metadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_connectivity_quickstart/pubspec.yaml
+++ b/examples/network_connectivity_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_management_vpc_flow_logs_quickstart/pubspec.yaml
+++ b/examples/network_management_vpc_flow_logs_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_backend_auth_quickstart/pubspec.yaml
+++ b/examples/network_security_backend_auth_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_dns_threat_quickstart/pubspec.yaml
+++ b/examples/network_security_dns_threat_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_gateway_policy_quickstart/pubspec.yaml
+++ b/examples/network_security_gateway_policy_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_lists_quickstart/pubspec.yaml
+++ b/examples/network_security_lists_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_tls_quickstart/pubspec.yaml
+++ b/examples/network_security_tls_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_security_ull_quickstart/pubspec.yaml
+++ b/examples/network_security_ull_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/network_services_mesh_quickstart/pubspec.yaml
+++ b/examples/network_services_mesh_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/notebooks_quickstart/pubspec.yaml
+++ b/examples/notebooks_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/observability_quickstart/pubspec.yaml
+++ b/examples/observability_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/ops_quickstart/pubspec.yaml
+++ b/examples/ops_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_autonomous_database_quickstart/pubspec.yaml
+++ b/examples/oracle_autonomous_database_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_db_system_quickstart/pubspec.yaml
+++ b/examples/oracle_db_system_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_exadata_quickstart/pubspec.yaml
+++ b/examples/oracle_exadata_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/oracle_goldengate_quickstart/pubspec.yaml
+++ b/examples/oracle_goldengate_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/org_leftover_quickstart/pubspec.yaml
+++ b/examples/org_leftover_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/parameter_manager_quickstart/pubspec.yaml
+++ b/examples/parameter_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/privileged_access_manager_quickstart/pubspec.yaml
+++ b/examples/privileged_access_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/project_iam_audit_config_quickstart/pubspec.yaml
+++ b/examples/project_iam_audit_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/public_ca_quickstart/pubspec.yaml
+++ b/examples/public_ca_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/pubsub_quickstart/pubspec.yaml
+++ b/examples/pubsub_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/scc_quickstart/pubspec.yaml
+++ b/examples/scc_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/secret_manager_quickstart/pubspec.yaml
+++ b/examples/secret_manager_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/service_directory_quickstart/pubspec.yaml
+++ b/examples/service_directory_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/sourcerepo_quickstart/pubspec.yaml
+++ b/examples/sourcerepo_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/spanner_instance_config_quickstart/pubspec.yaml
+++ b/examples/spanner_instance_config_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_intelligence_quickstart/pubspec.yaml
+++ b/examples/storage_intelligence_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_quickstart/pubspec.yaml
+++ b/examples/storage_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/storage_transfer_quickstart/pubspec.yaml
+++ b/examples/storage_transfer_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/tags_quickstart/pubspec.yaml
+++ b/examples/tags_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/transcoder_quickstart/pubspec.yaml
+++ b/examples/transcoder_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/usage_export_quickstart/pubspec.yaml
+++ b/examples/usage_export_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vector_quickstart/pubspec.yaml
+++ b/examples/vector_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vertex_ai_quickstart/pubspec.yaml
+++ b/examples/vertex_ai_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/vm_compliance_quickstart/pubspec.yaml
+++ b/examples/vm_compliance_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/wif_trust_domain_quickstart/pubspec.yaml
+++ b/examples/wif_trust_domain_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/examples/workflows_quickstart/pubspec.yaml
+++ b/examples/workflows_quickstart/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/terradart_agent/CHANGELOG.md
+++ b/packages/terradart_agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.28.1 - 2026-09-13
+
+Lockstep release with `terradart_migrate` 0.28.1 (passthrough emission fix — a bare `Map` / `List` parameter no longer comes out as `TfArg.literal`). No `terradart_agent` API changes. `terradart-mcp` picks up the `migrate_module` fix through `terradart_migrate`.
+
 ## 0.28.0 - 2026-09-13
 
 Lockstep release with `terradart_core` 0.28.0 (`TfArg.expression`, provider aliases, `timeouts:`, `Stack.addMoved`, `Stack.addModule`; the `terradart-migrate` epic #80).

--- a/packages/terradart_agent/lib/src/version.dart
+++ b/packages/terradart_agent/lib/src/version.dart
@@ -1,4 +1,4 @@
 /// The terradart-mcp binary version, kept in lockstep with pubspec.yaml's
 /// `version:` field by `tool/bump_version.sh`. The lockstep is guarded by
 /// test/version_test.dart so the two can never silently drift.
-const String packageVersion = '0.28.0';
+const String packageVersion = '0.28.1';

--- a/packages/terradart_agent/pubspec.yaml
+++ b/packages/terradart_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_agent
 description: terradart-mcp — MCP server exposing the curated GCP factory catalog of TerraDart.
-version: 0.28.0
+version: 0.28.1
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -16,11 +16,11 @@ executables:
   terradart-mcp: terradart_mcp
 
 dependencies:
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
-  terradart_coverage: ^0.28.0
-  terradart_hcl: ^0.28.0
-  terradart_migrate: ^0.28.0
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
+  terradart_coverage: ^0.28.1
+  terradart_hcl: ^0.28.1
+  terradart_migrate: ^0.28.1
   genkit: ^0.14.1
   genkit_mcp: ^0.2.1
   schemantic: ^0.2.0

--- a/packages/terradart_appwrite/CHANGELOG.md
+++ b/packages/terradart_appwrite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.28.1 - 2026-09-13
+
+Lockstep release with `terradart_migrate` 0.28.1 (passthrough emission fix — a bare `Map` / `List` parameter no longer comes out as `TfArg.literal`). No `terradart_appwrite` API changes.
+
 ## 0.28.0 - 2026-09-13
 
 - **`AppwriteProvider.alias`** (`provider "appwrite" { alias = "staging" }`) and a **`provider:`** parameter on every factory and data source, so a resource can select an aliased configuration (`provider: 'appwrite.staging'`) (#666).

--- a/packages/terradart_appwrite/pubspec.yaml
+++ b/packages/terradart_appwrite/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_appwrite
 description: Curated factory wrappers for Appwrite resources (official appwrite/appwrite Terraform provider) for Dart-first Terraform stacks.
-version: 0.28.0
+version: 0.28.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
+  terradart_core: ^0.28.1
   meta: ^1.15.0
 
 dev_dependencies:

--- a/packages/terradart_cloudflare/CHANGELOG.md
+++ b/packages/terradart_cloudflare/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.28.1 - 2026-09-13
+
+Lockstep release with `terradart_migrate` 0.28.1 (passthrough emission fix — a bare `Map` / `List` parameter no longer comes out as `TfArg.literal`). No `terradart_cloudflare` API changes.
+
 ## 0.28.0 - 2026-09-13
 
 - **`CloudflareProvider.alias`** (`provider "cloudflare" { alias = "other_account" }`) and a **`provider:`** parameter on every factory and data source, so a resource can select an aliased configuration (`provider: 'cloudflare.other_account'`) (#666).

--- a/packages/terradart_cloudflare/pubspec.yaml
+++ b/packages/terradart_cloudflare/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_cloudflare
 description: Curated factory wrappers for Cloudflare resources (official cloudflare/cloudflare Terraform provider) for Dart-first Terraform stacks.
-version: 0.28.0
+version: 0.28.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
+  terradart_core: ^0.28.1
   meta: ^1.15.0
 
 dev_dependencies:

--- a/packages/terradart_codegen/CHANGELOG.md
+++ b/packages/terradart_codegen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.28.1 - 2026-09-13
+
+Lockstep release with `terradart_migrate` 0.28.1 (passthrough emission fix — a bare `Map` / `List` parameter no longer comes out as `TfArg.literal`). No `terradart_codegen` API changes.
+
 ## 0.28.0 - 2026-09-13
 
 - `terradart wrap` emits Terraform's `provider` meta-argument on every generated constructor: `super.provider` on resource factories and data sources, and on a `--resource-provider` lane a `String? provider` parameter that defaults to the lane's provider (`provider: provider ?? 'google-beta'`), so a beta wrapper can still select an alias of it (#666).

--- a/packages/terradart_codegen/pubspec.yaml
+++ b/packages/terradart_codegen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_codegen
 description: terradart maintainer tooling — parses Terraform provider schema JSON and Magic Modules YAML and emits curated factory wrappers via terradart wrap. Ships the terradart CLI.
-version: 0.28.0
+version: 0.28.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -33,7 +33,7 @@ dependencies:
   meta: ^1.15.0
   dart_style: ^3.0.0
   stack_trace: ^1.11.1
-  terradart_core: ^0.28.0
+  terradart_core: ^0.28.1
 
 dev_dependencies:
   http: ^1.0.0

--- a/packages/terradart_core/CHANGELOG.md
+++ b/packages/terradart_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.28.1 - 2026-09-13
+
+Lockstep release with `terradart_migrate` 0.28.1 (passthrough emission fix — a bare `Map` / `List` parameter no longer comes out as `TfArg.literal`). No `terradart_core` API changes.
+
 ## 0.28.0 - 2026-09-13
 
 ### Added

--- a/packages/terradart_core/pubspec.yaml
+++ b/packages/terradart_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_core
 description: terradart core runtime — Stack, Resource, Provider, Variable, Data, TfArg, TfRef, and LifecycleOptions for Dart-first Terraform synthesis.
-version: 0.28.0
+version: 0.28.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues

--- a/packages/terradart_coverage/CHANGELOG.md
+++ b/packages/terradart_coverage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.28.1 - 2026-09-13
+
+Lockstep release with `terradart_migrate` 0.28.1 (passthrough emission fix — a bare `Map` / `List` parameter no longer comes out as `TfArg.literal`). No `terradart_coverage` API changes.
+
 ## 0.28.0 - 2026-09-13
 
 - The source scan (`--dir`, the default) parses `.tf` / `.tf.json` with `terradart_hcl` instead of a regex: block structure is exact (a `resource` inside a heredoc or comment is not counted), a literal `count` / `for_each` (`count = 3`, a literal object, `toset([...])`) is expanded, anything else is counted once and listed under **Counted once**, and module calls are read from the AST — remote, missing and out-of-tree local modules are reported as not analyzed, and a file that fails to parse is reported and skipped.

--- a/packages/terradart_coverage/pubspec.yaml
+++ b/packages/terradart_coverage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_coverage
 description: Read-only Terraform coverage checker — reports how much of a Terraform config is covered by curated TerraDart factories (google, google-beta, appwrite, cloudflare).
-version: 0.28.0
+version: 0.28.1
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -15,11 +15,11 @@ executables:
   terradart-coverage: terradart_coverage
 
 dependencies:
-  terradart_google: ^0.28.0
-  terradart_google_beta: ^0.28.0
-  terradart_appwrite: ^0.28.0
-  terradart_cloudflare: ^0.28.0
-  terradart_hcl: ^0.28.0
+  terradart_google: ^0.28.1
+  terradart_google_beta: ^0.28.1
+  terradart_appwrite: ^0.28.1
+  terradart_cloudflare: ^0.28.1
+  terradart_hcl: ^0.28.1
   args: ^2.5.0
 
 dev_dependencies:

--- a/packages/terradart_google/CHANGELOG.md
+++ b/packages/terradart_google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.28.1 - 2026-09-13
+
+Lockstep release with `terradart_migrate` 0.28.1 (passthrough emission fix — a bare `Map` / `List` parameter no longer comes out as `TfArg.literal`). No `terradart_google` API changes.
+
 ## 0.28.0 - 2026-09-13
 
 - **`GoogleProvider.alias`** (`provider "google" { alias = "eu" }`) and a **`provider:`** parameter on every resource factory and data source, for Terraform's `provider` meta-argument: `provider: 'google.eu'` selects an aliased configuration registered beside the default one, `provider: 'google-beta'` puts a GA type on the beta provider. `TimeProvider` takes `alias` too (#666).

--- a/packages/terradart_google/pubspec.yaml
+++ b/packages/terradart_google/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google
 description: Curated factory wrappers for Google Cloud resources (Compute, BigQuery, Cloud Run, Cloud SQL, Pub/Sub, Monitoring, ...) for Dart-first Terraform stacks.
-version: 0.28.0
+version: 0.28.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -22,11 +22,11 @@ false_secrets:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
+  terradart_core: ^0.28.1
   meta: ^1.15.0
 
 dev_dependencies:
-  terradart_codegen: ^0.28.0
+  terradart_codegen: ^0.28.1
   path: ^1.9.0
   lints: ^6.0.0
   test: ^1.25.6

--- a/packages/terradart_google_beta/CHANGELOG.md
+++ b/packages/terradart_google_beta/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.28.1 - 2026-09-13
+
+Lockstep release with `terradart_migrate` 0.28.1 (passthrough emission fix — a bare `Map` / `List` parameter no longer comes out as `TfArg.literal`). No `terradart_google_beta` API changes.
+
 ## 0.28.0 - 2026-09-13
 
 - **`GoogleBetaProvider.alias`** and a **`provider:`** parameter on every factory and data source. Wrappers keep pinning `provider = google-beta` by default; `provider: 'google-beta.<alias>'` selects an aliased `GoogleBetaProvider(alias: ...)` instead (#666).

--- a/packages/terradart_google_beta/pubspec.yaml
+++ b/packages/terradart_google_beta/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_google_beta
 description: Curated factory wrappers for beta-only Google Cloud resources (hashicorp/google-beta) for Dart-first Terraform stacks.
-version: 0.28.0
+version: 0.28.1
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
 issue_tracker: https://github.com/nozomi-koborinai/terradart/issues
@@ -18,7 +18,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  terradart_core: ^0.28.0
+  terradart_core: ^0.28.1
   meta: ^1.15.0
 
 dev_dependencies:

--- a/packages/terradart_hcl/CHANGELOG.md
+++ b/packages/terradart_hcl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.28.1 - 2026-09-13
+
+Lockstep release with `terradart_migrate` 0.28.1 (passthrough emission fix — a bare `Map` / `List` parameter no longer comes out as `TfArg.literal`). No `terradart_hcl` API changes.
+
 ## 0.28.0 - 2026-09-13
 
 Initial package (issue #657, part of the `terradart-migrate` epic #80).

--- a/packages/terradart_hcl/pubspec.yaml
+++ b/packages/terradart_hcl/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_hcl
 description: Pure Dart HCL (Terraform native syntax) parser and tf.json front-end producing a shared Terraform module model — the input side of terradart-migrate.
-version: 0.28.0
+version: 0.28.1
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart

--- a/packages/terradart_migrate/CHANGELOG.md
+++ b/packages/terradart_migrate/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.28.1 - 2026-09-13
 
 - Fix: a passthrough slot whose parameter is a bare `Map` / `List` rather than a `TfArg<Map<...>>` — `advancedExtra` on `SqlDatabaseInstanceSettings`, the raw-map escape hatch a hand-written helper spreads into its block — was emitted as `TfArg.literal({...})`, so a migrated Stack that carried an `insights_config` did not compile while the report counted the resource as migrated. The emitter now honours the manifest's `wrapped` flag (the manifests already recorded it), shapes the payload to the parameter (a block written once reads as one object: a `List<...>` parameter gets a one-element list, a `Map<...>` parameter takes the single element of a one-object list) and types empty payloads from the manifest. The round-trip gate had never exercised a passthrough slot because no quickstart used one; `cloud_sql_quickstart` now sets `insights_config` through `advancedExtra`, so it does.
 

--- a/packages/terradart_migrate/CHANGELOG.md
+++ b/packages/terradart_migrate/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix: a passthrough slot whose parameter is a bare `Map` / `List` rather than a `TfArg<Map<...>>` — `advancedExtra` on `SqlDatabaseInstanceSettings`, the raw-map escape hatch a hand-written helper spreads into its block — was emitted as `TfArg.literal({...})`, so a migrated Stack that carried an `insights_config` did not compile while the report counted the resource as migrated. The emitter now honours the manifest's `wrapped` flag (the manifests already recorded it), shapes the payload to the parameter (a block written once reads as one object: a `List<...>` parameter gets a one-element list, a `Map<...>` parameter takes the single element of a one-object list) and types empty payloads from the manifest. The round-trip gate had never exercised a passthrough slot because no quickstart used one; `cloud_sql_quickstart` now sets `insights_config` through `advancedExtra`, so it does.
+
 ## 0.28.0 - 2026-09-13
 
 - `--inline-locals` declares the `locals` entries whose value is a scalar literal — or a template made only of literal text and locals that are themselves inlined, resolved as a fixpoint — as Dart `final`s in the Stack (`final prefix = r'acme'; final bucketName = '$prefix-assets';`), and rebuilds `locals.tf` so it keeps only the entries something that stays in Terraform still reads (a kept block, a `terraform` setting, another local, or a `${local.x}` the Stack still emits as an expression); a local nothing in the Stack reads is never declared. A list, an object, a reference, a `%{ ... }` directive, or a name two `locals` blocks both declare stays, with its reason. Names come from the Stack's allocator after the blocks, types are carried (a bare `${local.port}` only fills a slot that takes a number), and `--lift-workspace` now shares the same `dartTemplate` rewrite. Refused together with `--merge-envs` (#672).

--- a/packages/terradart_migrate/lib/src/emit/value_emitter.dart
+++ b/packages/terradart_migrate/lib/src/emit/value_emitter.dart
@@ -181,11 +181,13 @@ final class ValueEmitter {
       if (rest.isNotEmpty) {
         _checkSensitiveJson(rest, level.path);
         named.add(
-          '${mergedPassthrough.dartName}: TfArg.literal(${dartValue(rest)})',
+          '${mergedPassthrough.dartName}: '
+          '${_passthroughValue(mergedPassthrough, rest)}',
         );
       } else if (mergedPassthrough.required) {
         named.add(
-          '${mergedPassthrough.dartName}: TfArg.literal(<String, dynamic>{})',
+          '${mergedPassthrough.dartName}: '
+          '${_passthroughValue(mergedPassthrough, const <String, Object?>{})}',
         );
       }
     }
@@ -269,7 +271,7 @@ final class ValueEmitter {
                     (throw MigrateBlocker('argument "$path" is not a block')),
                 path: '$path.',
               ),
-      MigrateSlotKind.passthrough => _passthrough(value, path: path),
+      MigrateSlotKind.passthrough => _passthrough(slot, value, path: path),
       MigrateSlotKind.sealed ||
       MigrateSlotKind.manual => throw StateError('handled above'),
     };
@@ -828,10 +830,56 @@ final class ValueEmitter {
     return '$className($args)';
   }
 
-  String _passthrough(Expr value, {required String path}) {
+  String _passthrough(MigrateSlot slot, Expr value, {required String path}) {
     final json = jsonValue(value);
     _checkSensitiveJson(json, '$path.');
-    return 'TfArg.literal(${dartValue(json)})';
+    return _passthroughValue(slot, json);
+  }
+
+  /// The Dart for a passthrough payload. The manifest's `wrapped` flag says
+  /// whether the parameter is `TfArg<Map<...>>` (an IAM `condition`, the
+  /// norm) or a bare `Map` / `List` spread into the block (`advancedExtra`
+  /// on a hand-written helper): only the former takes `TfArg.literal`.
+  /// Wrapping the latter produced a `TfArg<Map<...>>` where a `Map` was
+  /// expected, so a migrated Stack that used it did not compile.
+  ///
+  /// The payload is shaped to the parameter as well: a block written once
+  /// reads as one object, so a `List<...>` parameter gets it as a
+  /// one-element list, and a `Map<...>` parameter takes the single element
+  /// of a one-object list (the tf.json block form). An empty payload is
+  /// typed from the manifest, since [dartValue]'s `<Object?>[]` fits
+  /// neither a `List<Map<String, dynamic>>` nor strict inference.
+  String _passthroughValue(MigrateSlot slot, Object? json) {
+    final type = slot.dartType ?? '';
+    var payload = json;
+    if (type.startsWith('List<') && payload is Map) {
+      payload = [payload];
+    } else if (type.startsWith('Map<') &&
+        payload is List &&
+        payload.length == 1 &&
+        payload.single is Map) {
+      payload = payload.single;
+    }
+    final literal = _isEmptyCollection(payload)
+        ? _typedEmpty(type, payload)
+        : dartValue(payload);
+    return slot.wrapped ? 'TfArg.literal($literal)' : literal;
+  }
+
+  static bool _isEmptyCollection(Object? json) =>
+      (json is Map && json.isEmpty) || (json is List && json.isEmpty);
+
+  /// `<K, V>{}` / `<E>[]` for the manifest's payload type; [dartValue]'s
+  /// `Object?`-typed empties when the type is not a plain `Map<...>` /
+  /// `List<...>` spelling.
+  static String _typedEmpty(String type, Object? json) {
+    if (json is Map && type.startsWith('Map<') && type.endsWith('>')) {
+      return '<${type.substring(4, type.length - 1)}>{}';
+    }
+    if (json is List && type.startsWith('List<') && type.endsWith('>')) {
+      return '<${type.substring(5, type.length - 1)}>[]';
+    }
+    return dartValue(json);
   }
 
   /// Synth rejects a plain literal on a sensitive nested path; only a

--- a/packages/terradart_migrate/lib/src/migrate_manifest.dart
+++ b/packages/terradart_migrate/lib/src/migrate_manifest.dart
@@ -81,7 +81,11 @@ final class MigrateSlot {
 
   /// Whether a [MigrateSlotKind.scalar] / [MigrateSlotKind.enumValue] element
   /// is `TfArg`-wrapped (the norm) or a bare Dart value (a curator-flagged
-  /// exception, e.g. a Dart-side discriminant enum).
+  /// exception, e.g. a Dart-side discriminant enum). For a
+  /// [MigrateSlotKind.passthrough] payload: whether the parameter is
+  /// `TfArg<Map<...>>` (an IAM `condition`) or a bare `Map` / `List`
+  /// (`advancedExtra` on a hand-written helper, spread into the block) —
+  /// the emitter writes `TfArg.literal(...)` only for the former.
   final bool wrapped;
 
   /// Whether the parameter is positional rather than named (rare; only a

--- a/packages/terradart_migrate/lib/src/version.dart
+++ b/packages/terradart_migrate/lib/src/version.dart
@@ -2,4 +2,4 @@
 /// (`terradart_core: ^<version>` and the provider packages a Stack imports).
 /// Bumped by `tool/bump_version.sh`; `test/version_test.dart` keeps it equal
 /// to this package's own `pubspec.yaml`.
-const String packageVersion = '0.28.0';
+const String packageVersion = '0.28.1';

--- a/packages/terradart_migrate/pubspec.yaml
+++ b/packages/terradart_migrate/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terradart_migrate
 description: HCL → Dart migrator for existing Terraform users (terradart-migrate) — the migration manifests of the four curated catalogs and the emitter that turns a Terraform module into a Stack.
-version: 0.28.0
+version: 0.28.1
 publish_to: none
 homepage: https://github.com/nozomi-koborinai/terradart
 repository: https://github.com/nozomi-koborinai/terradart
@@ -18,12 +18,12 @@ dependencies:
   args: ^2.4.0
   dart_style: ^3.0.0
   path: ^1.9.0
-  terradart_appwrite: ^0.28.0
-  terradart_cloudflare: ^0.28.0
-  terradart_core: ^0.28.0
-  terradart_google: ^0.28.0
-  terradart_google_beta: ^0.28.0
-  terradart_hcl: ^0.28.0
+  terradart_appwrite: ^0.28.1
+  terradart_cloudflare: ^0.28.1
+  terradart_core: ^0.28.1
+  terradart_google: ^0.28.1
+  terradart_google_beta: ^0.28.1
+  terradart_hcl: ^0.28.1
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/terradart_migrate/test/migrate_test.dart
+++ b/packages/terradart_migrate/test/migrate_test.dart
@@ -32,6 +32,108 @@ const _google = {
 };
 
 void main() {
+  group('passthrough slots', () {
+    // The two passthrough parameter shapes the catalogs carry: a
+    // `TfArg<Map<String, dynamic>>` (an IAM `condition`) and a bare
+    // `Map<String, Object?>` spread into its block (`advancedExtra` on
+    // `SqlDatabaseInstanceSettings`). The manifest's `wrapped` flag tells
+    // them apart; emitting `TfArg.literal` for the bare one produced a Stack
+    // that did not compile, found on a real Cloud SQL module.
+    test('a bare Map parameter takes the collection itself', () {
+      final r = _migrateJson({
+        'terraform': _google,
+        'resource': {
+          'google_sql_database_instance': {
+            'primary': {
+              'name': 'primary',
+              'database_version': 'POSTGRES_16',
+              'region': 'asia-northeast1',
+              'settings': [
+                {
+                  'tier': 'db-f1-micro',
+                  'insights_config': [
+                    {
+                      'query_insights_enabled': true,
+                      'query_string_length': 1024,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      });
+      expect(r.report.isComplete, isTrue, reason: r.report.renderText());
+      expect(
+        r.stackSource,
+        contains(
+          "advancedExtra: {r'insights_config': [{r'query_insights_enabled': "
+          "true, r'query_string_length': 1024}]}",
+        ),
+      );
+      expect(r.stackSource, isNot(contains('advancedExtra: TfArg.literal(')));
+    });
+
+    test('a TfArg<Map> parameter keeps TfArg.literal, from tf.json and HCL', () {
+      const expected =
+          "condition: TfArg.literal({r'title': r'expires', r'expression': r'true'})";
+      final json = _migrateJson({
+        'terraform': _google,
+        'resource': {
+          'google_pubsub_topic_iam_member': {
+            'viewer': {
+              'topic': 'orders',
+              'role': 'roles/pubsub.viewer',
+              'member': 'user:a@example.com',
+              'condition': {'title': 'expires', 'expression': 'true'},
+            },
+          },
+        },
+      });
+      expect(json.report.isComplete, isTrue, reason: json.report.renderText());
+      expect(json.stackSource, contains(expected));
+
+      // The block form: written once, it reads as one object, not a list.
+      final hcl = _migrateHcl('''
+terraform {
+  required_providers {
+    google = { source = "hashicorp/google", version = "~> 7.0" }
+  }
+}
+
+resource "google_pubsub_topic_iam_member" "viewer" {
+  topic  = "orders"
+  role   = "roles/pubsub.viewer"
+  member = "user:a@example.com"
+  condition {
+    title      = "expires"
+    expression = "true"
+  }
+}
+''');
+      expect(hcl.report.isComplete, isTrue, reason: hcl.report.renderText());
+      expect(hcl.stackSource, contains(expected));
+
+      // The tf.json list form of a block written once fits a Map parameter.
+      final listForm = _migrateJson({
+        'terraform': _google,
+        'resource': {
+          'google_pubsub_topic_iam_member': {
+            'viewer': {
+              'topic': 'orders',
+              'role': 'roles/pubsub.viewer',
+              'member': 'user:a@example.com',
+              'condition': [
+                {'title': 'expires', 'expression': 'true'},
+              ],
+            },
+          },
+        },
+      });
+      expect(listForm.stackSource, contains(expected));
+    });
+  });
+
   group('pubsub_quickstart synth output', () {
     // The quickstart's synth output as of this package's last change; the
     // round-trip gate covers the live examples.


### PR DESCRIPTION
Two commits: the fix (`576106e8`) and the 0.28.1 lockstep bump that ships it (`b63e2aac`), stated separately per AGENTS.md **PR granularity**.

## The bug

Found migrating a real Cloud SQL module with `terradart-migrate 0.28.0`: the migrated Stack did not compile —

```
lib/cloud_sql_stack.dart: advancedExtra: TfArg.literal({...insights_config...})
The argument type 'TfArg<Map<...>>' can't be assigned to 'Map<String, Object?>?'.
```

while the report counted the resource as migrated. `advancedExtra` on `SqlDatabaseInstanceSettings` is the raw-map escape hatch a hand-written helper spreads into its block — a **bare** `Map<String, Object?>`, unlike the `TfArg<Map<String, dynamic>>` of an IAM `condition`. The migration manifests already record the difference (`wrapped: false` on the 12 bare `advancedExtra` slots; the 274 `condition` slots are wrapped), but `ValueEmitter._passthrough` and the merged-passthrough branch ignored `slot.wrapped` and always emitted `TfArg.literal(...)`.

## The fix (`packages/terradart_migrate/lib/src/emit/value_emitter.dart`)

- `TfArg.literal(...)` only when the slot is `wrapped`; the bare collection otherwise.
- The payload is shaped to the parameter: a block written once reads as one object (`bodyAsObject`), so a `List<...>` parameter gets a one-element list, and a `Map<...>` parameter takes the single element of a one-object list (the tf.json block form) — this also fixes `TfArg<Map>` slots fed the list form, which used to emit `TfArg.literal([{...}])`.
- Empty payloads are typed from the manifest (`<String, Object?>{}`, `<Map<String, dynamic>>[]`) instead of `dartValue`'s `<Object?>[]`, which fits neither a `List<Map<...>>` parameter nor strict inference.
- `MigrateSlot.wrapped` doc extended to the passthrough meaning.

## Why the gates missed it

No quickstart used a passthrough slot, so the round-trip gate (`synth(migrate(synth(S))) == synth(S)`, with `dart analyze` on the generated package) never exercised the path. `cloud_sql_quickstart` now sets `insights_config` through `advancedExtra`, and the gate migrates, analyzes and re-synthesizes it: `1/1 examples round-trip; 12 resources migrated, 0 kept`.

Regression tests (`migrate_test.dart`, group *passthrough slots*): the bare `Map` emits the collection; the `TfArg<Map>` `condition` keeps `TfArg.literal` from tf.json, from an HCL block and from the tf.json list form. Both tests fail on the previous emitter.

## Verification

- `terradart_migrate` suite: 228 tests green (goldens unchanged — no fixture carries a passthrough slot).
- `dart tool/migrate_roundtrip_gates.dart --only=cloud_sql_quickstart`: OK.
- `dart analyze` on `terradart_migrate` and `cloud_sql_quickstart`, `dart format` clean.
- After the bump: `check_docs_consistency` OK, agent + migrate version tests, `tool/agent_verify.sh --quick` green (four `wrap --check` lanes, four `lint-override` lanes). The full gates run here in CI; the `terraform validate` matrix covers the changed example.

## After merge

Tag the squash commit `v0.28.1` — `Publish to pub.dev` and `release-binary` run off the tag; the Homebrew formulas move to 0.28.1 automatically. No `MIGRATING.md` entry: nothing breaking vs 0.28.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KFBD9HLpPfb8WmXdrBPke

---
_Generated by [Claude Code](https://claude.ai/code/session_012KFBD9HLpPfb8WmXdrBPke)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted migrator emitter fix with regression tests and one example change; lockstep version bumps only elsewhere. No public API or breaking changes vs 0.28.0.
> 
> **Overview**
> **0.28.1** is a lockstep patch (no breaking changes vs 0.28.0). The functional change is in **`terradart_migrate`**: passthrough emission now respects the manifest's **`wrapped`** flag so bare `Map` / `List` parameters (e.g. `advancedExtra` on `SqlDatabaseInstanceSettings`) are emitted as plain Dart collections instead of **`TfArg.literal(...)`**, which previously produced stacks that failed `dart analyze` while the migration report still marked resources as migrated.
> 
> The emitter also **shapes** payloads to the declared parameter type (single-object blocks vs tf.json list form) and emits **typed empty** collections from the manifest. **`MigrateSlot.wrapped`** is documented for passthrough slots; **`migrate_test.dart`** adds regression tests for bare `Map` vs wrapped `TfArg<Map>` (`condition`). **`cloud_sql_quickstart`** now sets Query Insights via `advancedExtra` so the migrate round-trip gate exercises this path.
> 
> Everything else is the **0.28.1 version bump**: workspace package versions, changelogs, and dependency pins across examples and cookbooks; **`terradart-mcp`** picks up the fix via **`terradart_migrate`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b63e2aacf7756a49b48cc08b7535aa2c41f6b1f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->