### PR TITLE
chore: promo-video skill and tool/promo_video.sh for release demo clips

### DIFF
--- a/.agents/skills/terradart-promo-video/SKILL.md
+++ b/.agents/skills/terradart-promo-video/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: terradart-promo-video
+description: Record and post-produce a TerraDart release demo clip (3-beat terminal recording, TerraDart end card, phone-safe delivery encode) and draft the X / LinkedIn copy. Use when announcing a release with a video.
+---
+# TerraDart promo video
+
+Policy lives in [`AGENTS.md`](../../../AGENTS.md). This skill is the repeatable workflow for a release announcement clip. The deterministic ffmpeg work belongs to [`tool/promo_video.sh`](../../../tool/promo_video.sh); what stays here is the part a script cannot decide.
+
+## Contents
+
+- [When to use](#when-to-use)
+- [What a clip may claim](#what-a-clip-may-claim)
+- [Workflow](#workflow)
+- [Recording the beats](#recording-the-beats)
+- [Post-production](#post-production)
+- [Delivery](#delivery)
+- [Writing the copy](#writing-the-copy)
+- [Pitfalls](#pitfalls)
+
+## When to use
+
+- A release ships a user-visible command or capability the maintainer wants to announce.
+- An existing clip needs re-cutting (different zoom, different end card, a delivery encode for a new platform).
+
+Not for docs GIFs or `website/` assets — those are authored with the page, not as a release artifact.
+
+## What a clip may claim
+
+**The copy may only claim what the clip shows.** This is the highest-value rule here, because a wrong claim is a public credibility problem rather than rework.
+
+- A clip of a **fixture or sample tree** supports "converts a Terraform tree". It does **not** support "migrated a real app".
+- Only claim `terraform plan` reports *No changes* once the [status](../../../website/src/content/docs/docs/status.md) gate for it is actually ticked — that gate needs a real tree against real state, and it is maintainer work, not an agent's.
+- Numbers spoken in the copy must be the numbers on screen (`82 migrated, 0 kept`), from the version in the clip.
+- Never name a third-party repository as a migration success without the maintainer's explicit go-ahead.
+
+When a claim is tempting but unsupported, cut the claim, not the caveat.
+
+## Workflow
+
+**Task progress:**
+
+- [ ] 1. **Pick the story** — one capability, three beats (below). Write the beats down before recording.
+- [ ] 2. **Stage a demo source** you may show. A coverage fixture is a good one; copy it out of the repo first so the recording does not show repo paths:
+      ```bash
+      cp -r packages/terradart_coverage/test/fixtures/config_tree /tmp/promo-demo/infra
+      ```
+- [ ] 3. **Set up the terminal** — see [Recording the beats](#recording-the-beats).
+- [ ] 4. **Record** with `RecordScreen` + the `computerUse` subagent. One take per story; do not narrate setup.
+- [ ] 5. **Find the zoom timings** off real frames, not guesses:
+      ```bash
+      tool/promo_video.sh --in RAW.mp4 --dump-frames /tmp/promo-frames
+      ```
+      Frames are named by source seconds (`005.25.jpg`), so reading one gives both the time and the pixel the command sits at.
+- [ ] 6. **Cut it** — see [Post-production](#post-production).
+- [ ] 7. **Review the result** with the `videoReview` subagent before showing it. Ask it explicitly whether the Cursor mark is gone, whether the command is fully readable at peak zoom, and whether the end card is correct.
+- [ ] 8. **Write a delivery encode** and draft the copy ([below](#writing-the-copy)).
+- [ ] 9. The maintainer posts. Agents do not post to X or LinkedIn.
+
+## Recording the beats
+
+Three beats, nothing else. The clip is 15–25s; every extra command costs a viewer.
+
+1. **The input** — what the user already has (`tree -L 2 infra`).
+2. **One command** — the thing being announced, typed out.
+3. **The result** — the output that proves it (`head` of a generated file).
+
+Do **not** record `clear`, `--version`, `ls`, `dart pub get`, or "let me check that it worked" steps. They read as hesitation and they pushed an earlier cut from 20s to nearly two minutes. Put the version in the window title instead, where it is legible for the whole clip.
+
+Terminal setup that reads well at tweet size:
+
+| Setting | Value | Why |
+|---|---|---|
+| Window | **not** fullscreen, ~60% of screen | wallpaper frames the terminal; fullscreen reads as a screenshot |
+| Font | monospace ~17pt | smaller is unreadable inline on a timeline; much larger fits too few columns |
+| Background | `#1e1e1e` | sits with the dark end card |
+| Title | the command + version (`terradart-migrate 0.28.1`) | on screen for the whole clip, no beat spent on it |
+| Prompt | short, no host or long path | a long prompt pushes the command off the zoom |
+
+Keep the command on **one line** — a wrapped command cannot be zoomed into cleanly.
+
+## Post-production
+
+```bash
+tool/promo_video.sh \
+  --in RAW.mp4 \
+  --out /opt/cursor/artifacts/<name>.mp4 \
+  --zoom-in 5.15 --zoom-out 11.15 --zoom-focus 490,740 \
+  --deliver /opt/cursor/artifacts/<name>_1080p30.mp4
+```
+
+The script drops the Cursor outro (reading `cursor_brand_tag_duration_ms` off the input rather than assuming 2s), pushes in on the command and back out, appends the TerraDart end card from [`branding/`](../../../branding/), and strips the recorder's metadata.
+
+- `--zoom-focus` is in **source** pixels, measured off a dumped frame. Aim at the command line, not the window centre.
+- `--zoom-factor` defaults to `1.70`. Past roughly `2.0` a 1920-wide capture starts clipping the end of a long command — check the peak frame rather than trusting the number.
+- `--no-endcard` and `--trim-outro none` exist for clips going somewhere that brands them already.
+- Pass `--tagline ''` for the lockup with no strapline.
+
+## Delivery
+
+`--deliver` writes the encode that platforms and phones accept: 1080p30, H.264 High@4.1, a silent AAC track, `faststart`, `mp42` brand.
+
+This is not cosmetic. **iOS Photos silently refuses "Save Video"** on the raw recording shape — soundless, 1200 tall, 60fps, level 5.0 — with no error to explain it. The delivery encode is what saves to a phone and what to hand over for posting. On iOS, open it in **Safari** and use Share → Save Video; the in-app share sheet does not always offer it.
+
+## Writing the copy
+
+Draft both X and LinkedIn, and offer English (the audience for a Dart IaC tool skews international).
+
+- **Lead with the release, then the capability** — "TerraDart v0.28.1 is here, introducing the new migrate command". The reader learns what project this is before what the command does.
+- **Cut internal vocabulary.** *Leftover sidecar*, *resource-atomic*, *merged IR* are precise in this repo and opaque in a feed; "anything not yet converted simply stays as regular Terraform" says the same thing to someone who has never read the docs.
+- **Name the reassurance, not the mechanism.** The reason people care is that they do not have to rewrite everything at once.
+- Include the install line and the docs link. Hashtags: up to three on LinkedIn, none on X.
+- Let the video carry the demo — if the clip shows the tree and the counts, the copy does not need to.
+
+## Pitfalls
+
+- **Artifacts are immutable.** A re-cut needs a new filename under `/opt/cursor/artifacts/`; overwriting silently keeps the old upload.
+- **This ffmpeg build rejects `t`, `st()` and `ld()` inside `zoompan`,** and `drawtext` has no `letter_spacing`. The script writes the curve over `on` (frame index) for this reason — keep it there.
+- **Upscale before `zoompan`.** It samples one still per output frame, so zooming the source directly magnifies pixels. The script feeds it a 2x scale.
+- **Do not hand-edit `branding/`** to make a card fit. Colour tokens and the lockup rules are in [`BRAND.md`](../../../branding/BRAND.md); one Terra stratum, no gradient, `TerraDart` in CamelCase.
+- **Leave the recording desktop running** after a take. A re-cut usually needs one more beat from the same window, and the terminal geometry is hard to reproduce exactly.
+
+## Related
+
+- [`terradart-ship-wave`](../terradart-ship-wave/SKILL.md) — the release the clip announces
+- [`terradart-agent-verify`](../terradart-agent-verify/SKILL.md) — shared done gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,7 @@ Committed maintainer skills live under [`.agents/skills/`](.agents/skills/) (Age
 | [`terradart-ship-wave`](.agents/skills/terradart-ship-wave/SKILL.md) | Landing a Wave release (curated + example/docs + counts + CHANGELOG + GitHub release notes) |
 | [`terradart-backfill-examples`](.agents/skills/terradart-backfill-examples/SKILL.md) | Shrinking `tool/example_debt.yaml` (the maintenance-phase work queue) in existing quickstarts |
 | [`terradart-tighten-example-topology`](.agents/skills/terradart-tighten-example-topology/SKILL.md) | Wiring backfilled factories into sibling refs; `tool/check_example_topology.dart` |
+| [`terradart-promo-video`](.agents/skills/terradart-promo-video/SKILL.md) | Recording a release demo clip and drafting its X / LinkedIn copy; `tool/promo_video.sh` |
 
 Optional generic Dart skills from [dart-lang/skills](https://github.com/dart-lang/skills) (`npx skills add dart-lang/skills --skill '*' --agent universal --yes`) are not committed here. [flutter/skills](https://github.com/flutter/skills) targets Flutter apps and is not applicable to TerraDart.
 
@@ -281,6 +282,7 @@ There is no long-running dev server for core work. Primary flows:
 | Synth example stack | `cd examples/pubsub_quickstart && GCP_PROJECT_ID=ci-test-project-id dart run bin/infra.dart` |
 | Validate synth output | `cd examples/pubsub_quickstart/tf-out && terraform init -backend=false && terraform validate` |
 | MCP catalog server (stdio) | `cd packages/terradart_agent && dart run terradart-mcp` |
+| Release demo clip (cut a `RecordScreen` take) | `tool/promo_video.sh --in RAW.mp4 --out EDIT.mp4 --deliver DELIVERY.mp4` |
 | Docs site (optional) | `cd website && bun install && bun run dev` (needs Bun + Node ≥ 22) |
 
 `dart tool/example_synth_gates.dart` (inside `tool/agent_verify.sh`) synths every quickstart and runs `terraform validate` on each `tf-out/` when `terraform` is on `PATH`; `dart tool/check_docs_consistency.dart` is the text-only docs check. Neither replaces the parallel `terraform_validate` CI matrix on merge. Examples use `GCP_PROJECT_ID` (or `ci-test-project-id` for local smoke) — no live GCP credentials are required for synth or `terraform validate`.

--- a/tool/promo_video.sh
+++ b/tool/promo_video.sh
@@ -159,7 +159,9 @@ fi
 
 if [[ "$WITH_CARD" == 1 ]]; then
   [[ -f "$LOGO" ]] || die "no logo at $LOGO"
-  [[ -f "$FONT" ]] || die "no font at $FONT (pass --font, or --tagline '' to drop the text)"
+  if [[ -n "$TAGLINE" ]]; then
+    [[ -f "$FONT" ]] || die "no font at $FONT (pass --font, or --tagline '' to drop the text)"
+  fi
 
   CARD="$WORK/endcard.png"
   CARD_LOGO_W=$((SRC_W * 46 / 100))

--- a/tool/promo_video.sh
+++ b/tool/promo_video.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Post-produce a Cloud Agent screen recording into a TerraDart promo clip:
+# drop the Cursor outro, optionally push in on one command, append a TerraDart
+# end card, and write a phone/social delivery encode. Maintainer ops — not part
+# of any shipped package.
+#
+# Usage (from repo root):
+#   tool/promo_video.sh --in RAW.mp4 --dump-frames /tmp/frames
+#   tool/promo_video.sh --in RAW.mp4 --out EDIT.mp4 \
+#     --zoom-in 5.15 --zoom-out 11.15 --zoom-focus 490,740 \
+#     --deliver DELIVERY.mp4
+#
+# Editorial judgment (what to record, what a clip may claim) lives in
+# .agents/skills/terradart-promo-video/SKILL.md. This script only owns the
+# ffmpeg invocations that are deterministic and easy to get wrong.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+readonly LOGO_DEFAULT="$ROOT/branding/png/logo-horizontal-dark-1024.png"
+readonly FONT_DEFAULT="/usr/share/fonts/truetype/macos/Inter-Regular.ttf"
+# branding/BRAND.md: --paper-dark ground, --paper text.
+readonly CARD_BG="0x0B0D12"
+readonly CARD_FG="0xF6F3ECC0"
+
+IN=""
+OUT=""
+DELIVER=""
+DUMP_FRAMES=""
+LOGO="$LOGO_DEFAULT"
+FONT="$FONT_DEFAULT"
+TAGLINE="Type-safe IaC for Dart."
+CARD_SECONDS="2.2"
+ZOOM_IN=""
+ZOOM_OUT=""
+ZOOM_FOCUS=""
+ZOOM_FACTOR="1.70"
+ZOOM_RAMP="1.75"
+TRIM_OUTRO="auto"
+WITH_CARD=1
+
+die() {
+  echo "promo_video.sh: $*" >&2
+  exit 64
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --in) IN="${2:?--in needs a file}"; shift 2 ;;
+    --out) OUT="${2:?--out needs a file}"; shift 2 ;;
+    --deliver) DELIVER="${2:?--deliver needs a file}"; shift 2 ;;
+    --dump-frames) DUMP_FRAMES="${2:?--dump-frames needs a directory}"; shift 2 ;;
+    --logo) LOGO="${2:?--logo needs a file}"; shift 2 ;;
+    --font) FONT="${2:?--font needs a file}"; shift 2 ;;
+    --tagline) TAGLINE="${2-}"; shift 2 ;;
+    --card-seconds) CARD_SECONDS="${2:?--card-seconds needs a number}"; shift 2 ;;
+    --zoom-in) ZOOM_IN="${2:?--zoom-in needs seconds}"; shift 2 ;;
+    --zoom-out) ZOOM_OUT="${2:?--zoom-out needs seconds}"; shift 2 ;;
+    --zoom-focus) ZOOM_FOCUS="${2:?--zoom-focus needs X,Y}"; shift 2 ;;
+    --zoom-factor) ZOOM_FACTOR="${2:?--zoom-factor needs a number}"; shift 2 ;;
+    --zoom-ramp) ZOOM_RAMP="${2:?--zoom-ramp needs seconds}"; shift 2 ;;
+    --trim-outro) TRIM_OUTRO="${2:?--trim-outro needs seconds or auto or none}"; shift 2 ;;
+    --no-endcard) WITH_CARD=0; shift ;;
+    -h | --help)
+      sed -n '2,14p' "$0"
+      exit 0
+      ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+command -v ffmpeg >/dev/null 2>&1 || die "ffmpeg not on PATH"
+command -v ffprobe >/dev/null 2>&1 || die "ffprobe not on PATH"
+[[ -n "$IN" ]] || die "--in is required"
+[[ -f "$IN" ]] || die "no such input: $IN"
+
+probe() {
+  ffprobe -v error -select_streams v:0 -show_entries "$1" -of default=nw=1:nk=1 "$IN"
+}
+
+SRC_W="$(probe stream=width)"
+SRC_H="$(probe stream=height)"
+SRC_FPS_RAW="$(probe stream=r_frame_rate)"
+SRC_FPS="$(awk -v r="$SRC_FPS_RAW" 'BEGIN { split(r, p, "/"); printf "%.6f", p[1] / (p[2] == 0 ? 1 : p[2]) }')"
+SRC_DUR="$(ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$IN")"
+
+# RecordScreen tags the clip it appends its brand mark to; trust the tag over a guess.
+OUTRO_MS="$(ffprobe -v error -show_entries format_tags=cursor_brand_tag_duration_ms -of default=nw=1:nk=1 "$IN" 2>/dev/null || true)"
+
+echo ">> source: ${SRC_W}x${SRC_H} @ ${SRC_FPS}fps, ${SRC_DUR}s"
+
+if [[ -n "$DUMP_FRAMES" ]]; then
+  mkdir -p "$DUMP_FRAMES"
+  # 4fps, named by source timestamp, so zoom timings and focus pixels are
+  # picked off real frames instead of guessed.
+  ffmpeg -v error -y -i "$IN" -vf fps=4 -frame_pts 1 "$DUMP_FRAMES/t_%04d.jpg"
+  for f in "$DUMP_FRAMES"/t_*.jpg; do
+    [[ -e "$f" ]] || break
+    n="${f##*/t_}"
+    n="${n%.jpg}"
+    mv "$f" "$DUMP_FRAMES/$(awk -v n="$n" 'BEGIN { printf "%06.2f", n / 4 }').jpg"
+  done
+  echo ">> dumped 4fps frames (named by source seconds) to $DUMP_FRAMES"
+  [[ -n "$OUT" ]] || { echo "promo_video: OK"; exit 0; }
+fi
+
+[[ -n "$OUT" ]] || die "--out is required unless only --dump-frames is given"
+
+case "$TRIM_OUTRO" in
+  auto) TRIM_S="$(awk -v ms="${OUTRO_MS:-0}" 'BEGIN { printf "%.3f", ms / 1000 }')" ;;
+  none) TRIM_S="0.000" ;;
+  *) TRIM_S="$(awk -v s="$TRIM_OUTRO" 'BEGIN { printf "%.3f", s }')" ;;
+esac
+
+BODY_END="$(awk -v d="$SRC_DUR" -v t="$TRIM_S" 'BEGIN { printf "%.3f", d - t }')"
+awk -v e="$BODY_END" 'BEGIN { exit (e > 0.5) ? 0 : 1 }' || die "trimming ${TRIM_S}s leaves nothing of a ${SRC_DUR}s clip"
+
+if awk -v t="$TRIM_S" 'BEGIN { exit (t > 0) ? 0 : 1 }'; then
+  echo ">> trimming ${TRIM_S}s of Cursor outro (body ends at ${BODY_END}s)"
+elif [[ "$TRIM_OUTRO" == "auto" ]]; then
+  echo ">> no outro trim: input carries no cursor_brand_tag_duration_ms"
+else
+  echo ">> no outro trim: --trim-outro $TRIM_OUTRO"
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# zoompan samples a still per output frame, so feeding it a 2x upscale keeps
+# text crisp at peak zoom instead of magnifying source pixels.
+ZOOM_W=$((SRC_W * 2))
+ZOOM_H=$((SRC_H * 2))
+
+if [[ -n "$ZOOM_IN" || -n "$ZOOM_OUT" || -n "$ZOOM_FOCUS" ]]; then
+  [[ -n "$ZOOM_IN" && -n "$ZOOM_OUT" && -n "$ZOOM_FOCUS" ]] ||
+    die "--zoom-in, --zoom-out and --zoom-focus must be given together"
+  [[ "$ZOOM_FOCUS" == *,* ]] || die "--zoom-focus wants X,Y in source pixels"
+
+  FOCUS_X="${ZOOM_FOCUS%%,*}"
+  FOCUS_Y="${ZOOM_FOCUS##*,}"
+  # Focus is authored in source pixels (measurable off a dumped frame) but
+  # zoompan reads x/y in its own input space, which is the 2x upscale.
+  ZX=$((FOCUS_X * 2))
+  ZY=$((FOCUS_Y * 2))
+
+  read -r IN_F OUT_F RAMP_F DELTA < <(awk \
+    -v zi="$ZOOM_IN" -v zo="$ZOOM_OUT" -v rp="$ZOOM_RAMP" \
+    -v fps="$SRC_FPS" -v zf="$ZOOM_FACTOR" \
+    'BEGIN { printf "%d %d %d %.4f\n", zi * fps, zo * fps, (rp * fps < 1 ? 1 : rp * fps), zf - 1 }')
+
+  # Ramp in from IN_F, hold, ramp back out from OUT_F. zoompan in this ffmpeg
+  # build rejects `t`, `st()` and `ld()`, so the curve is written over `on`.
+  ZOOM_CHAIN="scale=${ZOOM_W}:${ZOOM_H}:flags=lanczos,zoompan=z='1+${DELTA}*min(1\\,max(0\\,(on-${IN_F})/${RAMP_F}))*max(0\\,1-min(1\\,max(0\\,(on-${OUT_F})/${RAMP_F})))':x='clip(${ZX}-iw/zoom/2\\,0\\,iw-iw/zoom)':y='clip(${ZY}-ih/zoom/2\\,0\\,ih-ih/zoom)':d=1:s=${SRC_W}x${SRC_H}:fps=${SRC_FPS}"
+  echo ">> zoom: ${ZOOM_FACTOR}x on source (${FOCUS_X},${FOCUS_Y}), in at ${ZOOM_IN}s, out at ${ZOOM_OUT}s, ${ZOOM_RAMP}s ramp"
+else
+  ZOOM_CHAIN="null"
+  echo ">> no zoom"
+fi
+
+if [[ "$WITH_CARD" == 1 ]]; then
+  [[ -f "$LOGO" ]] || die "no logo at $LOGO"
+  [[ -f "$FONT" ]] || die "no font at $FONT (pass --font, or --tagline '' to drop the text)"
+
+  CARD="$WORK/endcard.png"
+  CARD_LOGO_W=$((SRC_W * 46 / 100))
+  CARD_FILTER="[1:v]scale=${CARD_LOGO_W}:-1:flags=lanczos[logo];[0:v][logo]overlay=(W-w)/2:(H-h)/2-36:format=auto[bg]"
+  if [[ -n "$TAGLINE" ]]; then
+    CARD_FILTER="${CARD_FILTER};[bg]drawtext=fontfile=${FONT}:text='${TAGLINE}':fontsize=34:fontcolor=${CARD_FG}:x=(w-text_w)/2:y=(h/2)+148"
+  else
+    CARD_FILTER="${CARD_FILTER};[bg]null"
+  fi
+
+  ffmpeg -v error -y \
+    -f lavfi -i "color=c=${CARD_BG}:s=${SRC_W}x${SRC_H}:d=1:r=1" \
+    -i "$LOGO" \
+    -filter_complex "$CARD_FILTER" \
+    -frames:v 1 -update 1 "$CARD"
+
+  cat >"$WORK/edit.filter" <<FILTER
+[0:v]trim=start=0:end=${BODY_END},setpts=PTS-STARTPTS,${ZOOM_CHAIN},fade=t=out:st=$(awk -v e="$BODY_END" 'BEGIN { printf "%.3f", e - 0.38 }'):d=0.38,format=yuv420p[body];
+[1:v]fps=${SRC_FPS},fade=t=in:st=0:d=0.45,format=yuv420p[card];
+[body][card]concat=n=2:v=1:a=0[v]
+FILTER
+
+  ffmpeg -v error -y \
+    -i "$IN" \
+    -loop 1 -t "$CARD_SECONDS" -r "$SRC_FPS" -i "$CARD" \
+    -filter_complex_script "$WORK/edit.filter" \
+    -map '[v]' -an \
+    -c:v libx264 -preset medium -crf 18 -pix_fmt yuv420p \
+    -movflags +faststart -map_metadata -1 \
+    "$OUT"
+  echo ">> end card: TerraDart lockup${TAGLINE:+ + \"$TAGLINE\"}, ${CARD_SECONDS}s"
+else
+  cat >"$WORK/edit.filter" <<FILTER
+[0:v]trim=start=0:end=${BODY_END},setpts=PTS-STARTPTS,${ZOOM_CHAIN},format=yuv420p[v]
+FILTER
+
+  ffmpeg -v error -y \
+    -i "$IN" \
+    -filter_complex_script "$WORK/edit.filter" \
+    -map '[v]' -an \
+    -c:v libx264 -preset medium -crf 18 -pix_fmt yuv420p \
+    -movflags +faststart -map_metadata -1 \
+    "$OUT"
+  echo ">> no end card"
+fi
+
+echo ">> wrote $OUT ($(ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$OUT")s)"
+
+if [[ -n "$DELIVER" ]]; then
+  # iOS Photos silently refuses "Save Video" on the raw recording shape
+  # (soundless, 1200-tall, 60fps, H.264 level 5.0). 1080p30 High@4.1 with a
+  # silent AAC track, faststart and an mp42 brand is what it accepts, and is
+  # also inside X's and LinkedIn's upload envelope.
+  ffmpeg -v error -y \
+    -i "$OUT" \
+    -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=48000 \
+    -filter_complex "[0:v]scale=1920:1080:force_original_aspect_ratio=decrease:flags=lanczos,pad=1920:1080:(ow-iw)/2:(oh-ih)/2:black,fps=30,format=yuv420p[v]" \
+    -map '[v]' -map 1:a \
+    -c:v libx264 -profile:v high -level 4.1 -preset medium -crf 18 \
+    -c:a aac -b:a 128k -ac 2 -ar 48000 -shortest \
+    -movflags +faststart -brand mp42 -map_metadata -1 \
+    "$DELIVER"
+  echo ">> wrote $DELIVER (1080p30, High@4.1, silent AAC — iOS Photos / X / LinkedIn safe)"
+fi
+
+echo "promo_video: OK"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cutting the `terradart-migrate` announcement clip for v0.28.1 was hand-rolled ffmpeg, and most of the rework was not editorial judgment — it was environment-specific invocations that fail in ways you only notice later. This lands the script that owns them, plus the skill that keeps the parts a script cannot decide.

## Why a script and not prose

Three failure modes cost real iterations and are invisible up front:

- This ffmpeg build rejects `t`, `st()` and `ld()` inside `zoompan`, and `drawtext` has no `letter_spacing`. Three attempts failed on filter parse errors before the curve was rewritten over `on` (frame index).
- `RecordScreen` appends a Cursor brand mark whose length lives only in container metadata (`cursor_brand_tag_duration_ms`), so trimming it is a guess unless you read the tag.
- iOS Photos **silently refuses** "Save Video" on the raw recording shape (soundless, 1200 tall, 60fps, H.264 level 5.0). No error, no hint. This surfaced only when the maintainer tried to save the finished clip.

`tool/promo_video.sh` encodes all three. `AGENTS.md` already prefers a repeatable `tool/` script over long prose, so the judgment-free half goes there.

## What lands

`tool/promo_video.sh` — reads the source geometry and fps, drops the Cursor outro by tag (`--trim-outro auto|none|<seconds>`), optionally pushes in on one command and back out, appends the TerraDart end card built from `branding/`, strips recorder metadata, and writes the delivery encode.

- `--dump-frames DIR` dumps 4fps stills **named by source seconds** (`005.25.jpg`), so zoom timings and the focus pixel come off real frames instead of guesses. This was the other slow step.
- `--zoom-focus X,Y` is in source pixels; the script maps it into `zoompan`'s space and upscales 2x first, because `zoompan` samples one still per output frame and zooming the source directly magnifies pixels.
- `--deliver FILE` writes 1080p30 High@4.1 with a silent AAC track, `faststart` and an `mp42` brand — the shape iOS Photos, X and LinkedIn all accept.
- `--no-endcard`, `--tagline`, `--logo`, `--font`, `--card-seconds`, `--zoom-factor`, `--zoom-ramp` for the variations.

`.agents/skills/terradart-promo-video/SKILL.md` — the three-beat story structure (input → one command → result), the terminal setup that reads well at tweet size, and the copy guidance (lead with the release, cut internal vocabulary like *leftover sidecar*).

Its load-bearing section is **What a clip may claim**: copy may only claim what the clip shows. A fixture-tree clip supports "converts a Terraform tree" and not "migrated a real app"; *No changes* is off-limits until the [status](https://github.com/nozomi-koborinai/terradart/blob/main/website/src/content/docs/docs/status.md) gate for it is actually ticked. That one nearly went out wrong while drafting the v0.28.1 copy, and unlike a bad encode it is not recoverable after posting.

`AGENTS.md` — one row in the skill table, one row in the Cursor Cloud flows table.

## Scope

Docs, skill and maintainer tooling only. No runtime, package or generated-wrapper changes; nothing in any published package. No gate is added — a promo clip has no machine-checkable output, which is why the editorial rules stay prose.

The reference clip in the skill is a coverage fixture (`packages/terradart_coverage/test/fixtures/config_tree`), copied out before recording so the take does not show repo paths.

## Verification

`tool/agent_verify.sh` → `agent_verify: OK` (full gate, not `--quick`).

The script was validated by reproducing the already-published v0.28.1 clip from its raw recording, and each mode exercised separately:

| Run | Result |
|---|---|
| full pipeline (zoom + end card + deliver) | 19.9s edit at 1920x1200/60, delivery at 1920x1080/30 High@4.1 + AAC stereo |
| `--dump-frames` | 79 stills, named `000.00` … `019.50` |
| `--no-endcard --trim-outro none` | 19.7s, untrimmed, no card |
| `--zoom-in` without its siblings / missing input / unknown flag | exit 64 with a message each |

Peak-zoom and end-card frames from the script's own output:

[Peak zoom on the terradart-migrate command, produced by tool/promo_video.sh](https://cursor.com/agents/bc-01a098bb-bc68-73bb-855d-e4c5094768b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpromo_video_script_peak_zoom.jpg)

[TerraDart end card produced by tool/promo_video.sh](https://cursor.com/agents/bc-01a098bb-bc68-73bb-855d-e4c5094768b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpromo_video_script_endcard.jpg)

Committed with the exec bit (`100755`), matching the other `tool/*.sh`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a098bb-bc68-73bb-855d-e4c5094768b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a098bb-bc68-73bb-855d-e4c5094768b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

